### PR TITLE
fix: correct json flags for some open door terrains

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -3112,7 +3112,7 @@
     "color": "brown",
     "looks_like": "t_chickenwire_gate_o",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "DOOR", "PERMEABLE", "CONNECT_TO_WALL" ],
+    "flags": [ "TRANSPARENT", "INDOORS", "FLAT", "ROAD", "PERMEABLE", "CONNECT_TO_WALL" ],
     "close": "t_screen_door_c",
     "deconstruct": {
       "ter_set": "t_floor",

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -720,7 +720,7 @@
     "looks_like": "t_fencegate_o",
     "move_cost": 2,
     "coverage": 60,
-    "flags": [ "TRANSPARENT", "DOOR", "BURROWABLE", "FLAT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "BURROWABLE", "FLAT", "ROAD" ],
     "connects_to": "WOODFENCE",
     "close": "t_gate_metal_c",
     "deconstruct": {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

NPCs get stuck on opened metal gates and screen doors due to the `DOOR` flag telling them they must be opened (again) to walk through

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Remove the `DOOR` flag from `t_screen_door_o` and `t_gate_metal_o`

`t_screen_door_o` seems to also be missing `FLAT` and `ROAD` flags because of copy/paste error so add them as well
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

- Spawned an NPC and made them follow me
- Placed an open metal gate and screen door between them and my character and walked away
- Without changes NPC stops in front of the door
- With changes they walk through as expected
- Screen door can now be skated through without slowdown and allows furniture to be pushed through
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Related to #1663 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
