### PR TITLE
feat(mods): enforce strict semver versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
 endif ()
 
 include(CheckCXXCompilerFlag)
+include(FetchContent)
 
 #FIXME: Add dest build choice: m32 for 32 bit or m64 for 64 bit version
 #add_definitions("-m32")
@@ -153,6 +154,17 @@ if (NOT TARGET SQLite3::SQLite3 AND TARGET SQLite::SQLite3)
     add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
 endif ()
 find_package(ZLIB)
+
+set( SEMVER_OPT_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE )
+set( SEMVER_OPT_BUILD_TESTS OFF CACHE BOOL "" FORCE )
+set( SEMVER_OPT_INSTALL OFF CACHE BOOL "" FORCE )
+FetchContent_Declare(
+    neargye_semver
+    GIT_REPOSITORY https://github.com/Neargye/semver.git
+    GIT_TAG v0.3.1
+    GIT_PROGRESS TRUE )
+FetchContent_MakeAvailable( neargye_semver )
+
 if (NOT DYNAMIC_LINKING)
     if(NOT MSVC)
         set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.dll.a")

--- a/data/mods/CheesyInnaWoodsFixes/modinfo.json
+++ b/data/mods/CheesyInnaWoodsFixes/modinfo.json
@@ -5,7 +5,7 @@
     "name": "CheesyInnaWoodFixes",
     "authors": [ "CheeseAlmighty", "CleverRaven", "Light-Wave", "Sathra225" ],
     "description": "CheesyInnaWoodFixes ports CDDA innawoods content and makes industrial age possible.",
-    "version": "BN version, update 05/09/2024",
+    "version": "2024.5.9",
     "category": "items",
     "dependencies": [ "bn", "exotic_ammo" ]
   }

--- a/data/mods/JP_Weather_Variants/modinfo.json
+++ b/data/mods/JP_Weather_Variants/modinfo.json
@@ -8,7 +8,7 @@
     "category": "content",
     "dependencies": [ "bn" ],
     "lua_api_version": 2,
-    "version": "1",
+    "version": "1.0.0",
     "obsolete": false
   }
 ]

--- a/data/mods/change_hairstyle/modinfo.json
+++ b/data/mods/change_hairstyle/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Change Hairstyle",
     "authors": [ "jeremy7986" ],
     "description": "Hairdressing tools can now actually change your hairstyle! Change your hairstyle and your mood in the Cataclysm!",
-    "version": "<color_light_green>20260215</color>",
+    "version": "2026.2.15",
     "category": "misc_additions",
     "lua_api_version": 2,
     "dependencies": [ "bn" ]

--- a/data/mods/desert_region/modinfo.json
+++ b/data/mods/desert_region/modinfo.json
@@ -7,7 +7,7 @@
     "description": "A testbed/WIP mod to showcase regional_map_settings JSON changes.",
     "category": "content",
     "dependencies": [ "bn" ],
-    "version": "0.1",
+    "version": "0.1.0",
     "obsolete": false
   }
 ]

--- a/docs/en/mod/json/reference/mod_info.md
+++ b/docs/en/mod/json/reference/mod_info.md
@@ -35,10 +35,14 @@ Example:
     // Supported image extensions are .png, .jpg, .jpeg, .bmp, .gif, and .webp.
     // The author credit is taken from the image filename before the first underscore, e.g. "foo_rest.png" displays "by foo" in white text with a black outline.
     "loading_images": ["load_1.png", "load_2.png", "some_directory"],
-    // Mod version string. This is for users' and maintainers' convenience, so you can use whatever is most convenient here (e.g. date).
-    "version": "2021-12-02",
+    // Mod version string. Use strict semantic versioning: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD].
+    "version": "1.2.3",
     // List of mod's dependencies. Dependencies are guaranteed to be loaded before the mod is loaded.
-    "dependencies": ["bn", "zed_templates"],
+    // You can also use a project.json-style object when you want to annotate exact dependency versions.
+    "dependencies": {
+      "bn": "0.7.0",
+      "zed_templates": "1.2.3"
+    },
     // List of mods that are incompatible with this mod.
     "conflicts": ["worse_zeds"],
     // Special flag for core game data, can only be used by total overhaul mods. Only 1 core mod can be loaded at a time.

