### PR TITLE
feat: Add item count based vehicle storage

### DIFF
--- a/data/json/mapgen/lumbermill.json
+++ b/data/json/mapgen/lumbermill.json
@@ -59,7 +59,7 @@
       "terrain": { "o": "t_concrete" },
       "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 10000, 50000 ] } },
       "place_vehicles": [
-        { "vehicle": "flatbed_truck", "x": [ 43, 45 ], "y": 33, "chance": 30, "fuel": 25, "status": 1, "rotation": 90 },
+        { "vehicle": "log_truck", "x": [ 43, 45 ], "y": 33, "chance": 30, "fuel": 25, "status": 1, "rotation": 90 },
         {
           "vehicle": "pickup",
           "x": [ 35, 37 ],

--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -744,5 +744,5 @@
     "damage_modifier": 80,
     "description": "A truckbed designed to hold very few very large objects, primarily used for logs before the cataclysm, perhaps you can find other uses for it.",
     "flags": [ "CARGO", "CARGO_BY_CHARGES" ]
-  },
+  }
 ]

--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -721,5 +721,28 @@
       { "item": "motor_tiny", "prob": 25 }
     ],
     "damage_reduction": { "all": 32 }
-  }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "logtruckbed",
+    "name": { "str": "log truck bed" },
+    "symbol": "H",
+    "looks_like": "cargo_space",
+    "color": "brown",
+    "broken_symbol": "#",
+    "broken_color": "brown",
+    "durability": 350,
+    "cargo_charges": 3,
+    "item": "frame",
+    "location": "center",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
+      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
+    },
+    "damage_reduction": { "all": 28 },
+    "damage_modifier": 80,
+    "description": "A truckbed designed to hold very few very large objects, primarily used for logs before the cataclysm, perhaps you can find other uses for it.",
+    "flags": [ "CARGO", "CARGO_BY_CHARGES" ]
+  },
 ]

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -43,6 +43,12 @@
     "info": "You can store items here."
   },
   {
+    "id": "CARGO_BY_CHARGES",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ],
+    "info": "You can store very few, but infinite volume items here."
+  },
+  {
     "id": "CTRL_ELECTRONIC",
     "type": "json_flag",
     "context": [ "vehicle_part" ],

--- a/data/json/vehicles/trucks.json
+++ b/data/json/vehicles/trucks.json
@@ -743,5 +743,34 @@
       { "x": -4, "y": 1, "chance": 10, "//": { "item": "cat_food", "container-item": "can_food" } },
       { "x": -4, "y": 0, "chance": 3, "items": [ "beartrap" ] }
     ]
