### PR TITLE
fix: Change wielding messages to be a bit more intuitive

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4684,7 +4684,7 @@ void item::on_wield( player &p, int mv )
     if( mv > 500 ) {
         msg = _( "It takes you a long time to wield your %s." );
     } else if( mv > 250 ) {
-        msg = _( "It takes you a several to wield your %s." );
+        msg = _( "It takes you several seconds to wield your %s." );
     } else if( mv > 100 ) {
         msg = _( "It takes you a couple seconds to wield your %s." );
     } else if( mv > 50 ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4682,13 +4682,13 @@ void item::on_wield( player &p, int mv )
     std::string msg;
 
     if( mv > 500 ) {
-        msg = _( "It takes you an extremely long time to wield your %s." );
-    } else if( mv > 250 ) {
-        msg = _( "It takes you a very long time to wield your %s." );
-    } else if( mv > 100 ) {
         msg = _( "It takes you a long time to wield your %s." );
+    } else if( mv > 250 ) {
+        msg = _( "It takes you a several to wield your %s." );
+    } else if( mv > 100 ) {
+        msg = _( "It takes you a couple seconds to wield your %s." );
     } else if( mv > 50 ) {
-        msg = _( "It takes you several seconds to wield your %s." );
+        msg = _( "It takes you a moment to wield your %s." );
     } else {
         msg = _( "You wield your %s." );
     }


### PR DESCRIPTION
<!-- for small documentation fixes, it's okay to ignore the template -->

## Purpose of change (The Why)
The current wielding messages are:
```

    if( mv > 500 ) {
        msg = _( "It takes you an extremely long time to wield your %s." );
    } else if( mv > 250 ) {
        msg = _( "It takes you a very long time to wield your %s." );
    } else if( mv > 100 ) {
        msg = _( "It takes you a long time to wield your %s." );
    } else if( mv > 50 ) {
        msg = _( "It takes you several seconds to wield your %s." );
    } else {
        msg = _( "You wield your %s." );
```
I personally find them not very describing, and a bit misleading - taking baseline 100 moves as 1 second, then 0.5-1sec wielding time is not 'several seconds', and 2.5-5 seconds wielding time is not a very long time
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Edited the messages the messages to better signify how long it take for you to wield your things
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
1. New world
2. Spawn things, wield them
![изображение](https://github.com/user-attachments/assets/85b61aa6-9b3b-49ff-8550-f36d35d08e79)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
I find it a bit silly that you're forced to unfold your gun even if you wore it with a slung (practically, you don't fold the stock in such a case) but it's out of scope of what I'm doing here...
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.
