### PR TITLE
feat(lua): migrate achievements runtime to Lua

### DIFF
--- a/data/json/lua/achievements.lua
+++ b/data/json/lua/achievements.lua
@@ -1,0 +1,284 @@
+local achievements = {}
+
+local completion_pending = "pending"
+local completion_completed = "completed"
+local completion_failed = "failed"
+
+local function compare_value(comparison, target, value)
+  if comparison == ">=" then return value >= target end
+  if comparison == "<=" then return value <= target end
+  return true
+end
+
+local function get_state_root(storage)
+  storage.lua_achievements = storage.lua_achievements or {}
+  storage.lua_achievements.states = storage.lua_achievements.states or {}
+  storage.lua_achievements.initial_ids = storage.lua_achievements.initial_ids or {}
+  return storage.lua_achievements
+end
+
+local function load_definitions(mod)
+  if mod.achievement_defs then return mod.achievement_defs end
+
+  local defs = gapi.get_achievement_definitions()
+  mod.achievement_defs = defs or {}
+  mod.achievement_defs_by_id = {}
+
+  for _, ach in ipairs(mod.achievement_defs) do
+    mod.achievement_defs_by_id[ach.id] = ach
+  end
+
+  return mod.achievement_defs
+end
+
+local function now_turn() return gapi.current_turn():to_turn() end
+
+local function evaluate_time_constraint(ach)
+  local time_constraint = ach.time_constraint
+  if not time_constraint then return completion_completed end
+
+  local comparison = time_constraint.comparison
+  local target_turn = time_constraint.target_turn or 0
+  local now = now_turn()
+
+  if comparison == "<=" then
+    if now <= target_turn then return completion_completed end
+    return completion_failed
+  end
+
+  if comparison == ">=" then
+    if now >= target_turn then return completion_completed end
+    return completion_pending
+  end
+
+  return completion_completed
+end
+
+local function evaluate_kill_constraints(ach)
+  local kill_requirements = ach.kill_requirements or {}
+  if #kill_requirements == 0 then return completion_completed end
+
+  local status = completion_completed
+  for _, req in ipairs(kill_requirements) do
+    local comparison = req.comparison
+    local target = req.count or 0
+    local kills = 0
+
+    if req.monster ~= nil and req.monster ~= "" then
+      kills = gapi.get_monster_kill_count(req.monster)
+    elseif req.species ~= nil and req.species ~= "" then
+      kills = gapi.get_species_kill_count(req.species)
+    else
+      kills = gapi.get_total_monster_kill_count()
+    end
+
+    local ok = compare_value(comparison, target, kills)
+    if not ok then
+      if comparison == ">=" then
+        status = completion_pending
+      elseif comparison == "<=" then
+        return completion_failed
+      end
+    end
+  end
+
+  return status
+end
+
+local function evaluate_skill_constraints(ach)
+  local skill_requirements = ach.skill_requirements or {}
+  if #skill_requirements == 0 then return completion_completed end
+
+  local status = completion_completed
+  for _, req in ipairs(skill_requirements) do
+    local comparison = req.comparison
+    local target = req.level or 0
+    local level = gapi.get_avatar_skill_level(req.skill or "")
+    local ok = compare_value(comparison, target, level)
+    if not ok then
+      if comparison == ">=" then
+        status = completion_pending
+      elseif comparison == "<=" then
+        return completion_failed
+      end
+    end
+  end
+
+  return status
+end
+
+local function evaluate_requirements(ach)
+  local requirements = ach.requirements or {}
+  local all_satisfied = true
+  local became_false = false
+
+  for _, req in ipairs(requirements) do
+    local current = gapi.get_event_statistic(req.event_statistic or "")
+    local comparison = req.comparison
+    local target = req.target or 0
+    local ok = compare_value(comparison, target, current)
+    if not ok then
+      all_satisfied = false
+      if req.becomes_false then became_false = true end
+    end
+  end
+
+  return all_satisfied, became_false
+end
+
+local function ensure_achievement_state(root, id)
+  local state = root.states[id]
+  if state then return state end
+
+  state = {
+    completion = completion_pending,
+    last_state_change_turn = now_turn(),
+  }
+  root.states[id] = state
+  return state
+end
+
+local function mark_state(state, completion)
+  state.completion = completion
+  state.last_state_change_turn = now_turn()
+end
+
+local function evaluate_single(mod, root, ach)
+  local state = ensure_achievement_state(root, ach.id)
+  if state.completion ~= completion_pending then return end
+
+  local all_requirements_satisfied, requirement_failed = evaluate_requirements(ach)
+  local time_state = evaluate_time_constraint(ach)
+  local kill_state = evaluate_kill_constraints(ach)
+  local skill_state = evaluate_skill_constraints(ach)
+
+  local all_clear = all_requirements_satisfied
+    and time_state == completion_completed
+    and kill_state == completion_completed
+    and skill_state == completion_completed
+
+  if all_clear then
+    mark_state(state, completion_completed)
+    gapi.add_msg(MsgType.good, string.format(locale.gettext('You completed the achievement "%s".'), ach.name))
+    return
+  end
+
+  if
+    time_state == completion_failed
+    or kill_state == completion_failed
+    or skill_state == completion_failed
+    or requirement_failed
+  then
+    mark_state(state, completion_failed)
+  end
+end
+
+local function snapshot_initial_ids(mod, root)
+  if next(root.initial_ids) ~= nil then return end
+
+  load_definitions(mod)
+  for _, ach in ipairs(mod.achievement_defs) do
+    root.initial_ids[ach.id] = true
+  end
+end
+
+local function run_evaluation(mod)
+  local storage = mod.storage
+  if not storage then return end
+
+  local root = get_state_root(storage)
+  load_definitions(mod)
+  snapshot_initial_ids(mod, root)
+
+  for _, ach in ipairs(mod.achievement_defs) do
+    if root.initial_ids[ach.id] then evaluate_single(mod, root, ach) end
+  end
+end
+
+local function completion_rank(completion)
+  if completion == completion_pending then return 0 end
+  if completion == completion_completed then return 1 end
+  return 2
+end
+
+local function get_completion(mod, root, id)
+  local state = root.states[id]
+  if not state then return completion_pending end
+  return state.completion or completion_pending
+end
+
+local function is_hidden(mod, root, ach)
+  if get_completion(mod, root, ach.id) == completion_completed then return false end
+
+  local hidden_by = ach.hidden_by or {}
+  for _, blocker in ipairs(hidden_by) do
+    if get_completion(mod, root, blocker) ~= completion_completed then return true end
+  end
+  return false
+end
+
+local function status_prefix(completion)
+  if completion == completion_completed then return "[completed]" end
+  if completion == completion_failed then return "[failed]" end
+  return "[pending]"
+end
+
+local function sorted_visible_achievements(mod, root)
+  local out = {}
+  for _, ach in ipairs(mod.achievement_defs or {}) do
+    if root.initial_ids[ach.id] and not is_hidden(mod, root, ach) then table.insert(out, ach) end
+  end
+
+  table.sort(out, function(a, b)
+    local ac = get_completion(mod, root, a.id)
+    local bc = get_completion(mod, root, b.id)
+    local ar = completion_rank(ac)
+    local br = completion_rank(bc)
+    if ar ~= br then return ar < br end
+    return (a.name or "") < (b.name or "")
+  end)
+
+  return out
+end
+
+function achievements.get_ui_text(mod)
+  local storage = mod.storage
+  if not storage then return locale.gettext("This game has no valid achievements.\n") end
+
+  local root = get_state_root(storage)
+  load_definitions(mod)
+  snapshot_initial_ids(mod, root)
+
+  local lines = {}
+  local visible = sorted_visible_achievements(mod, root)
+  if #visible == 0 then
+    table.insert(lines, locale.gettext("This game has no valid achievements."))
+  else
+    for _, ach in ipairs(visible) do
+      local completion = get_completion(mod, root, ach.id)
+      local header = string.format("%s %s", status_prefix(completion), ach.name or ach.id)
+      table.insert(lines, header)
+      if ach.description and ach.description ~= "" then table.insert(lines, string.format("  %s", ach.description)) end
+    end
+  end
+
+  table.insert(
+    lines,
+    locale.gettext(
+      "Note that only achievements that existed when you started this game and still exist now will appear here."
+    )
+  )
+  return table.concat(lines, "\n")
+end
+
+function achievements.register(mod)
+  mod.on_achievements_game_started = function() run_evaluation(mod) end
+
+  mod.on_achievements_game_load = function() run_evaluation(mod) end
+
+  mod.on_achievements_mon_death = function() run_evaluation(mod) end
+
+  mod.on_achievements_tick = function() run_evaluation(mod) end
+end
+
+return achievements