--- a/docs/en/mod/json/tutorial/modding.md
+++ b/docs/en/mod/json/tutorial/modding.md
@@ -39,6 +39,7 @@ this:
     "authors": ["Your name here", "Your friend's name if you want"],
     "description": "Your description here",
     "category": "content",
+    "version": "1.0.0",
     "dependencies": ["bn"]
   }
 ]
@@ -68,7 +69,9 @@ document was written. Pick whichever one applies best to your mod when writing y
 The `dependencies` attribute is used to tell Cataclysm that your mod is dependent on something
 present in another mod. If you have no dependencies outside of the core game, then just including
 `bn` in the list is good enough. If your mod depends on another one to work properly, adding that
-mod's `id` attribute to the array causes Cataclysm to force that mod to load before yours.
+mod's `id` attribute to the array causes Cataclysm to force that mod to load before yours. Exact
+version metadata can also be written with a project.json-style object such as
+`{"bn": "0.7.0", "other_mod": "1.2.3"}`.
 
 For more details on `MOD_INFO` object, see [JSON_INFO.md](./../reference/mod_info).
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ function(setup_common_target_properties target_name)
     # Add common libraries
     target_link_libraries(${target_name} PUBLIC ZLIB::ZLIB)
     target_link_libraries(${target_name} PUBLIC SQLite3::SQLite3)
+    target_link_libraries(${target_name} PUBLIC semver::semver)
 
     # Setup threading
     if (CMAKE_USE_PTHREADS_INIT)

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -7,6 +7,8 @@
 #include <queue>
 #include <utility>
 
+#include <semver.hpp>
+
 #include "assign.h"
 #include "cata_utility.h"
 #include "debug.h"
@@ -21,6 +23,55 @@
 #include "worldfactory.h"
 
 static const std::string MOD_SEARCH_FILE( "modinfo.json" );
+
+namespace
+{
+
+auto is_valid_mod_semver( const std::string &version ) -> bool
+{
+    return semver::valid( version );
+}
+
+auto warn_on_non_semver_version( const JsonObject &jo, const std::string &version ) -> void
+{
+    if( version.empty() || is_valid_mod_semver( version ) ) {
+        return;
+    }
+
+    report_strict_violation(
+        jo,
+        string_format(
+            "mod version must use strict semantic versioning (MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]); got \"%s\"",
+            version ),
+        "version" );
+}
+
+auto read_mod_dependencies( const JsonObject &jo ) -> std::vector<mod_id>
+{
+    auto dependencies = std::vector<mod_id> {};
+
+    if( jo.has_array( "dependencies" ) ) {
+        assign( jo, "dependencies", dependencies );
+        return dependencies;
+    }
+
+    if( !jo.has_object( "dependencies" ) ) {
+        return dependencies;
+    }
+
+    for( const JsonMember &member : jo.get_object( "dependencies" ) ) {
+        if( member.is_comment() ) {
+            continue;
+        }
+
+        static_cast<void>( member.get_string() );
+        dependencies.emplace_back( member.name() );
+    }
+
+    return dependencies;
+}
+
+} // namespace
 
 template<>
 const MOD_INFORMATION &string_id<MOD_INFORMATION>::obj() const
