### PR TITLE
fix: force named palettes to be unique

### DIFF
--- a/doc/src/content/docs/en/mod/json/guides/map/mapgen.md
+++ b/doc/src/content/docs/en/mod/json/guides/map/mapgen.md
@@ -726,6 +726,8 @@ Everything else will look like a series of object entries, for example the roof_
 }
 ```
 
+Palette IDs must be unique. An error will be displayed if one is redefined and JSON loading will be aborted.
+
 If you want to look at more complex palettes, the standard_domestic_palette in
 [data/json/mapgen_palettes/house_general_palette.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/data/json/mapgen_palettes/house_general_palette.json)
 is a good look at a palette designed to work across all CDDA houses. It includes the loot spawns and

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3185,7 +3185,8 @@ void mapgen_palette::load( const JsonObject &jo, const std::string &src )
 
     // Emplacement fails if ret.id already exists
     if( !palettes.try_emplace( ret.id, ret ).second ) {
-        jo.throw_error( string_format( "Named palette needs a unique id. Found existing [%s]", ret.id.c_str() ) );
+        jo.throw_error( string_format( "Named palette needs a unique id. Found existing [%s]",
+                                       ret.id.c_str() ) );
     }
 }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3183,7 +3183,10 @@ void mapgen_palette::load( const JsonObject &jo, const std::string &src )
         jo.throw_error( "Named palette needs an id" );
     }
 
-    palettes[ ret.id ] = ret;
+    // Emplacement fails if ret.id already exists
+    if( !palettes.try_emplace( ret.id, ret ).second ) {
+        jo.throw_error( string_format( "Named palette needs a unique id. Found existing [%s]", ret.id.c_str() ) );
+    }
 }
 
 const mapgen_palette &mapgen_palette::get( const palette_id &id )


### PR DESCRIPTION
## Purpose of change (The Why)
In mods it's pretty common to add in new locations. Sometimes they're variants of existing locations and have a modified palette. The problem is that while the location definition becomes a variant, palettes are unilaterally overwritten if they redefine an existing one and will be used as the palette for all locations that use it. Redefinition of palettes has in the past caused various loading errors that were hard to diagnose because there was a disconnect between how the error was reported and where the error actually was.

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Force named palettes to be unique by using `map::try_emplace( key, val )` instead of `map[key] = val` and make it a fatal json loading error so that it's very obviously not allowed.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Could have not made it a fatal error, or had some way to define in the palette that it's intended to be a redefinition and is not incidental.

## Testing
Duplicated the palette in `./data/json/mapgen_palettes/abandoned_textile_mill.json` to force a redefinition.
Tried to load a character.
Got the expected error at the expected location and was kicked out to the main menu.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