--- a/data/json/main.lua
+++ b/data/json/main.lua
@@ -6,6 +6,7 @@ local item_var_viewer = require("lua/iuse/item_var_viewer")
 local lua_traits = require("lua/traits/lua_traits")
 local lab = require("lua/mapgen/lab")
 local cooking = require("lua/cooking")
+local achievements = require("lua/achievements")
 
 local mod = game.mod_runtime[game.current_mod]
 local storage = game.mod_storage[game.current_mod]
@@ -17,5 +18,9 @@ mod.artifact_analyzer = artifact_analyzer
 mod.item_var_viewer = item_var_viewer
 sonar.register(mod)
 mod.lua_traits = lua_traits
+mod.achievements = achievements
 lua_traits.register(mod)
 mod.cooking = cooking
+achievements.register(mod)
+
+game.cata_internal.get_lua_achievements_text = function() return achievements.get_ui_text(mod) end

--- a/data/json/preload.lua
+++ b/data/json/preload.lua
@@ -21,6 +21,11 @@ end)
 
 game.add_hook("on_character_try_move", function(...) return mod.on_character_try_move(...) end)
 game.add_hook("on_craft_result", function(...) return mod.cooking.on_craft_result(...) end)
+game.add_hook("on_game_started", function(...) return mod.on_achievements_game_started(...) end)
+game.add_hook("on_game_load", function(...) return mod.on_achievements_game_load(...) end)
+game.add_hook("on_mon_death", function(...) return mod.on_achievements_mon_death(...) end)
+
+gapi.add_on_every_x_hook(TimeDuration.from_turns(1), function(...) return mod.on_achievements_tick(...) end)
 
 -- Mapgen
 game.mapgen_functions["slimepit"] = function(...) return mod.slimepit.draw(...) end

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -46,6 +46,34 @@ std::string get_lapi_version_string()
     return string_format( "%d", get_lua_api_version() );
 }
 
