### PR TITLE
feat(mods/MagicalNights): reduce `Bless` recast frequency

### DIFF
--- a/data/mods/MagicalNights/Spells/animist.json
+++ b/data/mods/MagicalNights/Spells/animist.json
@@ -13,7 +13,7 @@
     "base_casting_time": 400,
     "casting_time_increment": -10,
     "final_casting_time": 250,
-    "base_energy_cost": 100,
+    "base_energy_cost": 1000,
     "energy_source": "MANA",
     "spell_class": "ANIMIST",
     "difficulty": 1,
@@ -22,9 +22,9 @@
     "max_range": 23,
     "range_increment": 1.5,
     "//": "duration is in moves, aka 100ths of a second",
-    "min_duration": 12000,
-    "max_duration": 36000,
-    "duration_increment": 800
+    "min_duration": 120000,
+    "max_duration": 360000,
+    "duration_increment": 8000
   },
   {
     "id": "holy_blade",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

2 mins timer is annoying to keep recasting when crafting or in combat compared to every other spell and its not even that op of a buff


<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

10x the cost, 10x the duration

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

20x or even 50x, less button press = more good

## Testing

Loaded into game just fine 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Number go up 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

