### PR TITLE
perf(UI): add sleep time skip option with safe fallback

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -72,6 +72,7 @@
 #include "mtype.h"
 #include "npc.h"
 #include "omdata.h"
+#include "options.h"
 #include "output.h"
 #include "overmapbuffer.h"
 #include "player.h"
@@ -3425,8 +3426,25 @@ void activity_handlers::try_sleep_do_turn( player_activity *act, player *p )
 {
     if( !p->has_effect( effect_sleep ) ) {
         if( character_funcs::roll_can_sleep( *p ) ) {
+            constexpr std::string_view sleep_skip_disabled_key = "sleep_skip_time_disabled";
+            const bool sleep_skip_time = get_option<bool>( "SLEEP_SKIP_TIME" );
+            const bool hostile_in_reality_bubble = sleep_skip_time && p->is_avatar() &&
+            !g->get_creatures_if( [&]( const Creature & critter ) {
+                return &critter != p && p->attitude_to( critter ) == Attitude::A_HOSTILE;
+            } ).empty();
+            const bool disable_sleep_skip_for_this_sleep = hostile_in_reality_bubble;
+            if( hostile_in_reality_bubble ) {
+                if( !query_yn(
+                        _( "you don't feel that safe. Go to sleep anyway? (do not skip time on sleeping)" ) ) ) {
+                    act->set_to_null();
+                    return;
+                }
+            }
             act->set_to_null();
             p->fall_asleep();
+            if( disable_sleep_skip_for_this_sleep ) {
+                p->set_value( sleep_skip_disabled_key.data(), "true" );
+            }
             p->remove_value( "sleep_query" );
         } else if( one_in( 1000 ) ) {
             p->add_msg_if_player( _( "You toss and turn…" ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8500,6 +8500,7 @@ void Character::cough( bool harmful, int loudness )
 
 void Character::wake_up()
 {
+    remove_value( "sleep_skip_time_disabled" );
     remove_effect( effect_slept_through_alarm );
     remove_effect( effect_lying_down );
     remove_effect( effect_alarm_clock );
@@ -10361,6 +10362,7 @@ void Character::fall_asleep( const time_duration &duration )
             cancel_activity();
         }
     }
+    remove_value( "sleep_skip_time_disabled" );
     add_effect( effect_sleep, duration );
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1842,11 +1842,33 @@ bool game::do_turn()
     const auto soundperf = asleep && get_option<bool>( "SLEEP_SKIP_SOUND" );
     const auto monperf = asleep && get_option<bool>( "SLEEP_SKIP_MON" );
     const auto npcperf = asleep && get_option<bool>( "SLEEP_SKIP_NPC" );
+    const bool sleep_skip_time = asleep && get_option<bool>( "SLEEP_SKIP_TIME" ) &&
+                                 u.get_value( "sleep_skip_time_disabled" ) != "true";
+    const bool hostile_in_reality_bubble = sleep_skip_time &&
+    !get_creatures_if( [&]( const Creature & critter ) {
+        return &critter != &u && u.attitude_to( critter ) == Attitude::A_HOSTILE;
+    } ).empty();
+    if( sleep_skip_time && !hostile_in_reality_bubble ) {
+        const auto sleep_duration = u.get_effect_dur( effect_sleep );
+        if( sleep_duration > 1_turns ) {
+            calendar::turn += sleep_duration - 1_turns;
+            m.process_items();
+            m.process_fields();
+            if( !vehperf ) {
+                for( auto &veh : m.get_vehicles() ) {
+                    veh.v->update_time( calendar::turn );
+                }
+                m.vehmove();
+            }
+        }
+    }
     // Actual stuff
     if( new_game ) {
         new_game = false;
     } else {
-        gamemode->per_turn();
+        if( gamemode != nullptr ) {
+            gamemode->per_turn();
+        }
         calendar::turn += 1_turns;
     }
     // Reset dimension swap flag now that the map is fully loaded and turn is processing

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2304,6 +2304,9 @@ void options_manager::add_options_performance()
                                "NPCs with non-interruptible activities (e.g. surgery) are frozen "
                                "for the turn instead." ),
              is_android ? false : true );
+        add( "SLEEP_SKIP_TIME", page_id, translate_marker( "Skip Time When Sleeping" ),
+             translate_marker( "When sleeping, completely skip time until wake-up unless an interruption is detected." ),
+             false );
 #if defined(__ANDROID__)
         add( "LOAD_FROM_EXTERNAL", page_id, translate_marker( "External Storage Saving" ),
              translate_marker( "Save in data/catalcysm... instead of Documents/..." ),

--- a/tests/sleep_skip_time_test.cpp
+++ b/tests/sleep_skip_time_test.cpp
@@ -1,0 +1,109 @@
+#include "catch/catch.hpp"
+
+#include "avatar.h"
+#include "calendar.h"
+#include "flag.h"
+#include "game.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "monster.h"
+#include "mtype.h"
+#include "options_helpers.h"
+#include "point.h"
+#include "state_helpers.h"
+#include "type_id.h"
+#include "vehicle.h"
+#include "vehicle_part.h"
+
+static const efftype_id effect_sleep( "sleep" );
+static const itype_id fuel_type_battery( "battery" );
+static const mtype_id mon_zombie( "mon_zombie" );
+
+namespace
+{
+
+auto run_sleep_turn( const time_duration &duration ) -> time_duration
+{
+    avatar &you = g->u;
+    const time_point before_sleep = calendar::turn;
+    you.fall_asleep( duration );
+    REQUIRE( you.has_effect( effect_sleep ) );
+    CHECK_FALSE( g->do_turn() );
+    return calendar::turn - before_sleep;
+}
+
+}
+
+TEST_CASE( "sleep skip time advances to wake up when safe", "[sleep][perf]" )
+{
+    clear_all_state();
+    build_test_map( ter_id( "t_pavement" ) );
+    clear_creatures();
+    override_option sleep_skip_time( "SLEEP_SKIP_TIME", "true" );
+    g->u.remove_value( "sleep_skip_time_disabled" );
+    calendar::turn = calendar::turn_zero + 1_days;
+
+    const time_duration elapsed = run_sleep_turn( 2_hours );
+
+    CHECK( elapsed >= 2_hours - 1_turns );
+    CHECK_FALSE( g->u.has_effect( effect_sleep ) );
+}
+
+TEST_CASE( "sleep skip time falls back when hostiles are nearby", "[sleep][perf]" )
+{
+    clear_all_state();
+    build_test_map( ter_id( "t_pavement" ) );
+    clear_creatures();
+    override_option sleep_skip_time( "SLEEP_SKIP_TIME", "true" );
+    g->u.remove_value( "sleep_skip_time_disabled" );
+    calendar::turn = calendar::turn_zero + 1_days;
+
+    avatar &you = g->u;
+    REQUIRE( g->place_critter_at( mon_zombie, you.pos() + tripoint_east ) != nullptr );
+
+    const time_duration elapsed = run_sleep_turn( 2_hours );
+
+    CHECK( elapsed < 2_hours );
+    CHECK( elapsed >= 1_turns );
+}
+
+TEST_CASE( "sleep skip time processes rotting and charging effects", "[sleep][perf]" )
+{
+    clear_all_state();
+    build_test_map( ter_id( "t_pavement" ) );
+    clear_creatures();
+    override_option sleep_skip_time( "SLEEP_SKIP_TIME", "true" );
+    g->u.remove_value( "sleep_skip_time_disabled" );
+    calendar::turn = calendar::turn_zero + 2_days;
+
+    map &here = get_map();
+    const tripoint item_pos = g->u.pos();
+    detached_ptr<item> rotting_item = item::spawn( "meat_cooked" );
+    rotting_item->mod_rot( 7_days );
+    here.add_item_or_charges( item_pos, std::move( rotting_item ), false );
+
+    const tripoint vehicle_origin = tripoint( 10, 10, 0 );
+    vehicle *veh_ptr = here.add_vehicle( vproto_id( "recharge_test" ), vehicle_origin, 0_degrees, 100,
+                                         0 );
+    REQUIRE( veh_ptr != nullptr );
+    auto cargo_part_index = veh_ptr->part_with_feature( point_zero, "CARGO", true );
+    REQUIRE( cargo_part_index >= 0 );
+
+    auto chargers = veh_ptr->get_parts_at( vehicle_origin, "RECHARGE", part_status_flag::available );
+    REQUIRE( chargers.size() == 1 );
+    chargers.front()->enabled = true;
+
+    detached_ptr<item> battery_item = item::spawn( "light_battery_cell" );
+    battery_item->ammo_unset();
+    REQUIRE( battery_item->has_flag( flag_RECHARGE ) );
+    veh_ptr->add_item( veh_ptr->part( cargo_part_index ), std::move( battery_item ) );
+
+    run_sleep_turn( 1_hours );
+
+    CHECK( here.i_at( item_pos ).empty() );
+    auto cargo_items = veh_ptr->get_items( cargo_part_index );
+    REQUIRE( cargo_items.size() == 1 );
+    CHECK( cargo_items.only_item().ammo_remaining() > 0 );
+    CHECK( veh_ptr->fuel_left( fuel_type_battery ) > 0 );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

Add a sleep performance option that skips rendering-heavy sleep turns while preserving gameplay effects and a safety fallback when hostiles are nearby.

## Describe the solution (The How)

- Added `SLEEP_SKIP_TIME` option (`Skip Time When Sleeping`) with requested description text.
- Added hostile-in-reality-bubble safety prompt and fallback to normal sleep flow.
- Added fast sleep-time progression path that advances turns without wait-popup rendering while still processing item/field/vehicle updates.
- Added tests for safe skip, hostile fallback behavior, and world progression effects (rot + charging).

## Describe alternatives you've considered

- Full inline reimplementation of `do_turn()` during sleep skip; rejected due to instability/segfault risk in tests.

## Testing

- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[sleep][perf]"`
- `./out/build/linux-full/tests/cata_test-tiles "Vehicle charging station"`

## Additional context

N/A

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.