### PR TITLE
Fix bionic complication bricking saves, failing to find faulty CBMs

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -325,7 +325,7 @@ void bionic_data::load( const JsonObject &jsobj, const std::string src )
 
 void bionic_data::finalize() const
 {
-    if( has_flag( STATIC( flag_str_id( "BIO_FAULTY" ) ) ) ) {
+    if( has_flag( STATIC( flag_str_id( "BIONIC_FAULTY" ) ) ) ) {
         faulty_bionics.push_back( id );
     }
 }
@@ -2379,14 +2379,20 @@ void Character::bionics_install_failure( const std::string &installer,
                     add_msg( m_bad, _( "%s lose power capacity!" ), disp_name() );
                     set_max_power_level( units::from_kilojoule( rng( 0,
                                          units::to_kilojoule( get_max_power_level() ) - 25 ) ) );
+                    if( get_max_power_level() < units::from_kilojoule( 0 ) ) {
+                        set_max_power_level( units::from_kilojoule( 0 ) );
+                    }
                     if( is_player() ) {
                         g->memorial().add(
                             pgettext( "memorial_male", "Lost %d units of power capacity." ),
                             pgettext( "memorial_female", "Lost %d units of power capacity." ),
                             units::to_kilojoule( old_power - get_max_power_level() ) );
                     }
+                    // If no faults available and no power capacity, downgrade to second-worst complication.
+                } else {
+                    do_damage_for_bionic_failure( 5, difficulty * 5 );
+                    break;
                 }
-                // TODO: What if we can't lose power capacity?  No penalty?
             } else {
                 const bionic_id &id = random_entry( valid );
                 add_bionic( id );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix bionic complications corrupting saves and failing to install faulty CBMs, fallback consequence for characters with all faults and no power storage"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Decided to look into some bionic installation bugs myself since I was 90% certain it'd be some stupidly simply if/else work, AKA the sort of C++ I'm halfway competent at. Fixes bugs involving bionic complications.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Updated bionics.cpp so that the "lose power capacity" complication sanity-checks if it tries to set power capacity negative, and if so zeros it out instead. This one's the most important bit, since it prevents save breakage.
2. Fixed the section looking for faulty bionics to look for `BIONIC_FAULTY` instead of `BIO_FAULTY`, fixing it assuming the player has all available faulty bionics due to not finding the right flag.
3. For bonus points, set it so so that if the extreme failure complication can't trigger (target has no power, and has all faulty bionics) then failure downgrades to second-worst complication result.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Putting it off and waiting for someone else to figure it out.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Spawned in a 4-int character.
3. Repeatedly bungled my way through installing CBMs, losing power.
4. Confirmed power went down to zero instead of negative, and that save/load didn't brick things.
5. Retested as a broken cyborg after fixing bionic faults.
6. Confirmed that bungling an installation now gives me the only faults prototype cyborg profession doesn't start with first.
7. Tanked my power storage after finishing my collection of power storage.
8. Confirmed I took damage on bungling a fail with all faulty bionics and no power storage left.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1260

One thing I might want to test as well though: getting max bionic storage and seeing if that causes the same "all CBMs can't be installed" thing that ensues when you get negative CBM power.

Also to ponder, how easy would it be to make uninstalling a faulty bionic return a burnt-out bionic instead of being able to re-install faults...