### PR TITLE
feat(UI): add canvas-based mouse callback system

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -1,0 +1,180 @@
+# Cataclysm-BN Development Skills
+
+This directory contains Claude Code command skills for developing Cataclysm: Bright Nights.
+
+## Available Skills
+
+### UI Development
+
+#### `add-mouse-support`
+**For**: Adding mouse interaction (click/hover) to UI elements
+
+**Use when**:
+- Making menus, buttons, or lists clickable
+- Adding hover effects to UI elements
+- Migrating keyboard-only UI to support mouse
+- Need context menus or tooltips
+
+**Example**:
+```
+Add mouse support to the inventory list
+```
+
+### Lua Bindings
+
+### 1. `add-lua-binding-simple` 
+**For**: Simple types like `string_id`, enums, basic data structures
+
+**Use when**:
+- Adding bindings for ID types (`my_type` → `MyTypeId`)
+- Exposing enums to Lua
+- Binding simple read-only data structures
+- Quick, straightforward bindings
+
+**Example**:
+```
+Add Lua binding for ammunition_type
+```
+
+### 2. `add-lua-binding-complex`
+**For**: Complex C++ classes with methods, inheritance, constructors
+
+**Use when**:
+- Binding classes with public APIs
+- Working with inheritance hierarchies
+- Need constructors, methods, properties
+- Complex object interactions
+
+**Example**:
+```
+Add comprehensive Lua bindings for the Vehicle class
+```
+
+### 3. `add-lua-binding-api`
+**For**: Global game functions and utilities
+
+**Use when**:
+- Creating new Lua API libraries (like `game.*`, `map.*`)
+- Exposing global helper functions
+- Adding RNG, UI, or utility functions
+- Need namespace organization
+
+**Example**:
+```
+Add Lua API for weather functions
+```
+
+### 4. `lua-binding-reference`
+**For**: Quick reference and troubleshooting
+
+**Use when**:
+- Need syntax reminder
+- Looking up macro definitions
+- Checking patterns and examples
+- Debugging binding issues
+
+## Quick Start
+
+### For UI Development
+
+1. **Determine your task**:
+   - Adding mouse support? → `add-mouse-support`
+
+2. **Invoke the skill**:
+   ```
+   /add-mouse-support inventory-list
+   ```
+
+3. **Follow the step-by-step instructions** and choose the appropriate approach
+
+### For Lua Bindings
+
+1. **Determine what you're binding**:
+   - Simple type (ID, enum)? → `add-lua-binding-simple`
+   - Complex class? → `add-lua-binding-complex`
+   - Global functions? → `add-lua-binding-api`
+
+2. **Invoke the skill**:
+   ```
+   /add-lua-binding-simple ammunition_type
+   ```
+
+3. **Follow the step-by-step instructions** in the skill output
+
+4. **Reference `lua-binding-reference`** for syntax and patterns
+
+## File Organization
+
+### Mouse Support
+When adding mouse support to UI:
+- Your UI file (e.g., `src/main_menu.cpp`, `src/inventory_ui.cpp`)
+- Reference: `src/mouse_input.h`, `src/output.h` (usually no changes needed)
+
+### Lua Bindings
+After adding bindings, you'll modify:
+- `src/catalua_luna_doc.h` - Type name registration (LUNA_* macros)
+- `src/catalua_bindings_*.cpp` - Implementation
+- `src/catalua_bindings.h` - Function declarations (if needed)
+- `src/catalua_bindings.cpp` - Registration calls (if needed)
+
+## Testing
+
+All skills include testing instructions:
+1. Build: `cmake --build --preset linux-full --target cataclysm-bn-tiles`
+2. Format: `cmake --build build --target astyle`
+3. Test in Lua console (Debug menu)
+
+## Project Context
+
+### Mouse Support System
+- **Issue**: #7736 - Canvas-based mouse callback system
+- **PR**: #7737
+- **Implementation**: Commits da47bfa → 4ce6f29d14
+- **Example**: `src/main_menu.cpp` (working reference)
+
+### Lua Binding System
+- **Lua Version**: 5.3.6 (bundled in `src/lua/`)
+- **Binding Library**: Sol2 v3.3.0 (in `src/sol/`)
+- **Custom System**: Luna (automatic documentation generation)
+- **Documentation**: Auto-generated to `docs/en/mod/lua/reference/lua.md`
+
+## Official Documentation
+
+### General
+- Code Style: `docs/en/dev/explanation/code_style.md`
+- Building: `docs/en/dev/guides/building/cmake.md`
+- Agent Guidelines: `AGENTS.md`
+
+### UI Development
+- Mouse System: Issue #7736, `src/mouse_input.h`, `src/output.h`
+- Input Handling: `src/input.h`, `src/ui_manager.h`
+
+### Lua Integration
+- Integration: `docs/en/mod/lua/explanation/lua_integration.md`
+- Style Guide: `docs/en/mod/lua/explanation/lua_style.md`
+- API Reference: `docs/en/mod/lua/reference/lua.md` (auto-generated)
+
+## Contributing
+
+When adding code:
+1. **Follow AGENTS.md**: C++23 conventions (auto, trailing returns, designated initializers, ranges)
+2. **Build and test**: Use cmake presets
+3. **Format code**: Run astyle before committing
+4. **Follow patterns**: Look for existing similar code first
+
+### Mouse Support Additions
+1. Choose appropriate approach (callbacks vs manual hit-testing)
+2. Test in both TILES and curses modes
+3. Verify coordinate conversion for pixel→cell
+
+### Lua Binding Additions
+1. Use the Luna system for documentation
+2. Group related bindings in appropriate files
+3. Test thoroughly in Lua console
+
+## Support
+
+For issues or questions:
+- **Mouse Support**: Check `add-mouse-support` skill, review `src/main_menu.cpp`
+- **Lua Bindings**: Check `lua-binding-reference`, review `src/catalua_bindings_*.cpp`
+- **General**: Consult official docs, check AGENTS.md

--- a/.claude/commands/add-mouse-support.md
+++ b/.claude/commands/add-mouse-support.md
@@ -87,7 +87,7 @@ clear_mouse_callback( window );
     scoped_mouse_callback guard( window, mouse_callback_options{
         .on_click = []( const mouse_event &ev ) { do_action(); }
     } );