+std::string get_lua_achievements_text()
+{
+    const auto fallback = std::string( "This game has no valid achievements.\n" );
+    lua_state *state_ptr = DynamicDataLoader::get_instance().lua.get();
+    if( !state_ptr ) {
+        return fallback;
+    }
+
+    sol::state &lua = state_ptr->lua;
+    const auto maybe_fn = lua.globals()["game"]["cata_internal"]["get_lua_achievements_text"]
+                          .get<sol::optional<sol::protected_function>>();
+    if( !maybe_fn ) {
+        return fallback;
+    }
+
+    try {
+        sol::protected_function_result res = ( *maybe_fn )();
+        check_func_result( res );
+        if( res.valid() && res.get_type() == sol::type::string ) {
+            return res.get<std::string>();
+        }
+    } catch( const std::runtime_error &e ) {
+        debugmsg( "Failed to get Lua achievements text: %s", e.what() );
+    }
+
+    return fallback;
+}
+
 void startup_lua_test()
 {
     sol::state lua = make_lua_state();

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -23,6 +23,7 @@ struct lua_state_deleter {
 bool has_lua();
 int get_lua_api_version();
 std::string get_lapi_version_string();
+std::string get_lua_achievements_text();
 void startup_lua_test();
 auto generate_lua_docs( const std::filesystem::path &script_path,
                         const std::filesystem::path &to ) -> bool;

--- a/src/catalua_bindings_game.cpp
+++ b/src/catalua_bindings_game.cpp
@@ -11,8 +11,13 @@
 #include <vector>
 
 #include "avatar.h"
+#include "achievement.h"
+#include "calendar.h"
+#include "cata_variant.h"
 #include "distribution_grid.h"
+#include "event_statistics.h"
 #include "game.h"
+#include "kill_tracker.h"
 #include "lightmap.h"
 #include "map.h"
 #include "catalua_log.h"
@@ -22,6 +27,8 @@
 #include "overmapbuffer.h"
 #include "line.h"
 #include "lua_action_menu.h"
+#include "skill.h"
+#include "stats_tracker.h"
 
 namespace
 {
@@ -126,6 +133,134 @@ void cata::detail::reg_game_api( sol::state &lua )
                        );
             out[idx + 1] = row;
         } );