+  },
+  {
+    "id": "log_truck",
+    "type": "vehicle",
+    "name": "Log Truck",
+    "blueprint": [
+      "-R-----^+'w",
+      "======='S'|",
+      "======='b'>",
+      "======='#'|",
+      "-R-----v+'W"
+    ],
+    "blueprint_origin": { "x": 8, "y": 1 },
+    "palette": {
+      "-": [ "frame_vertical", "halfboard_vertical" ],
+      "=": [ "frame_vertical", "logtruckbed" ],
+      "S": [ "frame_vertical_2", "seat", "seatbelt", "roof", "controls", "dashboard", "vehicle_alarm", "horn_car" ],
+      "R": [ "frame_vertical", "halfboard_vertical", "wheel_mount_medium", "wheel_wide" ],
+      "'": [ "frame_horizontal", "windshield" ],
+      "+": [ "frame_horizontal", "windshield" ],
+      "w": [ "frame_nw", "halfboard_nw", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ],
+      "W": [ "frame_ne", "halfboard_ne", "headlight", "wheel_mount_medium_steerable", "wheel_wide" ],
+      "b": [ "frame_vertical", "box", "roof" ],
+      "#": [ "frame_vertical_2", "seat", "seatbelt", "roof" ],
+      "^": [ "frame_sw", "board_sw", { "part": "tank", "fuel": "gasoline" } ],
+      "v": [ "frame_se", "board_se", { "part": "tank", "fuel": "gasoline" } ],
+      ">": [ "frame_cover", "halfboard_cover", "engine_v6", "alternator_truck", "battery_car" ],
+      "|": [ "frame_horizontal", "halfboard_horizontal" ]
+    }
   }
 ]

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -1633,6 +1633,7 @@ Those flags are added by the game code to specific items (that specific welder, 
 - `DOOR_LOCKING` This part is unopenable to non-faction NPCs and monsters if enabled from the electronics menu. Can only be
   installed on a part with `OPENABLE` flag.
 - `CARGO` Cargo holding area.
+- `CARGO_BY_CHARGES` Cargo holding area, uses charges instead of volume for limit; needs CARGO flag.
 - `CHIMES` Generates continuous noise when used.
 - `CIRCLE_LIGHT` Projects a circular radius of light when turned on.
 - `CONE_LIGHT` Projects a cone of light when turned on.

--- a/src/item_stack.cpp
+++ b/src/item_stack.cpp
@@ -89,6 +89,10 @@ units::volume item_stack::stored_volume() const
 
 int item_stack::amount_can_fit( const item &it ) const
 {
+    if( use_total_count() ) {
+        const int amt = get_total_free_count();
+        return std::min( amt, it.count() );
+    }
     // Without stacking charges, would we violate the count limit?
     const bool violates_count = size() >= static_cast<size_t>( count_limit() );
     const item *here = it.count_by_charges() ? stacks_with( it ) : nullptr;
@@ -137,4 +141,18 @@ void item_stack::remove_top_items_with( std::function < detached_ptr<item>
                                         ( detached_ptr<item> && ) > cb )
 {
     items->remove_with( std::move( cb ) );
+}
+
+int item_stack::get_total_stored_count() const
+{
+    int charges = 0;
+    for( item *&item : *items ) {
+        charges += item->count();
+    }
+    return charges;
+}
+
+int item_stack::get_total_free_count() const
+{
+    return total_count_limit() - get_total_stored_count();
 }

--- a/src/item_stack.h
+++ b/src/item_stack.h
@@ -54,6 +54,15 @@ class item_stack
         virtual int count_limit() const = 0;
         /** Maximum volume allowed here */
         virtual units::volume max_volume() const = 0;
+        /** Item Count */
+        virtual bool use_total_count() const {
+            return false;
+        }
+        virtual int total_count_limit() const {
+            return 0;
+        };
+        int get_total_stored_count() const;
+        int get_total_free_count() const;
         /** Total volume of the items here */
         units::volume stored_volume() const;
         units::volume free_volume() const;

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2540,10 +2540,14 @@ void veh_interact::display_stats() const
 
     units::volume total_cargo = 0_ml;
     units::volume free_cargo = 0_ml;
+    int total_items = 0;
+    int free_items = 0;
     for( const vpart_reference &vp : veh->get_any_parts( "CARGO" ) ) {
         const size_t p = vp.part_index();
         total_cargo += veh->max_volume( p );
         free_cargo += veh->free_volume( p );
+        total_items += veh->max_charges( p );
+        free_items += veh->free_charges( p );
     }
 
     const int second_column = 33 + ( extraw / 4 );
@@ -2668,6 +2672,9 @@ void veh_interact::display_stats() const
         _( "Cargo Volume: <color_light_blue>%s</color> / <color_light_blue>%s</color> %s" ),
         format_volume( total_cargo - free_cargo ),
         format_volume( total_cargo ), volume_units_abbr() );
+    print_stat(
+        _( "Cargo Charges: <color_light_blue>%s</color> / <color_light_blue>%s</color>" ),
+        total_items - free_items, total_items );
     // Write the overall damage
     mvwprintz( w_stats, point( x[i], y[i] ), c_light_gray, _( "Status:" ) );
     x[i] += utf8_width( _( "Status:" ) ) + 1;

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -425,6 +425,7 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
     assign( jo, "default_ammo", def.default_ammo );
     assign( jo, "folded_volume", def.folded_volume );
     assign( jo, "size", def.size );
+    assign( jo, "cargo_charges", def.cargo_charges );
     assign( jo, "difficulty", def.difficulty );
     assign( jo, "bonus", def.bonus );
     assign( jo, "cargo_weight_modifier", def.cargo_weight_modifier );

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -244,6 +244,9 @@ class vpart_info
         /** Cargo location volume */
         units::volume size = 0_ml;
 
+        /** Cargo location charge count */
+        int cargo_charges = 0;
+
         /** Mechanics skill required to install item */
         int difficulty = 0;
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -272,6 +272,19 @@ units::volume vehicle_stack::max_volume() const
     return 0_ml;
 }
 
