### PR TITLE
feat: add NO_REFOLD flag for folded vehicle items

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1808,6 +1808,11 @@
     "context": [  ]
   },
   {
+    "id": "NO_REFOLD",
+    "type": "json_flag",
+    "context": [  ]
+  },
+  {
     "id": "NO_INGEST",
     "type": "json_flag",
     "context": [  ]

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -744,6 +744,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `NO_PACKED` ... This item is not protected against contamination and won't stay sterile. Only
   applies to CBMs.
 - `NO_REPAIR` ... Prevents repairing of this item even if otherwise suitable tools exist.
+- `NO_REFOLD` ... Prevents folding the vehicle that this item creates
 - `NO_SALVAGE` ... Item cannot be broken down through a salvage process. Best used when something
   should not be able to be broken down (i.e. base components like leather patches).
 - `NO_STERILE` ... This item is not sterile. Only applies to CBMs.

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -369,6 +369,7 @@ const flag_id flag_ZOOM( "ZOOM" );
 const flag_id flag_wooled( "wooled" );
 const flag_id flag_MUTE( "MUTE" );
 const flag_id flag_NOT_FOOTWEAR( "NOT_FOOTWEAR" );
+const flag_id flag_NO_REFOLD( "NO_REFOLD" );
 const flag_id flag_WEATHER_FORECAST( "WEATHER_FORECAST" );
 const flag_id flag_WINDMETER( "WINDMETER" );
 const flag_id flag_INITIALLY_ACTIVATE( "INITIALLY_ACTIVATE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -371,6 +371,7 @@ extern const flag_id flag_ZOOM;
 extern const flag_id flag_wooled;
 extern const flag_id flag_MUTE;
 extern const flag_id flag_NOT_FOOTWEAR;
+extern const flag_id flag_NO_REFOLD;
 extern const flag_id flag_WEATHER_FORECAST;
 extern const flag_id flag_WINDMETER;
 extern const flag_id flag_INITIALLY_ACTIVATE;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -731,10 +731,12 @@ int unfold_vehicle_iuse::use( player &p, item &it, bool, const tripoint & ) cons
     }
     veh->set_owner( p );
 
-    // Mark the vehicle as foldable.
-    veh->tags.insert( "convertible" );
-    // Store the id of the item the vehicle is made of.
-    veh->tags.insert( std::string( "convertible:" ) + it.typeId().str() );
+    if( !it.has_flag( flag_NO_REFOLD ) ) {
+        // Mark the vehicle as foldable.
+        veh->tags.insert( "convertible" );
+        // Store the id of the item the vehicle is made of.
+        veh->tags.insert( std::string( "convertible:" ) + it.typeId().str() );
+    }
     if( !unfold_msg.empty() ) {
         p.add_msg_if_player( _( unfold_msg ), it.tname() );
     }


### PR DESCRIPTION
## Purpose of change (The Why)
> is there any way to make an unfoldable vehicle that can't be refolded?

Must solve simple problems like these, must let more stuff be added to the game

## Describe the solution (The How)
Add the NO_REFOLD flag, which prohibits the flag addition that permits reloading

## Describe alternatives you've considered
None

## Testing
Add it to the sea scooter it cannot be refolded

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.