+        return out;
+    } );
+    luna::set_fx( lib, "get_event_statistic", []( const std::string & stat_id ) -> int {
+        const auto stat = string_id<event_statistic>( stat_id );
+        if( !stat.is_valid() )
+        {
+            return 0;
+        }
+        const auto value = g->stats().value_of( stat );
+        if( value.type() != cata_variant_type::int_ )
+        {
+            return 0;
+        }
+        return value.get<int>();
+    } );
+    luna::set_fx( lib, "get_avatar_skill_level", []( const std::string & skill_str ) -> int {
+        const auto sid = skill_id( skill_str );
+        if( !sid.is_valid() )
+        {
+            return 0;
+        }
+        return get_avatar().get_skill_level( sid );
+    } );
+    luna::set_fx( lib, "get_monster_kill_count", []( const std::string & monster_str ) -> int {
+        const auto mid = mtype_id( monster_str );
+        if( !mid.is_valid() )
+        {
+            return 0;
+        }
+        return g->get_kill_tracker().kill_count( mid );
+    } );
+    luna::set_fx( lib, "get_species_kill_count", []( const std::string & species_str ) -> int {
+        const auto sid = species_id( species_str );
+        if( !sid.is_valid() )
+        {
+            return 0;
+        }
+        return g->get_kill_tracker().kill_count( sid );
+    } );
+    luna::set_fx( lib, "get_total_monster_kill_count", []() -> int {
+        return g->get_kill_tracker().monster_kill_count();
+    } );
+    luna::set_fx( lib, "get_achievement_definitions", []( sol::this_state lua_this ) {
+        const auto comparison_to_string = []( const achievement_comparison comp ) -> std::string {
+            switch( comp )
+            {
+                case achievement_comparison::less_equal:
+                    return "<=";
+                case achievement_comparison::greater_equal:
+                    return ">=";
+                case achievement_comparison::anything:
+                    return "anything";
+                case achievement_comparison::last:
+                    break;
+            }
+            return "anything";
+        };
+
+        sol::state_view lua( lua_this );
+        auto out = lua.create_table();
+        auto out_idx = 1;
+
+        for( const achievement &ach : achievement::get_all() ) {
+            auto row = lua.create_table();
+            row["id"] = ach.id.str();
+            row["name"] = ach.name().translated();
+            row["description"] = ach.description().translated();
+
+            auto hidden_by = lua.create_table();
+            auto hidden_idx = 1;
+            for( const string_id<achievement> &hidden : ach.hidden_by() ) {
+                hidden_by[hidden_idx++] = hidden.str();
+            }
+            row["hidden_by"] = hidden_by;
+
+            if( ach.time_constraint() ) {
+                auto time_row = lua.create_table();
+                time_row["comparison"] = comparison_to_string( ach.time_constraint()->comparison() );
+                time_row["target_turn"] = to_turn<int>( ach.time_constraint()->target() );
+                row["time_constraint"] = time_row;
+            }
+
+            auto requirements = lua.create_table();
+            auto req_idx = 1;
+            for( const achievement_requirement &req : ach.requirements() ) {
+                auto req_row = lua.create_table();
+                req_row["event_statistic"] = req.statistic.str();
+                req_row["comparison"] = comparison_to_string( req.comparison );
+                req_row["becomes_false"] = req.becomes_false;
+                if( req.comparison != achievement_comparison::anything ) {
+                    req_row["target"] = req.target;
+                }
+                requirements[req_idx++] = req_row;
+            }
+            row["requirements"] = requirements;
+
+            auto kill_requirements = lua.create_table();
+            auto kill_idx = 1;
+            for( const auto &[mid, pair] : ach.kill_requirements() ) {
+                auto kill_row = lua.create_table();
+                kill_row["monster"] = mid.is_null() ? std::string() : mid.str();
+                kill_row["comparison"] = comparison_to_string( pair.first );
+                kill_row["count"] = pair.second;
+                kill_requirements[kill_idx++] = kill_row;
+            }
+            for( const auto &[sid, pair] : ach.species_kill_requirements() ) {
+                auto kill_row = lua.create_table();
+                kill_row["species"] = sid.str();
+                kill_row["comparison"] = comparison_to_string( pair.first );
+                kill_row["count"] = pair.second;
+                kill_requirements[kill_idx++] = kill_row;
+            }
+            row["kill_requirements"] = kill_requirements;
+
+            auto skill_requirements = lua.create_table();
+            auto skill_idx = 1;
+            for( const auto &[sid, pair] : ach.skill_requirements() ) {
+                auto skill_row = lua.create_table();
+                skill_row["skill"] = sid.str();
+                skill_row["comparison"] = comparison_to_string( pair.first );
+                skill_row["level"] = pair.second;
+                skill_requirements[skill_idx++] = skill_row;
+            }
+            row["skill_requirements"] = skill_requirements;
+
+            out[out_idx++] = row;
+        }
+
         return out;
     } );
     luna::set_fx( lib, "add_on_every_x_hook",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -427,7 +427,6 @@ game::game() :
     events().subscribe( &*kill_tracker_ptr );
     events().subscribe( &*stats_tracker_ptr );
     events().subscribe( &*memorial_logger_ptr );
-    events().subscribe( &*achievements_tracker_ptr );
     events().subscribe( &*spell_events_ptr );
     world_generator = std::make_unique<worldfactory>();
     // do nothing, everything that was in here is moved to init_data() which is called immediately after g = new game; in main.cpp

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -146,7 +146,6 @@ void game::serialize( std::ostream &fout )
     // save stats.
     json.member( "kill_tracker", *kill_tracker_ptr );
     json.member( "stats_tracker", *stats_tracker_ptr );
-    json.member( "achievements_tracker", *achievements_tracker_ptr );
 
     json.member( "token_provider", *token_provider_ptr );
 
@@ -371,7 +370,6 @@ auto game::unserialize( std::istream &fin ) -> bool
         data.read( "player", u );
         inp_mngr.pump_events();
         data.read( "stats_tracker", *stats_tracker_ptr );
-        data.read( "achievements_tracker", *achievements_tracker_ptr );
         data.read( "token_provider", token_provider_ptr );
         inp_mngr.pump_events();
         Messages::deserialize( data );

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "achievement.h"
+#include "catalua.h"
 #include "color.h"
 #include "cursesdef.h"
 #include "event_statistics.h"
@@ -23,32 +24,8 @@
 
 static std::string get_achievements_text( const achievements_tracker &achievements )
 {
-    std::string os;
-    std::vector<const achievement *> valid_achievements = achievements.valid_achievements();
-    valid_achievements.erase(
-        std::remove_if( valid_achievements.begin(), valid_achievements.end(),
-    [&]( const achievement * a ) {
-        return achievements.is_hidden( a );
-    } ), valid_achievements.end() );
-    using sortable_achievement =
-        std::tuple<achievement_completion, std::string, const achievement *>;
-    std::vector<sortable_achievement> sortable_achievements;
-    std::transform( valid_achievements.begin(), valid_achievements.end(),
-                    std::back_inserter( sortable_achievements ),
-    [&]( const achievement * ach ) {
-        achievement_completion comp = achievements.is_completed( ach->id );
-        return std::make_tuple( comp, ach->name().translated(), ach );
-    } );
-    std::sort( sortable_achievements.begin(), sortable_achievements.end(), localized_compare );
-    for( const sortable_achievement &ach : sortable_achievements ) {
-        os += achievements.ui_text_for( std::get<const achievement *>( ach ) ) + "\n";
-    }
-    if( valid_achievements.empty() ) {
-        os += _( "This game has no valid achievements.\n" );
-    }
-    os += _( "Note that only achievements that existed when you started this game and still "
-             "exist now will appear here." );
-    return os;
+    ( void )achievements;
+    return cata::get_lua_achievements_text();
 }
 
 static std::string get_scores_text( stats_tracker &stats )

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -1087,3 +1087,130 @@ TEST_CASE( "lua_hooks_exit_early", "[lua]" )
     CHECK( results_tbl.get<bool>( "allowed" ) == false );
     CHECK( log_tbl.get<sol::optional<std::string>>( 2 ) == sol::nullopt );
 }
