### PR TITLE
feat: permit DROPPER vehicle parts to use place_monster use actions

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7985,13 +7985,14 @@ void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool sing
                 // DANGER: DO NOT PUT THIS IN THE FOR LOOP
                 const std::vector<item *> items = part->get_items();
                 for( item *it : items ) {
-                    if( it->get_use( "transform" ) ) {
-                        g->u.invoke_item( it, "transform" );
-                    }
                     g->m.add_item_or_charges( pos, part->remove_item( *it ) );
-                    it = get_last_dropped_item( pos );
-                    if( it->get_use( "place_monster" ) ) {
-                        g->u.invoke_item( it, "place_monster" );
+                    item *it2 = get_last_dropped_item( pos );
+                    if( it2->get_use( "transform" ) ) {
+                        g->u.invoke_item( it2, "transform" );
+                    }
+                    if( it2->get_use( "place_monster" ) ) {
+                        it2->activate();
+                        g->u.invoke_item( it2, "place_monster", pos );
                     }
                 }
             }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7942,6 +7942,13 @@ bool vehicle::has_item_stored( vehicle_part *part )
     return false;
 }
 
+static item *get_last_dropped_item( tripoint &p )
+{
+    point l;
+    submap *const current_submap = g->m.get_submap_at( p, l );
+    return *( current_submap->get_items( l ).end() - 1 );
+}
+
 void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool single )
 {
     if( single ) {
@@ -7982,6 +7989,10 @@ void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool sing
                         g->u.invoke_item( it, "transform" );
                     }
                     g->m.add_item_or_charges( pos, part->remove_item( *it ) );
+                    it = get_last_dropped_item( pos );
+                    if( it->get_use( "place_monster" ) ) {
+                        g->u.invoke_item( it, "place_monster" );
+                    }
                 }
             }
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7973,6 +7973,12 @@ void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool sing
             g->u.invoke_item( dropper, "transform" );
         }
         g->m.add_item_or_charges( pos, part->remove_item( *dropper ) );
+        item *it2 = get_last_dropped_item( pos );
+        if( it2->get_use( "place_monster" ) ) {
+            // Needed for stupid reasons
+            it2->activate();
+            g->u.invoke_item( it2, "place_monster", pos );
+        }
     } else {
         for( vehicle_part *d : droppers ) {
             vehicle_part *part = get_cargo_part( d );
@@ -7985,12 +7991,13 @@ void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool sing
                 // DANGER: DO NOT PUT THIS IN THE FOR LOOP
                 const std::vector<item *> items = part->get_items();
                 for( item *it : items ) {
+                    if( it->get_use( "transform" ) ) {
+                        g->u.invoke_item( it, "transform" );
+                    }
                     g->m.add_item_or_charges( pos, part->remove_item( *it ) );
                     item *it2 = get_last_dropped_item( pos );
-                    if( it2->get_use( "transform" ) ) {
-                        g->u.invoke_item( it2, "transform" );
-                    }
                     if( it2->get_use( "place_monster" ) ) {
+                        // Needed for stupid reasons
                         it2->activate();
                         g->u.invoke_item( it2, "place_monster", pos );
                     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8156,6 +8156,13 @@ bool vehicle::has_item_stored( vehicle_part *part )
     return false;
 }
 
+static item *get_last_dropped_item( tripoint &p )
+{
+    point l;
+    submap *const current_submap = g->m.get_submap_at( p, l );
+    return *( current_submap->get_items( l ).end() - 1 );
+}
+
 void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool single )
 {
     if( single ) {
@@ -8196,6 +8203,10 @@ void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool sing
                         g->u.invoke_item( it, "transform" );
                     }
                     g->m.add_item_or_charges( pos, part->remove_item( *it ) );
+                    it = get_last_dropped_item( pos );
+                    if( it->get_use( "place_monster" ) ) {
+                        g->u.invoke_item( it, "place_monster" );
+                    }
                 }
             }
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8199,13 +8199,14 @@ void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool sing
                 // DANGER: DO NOT PUT THIS IN THE FOR LOOP
                 const std::vector<item *> items = part->get_items();
                 for( item *it : items ) {
-                    if( it->get_use( "transform" ) ) {
-                        g->u.invoke_item( it, "transform" );
-                    }
                     g->m.add_item_or_charges( pos, part->remove_item( *it ) );
-                    it = get_last_dropped_item( pos );
-                    if( it->get_use( "place_monster" ) ) {
-                        g->u.invoke_item( it, "place_monster" );
+                    item *it2 = get_last_dropped_item( pos );
+                    if( it2->get_use( "transform" ) ) {
+                        g->u.invoke_item( it2, "transform" );
+                    }
+                    if( it2->get_use( "place_monster" ) ) {
+                        it2->activate();
+                        g->u.invoke_item( it2, "place_monster", pos );
                     }
                 }
             }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8187,6 +8187,12 @@ void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool sing
             g->u.invoke_item( dropper, "transform" );
         }
         g->m.add_item_or_charges( pos, part->remove_item( *dropper ) );
