### PR TITLE
feat: Remove z-level restriction for zone activities.

### DIFF
--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -675,24 +675,25 @@ bool zone_manager::has( const zone_type_id &type, const tripoint &where,
     return point_set.find( where ) != point_set.end() || vzone_set.find( where ) != vzone_set.end();
 }
 
-bool zone_manager::has_near( const zone_type_id &type, const tripoint &where, int range, const faction_id &fac ) const
+bool zone_manager::has_near( const zone_type_id &type, const tripoint &where, int range,
+                             const faction_id &fac ) const
 {
     const auto &point_set = get_point_set( type, fac );
     for( auto &point : point_set ) {
         //if( point.z == where.z ) {
-            if( square_dist( point, where ) <= range ) {
-                return true;
-            }
-       // }
+        if( square_dist( point, where ) <= range ) {
+            return true;
+        }
+        // }
     }
 
     const auto &vzone_set = get_vzone_set( type, fac );
     for( auto &point : vzone_set ) {
-       // if( point.z == where.z ) {
-            if( square_dist( point, where ) <= range ) {
-                return true;
-            }
-       // }
+        // if( point.z == where.z ) {
+        if( square_dist( point, where ) <= range ) {
+            return true;
+        }
+        // }
     }
 
     return false;
@@ -752,31 +753,31 @@ std::unordered_set<tripoint> zone_manager::get_near( const zone_type_id &type,
 
     for( auto &point : point_set ) {
         //if( point.z == where.z ) {
-            if( square_dist( point, where ) <= range ) {
-                if( it && has( zone_LOOT_CUSTOM, point ) ) {
-                    if( custom_loot_has( point, it ) ) {
-                        near_point_set.insert( point );
-                    }
-                } else {
+        if( square_dist( point, where ) <= range ) {
+            if( it && has( zone_LOOT_CUSTOM, point ) ) {
+                if( custom_loot_has( point, it ) ) {
                     near_point_set.insert( point );
                 }
+            } else {
+                near_point_set.insert( point );
             }
+        }
         //}
     }
 
     const auto &vzone_set = get_vzone_set( type, fac );
     for( auto &point : vzone_set ) {
-       // if( point.z == where.z ) {
-            if( square_dist( point, where ) <= range ) {
-                if( it && has( zone_LOOT_CUSTOM, point ) ) {
-                    if( custom_loot_has( point, it ) ) {
-                        near_point_set.insert( point );
-                    }
-                } else {
+        // if( point.z == where.z ) {
+        if( square_dist( point, where ) <= range ) {
+            if( it && has( zone_LOOT_CUSTOM, point ) ) {
+                if( custom_loot_has( point, it ) ) {
                     near_point_set.insert( point );
                 }
+            } else {
+                near_point_set.insert( point );
             }
-      //  }
+        }
+        //  }
     }
 
     return near_point_set;

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -675,25 +675,24 @@ bool zone_manager::has( const zone_type_id &type, const tripoint &where,
     return point_set.find( where ) != point_set.end() || vzone_set.find( where ) != vzone_set.end();
 }
 
-bool zone_manager::has_near( const zone_type_id &type, const tripoint &where, int range,
-                             const faction_id &fac ) const
+bool zone_manager::has_near( const zone_type_id &type, const tripoint &where, int range, const faction_id &fac ) const
 {
     const auto &point_set = get_point_set( type, fac );
     for( auto &point : point_set ) {
-        if( point.z == where.z ) {
+        //if( point.z == where.z ) {
             if( square_dist( point, where ) <= range ) {
                 return true;
             }
-        }
+       // }
     }
 
     const auto &vzone_set = get_vzone_set( type, fac );
     for( auto &point : vzone_set ) {
-        if( point.z == where.z ) {
+       // if( point.z == where.z ) {
             if( square_dist( point, where ) <= range ) {
                 return true;
             }
-        }
+       // }
     }
 
     return false;
@@ -752,7 +751,7 @@ std::unordered_set<tripoint> zone_manager::get_near( const zone_type_id &type,
     auto near_point_set = std::unordered_set<tripoint>();
 
     for( auto &point : point_set ) {
-        if( point.z == where.z ) {
+        //if( point.z == where.z ) {
             if( square_dist( point, where ) <= range ) {
                 if( it && has( zone_LOOT_CUSTOM, point ) ) {
                     if( custom_loot_has( point, it ) ) {
@@ -762,12 +761,12 @@ std::unordered_set<tripoint> zone_manager::get_near( const zone_type_id &type,
                     near_point_set.insert( point );
                 }
             }
-        }
+        //}
     }
 
     const auto &vzone_set = get_vzone_set( type, fac );
     for( auto &point : vzone_set ) {
-        if( point.z == where.z ) {
+       // if( point.z == where.z ) {
             if( square_dist( point, where ) <= range ) {
                 if( it && has( zone_LOOT_CUSTOM, point ) ) {
                     if( custom_loot_has( point, it ) ) {
@@ -777,7 +776,7 @@ std::unordered_set<tripoint> zone_manager::get_near( const zone_type_id &type,
                     near_point_set.insert( point );
                 }
             }
-        }
+      //  }
     }
 
     return near_point_set;

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -680,20 +680,16 @@ bool zone_manager::has_near( const zone_type_id &type, const tripoint &where, in
 {
     const auto &point_set = get_point_set( type, fac );
     for( auto &point : point_set ) {
-        //if( point.z == where.z ) {
         if( square_dist( point, where ) <= range ) {
             return true;
         }
-        // }
     }
 
     const auto &vzone_set = get_vzone_set( type, fac );
     for( auto &point : vzone_set ) {
-        // if( point.z == where.z ) {
         if( square_dist( point, where ) <= range ) {
             return true;
         }
-        // }
     }
 
     return false;
@@ -752,7 +748,6 @@ std::unordered_set<tripoint> zone_manager::get_near( const zone_type_id &type,
     auto near_point_set = std::unordered_set<tripoint>();
 
     for( auto &point : point_set ) {
-        //if( point.z == where.z ) {
         if( square_dist( point, where ) <= range ) {
             if( it && has( zone_LOOT_CUSTOM, point ) ) {
                 if( custom_loot_has( point, it ) ) {
@@ -762,12 +757,10 @@ std::unordered_set<tripoint> zone_manager::get_near( const zone_type_id &type,
                 near_point_set.insert( point );
             }
         }
-        //}
     }
 
     const auto &vzone_set = get_vzone_set( type, fac );
     for( auto &point : vzone_set ) {
-        // if( point.z == where.z ) {
         if( square_dist( point, where ) <= range ) {
             if( it && has( zone_LOOT_CUSTOM, point ) ) {
                 if( custom_loot_has( point, it ) ) {
@@ -777,7 +770,6 @@ std::unordered_set<tripoint> zone_manager::get_near( const zone_type_id &type,
                 near_point_set.insert( point );
             }
         }
-        //  }
     }
 
     return near_point_set;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6395,8 +6395,12 @@ void game::zones_manager()
                     break;
                 }
 
-                mgr.add( name, id, g->u.get_faction()->id, false, true, position->first,
-                         position->second, options );
+                if (position->first.z != position->second.z) {
+                    popup(_("The zone start and end should be on the same z-level!"));
+                    break;
+                }
+
+                mgr.add( name, id, g->u.get_faction()->id, false, true, position->first, position->second, options );
 
                 zones = get_zones();
                 active_index = zone_cnt - 1;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6395,12 +6395,13 @@ void game::zones_manager()
                     break;
                 }
 
-                if (position->first.z != position->second.z) {
-                    popup(_("The zone start and end should be on the same z-level!"));
+                if( position->first.z != position->second.z ) {
+                    popup( _( "The zone start and end should be on the same z-level!" ) );
                     break;
                 }
 
-                mgr.add( name, id, g->u.get_faction()->id, false, true, position->first, position->second, options );
+                mgr.add( name, id, g->u.get_faction()->id, false, true, position->first, position->second,
+                         options );
 
                 zones = get_zones();
                 active_index = zone_cnt - 1;


### PR DESCRIPTION
## Checklist


### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Note: : had to resubmit PR due to issues with my fork, should be good now.
Update the code to ignore z-level differences when working with zones. This should make it easier to setup loot zones across the z-levels for easier loot managements, i.e. basements, roofs, apartments and LMOE. It was a bit annoying to carry the loot up/down stairs.

## Describe the solution

Solution is to remove all checks for z-level, both in the GUI and code that interacts with zones.


## Describe alternatives you've considered

None. I think zones are currently the best way to manage loot, and just need to tweak them to work properly.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

This is half-tested. I compiled the code, did some zone setup in my LMOE bunker and asked my main char to sort out the loot. Seem(s) like it worked. However more testing will likely be required. Volunteers appreciated.

