### PR TITLE
fix: avoid invalid corpse reference dereference during butchery

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1158,10 +1158,11 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
 
     map &here = get_map();
     safe_reference<item> &target = act->targets.back();
+    auto *target_item = const_cast<item *>( target.get_const() );
     const inventory &inv = p->crafting_inventory();
 
     // Corpses can disappear (rezzing!), so check for that
-    if( !target || !target->is_corpse() ) {
+    if( target.is_destroyed() || target_item == nullptr || !target_item->is_corpse() ) {
         p->add_msg_if_player( m_info, _( "There's no corpse to butcher!" ) );
         act->set_to_null();
         return;
@@ -1188,12 +1189,12 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
 
     // index is a bool that determines if we are ready to start the next target
     if( act->index ) {
-        const butchery_setup setup = consider_butchery( *target, *p, action );
+        const butchery_setup setup = consider_butchery( *target_item, *p, action );
         set_up_butchery_activity( *act, *p, setup );
         return;
     }
 
-    item &corpse_item = *target;
+    item &corpse_item = *target_item;
     const mtype *corpse = corpse_item.get_mtype();
     const field_type_id type_blood = corpse->bloodType();
     const field_type_id type_gib = corpse->gibType();
@@ -1250,7 +1251,7 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
         }
 
         // Remove the target from the map
-        target->detach();
+        target_item->detach();
 
         act->targets.pop_back();
 
@@ -1310,7 +1311,7 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
                                   corpse_item.tname() );
 
             // Remove the target from the map
-            target->detach();
+            target_item->detach();
             if( !act->targets.empty() ) {
                 act->targets.pop_back();
             }
@@ -1319,7 +1320,7 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
             p->add_msg_if_player( m_good, _( "You finish butchering the %s." ), corpse_item.tname() );
 
             // Remove the target from the map
-            target->detach();
+            target_item->detach();
             if( !act->targets.empty() ) {
                 act->targets.pop_back();
             }
@@ -1429,7 +1430,7 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
             }
 
             // Remove the target from the map
-            target->detach();
+            target_item->detach();
             if( !act->targets.empty() ) {
                 act->targets.pop_back();
             }
@@ -1438,7 +1439,7 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
             p->add_msg_if_player( m_good, _( "You finish dissecting the %s." ), corpse_item.tname() );
 
             // Remove the target from the map
-            target->detach();
+            target_item->detach();
             if( !act->targets.empty() ) {
                 act->targets.pop_back();
             }


### PR DESCRIPTION
## Purpose of change (The Why)

closes #8180.

Prevent crashes when a corpse decays away during butchery/dissection activity processing.

## Describe the solution (The How)

Validate the butchery target once via `safe_reference::get_const()` and `is_destroyed()` before any dereference. Then reuse that validated pointer for `consider_butchery` and `detach()` calls, so we never call `operator->` on an invalid `safe_reference`.

## Describe alternatives you've considered

Handle this in `safe_reference::get()` globally, but that is broader and riskier than a focused fix in butchery activity handling.

## Testing

- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`

## Additional context

- None.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.