+
+TEST_CASE( "lua_achievements_runtime", "[lua][achievements]" )
+{
+    sol::state lua = make_lua_state();
+
+    auto stat_value = 0;
+    auto message_count = 0;
+    auto fake_turn = 0;
+
+    lua.script( R"(
+        MsgType = { good = 1, bad = 2 }
+        locale = { gettext = function( s ) return s end }
+
+        local function mk_td( v )
+          return setmetatable( { v = v }, {
+            __index = {
+              to_turns = function( self ) return self.v end
+            }
+          } )
+        end
+
+        TimeDuration = {
+          from_turns = function( v ) return mk_td( v ) end,
+          from_minutes = function( v ) return mk_td( v * 60 ) end,
+          from_hours = function( v ) return mk_td( v * 3600 ) end
+        }
+    )" );
+
+    sol::table gapi = lua.create_table();
+    gapi.set_function( "get_event_statistic", [&]( const std::string & ) {
+        return stat_value;
+    } );
+    gapi.set_function( "get_avatar_skill_level", []( const std::string & ) {
+        return 0;
+    } );
+    gapi.set_function( "get_monster_kill_count", []( const std::string & ) {
+        return 0;
+    } );
+    gapi.set_function( "get_species_kill_count", []( const std::string & ) {
+        return 0;
+    } );
+    gapi.set_function( "get_total_monster_kill_count", []() {
+        return 0;
+    } );
+    gapi.set_function( "current_turn", [&]( sol::this_state ts ) {
+        sol::state_view l( ts );
+        sol::table turn = l.create_table();
+        turn.set_function( "to_turn", [&]() {
+            return fake_turn;
+        } );
+        return turn;
+    } );
+    gapi.set_function( "add_msg", [&]( int, const std::string & ) {
+        ++message_count;
+    } );
+    gapi.set_function( "rng", []( int from, int ) {
+        return from;
+    } );
+
+    gapi.set_function( "get_achievement_definitions", [&]( sol::this_state ts ) {
+        sol::state_view l( ts );
+        sol::table out = l.create_table();
+        sol::table ach = l.create_table();
+        ach["id"] = "achievement_test";
+        ach["name"] = "Test Achievement";
+        ach["description"] = "";
+        ach["hidden_by"] = l.create_table();
+
+        sol::table requirements = l.create_table();
+        sol::table req = l.create_table();
+        req["event_statistic"] = "test_stat";
+        req["comparison"] = ">=";
+        req["target"] = 1;
+        req["becomes_false"] = false;
+        requirements[1] = req;
+        ach["requirements"] = requirements;
+        ach["kill_requirements"] = l.create_table();
+        ach["skill_requirements"] = l.create_table();
+        out[1] = ach;
+        return out;
+    } );
+
+    lua.globals()["gapi"] = gapi;
+
+    const auto load_res = lua.load_file( "data/json/lua/achievements.lua" );
+    REQUIRE( load_res.valid() );
+    sol::protected_function achievements_loader = load_res;
+    sol::protected_function_result achievements_result = achievements_loader();
+    REQUIRE( achievements_result.valid() );
+    sol::table achievements = achievements_result;
+    lua.globals()["achievements"] = achievements;
+
+    sol::table mod = lua.create_table();
+    mod["storage"] = lua.create_table();
+    lua.globals()["mod"] = mod;
+
+    sol::protected_function register_fn = achievements["register"];
+    REQUIRE( register_fn.valid() );
+    sol::protected_function_result register_res = register_fn( mod );
+    REQUIRE( register_res.valid() );
+
+    sol::protected_function on_game_started = lua["mod"]["on_achievements_game_started"];
+    sol::protected_function on_tick = lua["mod"]["on_achievements_tick"];
+    REQUIRE( on_game_started.valid() );
+    REQUIRE( on_tick.valid() );
+
+    on_game_started();
+
+    sol::table state_tbl = lua["mod"]["storage"]["lua_achievements"]["states"]["achievement_test"];
+    REQUIRE( state_tbl.valid() );
+    CHECK( state_tbl.get<std::string>( "completion" ) == "pending" );
+    CHECK( message_count == 0 );
+
+    stat_value = 1;
+    fake_turn = 10;
+    on_tick();
+
+    CHECK( state_tbl.get<std::string>( "completion" ) == "completed" );
+    CHECK( message_count == 1 );
+
+    sol::protected_function get_ui_text = lua["achievements"]["get_ui_text"];
+    REQUIRE( get_ui_text.valid() );
+    sol::protected_function_result ui_res = get_ui_text( lua["mod"] );
+    REQUIRE( ui_res.valid() );
+    const std::string ui_text = ui_res.get<std::string>();
+    CHECK( ui_text.find( "[completed] Test Achievement" ) != std::string::npos );
+}