-    
+
     mvwprintw( window, point( 10, 5 ), "Click Me" );
 }  // Callbacks cleared automatically
 ```
@@ -125,7 +125,7 @@ auto action = ctxt.handle_input();
 
 if( action == "SELECT" || action == "MOUSE_MOVE" ) {
     auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
-    
+
     for( const auto &btn : buttons ) {
         if( btn.area.contains( mouse_pos ) ) {
             if( action == "SELECT" ) {
@@ -212,7 +212,7 @@ std::vector<list_item_region> item_regions;
 for( size_t i = 0; i < items.size(); ++i ) {
     auto item_pos = point( list_x, list_y + i );
     mvwprintw( window, item_pos, items[i].name );
-    
+
     item_regions.push_back( list_item_region{
         .area = inclusive_rectangle<point>(
             item_pos,
@@ -225,7 +225,7 @@ for( size_t i = 0; i < items.size(); ++i ) {
 // In input handler:
 if( action == "SELECT" ) {
     auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
-    
+
     for( const auto &region : item_regions ) {
         if( region.area.contains( mouse_pos ) ) {
             select_item( region.item_index );
@@ -339,7 +339,7 @@ auto action = ctxt.handle_input();
 
 if( action == "MOUSE_MOVE" ) {
     auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
-    
+
     for( const auto &[area, item_id] : button_map ) {
         if( area.contains( mouse_pos ) ) {
             highlight_menu_item( item_id );
@@ -350,7 +350,7 @@ if( action == "MOUSE_MOVE" ) {
 
 if( action == "SELECT" ) {
     auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
-    
+
     for( const auto &[area, item_id] : button_map ) {
         if( area.contains( mouse_pos ) ) {
             activate_menu_item( item_id );

--- a/.claude/commands/add-mouse-support.md
+++ b/.claude/commands/add-mouse-support.md
@@ -1,0 +1,490 @@
+---
+description: Add canvas-based mouse support to UI elements with callback system
+argument-hint: ui-element-name [approach]
+---
+
+# Add Mouse Support to UI Elements
+
+This command helps you add mouse interaction (click and hover support) to UI elements using the canvas-based callback system.
+
+Human readable docs are at [docs/en/dev/guides/mouse_support.md](../../docs/en/dev/guides/mouse_support.md).
+
+> [!CAUTION]
+> You **MUST** update [docs/en/dev/guides/mouse_support.md](../../docs/en/dev/guides/mouse_support.md) after making changes here.
+
+## Overview
+
+The mouse callback system allows you to attach click and hover handlers directly to terminal cells as they're printed. No need to manually synchronize coordinates between drawing and input handling—callbacks are automatically stored in the canvas and dispatched when mouse events occur.
+
+## Core Concepts
+
+### Mouse Event Types
+
+```cpp
+enum class mouse_button {
+    none, left, right, middle,
+    scroll_up, scroll_down, back, forward
+};
+
+enum class mouse_event_type {
+    click_down, click_up,
+    hover_enter, hover_exit, hover_move
+};
+
+struct mouse_event {
+    point pos;          // Screen position
+    point local_pos;    // Window-relative position
+    mouse_button button;
+    mouse_event_type type;
+    bool shift_held, ctrl_held, alt_held;
+    bool left_held, right_held, middle_held;  // For drag detection
+};
+```
+
+### Callback Types
+
+```cpp
+using mouse_callback_t = std::function<void( const mouse_event & )>;
+
+struct mouse_callback_options {
+    mouse_callback_t on_click;
+    std::optional<mouse_callback_t> on_hover = std::nullopt;
+};
+```
+
+## Implementation Approaches
+
+Choose based on your UI complexity:
+
+### Approach 1: Canvas Callbacks (Recommended for New Code)
+
+**Best for**: New UI code, simple interactions, when drawing and logic are tightly coupled.
+
+```cpp
+// Set callback context, then print normally
+set_mouse_callback( window, mouse_callback_options{
+    .on_click = []( const mouse_event &ev ) {
+        if( ev.button == mouse_button::left ) {
+            do_action();
+        }
+    },
+    .on_hover = []( const mouse_event &ev ) {
+        show_tooltip();
+    }
+} );
+
+// All subsequent prints attach these callbacks to their cells
+mvwprintw( window, point( 10, 5 ), "Click Me" );
+
+// Clear callbacks when done
+clear_mouse_callback( window );
+```
+
+**Or use RAII**:
+
+```cpp
+{
+    scoped_mouse_callback guard( window, mouse_callback_options{
+        .on_click = []( const mouse_event &ev ) { do_action(); }
+    } );
+    
+    mvwprintw( window, point( 10, 5 ), "Click Me" );
+}  // Callbacks cleared automatically
+```
+
+### Approach 2: Manual Hit-Testing (For Existing Complex UI)
+
+**Best for**: Existing UI with complex layout, when callbacks would be messy, legacy code migration.
+
+```cpp
+// 1. Track clickable regions while drawing
+struct button_region {
+    inclusive_rectangle<point> area;
+    int action_id;
+};
+std::vector<button_region> buttons;
+
+// While drawing:
+auto button_pos = point( 10, 5 );
+auto button_text = "OK";
+mvwprintw( window, button_pos, button_text );
+buttons.push_back( button_region{
+    .area = inclusive_rectangle<point>(
+        button_pos,
+        button_pos + point( utf8_width( button_text ), 0 )
+    ),
+    .action_id = ACTION_OK
+} );
+
+// 2. Add MOUSE_MOVE and SELECT to input_context
+ctxt.register_action( "MOUSE_MOVE" );
+ctxt.register_action( "SELECT" );
+
+// 3. In input loop, handle mouse events
+auto action = ctxt.handle_input();
+
+if( action == "SELECT" || action == "MOUSE_MOVE" ) {
+    auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+    
+    for( const auto &btn : buttons ) {
+        if( btn.area.contains( mouse_pos ) ) {
+            if( action == "SELECT" ) {
+                handle_action( btn.action_id );
+            } else {
+                highlight_button( btn.action_id );
+            }
+            break;
+        }
+    }
+}
+```
+
+### Coordinate Conversion (CRITICAL for TILES mode)
+
+Mouse coordinates from `input_context` are in **pixels** (TILES) or **cells** (curses). You must convert pixels to cells:
+
+```cpp
+#if defined(TILES)
+extern int fontwidth;
+extern int fontheight;
+#endif
+
+static auto pixel_to_cell( point pixel_pos ) -> point
+{
+#if defined(TILES)
+    return point { pixel_pos.x / fontwidth, pixel_pos.y / fontheight };
+#else
+    return pixel_pos;
+#endif
+}
+
+// Usage in input handling:
+auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+```
+
+**Why this matters**: Forgetting this conversion will cause clicks to be off by a factor of font size (typically 12-16x).
+
+## Step-by-Step Implementation
+
+### For Simple Buttons/Items
+
+1. **Choose approach** (Approach 1 recommended for new code)
+
+2. **Register mouse actions** (if using manual hit-testing):
+   ```cpp
+   input_context ctxt( "MY_UI" );
+   ctxt.register_action( "MOUSE_MOVE" );  // For hover
+   ctxt.register_action( "SELECT" );      // For clicks
+   ctxt.register_action( "SCROLL_UP" );   // For mouse wheel up (CRITICAL for scrollable content)
+   ctxt.register_action( "SCROLL_DOWN" ); // For mouse wheel down (CRITICAL for scrollable content)
+   ```
+   
+   **IMPORTANT**: If your UI has any scrollable content (lists, text, etc.), you **MUST** register `SCROLL_UP` and `SCROLL_DOWN` or mouse wheel scrolling will not work!
+
+3. **Set up callbacks or tracking**:
+   - **Approach 1**: Call `set_mouse_callback()` before printing
+   - **Approach 2**: Create tracking structure for hit regions
+
+4. **Draw your UI normally**:
+   ```cpp
+   mvwprintw( window, point( x, y ), "Button Text" );
+   ```
+
+5. **Handle events** (Approach 2 only):
+   ```cpp
+   if( action == "SELECT" ) {
+       auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+       // Hit-test against your tracked regions
+   }
+   ```
+
+### For Complex Regions (Lists, Tables, etc.)
+
+```cpp
+// Track each list item's screen position
+struct list_item_region {
+    inclusive_rectangle<point> area;
+    size_t item_index;
+};
+std::vector<list_item_region> item_regions;
+
+// While rendering list:
+for( size_t i = 0; i < items.size(); ++i ) {
+    auto item_pos = point( list_x, list_y + i );
+    mvwprintw( window, item_pos, items[i].name );
+    
+    item_regions.push_back( list_item_region{
+        .area = inclusive_rectangle<point>(
+            item_pos,
+            item_pos + point( list_width, 0 )
+        ),
+        .item_index = i
+    } );
+}
+
+// In input handler:
+if( action == "SELECT" ) {
+    auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+    
+    for( const auto &region : item_regions ) {
+        if( region.area.contains( mouse_pos ) ) {
+            select_item( region.item_index );
+            break;
+        }
+    }
+}
+```
+
+### For Scrollable Content (CRITICAL)
+
+When adding mouse support to scrollable areas (text displays, long lists, etc.), you need:
+
+1. **Register scroll actions** in input context:
+   ```cpp
+   ctxt.register_action( "SCROLL_UP" );   // Mouse wheel up
+   ctxt.register_action( "SCROLL_DOWN" ); // Mouse wheel down
+   ```
+
+2. **Track scrollbar region** during drawing:
+   ```cpp
+   // In your drawing function
+   draw_scrollbar( w_border, scroll_pos, viewport_height, content_lines, point_south, BORDER_COLOR, true );
+   
+   // Store scrollbar position for click handling
+   if( content_lines > viewport_height ) {
+       auto scrollbar_x = border_x + point_south.x;
+       auto scrollbar_y = border_y + point_south.y;
+       scrollbar_region = inclusive_rectangle<point>(
+           point( scrollbar_x, scrollbar_y ),
+           point( scrollbar_x, scrollbar_y + viewport_height - 1 )
+       );
+       scroll_max = content_lines - viewport_height;
+   }
+   ```
+
+3. **Handle scroll events**:
+   ```cpp
+   // Handle keyboard/wheel scrolling
+   if( action == "UP" || action == "PAGE_UP" || action == "SCROLL_UP" ) {
+       if( scroll_pos > 0 ) {
+           scroll_pos--;
+       }
+   } else if( action == "DOWN" || action == "PAGE_DOWN" || action == "SCROLL_DOWN" ) {
+       if( scroll_pos < scroll_max ) {
+           scroll_pos++;
+       }
+   }
+   
+   // Handle scrollbar clicks
+   if( action == "SELECT" && scrollbar_region.has_value() &&
+       scrollbar_region->contains( mouse_pos ) ) {
+       auto relative_y = mouse_pos.y - scrollbar_region->p_min.y;
+       auto scrollbar_height = scrollbar_region->p_max.y - scrollbar_region->p_min.y + 1;
+       
+       if( relative_y == 0 ) {
+           // Up arrow clicked
+           if( scroll_pos > 0 ) {
+               scroll_pos--;
+           }
+       } else if( relative_y == scrollbar_height - 1 ) {
+           // Down arrow clicked
+           if( scroll_pos < scroll_max ) {
+               scroll_pos++;
+           }
+       } else {
+           // Track/bar clicked - jump to position
+           auto slot_height = scrollbar_height - 2;
+           auto slot_pos = relative_y - 1;
+           auto new_scroll_pos = ( slot_pos * scroll_max ) / slot_height;
+           scroll_pos = std::clamp( new_scroll_pos, 0, scroll_max );
+       }
+   }
+   ```
+
+**See**: `src/main_menu.cpp` `display_text()` and `opening_screen()` for a complete working example.
+
+## Complete Working Example
+
+See `src/main_menu.cpp` (commit 4ce6f29d14) for a real-world implementation:
+
+```cpp
+// 1. Coordinate conversion helper
+static auto pixel_to_cell( point pixel_pos ) -> point
+{
+#if defined(TILES)
+    return point { pixel_pos.x / fontwidth, pixel_pos.y / fontheight };
+#else
+    return pixel_pos;
+#endif
+}
+
+// 2. Track button regions while drawing
+std::vector<std::pair<inclusive_rectangle<point>, int>> button_map;
+
+// While printing menu items:
+for( size_t i = 0; i < menu_items.size(); ++i ) {
+    auto button_area = print_button( window, pos, menu_items[i] );
+    button_map.emplace_back( button_area, i );
+}
+
+// 3. Register mouse actions
+input_context ctxt( "MAIN_MENU" );
+ctxt.register_action( "MOUSE_MOVE" );
+ctxt.register_action( "SELECT" );
+ctxt.register_action( "SCROLL_UP" );   // Required for mouse wheel
+ctxt.register_action( "SCROLL_DOWN" ); // Required for mouse wheel
+
+// 4. Handle in input loop
+auto action = ctxt.handle_input();
+
+if( action == "MOUSE_MOVE" ) {
+    auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+    
+    for( const auto &[area, item_id] : button_map ) {
+        if( area.contains( mouse_pos ) ) {
+            highlight_menu_item( item_id );
+            break;
+        }
+    }
+}
+
+if( action == "SELECT" ) {
+    auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+    
+    for( const auto &[area, item_id] : button_map ) {
+        if( area.contains( mouse_pos ) ) {
+            activate_menu_item( item_id );
+            return;
+        }
+    }
+}
+```
+
+## Common Patterns
+
+### Button with Hover Effect
+
+```cpp
+auto button_highlighted = false;
+
+set_mouse_callback( window, mouse_callback_options{
+    .on_click = [&]( const mouse_event &ev ) {
+        if( ev.button == mouse_button::left ) {
+            execute_action();
+        }
+    },
+    .on_hover = [&]( const mouse_event &ev ) {
+        if( ev.type == mouse_event_type::hover_enter ) {
+            button_highlighted = true;
+            redraw();
+        } else if( ev.type == mouse_event_type::hover_exit ) {
+            button_highlighted = false;
+            redraw();
+        }
+    }
+} );
+
+mvwprintw( window, pos, button_highlighted ? "[ OK ]" : "  OK  " );
+clear_mouse_callback( window );
+```
+
+### Context Menu (Right-Click)
+
+```cpp
+set_mouse_callback( window, mouse_callback_options{
+    .on_click = []( const mouse_event &ev ) {
+        if( ev.button == mouse_button::left ) {
+            select_item();
+        } else if( ev.button == mouse_button::right ) {
+            show_context_menu( ev.pos );
+        }
+    }
+} );
+```
+
+### Drag Detection
+
+```cpp
+auto drag_start = std::optional<point>{};
+
+set_mouse_callback( window, mouse_callback_options{
+    .on_click = [&]( const mouse_event &ev ) {
+        if( ev.type == mouse_event_type::click_down && ev.button == mouse_button::left ) {
+            drag_start = ev.pos;
+        } else if( ev.type == mouse_event_type::click_up && drag_start.has_value() ) {
+            auto drag_end = ev.pos;
+            handle_drag( *drag_start, drag_end );
+            drag_start = std::nullopt;
+        }
+    }
+} );
+```
+
+## Testing Checklist
+
+After implementing mouse support:
+
+- [ ] Build succeeds
+  ```sh
+  cmake --build --preset linux-full --target cataclysm-bn-tiles
+  ```
+
+- [ ] Format code
+  ```sh
+  cmake --build out/build/linux-full --target astyle
+  ```
+
+- [ ] Test in TILES mode:
+  - [ ] Left-click activates correct action
+  - [ ] Hover shows correct visual feedback (if applicable)
+  - [ ] Right-click works (if applicable)
+  - [ ] Clicks on overlapping elements resolve correctly
+
+- [ ] Test in curses mode (if applicable):
+  - [ ] Mouse events still work
+  - [ ] No coordinate conversion issues
+
+- [ ] Edge cases:
+  - [ ] Click outside active region does nothing
+  - [ ] Click on partially visible elements
+  - [ ] Rapid clicking doesn't cause issues
+  - [ ] Works with scrolling content (if applicable)
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Clicks are offset | Add `pixel_to_cell()` conversion |
+| Callbacks not firing | Check if `input_context` has `"MOUSE_MOVE"` or `"SELECT"` registered |
+| **Mouse wheel not working** | **Register `"SCROLL_UP"` and `"SCROLL_DOWN"` actions in your input_context** |
+| Scrollbar clicks not working | Track scrollbar region and handle in `"SELECT"` action (see Scrollable Content section) |
+| Wrong button clicked | Check both `ev.button` and `ev.type` (down vs up) |
+| Hover not working | Ensure `on_hover` is set in `mouse_callback_options` |
+| Overlapping regions | Hit-test in reverse drawing order (last drawn = topmost) |
+| Memory issues | Use `scoped_mouse_callback` for RAII cleanup |
+
+## Files to Modify
+
+| File | Purpose |
+|------|---------|
+| `src/mouse_input.h` | Mouse event types (reference only) |
+| `src/output.h` | Callback API (reference only) |
+| Your UI file | Implementation |
+
+## References
+
+- **Mouse Infrastructure**: Issue #7736, PR #7737
+- **Working Example**: `src/main_menu.cpp` (commit 4ce6f29d14)
+- **API Reference**: `src/output.h` (mouse_callback_options, scoped_mouse_callback)
+- **Input Context**: `src/input.h` (register_action, handle_input)
+
+## Design Guidelines
+
+Following AGENTS.md conventions:
+
+- **Use `auto`** for all type declarations
+- **Trailing return types**: `auto foo() -> void`
+- **Designated initializers**: `mouse_callback_options{ .on_click = ... }`
+- **Options structs**: For helpers with >3 parameters
+- **Lambdas**: Prefer captures for local state
+- **RAII**: Use `scoped_mouse_callback` over manual cleanup

--- a/.github/llm_review_guide.md
+++ b/.github/llm_review_guide.md
@@ -9,6 +9,12 @@
 - Use **ONLY** when change is completely self-contained (no new variables/functions, single file):
 - **DON'T** use for multi-file changes or changes needing external context. Use regular code blocks instead.
 
+## Code Style
+
+- Functions with >3 parameters should use an options struct with designated initializers
+- Use `auto` with trailing return types
+- Prefer `std::optional`/`std::expected` over returning `nullptr` or error codes
+
 ## Security
 
 - Avoid unbounded loops/recursion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,97 @@
 # Cataclysm: Bright Nights - Agent Guidelines
 
-## C++23 & Style
+- **MUST** RE-READ AGENTS.md BETWEEN subtasks.
+- **MUST** FOLLOW for all code changes.
 
-- **Standard**: Use C++23: `auto`, trailing returns (`->`), designated initializers, `std::ranges`, `std::optional`, `std::expected`, `<=>`.
-- **Formatting**: Prefer single-line functions. Append `// *NOPAD*` to `<=>` and `-> <type>&` to prevent astyle bugs.
-- **Headers**: Avoid modifying headers with >10 usages. Create new file with pure functions.
-- **Refactoring**: Apply Boyscout rule to modified paths.
+## HARD CONSTRAINTS (NEVER VIOLATE)
+
+Before writing **ANY** code, verify:
+
+| ❌ VIOLATION                | ✅ REQUIRED                                       |
+| --------------------------- | ------------------------------------------------- |
+| `for (auto x : collection)` | `std::ranges::*` or `collection \| std::views::*` |
+| `int foo()`                 | `auto foo() -> int`                               |
+| `Type x = value`            | `auto x = value`                                  |
+| `void fn(a, b, c, d, e)`    | `void fn(options_struct)`                         |
+
+**If you write a for-loop over a collection, your code is WRONG. Rewrite with `std::ranges`.**
+
+## Coding Convention
+
+```c++
+auto foo = 3; //< **ALWAYS** use `auto` for type.
+
+auto bar() -> int; //< **ALWAYS** use trailing return types.
+using my_callback_t = std::function<auto( int ) -> bool>; //< **ALWAYS** use trailing return types in type aliases.
+auto baz() -> int&; // *NOPAD*  //< **ONLY** append `// *NOPAD*` for references/pointer returns to prevent astyle bugs.
+auto qux() -> int { return 42; } //< **ALWAYS** use single-line functions when possible.
+
+auto qux = my_struct{ .a = 1, .b = 2 }; //< **ALWAYS** use designated initializers.
+auto two_value() -> my_data; //< **AVOID** `std::pair`/`std::tuple` for multiple return values. Create a struct instead.
+auto may_have_value() -> std::optional<int>; //< **ALWAYS** use `std::optional` for functions that may not return a value.
+auto may_fail() -> std::expected<int, std::string>; //< ALWAYS use `std::expected` for functions that may fail.
+
+/// **ALWAYS** use triple slash for doc comments like rust's.
+/// **ALWAYS** use snake_case for functions and variables.
+struct comparable { //< **ALWAYS** use snake_case.
+  int x;
+  int y;
+  auto operator<=>( const comparable & ) const = default; // *NOPAD* //< **ALWAYS** use `<=>` for comparisons and append `// *NOPAD*` at the end to prevent astyle bugs.
+}
+
+auto values = xs
+  | std::views::filter( []( const auto & v ) { return v.is_valid(); } )
+  | std::views::transform( []( const auto & v ) { return v.get_value(); } )
+  | std::ranges::to<std::vector>(); //< **ALWAYS** use `std::ranges` over for loops for collections.
+
+// **ALWAYS** use options struct for functions with >3 parameters
+struct button_options {
+  point pos;
+  std::string text;
+  nc_color fg = c_white;
+  nc_color bg = c_black;
+  mouse_callback_t on_click;
+  bool enabled = true;
+};
+auto print_button( const catacurses::window &w, const button_options &opts ) -> void;
+```
+
+- **NEVER** modify existing headers with >10 usages. Create new header with pure functions.
+- **ALWAYS** use modern C++23 features.
+- **ALWAYS** use options struct for functions with more than 3 parameters. Use designated initializers at call sites.
+- **SHOULD** search for existing solution because it's a large, legacy codebase.
 
 ## Workflow
 
-1. **Context**: Fetch issue details via GitHub MCP (if applicable). `git switch -c <type>/<issue-id>/<slug>` (Types: feat, fix, refactor, chore, build, ci).
-2. **Develop**: Follow [Code Style](./docs/en/dev/explanation/code_style.md). Use `_( "text" )` for L10n.
-3. **Test**: Build and verify. Create/update `tests/` (Catch2).
-4. **Commit**: Run astyle. Follow Atomic Commit and [Conventional Commits](./docs/en/contribute/changelog_guidelines.md). **No body/footer unless critical.**
-5. **PR**: Use [Template](./.github/pull_request_template.md). **Zero fluff**.
+### WHEN given a link to an issue
 
-## Build & Verify
+- **Context**: Fetch issue details via GitHub MCP.
+- **Branch**: Switch to nwe branch with `git switch --create <type>/<issue-id>/<issue-slug>`
+  - type MUST be one of: `feat`, `fix`, `refactor`, `chore`, `build`, `ci`
+- **Code**: Refer to [code changes](#when-working-on-code-changes).
+- **PR**: Use [Template](./.github/pull_request_template.md). **DO NOT ADD fluff**. create via `git push && gh pr create --web --fill`.
+
+### WHEN working on code changes
+
+- **Style**: Follow [Code Style](./docs/en/dev/explanation/code_style.md). Use `_( "text" )` for L10n.
+- **Verify**: Build and fix any issues.
 
 ```sh
