### PR TITLE
revert: bring back option to use z-levels

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -596,6 +596,7 @@ void game::setup( bool load_world_modfiles )
     }
 
     init_bubble_config();
+    m = map( get_option<bool>( "ZLEVELS" ) );
     m.resize( g_mapsize );
 
     next_npc_id = character_id( 1 );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3182,6 +3182,10 @@ void options_manager::add_options_world_default()
         { "full", translate_marker( "Full (Everything)" ) }
     },
     "off" );
+    add( "ZLEVELS", world_default, translate_marker( "Z-levels" ),
+         translate_marker( "If true, enables several features related to vertical movement, such as hauling items up stairs, climbing downspouts, flying aircraft and ramps.  May cause problems if toggled mid-game." ),
+         true
+       );
 
     add_empty_line();
 

--- a/tests/ground_destroy_test.cpp
+++ b/tests/ground_destroy_test.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -19,12 +20,15 @@
 // Destroying pavement with a pickaxe should not leave t_flat_roof.
 // See issue #24707:
 // https://github.com/CleverRaven/Cataclysm-DDA/issues/24707
+// Behavior may depend on ZLEVELS being set.
 TEST_CASE( "pavement_destroy", "[.]" )
 {
     clear_all_state();
     const ter_id flat_roof_id = ter_id( "t_flat_roof" );
     REQUIRE( flat_roof_id != t_null );
 
+    const bool zlevels_set = get_option<bool>( "ZLEVELS" );
+    INFO( "ZLEVELS is " << zlevels_set );
     put_player_underground();
     map &here = get_map();
     // Populate the map with pavement.
@@ -43,11 +47,15 @@ TEST_CASE( "pavement_destroy", "[.]" )
 // Ground-destroying explosions on dirt or grass shouldn't leave t_flat_roof.
 // See issue #23250:
 // https://github.com/CleverRaven/Cataclysm-DDA/issues/23250
+// Behavior may depend on ZLEVELS being set.
 TEST_CASE( "explosion_on_ground", "[.]" )
 {
     clear_all_state();
     ter_id flat_roof_id = ter_id( "t_flat_roof" );
     REQUIRE( flat_roof_id != t_null );
+
+    const bool zlevels_set = get_option<bool>( "ZLEVELS" );
+    INFO( "ZLEVELS is " << zlevels_set );
 
     put_player_underground();
     std::vector<ter_id> test_terrain_id = {
@@ -87,6 +95,7 @@ TEST_CASE( "explosion_on_ground", "[.]" )
 // Ground-destroying explosions on t_floor with a t_rock_floor basement
 // below should create some t_open_air, not just t_flat_roof (which is
 // the defined roof of a t_rock-floor).
+// Behavior depends on ZLEVELS being set.
 TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
 {
     clear_all_state();
@@ -99,6 +108,9 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
     REQUIRE( floor_id != t_null );
     REQUIRE( rock_floor_id != t_null );
     REQUIRE( open_air_id != t_null );
+
+    const bool zlevels_set = get_option<bool>( "ZLEVELS" );
+    INFO( "ZLEVELS is " << zlevels_set );
 
     put_player_underground();
 
@@ -143,6 +155,7 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
 
 // Destroying interior floors shouldn't cause the roofs above to collapse.
 // Destroying supporting walls should cause the roofs above to collapse.
+// Behavior may depend on ZLEVELS being set.
 TEST_CASE( "collapse_checks", "[.]" )
 {
     clear_all_state();
@@ -158,6 +171,8 @@ TEST_CASE( "collapse_checks", "[.]" )
     REQUIRE( wall_id != t_null );
     REQUIRE( open_air_id != t_null );
 
+    const bool zlevels_set = get_option<bool>( "ZLEVELS" );
+    INFO( "ZLEVELS is " << zlevels_set );
     put_player_underground();
 
     map &here = get_map();

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -26,7 +26,8 @@ static const time_point midday = calendar::turn_zero + 12_hours;
 TEST_CASE( "monsters shouldn't see through floors", "[vision]" )
 {
     clear_all_state();
-    override_option opt( "FOV_3D", "true" );
+    override_option opt( "ZLEVELS", "true" );
+    override_option opt2( "FOV_3D", "true" );
     bool old_fov_3d = fov_3d;
     fov_3d = true;
     calendar::turn = midday;

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -161,7 +161,7 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
     g->u = avatar();
     g->u.create( character_type::NOW );
 
-    g->m = map();
+    g->m = map( get_option<bool>( "ZLEVELS" ) );
     disable_mapgen = true;
 
     g->m.load( tripoint( g->get_levx(), g->get_levy(), g->get_levz() ), false );


### PR DESCRIPTION
## Purpose of change (The Why)

- players may need it for extra performance
- we haven't made much changes to map nor it seems to affect editing with map

## Describe the solution (The How)

- This reverts #3909
- removed elevated bridges mod check as it's gone
- kept default Z-Level enabled on map constructor as that sounded more natural

## Describe alternatives you've considered

maybe also introduce sleep-disable-z-level option like 7494 

## Testing

doesn't seem to error? tbh it's more of a debug feature so players are expecting it to be buggy

## Additional context


## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