### PR DESCRIPTION
## Purpose of change (The Why)
- Continue Lua migration by moving achievements runtime evaluation and UI text generation out of C++ tracker flow.

## Describe the solution (The How)
- Added `data/json/achievements.lua` runtime, wired through `data/json/preload.lua` and `data/json/main.lua`.
- Added Lua-facing game APIs for achievement/stat/skill/kill queries in `src/catalua_bindings_game.cpp` and Lua UI text bridge in `src/catalua.cpp`/`src/catalua.h`.
- Redirected achievements tab rendering to Lua text in `src/scores_ui.cpp`; removed C++ tracker event subscription/save serialization usage in `src/game.cpp` and `src/savegame.cpp`.
- Added `lua_achievements_runtime` coverage in `tests/catalua_test.cpp`.

## Describe alternatives you've considered
- Keeping the C++ tracker as the runtime authority and only mirroring to Lua; rejected to satisfy full Lua runtime migration goal.

## Testing
- `cmake --build build --target astyle`
- `cmake --build build --target style-json-parallel`
- `deno task dprint fmt`
- `cmake --preset linux-full`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "lua_achievements_runtime"`
- `./out/build/linux-full/tests/cata_test-tiles "achievements_tracker"`
- `./out/build/linux-full/src/cataclysm-bn-tiles --check-mods` (fails due local external user mods unrelated to this PR)

## Additional context
- No related issue linked.

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
  - [x] I have committed the output of `deno task docs:gen` so the Lua API documentation is updated.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [190f1d8](https://github.com/cataclysmbn/Cataclysm-BN/commit/190f1d89ecc2eaef9499e0ed60665d4de3114f3c) (feat(lua): migrate achievements runtime to Lua) on 2026-05-29 00:16:14

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26607809365/artifacts/7279801354)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26607809365/artifacts/7280156114)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26607809365/artifacts/7279791627)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26607809365/artifacts/7279745608)
<!-- END artifact comment -->