### PR TITLE
Store power in joules to fix power storage cap

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3436,7 +3436,7 @@ void activity_handlers::operation_do_turn( player_activity *act, player *p )
 
             if( p->has_bionic( bid ) ) {
                 p->perform_uninstall( bid, act->values[0], act->values[1],
-                                      units::from_millijoule( act->values[2] ), act->values[3] );
+                                      units::from_joule( act->values[2] ), act->values[3] );
             } else {
                 debugmsg( _( "Tried to uninstall %s, but you don't have this bionic installed." ), bid.c_str() );
                 p->remove_effect( effect_under_op );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -462,7 +462,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
     }
     const float allowed_ratio = static_cast<int>( rules.cbm_reserve ) / 100.0f;
     const units::energy free_power = get_power_level() - get_max_power_level() * allowed_ratio;
-    if( free_power <= 0_mJ ) {
+    if( free_power <= 0_J ) {
         return;
     }
 
@@ -1535,7 +1535,7 @@ void Character::process_bionic( int b )
                 bio.charge_timer = bio.info().charge_time;
             } else {
                 // Try to recharge our bionic if it is made for it
-                units::energy cost = 0_mJ;
+                units::energy cost = 0_J;
                 bool recharged = attempt_recharge( *this, bio, cost, discharge_factor, discharge_rate );
                 if( !recharged ) {
                     // No power to recharge, so deactivate
@@ -1545,7 +1545,7 @@ void Character::process_bionic( int b )
                     deactivate_bionic( b, true );
                     return;
                 }
-                if( cost > 0_mJ ) {
+                if( cost > 0_J ) {
                     mod_power_level( -cost );
                 }
             }
@@ -2231,7 +2231,7 @@ bool Character::install_bionics( const itype &type, player &installer, bool auto
     assign_activity( ACT_OPERATION, to_moves<int>( difficulty * 20_minutes ) );
     activity.values.push_back( difficulty );
     activity.values.push_back( success );
-    activity.values.push_back( units::to_millijoule( bioid->capacity ) );
+    activity.values.push_back( units::to_joule( bioid->capacity ) );
     activity.values.push_back( pl_skill );
     activity.str_values.push_back( "install" );
     activity.str_values.push_back( bioid.str() );

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -224,24 +224,18 @@ static void draw_bionics_titlebar( const catacurses::window &window, player *p,
         fuel_string.clear();
     }
     std::string power_string;
-    const int curr_power = units::to_millijoule( p->get_power_level() );
-    const int kilo = curr_power / units::to_millijoule( 1_kJ );
-    const int joule = ( curr_power % units::to_millijoule( 1_kJ ) ) / units::to_millijoule( 1_J );
-    const int milli = curr_power % units::to_millijoule( 1_J );
+    const int curr_power = units::to_joule( p->get_power_level() );
+    const int kilo = curr_power / units::to_joule( 1_kJ );
+    const int joule = ( curr_power % units::to_joule( 1_kJ ) ) / units::to_joule( 1_J );
     if( kilo > 0 ) {
         power_string = std::to_string( kilo );
         if( joule > 0 ) {
             power_string += pgettext( "decimal separator", "." ) + std::to_string( joule );
         }
         power_string += pgettext( "energy unit: kilojoule", "kJ" );
-    } else if( joule > 0 ) {
-        power_string = std::to_string( joule );
-        if( milli > 0 ) {
-            power_string += pgettext( "decimal separator", "." ) + std::to_string( milli );
-        }
-        power_string += pgettext( "energy unit: joule", "J" );
     } else {
-        power_string = std::to_string( milli ) + pgettext( "energy unit: millijoule", "mJ" );
+        power_string = std::to_string( joule );
+        power_string += pgettext( "energy unit: joule", "J" );
     }
 
     const int pwr_str_pos = right_print( window, 1, 1, c_white,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2918,10 +2918,7 @@ void item::battery_info( std::vector<iteminfo> &info, const iteminfo_query * /*p
     }
 
     std::string info_string;
-    if( type->battery->max_capacity < 1_J ) {
-        info_string = string_format( _( "<bold>Capacity</bold>: %dmJ" ),
-                                     to_millijoule( type->battery->max_capacity ) );
-    } else if( type->battery->max_capacity < 1_kJ ) {
+    if( type->battery->max_capacity < 1_kJ ) {
         info_string = string_format( _( "<bold>Capacity</bold>: %dJ" ),
                                      to_joule( type->battery->max_capacity ) );
     } else if( type->battery->max_capacity >= 1_kJ ) {
@@ -3162,10 +3159,10 @@ void item::bionic_info( std::vector<iteminfo> &info, const iteminfo_query *parts
 
     insert_separation_line( info );
 
-    if( bid->capacity > 0_mJ ) {
-        info.push_back( iteminfo( "CBM", _( "<bold>Power Capacity</bold>:" ), _( " <num> mJ" ),
+    if( bid->capacity > 0_J ) {
+        info.push_back( iteminfo( "CBM", _( "<bold>Power Capacity</bold>:" ), _( " <num> J" ),
                                   iteminfo::no_newline,
-                                  units::to_millijoule( bid->capacity ) ) );
+                                  units::to_joule( bid->capacity ) ) );
     }
 
     insert_separation_line( info );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1206,7 +1206,7 @@ void Item_factory::check_definitions() const
             }
         }
         if( type->battery ) {
-            if( type->battery->max_capacity < 0_mJ ) {
+            if( type->battery->max_capacity < 0_J ) {
                 msg += "battery cannot have negative maximum charge\n";
             }
         }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -632,9 +632,9 @@ void Character::activate_mutation( const trait_id &mut )
         return;
     } else if( mut == trait_DEBUG_BIONIC_POWERGEN ) {
         int npower;
-        if( query_int( npower, "Modify bionic power by how much?  (Values are in millijoules)" ) ) {
-            mod_power_level( units::from_millijoule( npower ) );
-            add_msg_if_player( m_good, "Bionic power increased by %dmJ.", npower );
+        if( query_int( npower, "Modify bionic power by how much?  (Values are in joules)" ) ) {
+            mod_power_level( units::from_joule( npower ) );
+            add_msg_if_player( m_good, "Bionic power increased by %dJ.", npower );
             tdata.powered = false;
         }
         return;

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -800,10 +800,7 @@ static std::pair<nc_color, std::string> power_stat( const avatar &u )
             c_pwr = c_red;
         }
 
-        if( u.get_power_level() < 1_J ) {
-            s_pwr = std::to_string( units::to_millijoule( u.get_power_level() ) ) +
-                    pgettext( "energy unit: millijoule", "mJ" );
-        } else if( u.get_power_level() < 1_kJ ) {
+        if( u.get_power_level() < 1_kJ ) {
             s_pwr = std::to_string( units::to_joule( u.get_power_level() ) ) +
                     pgettext( "energy unit: joule", "J" );
         } else {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -594,8 +594,8 @@ void Character::load( const JsonObject &data )
     assign( data, "max_power_level", max_power_level, false, 0_kJ );
 
     // Bionic power should not be negative!
-    if( power_level < 0_mJ ) {
-        power_level = 0_mJ;
+    if( power_level < 0_J ) {
+        power_level = 0_J;
     }
 
     JsonArray overmap_time_array = data.get_array( "overmap_time" );
@@ -724,9 +724,7 @@ void Character::store( JsonOut &json ) const
     json.end_object();
 
     // npc; unimplemented
-    if( power_level < 1_J ) {
-        json.member( "power_level", std::to_string( units::to_millijoule( power_level ) ) + " mJ" );
-    } else if( power_level < 1_kJ ) {
+    if( power_level < 1_kJ ) {
         json.member( "power_level", std::to_string( units::to_joule( power_level ) ) + " J" );
     } else {
         json.member( "power_level", units::to_kilojoule( power_level ) );
@@ -2180,7 +2178,7 @@ void item::io( Archive &archive )
     archive.io( "charges", charges, 0 );
     charges = std::max( charges, 0 );
 
-    archive.io( "energy", energy, 0_mJ );
+    archive.io( "energy", energy, 0_J );
 
     archive.io( "burnt", burnt, 0 );
     archive.io( "poison", poison, 0 );

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -31,12 +31,10 @@ void mass::serialize( JsonOut &jsout ) const
 template<>
 void energy::serialize( JsonOut &jsout ) const
 {
-    if( value_ % 1000000 == 0 ) {
-        jsout.write( string_format( "%d kJ", value_ / 1000000 ) );
-    } else if( value_ % 1000 == 0 ) {
-        jsout.write( string_format( "%d J", value_ / 1000 ) ) ;
+    if( value_ % 1000 == 0 ) {
+        jsout.write( string_format( "%d kJ", value_ / 1000 ) );
     } else {
-        jsout.write( string_format( "%d mJ", value_ ) );
+        jsout.write( string_format( "%d J", value_ ) ) ;
     }
 }
 
@@ -54,11 +52,6 @@ std::string display( const units::energy v )
     if( kj >= 1 && float( j ) / kj == 1000 ) {
         return std::to_string( kj ) + ' ' + pgettext( "energy unit: kilojoule", "kJ" );
     }
-    const int mj = units::to_millijoule( v );
-    // at least 1 J and there is no fraction
-    if( j >= 1 && float( mj ) / j  == 1000 ) {
-        return std::to_string( j ) + ' ' + pgettext( "energy unit: joule", "J" );
-    }
-    return std::to_string( mj ) + ' ' + pgettext( "energy unit: millijoule", "mJ" );
+    return std::to_string( j ) + ' ' + pgettext( "energy unit: joule", "J" );
 }
 } // namespace units

--- a/src/units.h
+++ b/src/units.h
@@ -31,9 +31,9 @@ inline std::ostream &operator<<( std::ostream &o, volume_in_milliliter_tag )
     return o << "ml";
 }
 
-inline std::ostream &operator<<( std::ostream &o, energy_in_millijoule_tag )
+inline std::ostream &operator<<( std::ostream &o, energy_in_joule_tag )
 {
-    return o << "mJ";
+    return o << "J";
 }
 
 inline std::ostream &operator<<( std::ostream &o, money_in_cent_tag )
@@ -59,7 +59,6 @@ std::string display( units::energy v );
 namespace units
 {
 static const std::vector<std::pair<std::string, energy>> energy_units = { {
-        { "mJ", 1_mJ },
         { "J", 1_J },
         { "kJ", 1_kJ },
     }

--- a/src/units.h
+++ b/src/units.h
@@ -59,6 +59,7 @@ std::string display( units::energy v );
 namespace units
 {
 static const std::vector<std::pair<std::string, energy>> energy_units = { {
+        { "mJ", 1_J }, // Millijoules are depreciated, this is only defined to migrate old saves.
         { "J", 1_J },
         { "kJ", 1_kJ },
     }

--- a/src/units_energy.h
+++ b/src/units_energy.h
@@ -9,11 +9,11 @@
 namespace units
 {
 
-class energy_in_millijoule_tag
+class energy_in_joule_tag
 {
 };
 
-using energy = quantity<int, energy_in_millijoule_tag>;
+using energy = quantity<int, energy_in_joule_tag>;
 
 const energy energy_min = units::energy( std::numeric_limits<units::energy::value_type>::min(),
                           units::energy::unit_type{} );
@@ -22,70 +22,40 @@ const energy energy_max = units::energy( std::numeric_limits<units::energy::valu
                           units::energy::unit_type{} );
 
 template<typename value_type>
-inline constexpr quantity<value_type, energy_in_millijoule_tag> from_millijoule(
+inline constexpr quantity<value_type, energy_in_joule_tag> from_joule(
     const value_type v )
 {
-    return quantity<value_type, energy_in_millijoule_tag>( v, energy_in_millijoule_tag{} );
+    return quantity<value_type, energy_in_joule_tag>( v, energy_in_joule_tag{} );
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, energy_in_millijoule_tag> from_joule( const value_type v )
+inline constexpr quantity<value_type, energy_in_joule_tag> from_kilojoule( const value_type v )
 {
     const value_type max_energy_joules = std::numeric_limits<value_type>::max() / 1000;
-    // Check for overflow - if the energy provided is greater than max energy, then it
-    // if overflow when converted to millijoules
-    const value_type energy = v > max_energy_joules ? max_energy_joules : v;
-    return from_millijoule<value_type>( energy * 1000 );
-}
-
-template<typename value_type>
-inline constexpr quantity<value_type, energy_in_millijoule_tag> from_kilojoule( const value_type v )
-{
-    const value_type max_energy_joules = std::numeric_limits<value_type>::max() / 1000;
-    // This checks for value_type overflow - if the energy we are given in Joules is greater
-    // than the max energy in Joules, overflow will occur when it is converted to millijoules
-    // The value we are given is in kJ, multiply by 1000 to convert it to joules, for use in from_joule
     value_type energy = v * 1000 > max_energy_joules ? max_energy_joules : v * 1000;
     return from_joule<value_type>( energy );
 }
 
 template<typename value_type>
-inline constexpr value_type to_millijoule( const quantity<value_type, energy_in_millijoule_tag> &v )
+inline constexpr value_type to_joule( const quantity<value_type, energy_in_joule_tag> &v )
 {
-    return v / from_millijoule<value_type>( 1 );
+    return v / from_joule<value_type>( 1 );
 }
 
 template<typename value_type>
-inline constexpr value_type to_joule( const quantity<value_type, energy_in_millijoule_tag> &v )
-{
-    return to_millijoule( v ) / 1000.0;
-}
-
-template<typename value_type>
-inline constexpr value_type to_kilojoule( const quantity<value_type, energy_in_millijoule_tag> &v )
+inline constexpr value_type to_kilojoule( const quantity<value_type, energy_in_joule_tag> &v )
 {
     return to_joule( v ) / 1000.0;
 }
 
 } // namespace units
 
-inline constexpr units::energy operator"" _mJ( const unsigned long long v )
-{
-    return units::from_millijoule( v );
-}
-
-inline constexpr units::quantity<double, units::energy_in_millijoule_tag> operator"" _mJ(
-    const long double v )
-{
-    return units::from_millijoule( v );
-}
-
 inline constexpr units::energy operator"" _J( const unsigned long long v )
 {
     return units::from_joule( v );
 }
 
-inline constexpr units::quantity<double, units::energy_in_millijoule_tag> operator"" _J(
+inline constexpr units::quantity<double, units::energy_in_joule_tag> operator"" _J(
     const long double v )
 {
     return units::from_joule( v );
@@ -96,7 +66,7 @@ inline constexpr units::energy operator"" _kJ( const unsigned long long v )
     return units::from_kilojoule( v );
 }
 
-inline constexpr units::quantity<double, units::energy_in_millijoule_tag> operator"" _kJ(
+inline constexpr units::quantity<double, units::energy_in_joule_tag> operator"" _kJ(
     const long double v )
 {
     return units::from_kilojoule( v );

--- a/tests/units_test.cpp
+++ b/tests/units_test.cpp
@@ -16,8 +16,6 @@ TEST_CASE( "units_have_correct_ratios", "[units]" )
     CHECK( 1.0_gram == 1000.0_milligram );
     CHECK( 1_kilogram == 1000_gram );
     CHECK( 1.0_kilogram == 1000.0_gram );
-    CHECK( 1_J == 1000_mJ );
-    CHECK( 1.0_J == 1000.0_mJ );
     CHECK( 1_kJ == 1000_J );
     CHECK( 1.0_kJ == 1000.0_J );
     CHECK( 1_USD == 100_cent );
@@ -28,7 +26,6 @@ TEST_CASE( "units_have_correct_ratios", "[units]" )
     CHECK( 1_hours == 60_minutes );
     CHECK( 1_minutes == 60_seconds );
 
-    CHECK( 1_mJ == units::from_millijoule( 1 ) );
     CHECK( 1_J == units::from_joule( 1 ) );
     CHECK( 1_kJ == units::from_kilojoule( 1 ) );
 
@@ -52,15 +49,13 @@ TEST_CASE( "energy parsing from JSON", "[units]" )
     CHECK_THROWS( parse_energy_quantity( "\"    \"" ) ); // only spaces
     CHECK_THROWS( parse_energy_quantity( "\"27\"" ) ); // no energy unit
 
-    CHECK( parse_energy_quantity( "\"1 mJ\"" ) == 1_mJ );
     CHECK( parse_energy_quantity( "\"1 J\"" ) == 1_J );
     CHECK( parse_energy_quantity( "\"1 kJ\"" ) == 1_kJ );
-    CHECK( parse_energy_quantity( "\"+1 mJ\"" ) == 1_mJ );
     CHECK( parse_energy_quantity( "\"+1 J\"" ) == 1_J );
     CHECK( parse_energy_quantity( "\"+1 kJ\"" ) == 1_kJ );
 
-    CHECK( parse_energy_quantity( "\"1 mJ 1 J 1 kJ\"" ) == 1_mJ + 1_J + 1_kJ );
-    CHECK( parse_energy_quantity( "\"1 mJ -4 J 1 kJ\"" ) == 1_mJ - 4_J + 1_kJ );
+    CHECK( parse_energy_quantity( "\"1 J 1 kJ\"" ) == 1_J + 1_kJ );
+    CHECK( parse_energy_quantity( "\"1 kJ -4 J\"" ) == 1_kJ - 4_J );
 }
 
 static time_duration parse_time_duration( const std::string &json )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Features "Store bionic power in joules, not millijoules"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So I was recently reminded by EkarusRynden about the bionic power storage cap being overly restricted, and after looking into it I read through https://github.com/cataclysmbnteam/Cataclysm-BN/pull/489 and realized that the alternative proposed, just storing power in joules instead of millijoules, would be a lot easier to implement, and less tricky than converting the max from 32-bit to 64-bit. Seeing as that PR stalled, I decided I'd take a stab at it.

To my knowledge, literally NOTHING in the game even uses less than 1 joule of power, with the closest we even come to it being some CBMs being capable of faking it via defining a greater-than-1 `time` to apply their `react_cost` more slowly. So this method should give us an effective power cap of over 2 million kJ with nothing lost. That's over 8000 (https://www.youtube.com/watch?v=J5wEER4YkMU) Mk. II Power Storage CBMs, and good luck hitting the cap 100 kJ at a time.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can 
get merged.  -->

Depreciated use of millijoule as a unit, allowing base unit to be stored in joules instead of millijoules.

I retained a definition for millijoules in unit.h so that old saves won't break, which translates it into joules. The only time this would even be a problem would be for saves with characters that have zero current power, because the save would write it as "0 mJ". This retention gives it the ability to read those old saves.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Converting the integer to 64-bit is the main alternative, but that means having to fiddle with more numbers that may be buried in the code.
2. If we really want we can hack in a JSON-accessible cap on top of this to set it to whatever value we like that's less than the 32-bit cap, hack in a way to assign powergen CBMs body slots, or whatever, but I feel that'd be a better fit for a follow-up PR, when fixing a dangerously-easy-to-hit hardcap is higher-priority.
3. If there was a less-extensive way to make sure bionic power was tored in joules without completely axing the ability to track millijoules that works too, but I wasn't sure how to only partially remove the feature since it's all very interconnected.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Tested ramping over power storage in a test build, using Debug Bionic Power mutation.
2. Power overflows and no longer shows on the menu after you reach 2100 power and activate it one more time.
3. Compiled and load-tested changes.
4. Spawned in a power storage CBM, confirmed item description lists right amount of joules.
5. Gave myself Debug Bionic Installation mutation and installed a Mk. II power storage, confirmed I had 250 kJ capacity.
6. Spawned in a light battery, gave myself Battery System CBM, ate it. Confirmed it gave me 100 kJ of power.
7. Gave myself Debug Bionic Power mutation and spawned it. Was able to go over 2100 kJ of power without overflow.
8. Started anew and spammed Mk. II Power Storage CBMs with Debug Bionic Installation, was able to go over 2100 kJ naturally as well.

~~PROBLEM: The actual bionic installation function still acts like `energy_max` is getting the numeric limit in millijoules, meaning you can't actually install more than 2100 kJ of power without debug.~~ Test build mixup, I had both open and double-checked power storage installation at the last moment, and didn't realize I was in the comparison build, not the compiled build.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://user-images.githubusercontent.com/11582235/137823747-5b4feec9-a3af-4c8b-83c2-de87aa83f1ce.png)

~~Cyborgs in old saves might hypothetically have their power capacity expand by a thousandfold?~~ Due to the way that current and max power is stored in saves, turns out old saves will be fine.

Amusing thing though: if you somehow got less than a joule of power in you in an old save, you'll loading in with those millijoules converted into joules. This is so entirely minor as to not even be an issue since literally nothing generated less than 1 joule of power, and as soon as you go past 999 mJ it'll be stored in joules or kJ.