@@ -292,8 +343,9 @@ std::optional<MOD_INFORMATION> load_modfile( const JsonObject &jo, const std::st
     assign( jo, "maintainers", modfile.maintainers );
     assign( jo, "loading_images", modfile.loading_images );
     assign( jo, "version", modfile.version );
+    warn_on_non_semver_version( jo, modfile.version );
     assign( jo, "lua_api_version", modfile.lua_api_version );
-    assign( jo, "dependencies", modfile.dependencies );
+    modfile.dependencies = read_mod_dependencies( jo );
     assign( jo, "conflicts", modfile.conflicts );
     assign( jo, "core", modfile.core );
     assign( jo, "obsolete", modfile.obsolete );

--- a/tests/mod_manager_test.cpp
+++ b/tests/mod_manager_test.cpp
@@ -1,0 +1,115 @@
+#include "catch/catch.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <semver.hpp>
+
+#include "filesystem.h"
+#include "fstream_utils.h"
+#include "json.h"
+#include "mod_manager.h"
+
+namespace
+{
+
+struct mod_version_entry {
+    std::string path;
+    std::string id;
+    std::string version;
+};
+
+auto load_single_modfile( const std::string &json ) -> std::optional<MOD_INFORMATION>
+{
+    auto stream = std::istringstream( json );
+    auto jsin = JsonIn( stream, "mod_manager_test" );
+    auto jo = jsin.get_object();
+    auto result = mod_management::load_modfile( jo, "data/mods/test_mod" );
+    jo.finish();
+    return result;
+}
+
+auto collect_mod_versions_from_file( const std::string &path ) -> std::vector<mod_version_entry>
+{
+    auto versions = std::vector<mod_version_entry> {};
+
+    read_from_file_json( path, [&]( JsonIn & jsin ) {
+        const auto append_mod_version = [&]( const JsonObject & jo ) {
+            jo.allow_omitted_members();
+
+            if( !jo.has_string( "type" ) || jo.get_string( "type" ) != "MOD_INFO" ||
+                !jo.has_string( "version" ) ) {
+                return;
+            }
+
+            const auto id = jo.has_string( "id" ) ? jo.get_string( "id" ) : jo.get_string( "ident" );
+
+            versions.push_back( mod_version_entry{
+                .path = path,
+                .id = id,
+                .version = jo.get_string( "version" ),
+            } );
+        };
+
+        if( jsin.test_object() ) {
+            auto jo = jsin.get_object();
+            append_mod_version( jo );
+            return;
+        }
+
+        auto entries = jsin.get_array();
+        while( entries.has_more() ) {
+            auto jo = entries.next_object();
+            append_mod_version( jo );
+        }
+    }, true );
+
+    return versions;
+}
+
+} // namespace
+
+TEST_CASE( "load_modfile accepts project-style dependency maps", "[mod_manager]" )
+{
+    const auto mod = load_single_modfile( R"JSON(
+        {
+          "type": "MOD_INFO",
+          "id": "dependency_map_test",
+          "name": "Dependency Map Test",
+          "description": "Tests dependency maps.",
+          "version": "1.2.3",
+          "dependencies": {
+            "bn": "0.7.0",
+            "aftershock": "1.0.0"
+          }
+        }
+    )JSON" );
+
+    REQUIRE( mod );
+
+    auto dependency_ids = std::vector<std::string> {};
+    for( const auto &dependency : mod->dependencies ) {
+        dependency_ids.emplace_back( dependency.str() );
+    }
+    std::ranges::sort( dependency_ids );
+
+    CHECK( dependency_ids == std::vector<std::string> { "aftershock", "bn" } );
+}
+
+TEST_CASE( "bundled mods use strict semantic versions", "[mod_manager]" )
+{
+    auto bundled_versions = std::vector<mod_version_entry> {};
+    for( const auto &path : get_files_from_path( "modinfo.json", "data/mods", true ) ) {
+        auto versions = collect_mod_versions_from_file( path );
+        bundled_versions.insert( bundled_versions.end(), versions.begin(), versions.end() );
+    }
+
+    for( const auto &entry : bundled_versions ) {
+        CAPTURE( entry.path );
+        CAPTURE( entry.id );
+        CAPTURE( entry.version );
+        CHECK( semver::valid( entry.version ) );
+    }
+}


### PR DESCRIPTION
## Purpose of change (The Why)

Make bundled mod metadata machine-readable so mod tooling can rely on strict semver and authors can attach exact dependency versions without breaking load order parsing.

## Describe the solution (The How)

- fetch `Neargye/semver` through CMake and validate `MOD_INFO.version` against strict semver
- warn on non-semver mod versions, accept project.json-style dependency maps, and migrate bundled non-semver mods
- update modding docs to show the strict semver requirement and dependency object form

## Testing

- `cmake --preset linux-full`
- `cmake --build --preset linux-full --target astyle style-json-parallel cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[mod_manager]"`
- `./build-scripts/lint-json.sh`
- `./out/build/linux-full/src/cataclysm-bn-tiles --check-mods` (timed out locally after 5 minutes)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
  - [x] If applicable, add checks on game load that would validate the loaded data.

<sup>PR opened by gpt-5.4 high on opencode</sup>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [26575e1](https://github.com/cataclysmbn/Cataclysm-BN/commit/26575e123af6f7f4bf2a41231107b72d8d87d1c6) (feat(mods): enforce strict semver versions) on 2026-05-28 19:15:13

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589860520)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589860520/artifacts/7273393431)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589860520/artifacts/7273477105)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589860520)
<!-- END artifact comment -->