+bool vehicle_stack::use_total_count() const
+{
+    return myorigin->part_flag( part_num, "CARGO_BY_CHARGES" );
+}
+int vehicle_stack::total_count_limit() const
+{
+    if( myorigin->part_flag( part_num, "CARGO_BY_CHARGES" ) &&
+        !myorigin->part( part_num ).is_broken() ) {
+        return myorigin->part( part_num ).info().cargo_charges;
+    }
+    return 0;
+}
+
 // Vehicle class methods.
 
 void vehicle::copy_static_from( const vehicle &source )
@@ -6077,6 +6090,21 @@ units::volume vehicle::max_volume( const int part ) const
 units::volume vehicle::free_volume( const int part ) const
 {
     return get_items( part ).free_volume();
+}
+
+int vehicle::stored_charges( const int part ) const
+{
+    return get_items( part ).get_total_stored_count();
+}
+
+int vehicle::max_charges( const int part ) const
+{
+    return get_items( part ).total_count_limit();
+}
+
+int vehicle::free_charges( const int part ) const
+{
+    return get_items( part ).get_total_free_count();
 }
 
 void vehicle::make_inactive( item &target )

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -134,6 +134,8 @@ class vehicle_stack : public item_stack
         int count_limit() const override {
             return MAX_ITEM_IN_VEHICLE_STORAGE;
         }
+        bool use_total_count() const override;
+        int total_count_limit() const override;
         units::volume max_volume() const override;
 };
 
@@ -1286,6 +1288,9 @@ class vehicle
         units::volume max_volume( int part ) const;
         units::volume free_volume( int part ) const;
         units::volume stored_volume( int part ) const;
+        int max_charges( int part ) const;
+        int free_charges( int part ) const;
+        int stored_charges( int part ) const;
 
         /**
          * Remove an item from active item processing queue as necessary

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -200,11 +200,18 @@ int vehicle::print_part_list( const catacurses::window &win, int y1, const int m
         }
 
         if( part_flag( pl[i], "CARGO" ) ) {
-            //~ used/total volume of a cargo vehicle part
-            partname += string_format( _( " (vol: %s/%s %s)" ),
-                                       format_volume( stored_volume( pl[i] ) ),
-                                       format_volume( max_volume( pl[i] ) ),
-                                       volume_units_abbr() );
+            if( part_flag( pl[i], "CARGO_BY_CHARGES" ) ) {
+                partname += string_format( _( " (items: %s/%s)" ),
+                                           stored_charges( pl[i] ),
+                                           max_charges( pl[i] ) );
+
+            } else {
+                //~ used/total volume of a cargo vehicle part
+                partname += string_format( _( " (vol: %s/%s %s)" ),
+                                           format_volume( stored_volume( pl[i] ) ),
+                                           format_volume( max_volume( pl[i] ) ),
+                                           volume_units_abbr() );
+            }
         }
 
         bool armor = part_flag( pl[i], "ARMOR" );


### PR DESCRIPTION
## Purpose of change (The Why)
> Some kind of cheap option that can load one single furniture or object regardless of volume would be nice

## Describe the solution (The How)
Add a new way for item stacks to count storage: total charges
This limits storage to a certain number of charges
While it could be implemented in furnture, currently only implemented in vehicle land

## Describe alternatives you've considered
Give up on balanced storage and give massive storage options because we want to be able to haul the one corpse
Let there be an total volume limit too?

## Testing
Log truck works as expected

## Additional context
I sadly did not ave a PR that reduced lines more then it added them today :(

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.