+        item *it2 = get_last_dropped_item( pos );
+        if( it2->get_use( "place_monster" ) ) {
+            // Needed for stupid reasons
+            it2->activate();
+            g->u.invoke_item( it2, "place_monster", pos );
+        }
     } else {
         for( vehicle_part *d : droppers ) {
             vehicle_part *part = get_cargo_part( d );
@@ -8199,12 +8205,13 @@ void vehicle::item_dropper_drop( std::vector<vehicle_part *> droppers, bool sing
                 // DANGER: DO NOT PUT THIS IN THE FOR LOOP
                 const std::vector<item *> items = part->get_items();
                 for( item *it : items ) {
+                    if( it->get_use( "transform" ) ) {
+                        g->u.invoke_item( it, "transform" );
+                    }
                     g->m.add_item_or_charges( pos, part->remove_item( *it ) );
                     item *it2 = get_last_dropped_item( pos );
-                    if( it2->get_use( "transform" ) ) {
-                        g->u.invoke_item( it2, "transform" );
-                    }
                     if( it2->get_use( "place_monster" ) ) {
+                        // Needed for stupid reasons
                         it2->activate();
                         g->u.invoke_item( it2, "place_monster", pos );
                     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -877,26 +877,18 @@ void vehicle::use_controls( const tripoint &pos )
 
     }
 
-    if( has_part( "DROPPER" ) ) {
-        std::vector<vehicle_part *> droppers;
-        for( auto &p : parts ) {
-            if( p.has_flag( VPFLAG_DROPPER ) && !p.removed ) {
-                droppers.push_back( &p );
-            }
-        }
-        if( !droppers.empty() ) {
-            options.emplace_back( _( "Activate all item droppers (Drop Everything)" ),
-                                  keybind( "DROPPER_ALL" ) );
-            actions.emplace_back( [&] { item_dropper_drop_all(); refresh(); } );
+    if( !droppers.empty() ) {
+        options.emplace_back( _( "Activate all item droppers (Drop Everything)" ),
+                              keybind( "DROPPER_ALL" ) );
+        actions.emplace_back( [&] { item_dropper_drop_all(); refresh(); } );
 
-            options.emplace_back( _( "Activate one item dropper (Drop Everything)" ),
-                                  keybind( "DROPPER_SINGLE_ALL" ) );
-            actions.emplace_back( [&] { item_dropper_drop_single( false ); refresh(); } );
+        options.emplace_back( _( "Activate one item dropper (Drop Everything)" ),
+                              keybind( "DROPPER_SINGLE_ALL" ) );
+        actions.emplace_back( [&] { item_dropper_drop_single( false ); refresh(); } );
 
-            options.emplace_back( _( "Activate one item dropper (Drop One Thing)" ),
-                                  keybind( "DROPPER_SINGLE" ) );
-            actions.emplace_back( [&] { item_dropper_drop_single( true ); refresh(); } );
-        }
+        options.emplace_back( _( "Activate one item dropper (Drop One Thing)" ),
+                              keybind( "DROPPER_SINGLE" ) );
+        actions.emplace_back( [&] { item_dropper_drop_single( true ); refresh(); } );
     }
     uilist menu;
     menu.text = _( "Vehicle controls" );


### PR DESCRIPTION
## Purpose of change (The Why)
#7647

People seem to really want it
I see no reason why it would be bad

## Describe the solution (The How)
Call place_monster also

## Describe alternatives you've considered
Wait until #7797 is merged and just data_var it

## Testing
I dropped a bunch of manhacks
They spawned on the ground

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.