### PR TITLE
Fix save-breaking issue with intermittent_activation

### DIFF
--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -153,7 +153,7 @@
     "id": "debug_active_relic_test",
     "type": "TOOL",
     "name": { "str_sp": "Cube of Shame" },
-    "description": "This is a debug-only item for testing relic properties, powered by batteries.  Turn it on to lose intelligence and perception, but gain clairvoyance",
+    "description": "This is a debug-only item for testing relic properties, powered by batteries.  Turn it on to lose intelligence and perception, but gain clairvoyance.",
     "material": [ "steel" ],
     "symbol": ";",
     "color": "blue",
@@ -186,7 +186,7 @@
     "magazine_well": 1,
     "relic_data": {
       "passive_effects": [
-        { "has": "HELD", "condition": "ALWAYS", "mutations": [ "SCHIZOPHRENIC" ] },
+        { "has": "HELD", "condition": "ALWAYS", "mutations": [ "CARNIVORE" ], "intermittent_activation": { "effects": [ { "frequency": "5 minutes", "spell_effects": [ { "id": "AEA_HEAL" } ] } ] } },
         {
           "has": "HELD",
           "condition": "ACTIVE",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -186,7 +186,12 @@
     "magazine_well": 1,
     "relic_data": {
       "passive_effects": [
-        { "has": "HELD", "condition": "ALWAYS", "mutations": [ "CARNIVORE" ], "intermittent_activation": { "effects": [ { "frequency": "5 minutes", "spell_effects": [ { "id": "AEA_HEAL" } ] } ] } },
+        {
+          "has": "HELD",
+          "condition": "ALWAYS",
+          "mutations": [ "CARNIVORE" ],
+          "intermittent_activation": { "effects": [ { "frequency": "5 minutes", "spell_effects": [ { "id": "AEA_HEAL" } ] } ] }
+        },
         {
           "has": "HELD",
           "condition": "ACTIVE",

--- a/data/json/legacy_artifact_active.json
+++ b/data/json/legacy_artifact_active.json
@@ -38,8 +38,8 @@
     "valid_targets": [ "self" ],
     "effect": "target_attack",
     "base_casting_time": 100,
-    "min_damage": 2,
-    "max_damage": 2,
+    "min_damage": -2,
+    "max_damage": -2,
     "message": "You feel healed."
   },
   {

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -297,7 +297,8 @@ void enchantment::serialize( JsonOut &jsout ) const
         jsout.start_object();
         for( const std::pair<time_duration, std::vector<fake_spell>> pair : intermittent_activation ) {
             jsout.member( "duration", pair.first );
-            jsout.start_array( "effects" );
+            jsout.member( "spell_effects" );
+            jsout.start_array();
             for( const fake_spell &sp : pair.second ) {
                 sp.serialize( jsout );
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix intermittent_activation in relic_data causing bad save JSON."

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes the actual save-breakage, and makes it easier to test a second issue that I've discovered afterward. Even after fixing this, save/load breaks intermittent_activation in a way that simply causes it to not cast the spells anymore, and this applies even to enchantments defined as explicit JSON objects (which wouldn't break saves like in-item intermittent_activation does).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Implemented the proposed fix to magic_enchantment.cpp. This only fixes the save JSON breaking, underneath there's still the underlying issue of all intermittent functions being busted by a save/load.
2. Fixed AEA_HEAL dealing damage instead of healing, since it's being used to test this function.
3. Added an intermittent_activation effect to the Cube of Shame for testing this.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Trying to figure out how to fix the underlying issue first.
2. Not using intermittent effects at all, like already done for Arcana's DDA incarnation.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compile and load test.
2. Spawn in a Cube of Shame.
3. Wait 5 minutes for the "your wounds are closing up" message, which applies even at full HP.
4. Save game.
5. Load game, confirm that game loads correctly.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Relevant DDA issue here: https://github.com/CleverRaven/Cataclysm-DDA/issues/41261

With thanks to @anothersimulacrum for the proposed code change.

Underlying issue: https://github.com/cataclysmbnteam/Cataclysm-BN/issues/186 which appears to affect DDA as well as BN.