### PR TITLE
fix: Make No NPC Needs set fatigue to 0

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4791,7 +4791,7 @@ void Character::update_needs( int rate_multiplier )
     const bool wasnt_fatigued = get_fatigue() <= fatigue_levels::dead_tired;
     // Don't increase fatigue if sleeping or trying to sleep or if we're at the cap.
     if( get_fatigue() < 1050 && !asleep && !debug_ls ) {
-        if( rates.fatigue > 0.0f ) {
+        if( !npc_no_food && rates.fatigue > 0.0f ) {
             int fatigue_roll = roll_remainder( rates.fatigue * rate_multiplier );
             mod_fatigue( fatigue_roll );
 
@@ -4804,13 +4804,9 @@ void Character::update_needs( int rate_multiplier )
                 // 5. If rate_multiplier is > 1, fatigue_roll will be higher and this will work out.
                 mod_sleep_deprivation( fatigue_roll * 5 );
             }
-
-            if( npc_no_food && get_fatigue() > fatigue_levels::tired ) {
-                set_fatigue( static_cast<int>( fatigue_levels::tired ) );
-            }
-            if( npc_no_food ) {
-                set_sleep_deprivation( 0 );
-            }
+        } else if( npc_no_food ) {
+            set_fatigue( 0 );
+            set_sleep_deprivation( 0 );
         }
     } else if( asleep && rates.recovery > 0.0f ) {
         int recovered = roll_remainder( rates.recovery * rate_multiplier );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Make No NPC Needs set fatigue to 0"

#### Purpose of change

No NPC Needs currently sets NPC fatigue to "tired" when more than tired. This leads to NPCs complaining about needing sleep despite the mod being on, and making them randomly choose to sleep if the NPC settings has them on allow sleep.

#### Describe the solution

Refactors the code somewhat since it looked like some unnecessary code was firing despite No NPC Needs being turned on. Then made it so that it just directly sets the NPC's fatigue and sleep deprivation to 0

#### Describe alternatives you've considered

- Leave as is and refactor NPC AI instead.
Look, NPC AI needs a _lot_ of work that much is true, but not on this.

#### Testing

Spawn in evac shelter, mind control companion, wait 24 hours, check needs.

#### Additional context