### PR TITLE
feat: allow holstering to use a `weapon_category` instead of a flag

### DIFF
--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -309,7 +309,8 @@
       "min_volume": "15 ml",
       "max_volume": "250 ml",
       "draw_cost": 50,
-      "flags": [ "SHEATH_KNIFE" ]
+      "flags": [ "SHEATH_KNIFE" ],
+      "weapon_category": "KNIVES"
     },
     "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ]
   }

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -103,7 +103,7 @@
     "symbol": ";",
     "color": "light_gray",
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 12 ] ],
-    "flags": [ "STAB", "BELT_CLIP", "SHEATH_KNIFE" ]
+    "flags": [ "STAB", "BELT_CLIP" ]
   },
   {
     "id": "knife_combat",

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2670,6 +2670,10 @@ void holster_actor::load( const JsonObject &obj )
     } );
 
     flags = obj.get_string_array( "flags" );
+    auto wc = obj.get_string_maybe( "weapon_category" );
+    if( wc != std::nullopt ) {
+        weapon_category = weapon_category_id( *wc );
+    }
 }
 
 bool holster_actor::can_holster( const item &obj ) const
@@ -2686,7 +2690,8 @@ bool holster_actor::can_holster( const item &obj ) const
     return std::any_of( flags.begin(), flags.end(), [&]( const std::string & f ) {
         return obj.has_flag( flag_id( f ) );
     } ) ||
-    std::find( skills.begin(), skills.end(), obj.gun_skill() ) != skills.end();
+    std::find( skills.begin(), skills.end(), obj.gun_skill() ) != skills.end() ||
+    ( weapon_category != std::nullopt && obj.type->weapon_category.contains( *weapon_category ) );
 }
 
 detached_ptr<item> holster_actor::store( player &p, item &holster, detached_ptr<item> &&obj ) const
@@ -2723,7 +2728,9 @@ detached_ptr<item> holster_actor::store( player &p, item &holster, detached_ptr<
 
     if( std::none_of( flags.begin(), flags.end(), [&]( const std::string & f ) {
     return obj->has_flag( flag_id( f ) );
-    } ) &&
+    } ) && !( weapon_category != std::nullopt &&
+              obj->type->weapon_category.contains( *weapon_category ) )
+    &&
     std::find( skills.begin(), skills.end(), obj->gun_skill() ) == skills.end() ) {
         p.add_msg_if_player( m_info, _( "You can't put your %1$s in your %2$s" ),
                              obj->tname(), holster.tname() );

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -845,6 +845,8 @@ class holster_actor : public iuse_actor
         std::vector<skill_id> skills;
         /** Items with any of these flags set can be holstered */
         std::vector<std::string> flags;
+        /** Items in this weapon_cateogry can be holstered */
+        std::optional<weapon_category_id> weapon_category;
 
         /** Check if obj could be stored in the holster */
         bool can_holster( const item &obj ) const;

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -405,6 +405,17 @@ std::string JsonObject::get_string( const std::string &name, const std::string &
     return jsin->get_string();
 }
 
+std::optional<std::string> JsonObject::get_string_maybe( const std::string &name ) const
+{
+    int pos = verify_position( name, false );
+    if( !pos ) {
+        return std::nullopt;
+    }
+    mark_visited( name );
+    jsin->seek( pos );
+    return jsin->get_string();
+}
+
 /* returning containers by name */
 
 JsonArray JsonObject::get_array( const std::string &name ) const

--- a/src/json.h
+++ b/src/json.h
@@ -969,6 +969,7 @@ class JsonObject
         double get_float( const std::string &name, double fallback ) const;
         std::string get_string( const std::string &name ) const;
         std::string get_string( const std::string &name, const std::string &fallback ) const;
+        std::optional<std::string> get_string_maybe( const std::string &name ) const;
 
         template<typename E>
         E get_enum_value( const std::string &name,


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

In #1709 it was mentioned:

> hopefully in the future can be used to aid with holsters and magazines, to define what can and cannot be stored without writing a full thesis.

This is an experiment in that regard

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

Add `weapon_category` as a optional `use_action` field, this allows both `flags` and `weapon_category` to be used so it should be backwards compatible with existing mods/json data without change.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

The `weapon_category` field in a `use_action` object could be an array or some such instead of just a string?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

The `KNIVES` field was added to the `bandolier_knife`, and the `SHEATH_KNIFE` field was removed from the `folding_knife`.
It was tested that the folding knife, and another knife still can be sheathed and drawn from the bandolier.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
