### PR TITLE
feat: graphic effect and morale bonus for sunset/sunrise

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -326,6 +326,13 @@
   },
   {
     "type": "effect_type",
+    "id": "scenery_cooldown",
+    "name": [ "Scenery Cooldown" ],
+    "desc": [ "You recently appreciated some scenery." ],
+    "max_duration": "12 h"
+  },
+  {
+    "type": "effect_type",
     "id": "heating_bionic",
     "name": [ "Heated" ],
     "max_intensity": 1000,

--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -419,5 +419,15 @@
     "type": "morale_type",
     "text": "Debug Morale",
     "permanent": true
+  },
+  {
+    "id": "morale_sunrise",
+    "type": "morale_type",
+    "text": "Watched the Sunrise"
+  },
+  {
+    "id": "morale_sunset",
+    "type": "morale_type",
+    "text": "Watched the Sunset"
   }
 ]

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1937,6 +1937,30 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
     std::vector<tile_render_info> &draw_points = *draw_points_cache;
     int min_z = OVERMAP_HEIGHT;
 
+    // Calculate sunset/sunrise overlay state once
+    int sunset_sunrise_alpha = 0;
+    bool is_sunrise = false;
+    {
+        const auto now = calendar::turn;
+        const auto sunrise_time = sunrise( now );
+        const auto sunset_time = sunset( now );
+        const auto window = 30_minutes;
+
+        const int time_to_sunrise = to_turns<int>( now - sunrise_time );
+        const int time_to_sunset = to_turns<int>( now - sunset_time );
+        const int window_turns = to_turns<int>( window );
+
+        const bool near_sunrise = std::abs( time_to_sunrise ) <= window_turns;
+        const bool near_sunset = std::abs( time_to_sunset ) <= window_turns;
+
+        if( near_sunrise || near_sunset ) {
+            is_sunrise = near_sunrise;
+            const int time_delta = near_sunrise ? std::abs( time_to_sunrise ) : std::abs( time_to_sunset );
+            const float progress = 1.0f - ( static_cast<float>( time_delta ) / window_turns );
+            sunset_sunrise_alpha = static_cast<int>( progress * 40.0f );
+        }
+    }
+
     for( int row = min_row; row < max_row; row ++ ) {
 
         draw_points.clear();
@@ -2041,6 +2065,16 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                 overlay_strings.emplace(
                     player_to_screen( point( temp_x, temp_y ) ) + point( tile_width / 4, tile_height / 4 ),
                     formatted_text( visibility_str, catacurses::black, direction::NORTH ) );
+            }
+
+            // Sunset/sunrise atmospheric overlay on outdoor tiles
+            if( sunset_sunrise_alpha > 0 && !invis && here.is_outside( {temp_x, temp_y, center.z} ) ) {
+                // sunrise = warm orange, sunset = warm redish purple
+                auto overlay_color = is_sunrise ?
+                                     SDL_Color{ 255, 153, 51, static_cast<Uint8>( sunset_sunrise_alpha ) } :
+                                     SDL_Color{ 204, 51, 102, static_cast<Uint8>( sunset_sunrise_alpha ) };
+                color_blocks.first = SDL_BLENDMODE_BLEND;
+                color_blocks.second.emplace( player_to_screen( point( temp_x, temp_y ) ), overlay_color );
             }
 
             static std::vector<SDL_Color> lighting_colors;

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -86,6 +86,8 @@ const morale_type MORALE_FUNERAL( "morale_funeral" );
 const morale_type MORALE_TREE_COMMUNION( "morale_tree_communion" );
 const morale_type MORALE_ACCOMPLISHMENT( "morale_accomplishment" );
 const morale_type MORALE_FAILURE( "morale_failure" );
+const morale_type MORALE_SUNRISE( "morale_sunrise" );
+const morale_type MORALE_SUNSET( "morale_sunset" );
 
 namespace
 {

--- a/src/morale_types.h
+++ b/src/morale_types.h
@@ -113,5 +113,7 @@ extern const morale_type MORALE_FUNERAL;
 extern const morale_type MORALE_TREE_COMMUNION;
 extern const morale_type MORALE_ACCOMPLISHMENT;
 extern const morale_type MORALE_FAILURE;
+extern const morale_type MORALE_SUNRISE;
+extern const morale_type MORALE_SUNSET;
 
 

--- a/tests/scenery_morale_test.cpp
+++ b/tests/scenery_morale_test.cpp
@@ -1,0 +1,48 @@
+#include "catch/catch.hpp"
+
+#include "avatar.h"
+#include "calendar.h"
+#include "map_helpers.h"
+#include "morale_types.h"
+#include "player_helpers.h"
+#include "state_helpers.h"
+#include "type_id.h"
+
+static const efftype_id effect_scenery_cooldown( "scenery_cooldown" );
+
+TEST_CASE( "sunrise_morale_applied_outdoors", "[scenery_morale]" )
+{
+    clear_all_state();
+
+    avatar &dummy = get_avatar();
+    build_test_map( ter_id( "t_grass" ) );
+
+    const time_point t_sunrise = sunrise( calendar::turn_zero );
+    set_time( t_sunrise + 30_minutes );
+
+    dummy.update_morale();
+    CHECK( dummy.has_morale( MORALE_SUNRISE ) );
+    CHECK( dummy.get_morale( MORALE_SUNRISE ) == 10 );
+    CHECK( dummy.has_effect( effect_scenery_cooldown ) );
+
+    // Cooldown should prevent re-triggering.
+    dummy.clear_morale();
+    dummy.update_morale();
+    CHECK_FALSE( dummy.has_morale( MORALE_SUNRISE ) );
+}
+
+TEST_CASE( "sunset_morale_applied_outdoors", "[scenery_morale]" )
+{
+    clear_all_state();
+
+    avatar &dummy = get_avatar();
+    build_test_map( ter_id( "t_grass" ) );
+
+    const time_point t_sunset = sunset( calendar::turn_zero );
+    set_time( t_sunset + 30_minutes );
+
+    dummy.update_morale();
+    CHECK( dummy.has_morale( MORALE_SUNSET ) );
+    CHECK( dummy.get_morale( MORALE_SUNSET ) == 10 );
+    CHECK( dummy.has_effect( effect_scenery_cooldown ) );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

> - "mom, i want https://github.com/CleverRaven/Cataclysm-DDA/pull/74899"
> - "we have sunset at home"
> - the sunset at home:

## Describe the solution (The How)

- morale bonus for watching sunset/sunrise in 2 tile radius (to account for watching from window)
- visual effect for sunset/sunrise

## Describe alternatives you've considered

Lua-ify it

## Testing

### sunset

https://github.com/user-attachments/assets/a663f933-72c9-42d0-9255-b2afa9eefe53

### sunrise

https://github.com/user-attachments/assets/61b26ca8-6358-4ebb-8bbe-81680e79abc1

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