-# Build Game & Tests
+# Build project and tests
 cmake --preset linux-full
 cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles
+```
+
+- **Test**: Run formatters, THEN run tests. Create/update relevant `tests/` (Catch2).
+
+```sh
+# Format C++ code
+cmake --build build --target astyle
+# Format JSON files
+cmake --build build --target style-json-parallel
+# Format scripts
+deno fmt
+deno task dprint fmt
 
 # Run Tests
 ./out/build/linux-full/tests/cata_test-tiles "[optional-filter]"
@@ -28,6 +99,8 @@ cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles
 # Validate JSON
 ./build-scripts/lint-json.sh
 ```
+
+- **Commit**: Commit **ATOMICALLY**. **ALWAYS** Follow [Conventional Commits](./docs/en/contribute/changelog_guidelines.md). **NEVER** add body/footer unless critical.
 
 ## References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ auto values = xs
   | std::views::transform( []( const auto & v ) { return v.get_value(); } )
   | std::ranges::to<std::vector>(); //< **ALWAYS** use `std::ranges` over for loops for collections.
 
+namespace { // **ALWAYS** use anonymous namespace for internal linkage over `static`.
+
 // **ALWAYS** use options struct for functions with >3 parameters
 struct button_options {
   point pos;
@@ -54,6 +56,8 @@ struct button_options {
   bool enabled = true;
 };
 auto print_button( const catacurses::window &w, const button_options &opts ) -> void;
+
+} // namespace
 ```
 
 - **NEVER** modify existing headers with >10 usages. Create new header with pure functions.

--- a/docs/en/dev/explanation/best_practices.md
+++ b/docs/en/dev/explanation/best_practices.md
@@ -31,6 +31,41 @@ Good names:
 - Avoid using `std::pair` and `std::tuple` in headers, instead create a named struct
 - Avoid using `int` or `std::string` where an `enum class` would work
 
+## Function Parameters
+
+For functions with **more than 3 parameters**, use an options struct:
+
+```cpp
+// Bad: Long parameter list
+void render_ui( const catacurses::window &w, point pos, point size,
+                const std::string &title, nc_color title_color,
+                bool show_border, border_style style );
+
+// Good: Options struct with designated initializers
+struct ui_render_options {
+    point pos;
+    point size;
+    std::string title;
+    nc_color title_color = c_white;
+    bool show_border = true;
+    border_style style = border_style::solid;
+};
+
+auto render_ui( const catacurses::window &w, const ui_render_options &opts ) -> void;
+
+// Usage is clear and maintainable
+render_ui( win, {
+    .pos = point_zero,
+    .size = point( 50, 20 ),
+    .title = "Inventory"
+} );
+```
+
+Benefits:
+- Self-documenting call sites via designated initializers
+- Easy to add/remove parameters without breaking existing code
+- Optional parameters get sensible defaults
+
 ## File organization
 
 Try to avoid including headers from other headers. This negatively impacts compilation times (both

--- a/docs/en/dev/explanation/best_practices.md
+++ b/docs/en/dev/explanation/best_practices.md
@@ -62,6 +62,7 @@ render_ui( win, {
 ```
 
 Benefits:
+
 - Self-documenting call sites via designated initializers
 - Easy to add/remove parameters without breaking existing code
 - Optional parameters get sensible defaults

--- a/docs/en/dev/explanation/code_style.md
+++ b/docs/en/dev/explanation/code_style.md
@@ -116,6 +116,7 @@ These are less generic guidelines and more pain points we've stumbled across ove
 ## Function Parameters
 
 When a function has **more than 3 parameters**, use an options struct instead of a long parameter list. This improves:
+
 - **Readability**: Named fields are self-documenting
 - **Maintainability**: Adding/removing parameters doesn't break all call sites
 - **Usability**: Designated initializers make call sites clear

--- a/docs/en/dev/explanation/code_style.md
+++ b/docs/en/dev/explanation/code_style.md
@@ -112,3 +112,52 @@ These are less generic guidelines and more pain points we've stumbled across ove
   +     return c.prof->description( c.male );
   + }
   ```
+
+## Function Parameters
+
+When a function has **more than 3 parameters**, use an options struct instead of a long parameter list. This improves:
+- **Readability**: Named fields are self-documenting
+- **Maintainability**: Adding/removing parameters doesn't break all call sites
+- **Usability**: Designated initializers make call sites clear
+
+### Before (Bad - Too many parameters)
+
+```cpp
+void print_button( const catacurses::window &w, point pos, 
+                   const std::string &text, nc_color fg, nc_color bg,
+                   std::function<void()> on_click, bool enabled );
+
+// Call site is unclear
+print_button( win, point( 10, 5 ), "OK", c_green, c_black, 
+              []{ do_action(); }, true );
+```
+
+### After (Good - Options struct)
+
+```cpp
+struct button_options {
+    point pos;
+    std::string text;
+    nc_color fg = c_white;
+    nc_color bg = c_black;
+    std::function<void()> on_click;
+    bool enabled = true;
+};
+
+auto print_button( const catacurses::window &w, const button_options &opts ) -> void;
+
+// Call site is self-documenting with designated initializers
+print_button( win, {
+    .pos = point( 10, 5 ),
+    .text = "OK",
+    .fg = c_green,
+    .on_click = []{ do_action(); }
+} );
+```
+
+### Guidelines
+
+- **Required parameters** (no default): Put first in struct, no default value
+- **Optional parameters**: Provide sensible defaults
+- **Pass by const reference**: `const options_struct &opts` to avoid copies
+- **Naming**: Use `<function_name>_options` or `<feature>_config` for the struct name

--- a/docs/en/dev/explanation/user_interface.md
+++ b/docs/en/dev/explanation/user_interface.md
@@ -9,3 +9,39 @@ Some good examples of the usage of `ui_adaptor` can be found within the followin
 
 - `query_popup` and `static_popup` in `popup.h/cpp`
 - `Messages::dialog` in `messages.cpp`
+
+## Mouse Support
+
+Since [PR #7737](https://github.com/cataclysmbn/Cataclysm-BN/pull/7737), the game supports a canvas-based mouse callback system. Mouse interaction (clicking and hovering) can be added to UI elements by attaching callbacks directly to terminal cells as they're printed.
+
+### Architecture
+
+- **Callback Storage**: Each `cursecell` stores optional `on_click` and `on_hover` callback pointers (`mouse_callback_ptr`)
+- **Context API**: `set_mouse_callback()` and `scoped_mouse_callback` in `output.h` manage callback attachment
+- **Dispatch**: SDL/ncurses mouse events are converted to `mouse_event` structs and dispatched through the window stack
+- **Hit-Testing**: The topmost visible window at cursor position receives the event
+
+### Quick Example
+
+```cpp
+scoped_mouse_callback guard( window, mouse_callback_options{
+    .on_click = []( const mouse_event &ev ) {
+        if( ev.button == mouse_button::left ) {
+            handle_click();
+        }
+    }
+} );
+
+mvwprintw( window, point( 10, 5 ), "Click Me" );
+// Callback automatically attached to printed cells
+```
+
+### Documentation
+
+- **How-to Guide**: [Adding Mouse Support](../guides/mouse_support.md)
+- **API Reference**: `src/mouse_input.h`, `src/output.h`
+- **Working Example**: `src/main_menu.cpp`
+
+### Design Principle
+
+The system eliminates manual coordinate synchronization between drawing and input handling. Callbacks are stored directly in the canvas, and the window manager handles hit-testing and dispatch automatically.

--- a/docs/en/dev/guides/mouse_support.md
+++ b/docs/en/dev/guides/mouse_support.md
@@ -424,15 +424,15 @@ void show_menu() {
 
 ## Troubleshooting
 
-| Problem                      | Solution                                                          |
-| ---------------------------- | ----------------------------------------------------------------- |
-| Clicks offset by 12-16 cells | Add `pixel_to_cell()` conversion                                  |
-| Callbacks not firing         | Check `input_context` has `"MOUSE_MOVE"` or `"SELECT"` registered |
-| **Mouse wheel not working**  | **Register `"SCROLL_UP"` and `"SCROLL_DOWN"` actions in input_context** |
+| Problem                      | Solution                                                                        |
+| ---------------------------- | ------------------------------------------------------------------------------- |
+| Clicks offset by 12-16 cells | Add `pixel_to_cell()` conversion                                                |
+| Callbacks not firing         | Check `input_context` has `"MOUSE_MOVE"` or `"SELECT"` registered               |
+| **Mouse wheel not working**  | **Register `"SCROLL_UP"` and `"SCROLL_DOWN"` actions in input_context**         |
 | Scrollbar clicks not working | Track scrollbar region and handle in `"SELECT"` action (see Scrollable Content) |
-| Wrong button clicked         | Check both `ev.button` and `ev.type` (down vs up)                 |
-| Hover not working            | Ensure `on_hover` is set in `mouse_callback_options`              |
-| Overlapping regions          | Hit-test in reverse drawing order (last drawn = topmost)          |
+| Wrong button clicked         | Check both `ev.button` and `ev.type` (down vs up)                               |
+| Hover not working            | Ensure `on_hover` is set in `mouse_callback_options`                            |
+| Overlapping regions          | Hit-test in reverse drawing order (last drawn = topmost)                        |
 
 ## Code References
 

--- a/docs/en/dev/guides/mouse_support.md
+++ b/docs/en/dev/guides/mouse_support.md
@@ -1,0 +1,451 @@
+# Adding Mouse Support to UI Elements
+
+This guide shows you how to add mouse interaction (clicking and hovering) to UI elements using the [canvas-based callback system](https://github.com/cataclysmbn/Cataclysm-BN/issues/7736).
+
+## Quick Start
+
+The mouse callback system lets you attach click and hover handlers directly to terminal cells as they're printed. No manual coordinate synchronization needed—callbacks are stored in the canvas and automatically dispatched when mouse events occur.
+
+**Minimum example:**
+
+```cpp
+#include "output.h"
+#include "mouse_input.h"
+
+// Set callback, print text, callbacks automatically attached
+set_mouse_callback( window, mouse_callback_options{
+    .on_click = []( const mouse_event &ev ) {
+        if( ev.button == mouse_button::left ) {
+            do_action();
+        }
+    }
+} );
+
+mvwprintw( window, point( 10, 5 ), "Click Me" );
+clear_mouse_callback( window );
+```
+
+## Architecture Overview
+
+### Mouse Event Types
+
+```cpp
+enum class mouse_button {
+    none, left, right, middle,
+    scroll_up, scroll_down, back, forward
+};
+
+enum class mouse_event_type {
+    click_down,     // Button pressed
+    click_up,       // Button released
+    hover_enter,    // Cursor entered cell
+    hover_exit,     // Cursor left cell
+    hover_move      // Cursor moving within region
+};
+
+struct mouse_event {
+    point pos;              // Screen-space position
+    point local_pos;        // Window-relative position
+    mouse_button button;
+    mouse_event_type type;
+    bool shift_held, ctrl_held, alt_held;
+    bool left_held, right_held, middle_held;  // For drag detection
+};
+```
+
+### How It Works
+
+1. **Callback Storage**: Each `cursecell` has `on_click` and `on_hover` callback pointers
+2. **Attachment**: `set_mouse_callback()` sets a "current callback" for the window
+3. **Printing**: All print functions check for current callback and attach to written cells
+4. **Dispatch**: SDL/ncurses mouse events → coordinate lookup → callback invocation
+5. **Window Stack**: Hit-testing resolves topmost visible window at cursor position
+
+## Two Approaches
+
+Choose based on your use case:
+
+### Approach 1: Canvas Callbacks (Recommended)
+
+**Best for:** New UI code, simple interactions, when drawing and logic are coupled.
+
+```cpp
+// RAII-style (recommended)
+{
+    scoped_mouse_callback guard( window, mouse_callback_options{
+        .on_click = []( const mouse_event &ev ) { 
+            if( ev.button == mouse_button::left ) {
+                select_item();
+            }
+        },
+        .on_hover = []( const mouse_event &ev ) {
+            if( ev.type == mouse_event_type::hover_enter ) {
+                highlight_item();
+            }
+        }
+    } );
+
+    mvwprintw( window, point( 10, 5 ), "OK" );
+}  // Callbacks cleared automatically
+```
+
+**Pros:** Simple, automatic cleanup, no coordinate math
+**Cons:** All printed text in scope gets the same callback
+
+### Approach 2: Manual Hit-Testing (For Complex UI)
+
+**Best for:** Existing UI with complex layout, different actions per item, legacy code.
+
+```cpp
+// 1. Track clickable regions while drawing
+struct button_region {
+    inclusive_rectangle<point> area;
+    int action_id;
+};
+std::vector<button_region> buttons;
+
+auto btn_pos = point( 10, 5 );
+mvwprintw( window, btn_pos, "OK" );
+buttons.push_back( button_region{
+    .area = inclusive_rectangle<point>( btn_pos, btn_pos + point( 2, 0 ) ),
+    .action_id = ACTION_OK
+} );
+
+// 2. Register mouse actions in input_context
+input_context ctxt( "MY_UI" );
+ctxt.register_action( "MOUSE_MOVE" );
+ctxt.register_action( "SELECT" );
+ctxt.register_action( "SCROLL_UP" );   // CRITICAL: Required for mouse wheel scrolling
+ctxt.register_action( "SCROLL_DOWN" ); // CRITICAL: Required for mouse wheel scrolling
+
+// 3. Handle in input loop
+auto action = ctxt.handle_input();
+if( action == "SELECT" ) {
+    auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+
+    for( const auto &btn : buttons ) {
+        if( btn.area.contains( mouse_pos ) ) {
+            handle_action( btn.action_id );
+            break;
+        }
+    }
+}
+```
+
+**Pros:** Precise per-item control, works with existing patterns
+**Cons:** Manual coordinate tracking, more boilerplate
+
+## Critical: Coordinate Conversion
+
+**In TILES mode, mouse coordinates are PIXELS, not cells. You MUST convert:**
+
+```cpp
+#if defined(TILES)
+extern int fontwidth;
+extern int fontheight;
+#endif
+
+static auto pixel_to_cell( point pixel_pos ) -> point
+{
+#if defined(TILES)
+    return point { pixel_pos.x / fontwidth, pixel_pos.y / fontheight };
+#else
+    return pixel_pos;  // Already in cells for curses
+#endif
+}
+
+// Usage:
+auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+```
+
+**Forgetting this causes clicks to be off by font size (12-16x).**
+
+## Common Patterns
+
+### Button with Hover Effect
+
+```cpp
+auto highlighted = false;
+
+scoped_mouse_callback guard( window, mouse_callback_options{
+    .on_click = [&]( const mouse_event &ev ) {
+        if( ev.button == mouse_button::left ) {
+            execute_action();
+        }
+    },
+    .on_hover = [&]( const mouse_event &ev ) {
+        highlighted = ( ev.type == mouse_event_type::hover_enter );
+        redraw();
+    }
+} );
+
+mvwprintw( window, pos, highlighted ? "[ OK ]" : "  OK  " );
+```
+
+### Right-Click Context Menu
+
+```cpp
+scoped_mouse_callback guard( window, mouse_callback_options{
+    .on_click = [&]( const mouse_event &ev ) {
+        if( ev.button == mouse_button::left ) {
+            select_item();
+        } else if( ev.button == mouse_button::right ) {
+            show_context_menu( ev.pos );
+        }
+    }
+} );
+```
+
+### Drag Detection
+
+```cpp
+auto drag_start = std::optional<point>{};
+
+scoped_mouse_callback guard( window, mouse_callback_options{
+    .on_click = [&]( const mouse_event &ev ) {
+        if( ev.type == mouse_event_type::click_down && ev.button == mouse_button::left ) {
+            drag_start = ev.pos;
+        } else if( ev.type == mouse_event_type::click_up && drag_start.has_value() ) {
+            handle_drag( *drag_start, ev.pos );
+            drag_start = std::nullopt;
+        }
+    }
+} );
+```
+
+### List Items (Different Action Per Row)
+
+Use manual hit-testing for this:
+
+```cpp
+struct list_item_region {
+    inclusive_rectangle<point> area;
+    size_t item_index;
+};
+std::vector<list_item_region> item_regions;
+
+// While rendering:
+for( size_t i = 0; i < items.size(); ++i ) {
+    auto item_pos = point( list_x, list_y + i );
+    mvwprintw( window, item_pos, items[i].name );
+
+    item_regions.push_back( list_item_region{
+        .area = inclusive_rectangle<point>( item_pos, item_pos + point( list_width, 0 ) ),
+        .item_index = i
+    } );
+}
+
+// In input handler:
+if( action == "SELECT" ) {
+    auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+
+    for( const auto &region : item_regions ) {
+        if( region.area.contains( mouse_pos ) ) {
+            select_item( region.item_index );
+            return;
+        }
+    }
+}
+```
+
+### Scrollable Content (CRITICAL)
+
+**If your UI has ANY scrollable content (text, lists, etc.), you MUST register scroll actions:**
+
+```cpp
+input_context ctxt( "MY_UI" );
+ctxt.register_action( "SCROLL_UP" );   // Mouse wheel up
+ctxt.register_action( "SCROLL_DOWN" ); // Mouse wheel down
+// ... other actions
+```
+
+**Complete scrollbar interaction example:**
+
+```cpp
+// 1. Draw scrollbar and track its region
+draw_scrollbar( w_border, scroll_pos, viewport_height, content_lines, point_south, BORDER_COLOR, true );
+
+// Store scrollbar position for click handling
+std::optional<inclusive_rectangle<point>> scrollbar_region;
+int scroll_max = 0;
+
+if( content_lines > viewport_height ) {
+    auto scrollbar_x = border_x + point_south.x;
+    auto scrollbar_y = border_y + point_south.y;
+    scrollbar_region = inclusive_rectangle<point>(
+        point( scrollbar_x, scrollbar_y ),
+        point( scrollbar_x, scrollbar_y + viewport_height - 1 )
+    );
+    scroll_max = content_lines - viewport_height;
+}
+
+// 2. Handle scroll events
+auto action = ctxt.handle_input();
+
+// Handle keyboard/wheel scrolling
+if( action == "UP" || action == "PAGE_UP" || action == "SCROLL_UP" ) {
+    if( scroll_pos > 0 ) {
+        scroll_pos--;
+    }
+} else if( action == "DOWN" || action == "PAGE_DOWN" || action == "SCROLL_DOWN" ) {
+    if( scroll_pos < scroll_max ) {
+        scroll_pos++;
+    }
+}
+
+// Handle scrollbar clicks
+if( action == "SELECT" && scrollbar_region.has_value() &&
+    scrollbar_region->contains( mouse_pos ) ) {
+    auto relative_y = mouse_pos.y - scrollbar_region->p_min.y;
+    auto scrollbar_height = scrollbar_region->p_max.y - scrollbar_region->p_min.y + 1;
+
+    if( relative_y == 0 ) {
+        // Up arrow clicked
+        if( scroll_pos > 0 ) {
+            scroll_pos--;
+        }
+    } else if( relative_y == scrollbar_height - 1 ) {
+        // Down arrow clicked
+        if( scroll_pos < scroll_max ) {
+            scroll_pos++;
+        }
+    } else {
+        // Track/bar clicked - jump to position
+        auto slot_height = scrollbar_height - 2;
+        auto slot_pos = relative_y - 1;
+        auto new_scroll_pos = ( slot_pos * scroll_max ) / slot_height;
+        scroll_pos = std::clamp( new_scroll_pos, 0, scroll_max );
+    }
+}
+```
+
+**See**: `src/main_menu.cpp` `display_text()` and `opening_screen()` for a complete working example.
+
+## Step-by-Step Migration Example
+
+**Before (keyboard-only menu):**
+
+```cpp
+void show_menu() {
+    input_context ctxt( "MENU" );
+    ctxt.register_action( "SELECT" );
+    ctxt.register_action( "QUIT" );
+
+    catacurses::window w = catacurses::newwin( 10, 30, point( 5, 5 ) );
+
+    while( true ) {
+        werase( w );
+        mvwprintw( w, point( 2, 2 ), "[O]K" );
+        mvwprintw( w, point( 2, 4 ), "[C]ancel" );
+        wrefresh( w );
+
+        auto action = ctxt.handle_input();
+        if( action == "SELECT" ) {
+            return;
+        }
+    }
+}
+```
+
+**After (with mouse support using manual hit-testing):**
+
+```cpp
+void show_menu() {
+    input_context ctxt( "MENU" );
+    ctxt.register_action( "SELECT" );
+    ctxt.register_action( "QUIT" );
+    ctxt.register_action( "MOUSE_MOVE" );  // Added for hover
+    ctxt.register_action( "SCROLL_UP" );   // Added for mouse wheel (if menu scrolls)
+    ctxt.register_action( "SCROLL_DOWN" ); // Added for mouse wheel (if menu scrolls)
+
+    catacurses::window w = catacurses::newwin( 10, 30, point( 5, 5 ) );
+
+    struct button_area {
+        inclusive_rectangle<point> area;
+        std::string action;
+    };
+
+    while( true ) {
+        werase( w );
+
+        std::vector<button_area> buttons;
+
+        auto ok_pos = point( 2, 2 );
+        mvwprintw( w, ok_pos, "[O]K" );
+        buttons.push_back( button_area{
+            .area = inclusive_rectangle<point>( ok_pos, ok_pos + point( 3, 0 ) ),
+            .action = "SELECT"
+        } );
+
+        auto cancel_pos = point( 2, 4 );
+        mvwprintw( w, cancel_pos, "[C]ancel" );
+        buttons.push_back( button_area{
+            .area = inclusive_rectangle<point>( cancel_pos, cancel_pos + point( 7, 0 ) ),
+            .action = "QUIT"
+        } );
+
+        wrefresh( w );
+
+        auto action = ctxt.handle_input();
+
+        // Handle mouse clicks
+        if( action == "MOUSE_MOVE" || action == "SELECT" ) {
+            auto mouse_pos = pixel_to_cell( ctxt.get_raw_input().mouse_pos );
+            
+            for( const auto &btn : buttons ) {
+                if( btn.area.contains( mouse_pos ) ) {
+                    if( action == "SELECT" ) {
+                        action = btn.action;  // Treat click as that action
+                    }
+                    // Could add hover highlighting here
+                    break;
+                }
+            }
+        }
+
+        if( action == "SELECT" ) {
+            return;
+        } else if( action == "QUIT" ) {
+            return;
+        }
+    }
+}
+```
+
+## Testing Checklist
+
+- [ ] Build succeeds in both TILES and curses modes
+- [ ] Left-click activates correct action
+- [ ] Right-click works (if implemented)
+- [ ] Hover effects appear (if implemented)
+- [ ] Clicks outside active regions do nothing
+- [ ] Works with window scrolling (if applicable)
+- [ ] No coordinate offset issues (test at different screen resolutions)
+
+## Troubleshooting
+
+| Problem                      | Solution                                                          |
+| ---------------------------- | ----------------------------------------------------------------- |
+| Clicks offset by 12-16 cells | Add `pixel_to_cell()` conversion                                  |
+| Callbacks not firing         | Check `input_context` has `"MOUSE_MOVE"` or `"SELECT"` registered |
+| **Mouse wheel not working**  | **Register `"SCROLL_UP"` and `"SCROLL_DOWN"` actions in input_context** |
+| Scrollbar clicks not working | Track scrollbar region and handle in `"SELECT"` action (see Scrollable Content) |
+| Wrong button clicked         | Check both `ev.button` and `ev.type` (down vs up)                 |
+| Hover not working            | Ensure `on_hover` is set in `mouse_callback_options`              |
+| Overlapping regions          | Hit-test in reverse drawing order (last drawn = topmost)          |
+
+## Code References
+
+- **Main example**: `src/main_menu.cpp` (commit 4ce6f29d14)
+- **Mouse types**: `src/mouse_input.h`
+- **Callback API**: `src/output.h` (`mouse_callback_options`, `scoped_mouse_callback`)
+- **Input handling**: `src/input.h` (`input_context`)
+- **Issue/PR**: #7736, #7737
+
+## Design Philosophy
+
+The canvas callback system follows the principle from issue #7736:
+
+> "No need to synchronize coordinates between mouse click callback and UI output functions, no need to handle how windows obscure one another—just sample the canvas under cursor, grab the callback pointer and call the function."
+
+For simple UIs, use canvas callbacks (Approach 1). For complex existing UIs, manual hit-testing (Approach 2) provides more control while still being cleaner than the old coordinate synchronization approach.

--- a/src/cursesport.h
+++ b/src/cursesport.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "mouse_input.h"
 #include "point.h"
 
 namespace catacurses
@@ -31,16 +32,17 @@ struct pairs {
     base_color BG;
 };
 
-//Individual lines, so that we can track changed lines
 struct cursecell {
     std::string ch;
     base_color FG = static_cast<base_color>( 0 );
     base_color BG = static_cast<base_color>( 0 );
+    mouse_callback_ptr on_click;
+    mouse_callback_ptr on_hover;
 
     cursecell( std::string ch ) : ch( std::move( ch ) ) { }
     cursecell() : cursecell( std::string( 1, ' ' ) ) { }
 
-    bool operator==( const cursecell &b ) const {
+    auto operator==( const cursecell &b ) const -> bool {
         return FG == b.FG && BG == b.BG && ch == b.ch;
     }
 };
@@ -50,22 +52,18 @@ struct curseline {
     std::vector<cursecell> chars;
 };
 
-// The curses window struct
 struct WINDOW {
-    // Top-left corner of window
     point pos;
     int width;
     int height;
-    // Current foreground color from attron
     base_color FG;
-    // Current background color from attron
     base_color BG;
-    // Does this window actually exist?
     bool inuse;
-    // Tracks if the window text has been changed
     bool draw;
     point cursor;
     std::vector<curseline> line;
+    mouse_callback_ptr current_on_click;
+    mouse_callback_ptr current_on_hover;
 };
 
 extern std::array<pairs, 100> colorpairs;

--- a/src/main_menu.h
+++ b/src/main_menu.h
@@ -76,6 +76,8 @@ class main_menu
         std::vector<save_t> savegames;
         std::vector<std::pair<inclusive_rectangle<point>, std::pair<int, int>>> main_menu_sub_button_map;
         std::vector<std::pair<inclusive_rectangle<point>, int>> main_menu_button_map;
+        std::optional<inclusive_rectangle<point>> text_scrollbar_region;
+        int text_scroll_max = 0;
 
         /**
          * Prints a horizontal list of options
@@ -113,6 +115,9 @@ class main_menu
 
         static std::string halloween_spider();
         std::string halloween_graves();
+
+        auto get_main_menu_item_at( point p ) const -> int;
+        auto get_sub_menu_item_at( point p ) const -> std::optional<std::pair<int, int>>;
 };
 
 

--- a/src/mouse_input.h
+++ b/src/mouse_input.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include "point.h"
+
+enum class mouse_button : int {
+    none = 0,
+    left = 1,
+    right = 2,
+    middle = 3,
+    scroll_up = 4,
+    scroll_down = 5,
+    back = 6,
+    forward = 7,
+};
+
+enum class mouse_event_type : int {
+    click_down,
+    click_up,
+    hover_enter,
+    hover_exit,
+    hover_move,
+};
+
+struct mouse_event {
+    point pos;
+    point local_pos;
+    mouse_button button = mouse_button::none;
+    mouse_event_type type = mouse_event_type::click_down;
+    bool shift_held = false;
+    bool ctrl_held = false;
+    bool alt_held = false;
+    bool left_held = false;
+    bool right_held = false;
+    bool middle_held = false;
+};
+
+using mouse_callback_t = std::function<void( const mouse_event & )>;
+using mouse_callback_ptr = std::shared_ptr<mouse_callback_t>;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -530,6 +530,49 @@ void mvwputch_hi( const catacurses::window &w, point p, nc_color FG, const std::
     wattroff( w, HC );
 }
 
+void set_mouse_callback( const catacurses::window &w, const mouse_callback_options &opts )
+{
+#if defined( TILES ) || defined( _WIN32 )
+    auto *const win = w.get<cata_cursesport::WINDOW>();
+    if( win != nullptr ) {
+        win->current_on_click = opts.on_click
+                                ? std::make_shared<mouse_callback_t>( opts.on_click )
+                                : nullptr;
+        win->current_on_hover = opts.on_hover
+                                ? std::make_shared<mouse_callback_t>( *opts.on_hover )
+                                : nullptr;
+    }
+#else
+    ( void )w;
+    ( void )opts;
+#endif
+}
+
+void clear_mouse_callback( const catacurses::window &w )
+{
+#if defined( TILES ) || defined( _WIN32 )
+    auto *const win = w.get<cata_cursesport::WINDOW>();
+    if( win != nullptr ) {
+        win->current_on_click = nullptr;
+        win->current_on_hover = nullptr;
+    }
+#else
+    ( void )w;
+#endif
+}
+
+scoped_mouse_callback::scoped_mouse_callback( const catacurses::window &w,
+        const mouse_callback_options &opts )
+    : win( w )
+{
+    set_mouse_callback( w, opts );
+}
+
+scoped_mouse_callback::~scoped_mouse_callback()
+{
+    clear_mouse_callback( win );
+}
+
 void draw_custom_border(
     const catacurses::window &w, const catacurses::chtype ls, const catacurses::chtype rs,
     const catacurses::chtype ts, const catacurses::chtype bs, const catacurses::chtype tl,

--- a/src/output.h
+++ b/src/output.h
@@ -15,9 +15,11 @@
 
 #include "catacharset.h"
 #include "color.h"
+#include "cursesdef.h"
 #include "debug.h"
 #include "enums.h"
 #include "line.h"
+#include "mouse_input.h"
 #include "point.h"
 #include "string_formatter.h"
 #include "translations.h"
@@ -355,6 +357,27 @@ inline void wprintz( const catacurses::window &w, const nc_color &FG, const char
 {
     wprintz( w, FG, string_format( mes, std::forward<Args>( args )... ) );
 }
+
+struct mouse_callback_options {
+    mouse_callback_t on_click;
+    std::optional<mouse_callback_t> on_hover = std::nullopt;
+};
+
+void set_mouse_callback( const catacurses::window &w, const mouse_callback_options &opts );
+void clear_mouse_callback( const catacurses::window &w );
+
+class scoped_mouse_callback
+{
+    public:
+        scoped_mouse_callback( const catacurses::window &w, const mouse_callback_options &opts );
+        ~scoped_mouse_callback();
+        scoped_mouse_callback( const scoped_mouse_callback & ) = delete;
+        auto operator=( const scoped_mouse_callback & ) -> scoped_mouse_callback & = delete;
+        scoped_mouse_callback( scoped_mouse_callback && ) = delete;
+        auto operator=( scoped_mouse_callback && ) -> scoped_mouse_callback & = delete;
+    private:
+        catacurses::window win;
+};
 
 void draw_custom_border(
     const catacurses::window &w, catacurses::chtype ls = 1, catacurses::chtype rs = 1,


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #7736

Provides infrastructure for canvas-based mouse callbacks, enabling future UI improvements like clickable buttons, tooltips, and interactive elements in inventory/crafting menus.

## Describe the solution (The How)

1. **Mouse Event Types** (`src/mouse_input.h`)
   - `mouse_button` enum (left, right, middle, scroll, back, forward)
   - `mouse_event_type` enum (click_down, click_up, hover_enter/exit/move)
   - `mouse_event` struct with position, button, type, and modifier keys

2. **Callback Storage** (`src/cursesport.h`)
   - Added `mouse_callback_ptr` (shared_ptr<function>) to `cursecell`
   - Added `current_on_click/on_hover` to `WINDOW` struct

3. **Context API** (`src/output.h/.cpp`)
   - `set_mouse_callback(window, {.on_click=..., .on_hover=...})`
   - `clear_mouse_callback(window)`
   - `scoped_mouse_callback` RAII guard

4. **SDL Event Dispatch** (`src/sdltiles.cpp`)
   - Hooks into MOUSEBUTTONDOWN/UP, MOUSEMOTION, MOUSEWHEEL
   - Checks both `terminal_framebuffer` and `oversized_framebuffer`
   - Hover tracking with enter/exit/move events

## Describe alternatives you've considered

- Widget-based system: More complex, requires larger refactor
- Global callback registry: Less composable, harder to scope to windows

## Testing

- ✅ Builds successfully (`cmake --build --preset linux-full`)
- ✅ astyle passes (no changes)
- ⚠️ No unit tests yet (requires SDL context, will need manual UI testing when integrated)

## Additional context

boy burned some tokens with opus; it sure did gave satisfactory results, but primarily only because @olanti-p wrote the specification for the whole mouse callback framework from scratch.

### Usage Example
```cpp
// Click-only
set_mouse_callback(win, {
    .on_click = [](const mouse_event& e) {
        if (e.button == mouse_button::left) { do_action(); }
    }
});

// Click + hover with RAII
scoped_mouse_callback guard(win, {
    .on_click = click_handler,
    .on_hover = hover_handler
});
```

### Design Notes
- Callbacks attached per-cell during `printstring()` from window's `current_*` state
- Only active in TILES/WIN32 builds (no-op in ncurses)
- Future work: Integrate with inventory/crafting/building UIs (Phase 4-5)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [x] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet. (N/A - no new localizable fields)
  - [x] If applicable, add checks on game load that would validate the loaded data. (N/A - runtime callbacks only)
  - [x] If it modifies format of save files, please add migration from the old format. (N/A - no save file changes)