### PR TITLE
feat(lua): Thread-Safe Hook Infrastructure

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -17,6 +17,8 @@ constexpr int LUA_API_VERSION = 2;
 #include "bionics.h"
 #include "catalua_console.h"
 #include "catalua_hooks.h"
+#include "catalua_threaded_hooks.h"
+#include "catalua_worker.h"
 #include "catalua_impl.h"
 #include "catalua_icallback_actor.h"
 #include "catalua_readonly.h"
@@ -112,9 +114,13 @@ void reload_lua_code()
         debugmsg( "%s", e.what() );
     }
     clear_mod_being_loaded( state );
-    // Refresh the cached flag so worker threads immediately see any change to
-    // on_mapgen_postprocess hook registration caused by the reload.
+    // Refresh cached flags so worker threads immediately see any change to hook
+    // registrations caused by the reload.
+    // Threaded presence must be refreshed first — the combined g_has_mapgen_hooks
+    // flag reads the threaded result.
+    cata::refresh_threaded_mapgen_hook_presence();
     refresh_mapgen_postprocess_hook_presence( state );
+    cata::invalidate_worker_states();
 }
 
 void debug_write_lua_backtrace( std::ostream &out )
@@ -258,6 +264,7 @@ void init_global_state_tables( lua_state &state, const std::vector<mod_id> &modl
 
     // hooks
     cata::define_hooks( state );
+    cata::define_threaded_hooks( state );
 
     gt["add_hook"] = [&lua]( const std::string & hook_name, const sol::object & entry ) {
         auto *L = lua.lua_state();

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -44,7 +44,7 @@ void run_on_game_save_hooks( lua_state &state );
 void run_on_every_x_hooks( lua_state &state );
 void run_on_mapgen_postprocess_hooks( lua_state &state, map &m, const tripoint &p,
                                       const time_point &when );
-/** Return true if at least one on_mapgen_postprocess hook is registered. */
+/** Return true if at least one serial on_mapgen_postprocess hook is registered. */
 bool has_mapgen_postprocess_hooks( lua_state &state );
 void reg_lua_icallback_actors( lua_state &state, Item_factory &ifactory );
 void resolve_lua_bionic_and_mutation_callbacks();

--- a/src/catalua_threaded_hook_types.h
+++ b/src/catalua_threaded_hook_types.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace cata
+{
+
+/// Primitive value that can cross the worker→main-thread boundary.
+/// Complex types (usertypes, functions, tables) are intentionally excluded.
+using hook_intent_value = std::variant<std::monostate, int, double, bool, std::string>;
+
+/// Flat key→primitive map passed from a threaded hook pre-pass to its post-pass.
+/// No Lua objects cross the state boundary — only these serialized primitives.
+using hook_intent = std::unordered_map<std::string, hook_intent_value>;
+
+/// Result from one threaded hook entry's pre-pass.
+struct hook_pre_result {
+    bool        run_post   = false; ///< If false, post-pass is skipped for this entry.
+    uint64_t    post_fn_id = 0;     ///< ID of the post function stored in global Lua state.
+    std::string mod_id;
+    hook_intent intent;
+};
+
+} // namespace cata

--- a/src/catalua_threaded_hooks.cpp
+++ b/src/catalua_threaded_hooks.cpp
@@ -1,0 +1,244 @@
+#include "catalua_threaded_hooks.h"
+
+#include "catalua_impl.h"
+#include "catalua_sol.h"
+#include "catalua_worker.h"
+#include "debug.h"
+#include "string_formatter.h"
+
+#include <atomic>
+#include <cstddef>
+#include <ranges>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace
+{
+
+struct threaded_hook_entry {
+    uint64_t    pre_fn_id  = 0;
+    uint64_t    post_fn_id = 0;  ///< 0 = isolated-writer (no post-pass)
+    int         priority   = 0;
+    std::string mod_id;
+    std::vector<std::byte> pre_bytecode;
+};
+
+/// Global registry: hook_name → priority-sorted entries.
+/// Written on the main thread during mod loading; read from worker threads during gameplay.
+std::unordered_map<std::string, std::vector<threaded_hook_entry>> g_registry;
+std::shared_mutex g_registry_mutex;
+
+std::atomic<uint64_t> g_next_fn_id{ 1 };
+
+/// Cached presence flag for on_mapgen_postprocess threaded hooks.
+/// Written on main thread; read from worker threads via has_threaded_mapgen_hooks().
+std::atomic<bool> g_has_threaded_mapgen_hooks{ false };
+
+/// Dump a Lua function to bytecode via lua_dump.
+/// Returns empty vector on failure (e.g. C function, unsupported closure).
+auto dump_lua_fn( lua_State *L, const sol::protected_function &fn ) -> std::vector<std::byte>
+{
+    auto result = std::vector<std::byte>{};
+
+    fn.push();  // pushes the function onto the Lua stack
+
+    const int status = lua_dump(
+        L,
+        []( lua_State *, const void *data, size_t sz, void *ud ) -> int {
+            auto *vec = static_cast<std::vector<std::byte> *>( ud );
+            const auto *bytes = static_cast<const std::byte *>( data );
+            vec->insert( vec->end(), bytes, bytes + sz );
+            return 0;
+        },
+        &result,
+        /*strip=*/0
+    );
+
+    lua_pop( L, 1 );  // pop the function that fn.push() left on the stack
+
+    if( status != 0 ) {
+        return {};
+    }
+    return result;
+}
+
+} // namespace
+
+namespace cata
+{
+
+void define_threaded_hooks( lua_state &state )
+{
+    sol::state &lua = state.lua;
+
+    // Ensure the internal post-function registry exists.
+    sol::table it = lua.globals()["game"]["cata_internal"];
+    it["threaded_hook_post_fns"] = lua.create_table();
+
+    // Informational table — modders can read registered hook names from it.
+    sol::table gt = lua.globals()["game"];
+    gt["threaded_hooks"] = lua.create_table();
+
+    gt["register_threaded_hook"] = [&lua]( const std::string & hook_name,
+    const sol::table & entry ) {
+        const auto mod_id   = entry.get<sol::optional<std::string>>( "mod_id" ).value_or( "<unknown>" );
+        const auto priority = entry.get<sol::optional<int>>( "priority" ).value_or( 0 );
+        const auto pre_fn_opt  = entry.get<sol::optional<sol::protected_function>>( "pre" );
+        const auto fn_fn_opt   = entry.get<sol::optional<sol::protected_function>>( "fn" );
+
+        sol::protected_function pre_fn;
+        bool is_pre_post = false;
+
+        if( pre_fn_opt ) {
+            pre_fn      = *pre_fn_opt;
+            is_pre_post = true;
+        } else if( fn_fn_opt ) {
+            pre_fn      = *fn_fn_opt;
+            is_pre_post = false;
+        } else {
+            debugmsg( "register_threaded_hook '%s' (mod '%s'): entry must have a 'pre' or 'fn' function",
+                      hook_name.c_str(), mod_id.c_str() );
+            return;
+        }
+
+        auto bytecode = dump_lua_fn( lua.lua_state(), pre_fn );
+        if( bytecode.empty() ) {
+            debugmsg( "register_threaded_hook '%s' (mod '%s'): failed to serialize pre/fn to bytecode",
+                      hook_name.c_str(), mod_id.c_str() );
+            return;
+        }
+
+        const auto pre_fn_id = g_next_fn_id.fetch_add( 1, std::memory_order_relaxed );
+        auto       post_fn_id = uint64_t{ 0 };
+
+        if( is_pre_post ) {
+            const auto post_fn_opt = entry.get<sol::optional<sol::protected_function>>( "post" );
+            if( post_fn_opt ) {
+                post_fn_id = g_next_fn_id.fetch_add( 1, std::memory_order_relaxed );
+                sol::table post_fns = lua["game"]["cata_internal"]["threaded_hook_post_fns"];
+                post_fns[post_fn_id] = *post_fn_opt;
+            }
+            // Post is optional — absence means pre-only (filter that never triggers a post-pass).
+        }
+
+        {
+            std::unique_lock lock( g_registry_mutex );
+            auto &entries = g_registry[hook_name];
+            entries.emplace_back();
+            auto &e       = entries.back();
+            e.pre_fn_id   = pre_fn_id;
+            e.post_fn_id  = post_fn_id;
+            e.priority    = priority;
+            e.mod_id      = mod_id;
+            e.pre_bytecode = std::move( bytecode );
+            std::ranges::stable_sort( entries, std::ranges::greater{},
+                []( const threaded_hook_entry & e2 ) { return e2.priority; } );
+        }
+    };
+}
+
+auto intent_to_table( sol::state_view lua, const hook_intent &intent ) -> sol::table
+{
+    auto t = lua.create_table();
+    std::ranges::for_each( intent, [&t]( const auto &kv ) {
+        std::visit( [&t, &kv]( const auto &v ) {
+            using V = std::decay_t<decltype( v )>;
+            if constexpr( !std::is_same_v<V, std::monostate> ) {
+                t[kv.first] = v;
+            }
+        }, kv.second );
+    } );
+    return t;
+}
+
+auto run_threaded_hook_pre(
+    std::string_view hook_name,
+    std::function<void( sol::table & )> init
+) -> std::vector<hook_pre_result>
+{
+    auto results = std::vector<hook_pre_result>{};
+
+    std::shared_lock lock( g_registry_mutex );
+    const auto it = g_registry.find( std::string( hook_name ) );
+    if( it == g_registry.end() ) {
+        return results;
+    }
+
+    results.reserve( it->second.size() );
+
+    std::ranges::for_each( it->second, [&]( const threaded_hook_entry &entry ) {
+        auto intent = hook_intent{};
+        const bool fired = cata::call_pre_fn_in_worker(
+            pre_fn_call_opts{
+                .fn_id      = entry.pre_fn_id,
+                .bytecode   = &entry.pre_bytecode,
+                .debug_name = string_format( "%s/%s", entry.mod_id, hook_name ),
+            },
+            init,
+            intent
+        );
+
+        results.push_back( hook_pre_result{
+            .run_post   = fired && entry.post_fn_id != 0,
+            .post_fn_id = entry.post_fn_id,
+            .mod_id     = entry.mod_id,
+            .intent     = std::move( intent ),
+        } );
+    } );
+
+    return results;
+}
+
+void run_threaded_hook_post(
+    lua_state &global,
+    const std::vector<hook_pre_result> &results,
+    std::function<void( sol::table & )> init )
+{
+    sol::state &lua = global.lua;
+    sol::table post_fns = lua["game"]["cata_internal"]["threaded_hook_post_fns"];
+
+    std::ranges::for_each( results, [&]( const hook_pre_result &r ) {
+        if( !r.run_post || r.post_fn_id == 0 ) {
+            return;
+        }
+
+        const auto maybe_fn = post_fns.get<sol::optional<sol::protected_function>>( r.post_fn_id );
+        if( !maybe_fn ) {
+            debugmsg( "run_threaded_hook_post: post fn id %llu not found (mod '%s')",
+                      r.post_fn_id, r.mod_id.c_str() );
+            return;
+        }
+
+        auto params = lua.create_table();
+        if( init ) {
+            init( params );
+        }
+        auto intent_tbl = intent_to_table( lua, r.intent );
+
+        auto res = ( *maybe_fn )( params, intent_tbl );
+        if( !res.valid() ) {
+            sol::error err = res;
+            debugmsg( "run_threaded_hook_post: mod '%s' post error: %s",
+                      r.mod_id.c_str(), err.what() );
+        }
+    } );
+}
+
+auto has_threaded_mapgen_hooks() -> bool
+{
+    return g_has_threaded_mapgen_hooks.load( std::memory_order_relaxed );
+}
+
+void refresh_threaded_mapgen_hook_presence()
+{
+    std::shared_lock lock( g_registry_mutex );
+    const auto it = g_registry.find( "on_mapgen_postprocess" );
+    g_has_threaded_mapgen_hooks.store(
+        it != g_registry.end() && !it->second.empty(),
+        std::memory_order_relaxed
+    );
+}
+
+} // namespace cata

--- a/src/catalua_threaded_hooks.cpp
+++ b/src/catalua_threaded_hooks.cpp
@@ -40,21 +40,21 @@ std::atomic<bool> g_has_threaded_mapgen_hooks{ false };
 /// Returns empty vector on failure (e.g. C function, unsupported closure).
 auto dump_lua_fn( lua_State *L, const sol::protected_function &fn ) -> std::vector<std::byte>
 {
-    auto result = std::vector<std::byte>{};
+    auto result = std::vector<std::byte> {};
 
     fn.push();  // pushes the function onto the Lua stack
 
     const int status = lua_dump(
-        L,
-        []( lua_State *, const void *data, size_t sz, void *ud ) -> int {
-            auto *vec = static_cast<std::vector<std::byte> *>( ud );
-            const auto *bytes = static_cast<const std::byte *>( data );
-            vec->insert( vec->end(), bytes, bytes + sz );
-            return 0;
-        },
-        &result,
-        /*strip=*/0
-    );
+                           L,
+    []( lua_State *, const void *data, size_t sz, void *ud ) -> int {
+        auto *vec = static_cast<std::vector<std::byte> *>( ud );
+        const auto *bytes = static_cast<const std::byte *>( data );
+        vec->insert( vec->end(), bytes, bytes + sz );
+        return 0;
+    },
+    &result,
+    /*strip=*/0
+                       );
 
     lua_pop( L, 1 );  // pop the function that fn.push() left on the stack
 
@@ -134,7 +134,7 @@ void define_threaded_hooks( lua_state &state )
             e.mod_id      = mod_id;
             e.pre_bytecode = std::move( bytecode );
             std::ranges::stable_sort( entries, std::ranges::greater{},
-                []( const threaded_hook_entry & e2 ) { return e2.priority; } );
+            []( const threaded_hook_entry & e2 ) { return e2.priority; } );
         }
     };
 }
@@ -142,8 +142,8 @@ void define_threaded_hooks( lua_state &state )
 auto intent_to_table( sol::state_view lua, const hook_intent &intent ) -> sol::table
 {
     auto t = lua.create_table();
-    std::ranges::for_each( intent, [&t]( const auto &kv ) {
-        std::visit( [&t, &kv]( const auto &v ) {
+    std::ranges::for_each( intent, [&t]( const auto & kv ) {
+        std::visit( [&t, &kv]( const auto & v ) {
             using V = std::decay_t<decltype( v )>;
             if constexpr( !std::is_same_v<V, std::monostate> ) {
                 t[kv.first] = v;
@@ -158,7 +158,7 @@ auto run_threaded_hook_pre(
     std::function<void( sol::table & )> init
 ) -> std::vector<hook_pre_result>
 {
-    auto results = std::vector<hook_pre_result>{};
+    auto results = std::vector<hook_pre_result> {};
 
     std::shared_lock lock( g_registry_mutex );
     const auto it = g_registry.find( std::string( hook_name ) );
@@ -168,17 +168,17 @@ auto run_threaded_hook_pre(
 
     results.reserve( it->second.size() );
 
-    std::ranges::for_each( it->second, [&]( const threaded_hook_entry &entry ) {
+    std::ranges::for_each( it->second, [&]( const threaded_hook_entry & entry ) {
         auto intent = hook_intent{};
         const bool fired = cata::call_pre_fn_in_worker(
-            pre_fn_call_opts{
-                .fn_id      = entry.pre_fn_id,
-                .bytecode   = &entry.pre_bytecode,
-                .debug_name = string_format( "%s/%s", entry.mod_id, hook_name ),
-            },
-            init,
-            intent
-        );
+        pre_fn_call_opts{
+            .fn_id      = entry.pre_fn_id,
+            .bytecode   = &entry.pre_bytecode,
+            .debug_name = string_format( "%s/%s", entry.mod_id, hook_name ),
+        },
+        init,
+        intent
+                           );
 
         results.push_back( hook_pre_result{
             .run_post   = fired && entry.post_fn_id != 0,
@@ -199,7 +199,7 @@ void run_threaded_hook_post(
     sol::state &lua = global.lua;
     sol::table post_fns = lua["game"]["cata_internal"]["threaded_hook_post_fns"];
 
-    std::ranges::for_each( results, [&]( const hook_pre_result &r ) {
+    std::ranges::for_each( results, [&]( const hook_pre_result & r ) {
         if( !r.run_post || r.post_fn_id == 0 ) {
             return;
         }

--- a/src/catalua_threaded_hooks.h
+++ b/src/catalua_threaded_hooks.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "catalua_sol_fwd.h"
+#include "catalua_threaded_hook_types.h"
+
+#include <functional>
+#include <string_view>
+#include <vector>
+
+namespace cata
+{
+
+struct lua_state;
+
+/// Create the game.threaded_hooks table and register game.register_threaded_hook.
+/// Called from init_global_state_tables alongside define_hooks().
+void define_threaded_hooks( lua_state &state );
+
+/// Serialize a hook_intent to a Lua table in the given state (for passing to post functions).
+auto intent_to_table( sol::state_view lua, const hook_intent &intent ) -> sol::table;
+
+/// Run all pre-pass functions for the given hook name in the calling thread's worker state.
+/// Returns one result per registered entry; entries with run_post=false need no follow-up.
+/// Safe to call from worker threads.
+auto run_threaded_hook_pre(
+    std::string_view hook_name,
+    std::function<void( sol::table & )> init
+) -> std::vector<hook_pre_result>;
+
+/// Run post-pass functions for all results that have run_post=true.
+/// Must be called on the main thread only.
+/// @param global   The main-thread Lua state.
+/// @param results  Pre-pass results from run_threaded_hook_pre.
+/// @param init     Populates the params table passed to each post function.
+void run_threaded_hook_post(
+    lua_state &global,
+    const std::vector<hook_pre_result> &results,
+    std::function<void( sol::table & )> init
+);
+
+/// Returns true if any threaded on_mapgen_postprocess hooks are registered.
+/// Thread-safe (reads a cached atomic flag).
+auto has_threaded_mapgen_hooks() -> bool;
+
+/// Update the cached flag returned by has_threaded_mapgen_hooks().
+/// Must be called on the main thread after hook registration changes.
+void refresh_threaded_mapgen_hook_presence();
+
+} // namespace cata

--- a/src/catalua_worker.cpp
+++ b/src/catalua_worker.cpp
@@ -51,7 +51,7 @@ auto get_or_create_worker_state() -> worker_lua_state &
 auto table_to_intent( const sol::table &t ) -> cata::hook_intent
 {
     auto result = cata::hook_intent{};
-    t.for_each( [&]( const sol::object &key, const sol::object &val ) {
+    t.for_each( [&]( const sol::object & key, const sol::object & val ) {
         if( !key.is<std::string>() ) {
             return;
         }
@@ -92,11 +92,11 @@ auto call_pre_fn_in_worker(
         }
         auto *L = ws.lua.lua_state();
         const int status = luaL_loadbuffer(
-            L,
-            reinterpret_cast<const char *>( opts.bytecode->data() ),
-            opts.bytecode->size(),
-            std::string( opts.debug_name ).c_str()
-        );
+                               L,
+                               reinterpret_cast<const char *>( opts.bytecode->data() ),
+                               opts.bytecode->size(),
+                               std::string( opts.debug_name ).c_str()
+                           );
         if( status != 0 ) {
             const char *err_msg = lua_tostring( L, -1 );
             lua_pop( L, 1 );

--- a/src/catalua_worker.cpp
+++ b/src/catalua_worker.cpp
@@ -1,0 +1,149 @@
+#include "catalua_worker.h"
+
+#include "catalua_sol.h"
+#include "debug.h"
+#include "string_formatter.h"
+
+#include <atomic>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace
+{
+
+/// Monotonically increasing generation counter.
+/// Incremented by invalidate_worker_states(); worker states rebuild when their
+/// cached generation doesn't match.
+std::atomic<uint64_t> g_generation{ 1 };
+
+struct worker_lua_state {
+    sol::state lua;
+    std::unordered_map<uint64_t, sol::protected_function> fn_cache;
+    uint64_t generation = 0;
+};
+
+auto make_worker_lua_state() -> std::unique_ptr<worker_lua_state>
+{
+    auto ws = std::make_unique<worker_lua_state>();
+    ws->lua.open_libraries(
+        sol::lib::base,
+        sol::lib::math,
+        sol::lib::string,
+        sol::lib::table
+    );
+    ws->generation = g_generation.load( std::memory_order_relaxed );
+    return ws;
+}
+
+auto get_or_create_worker_state() -> worker_lua_state &
+{
+    thread_local std::unique_ptr<worker_lua_state> tl_state;
+    const auto cur_gen = g_generation.load( std::memory_order_relaxed );
+    if( !tl_state || tl_state->generation != cur_gen ) {
+        tl_state = make_worker_lua_state();
+    }
+    return *tl_state;
+}
+
+/// Deserialize a flat Lua table of primitives into a hook_intent.
+/// Non-string keys and non-primitive values are silently skipped.
+auto table_to_intent( const sol::table &t ) -> cata::hook_intent
+{
+    auto result = cata::hook_intent{};
+    t.for_each( [&]( const sol::object &key, const sol::object &val ) {
+        if( !key.is<std::string>() ) {
+            return;
+        }
+        const auto k = key.as<std::string>();
+        if( val.is<bool>() ) {
+            result[k] = val.as<bool>();
+        } else if( val.is<int>() ) {
+            result[k] = val.as<int>();
+        } else if( val.is<double>() ) {
+            result[k] = val.as<double>();
+        } else if( val.is<std::string>() ) {
+            result[k] = val.as<std::string>();
+        }
+        // Non-primitive types silently ignored — documented constraint of threaded hooks.
+    } );
+    return result;
+}
+
+} // namespace
+
+namespace cata
+{
+
+auto call_pre_fn_in_worker(
+    const pre_fn_call_opts &opts,
+    std::function<void( sol::table & )> init,
+    hook_intent &result ) -> bool
+{
+    auto &ws = get_or_create_worker_state();
+
+    // Load function from bytecode into cache on first use.
+    auto it = ws.fn_cache.find( opts.fn_id );
+    if( it == ws.fn_cache.end() ) {
+        if( !opts.bytecode || opts.bytecode->empty() ) {
+            debugmsg( "call_pre_fn_in_worker: no bytecode for fn_id %llu ('%s')",
+                      opts.fn_id, opts.debug_name );
+            return false;
+        }
+        auto *L = ws.lua.lua_state();
+        const int status = luaL_loadbuffer(
+            L,
+            reinterpret_cast<const char *>( opts.bytecode->data() ),
+            opts.bytecode->size(),
+            std::string( opts.debug_name ).c_str()
+        );
+        if( status != 0 ) {
+            const char *err_msg = lua_tostring( L, -1 );
+            lua_pop( L, 1 );
+            debugmsg( "call_pre_fn_in_worker: failed to load '%s': %s",
+                      opts.debug_name, err_msg ? err_msg : "unknown error" );
+            return false;
+        }
+        // Stack top is now the loaded function.  protected_function(L, idx) calls
+        // lua_pushvalue + luaL_ref internally, leaving the original on the stack.
+        sol::protected_function fn( L, lua_gettop( L ) );
+        lua_pop( L, 1 );
+        auto [ins_it, ok] = ws.fn_cache.emplace( opts.fn_id, std::move( fn ) );
+        it = ins_it;
+    }
+
+    // Build params table and populate via caller-provided init.
+    auto params = ws.lua.create_table();
+    if( init ) {
+        init( params );
+    }
+
+    auto res = it->second( params );
+    if( !res.valid() ) {
+        sol::error err = res;
+        debugmsg( "call_pre_fn_in_worker '%s': runtime error: %s",
+                  opts.debug_name, err.what() );
+        return false;
+    }
+
+    auto retval = res.get<sol::object>();
+    if( retval == sol::nil || retval.get_type() == sol::type::lua_nil ) {
+        return false;
+    }
+    if( !retval.is<sol::table>() ) {
+        debugmsg( "call_pre_fn_in_worker '%s': expected nil or table return, got %s",
+                  opts.debug_name,
+                  sol::type_name( ws.lua.lua_state(), retval.get_type() ) );
+        return false;
+    }
+
+    result = table_to_intent( retval.as<sol::table>() );
+    return true;
+}
+
+void invalidate_worker_states()
+{
+    g_generation.fetch_add( 1, std::memory_order_relaxed );
+}
+
+} // namespace cata

--- a/src/catalua_worker.h
+++ b/src/catalua_worker.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "catalua_sol_fwd.h"
+#include "catalua_threaded_hook_types.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string_view>
+#include <vector>
+
+namespace cata
+{
+
+/// Opaque per-thread Lua state for worker threads.
+/// Defined privately in catalua_worker.cpp.
+struct worker_lua_state;
+
+/// Options for calling a pre/fn function in a worker state.
+struct pre_fn_call_opts {
+    uint64_t                    fn_id      = 0;
+    const std::vector<std::byte> *bytecode = nullptr;
+    std::string_view            debug_name;
+};
+
+/// Call a Lua function in the calling thread's worker state.
+/// The function is loaded from bytecode on first call and cached by fn_id.
+/// @param opts     Identifies the function to call.
+/// @param init     Populates the params table passed to the Lua function (primitives only).
+/// @param result   Receives the deserialized intent if the function returns a non-nil table.
+/// @return true if the function returned a non-nil table (post-pass should run).
+/// Must be called from a worker thread (is_pool_worker_thread() must be true).
+auto call_pre_fn_in_worker(
+    const pre_fn_call_opts &opts,
+    std::function<void( sol::table & )> init,
+    hook_intent &result
+) -> bool;
+
+/// Signal all worker states to reinitialize on next use.
+/// Call on the main thread after hook registrations change (e.g. after mod reload).
+void invalidate_worker_states();
+
+} // namespace cata

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -66,6 +66,8 @@
 #include "mapdata.h"
 #include "mapgen.h"
 #include "mapgen_async.h"
+#include "catalua_threaded_hooks.h"
+#include "catalua_worker.h"
 #include "martialarts.h"
 #include "material.h"
 #include "mission.h"
@@ -908,10 +910,14 @@ static void load_and_finalize_packs( loading_ui &ui, const std::string &msg,
 
     init::load_main_lua_scripts( *loader.lua, packs );
     cata::clear_mod_being_loaded( *loader.lua );
-    // Update cached hook-presence flag so worker threads know whether to queue
+    // Update cached hook-presence flags so worker threads know whether to queue
     // deferred mapgen postprocess hooks (avoids lock + allocation overhead per quad
     // when no on_mapgen_postprocess hooks are registered).
+    // Threaded presence must be refreshed first — the combined g_has_mapgen_hooks
+    // flag reads the threaded result.
+    cata::refresh_threaded_mapgen_hook_presence();
     refresh_mapgen_postprocess_hook_presence( *loader.lua );
+    cata::invalidate_worker_states();
 }
 
 auto init::load_main_lua_scripts( cata::lua_state &state, const std::vector<mod_id> &packs ) -> int

--- a/src/mapgen_async.cpp
+++ b/src/mapgen_async.cpp
@@ -9,6 +9,8 @@
 
 #include "auto_note.h"
 #include "catalua.h"
+#include "catalua_sol.h"
+#include "catalua_threaded_hooks.h"
 #include "color.h"
 #include "coordinate_conversions.h"
 #include "init.h"
@@ -30,7 +32,7 @@ std::vector<deferred_mapgen_hook> g_hooks;
 std::mutex                      g_autonote_mutex;
 std::vector<deferred_autonote>  g_autonotes;
 
-// Cached flag: are any on_mapgen_postprocess hooks registered?
+// Cached flag: are any on_mapgen_postprocess hooks registered (serial OR threaded)?
 // Written on the main thread after mod load; read from worker threads.
 // Plain std::atomic<bool> — no Android-specific fallback needed
 // (the atomic_ref<float> workaround in shadowcasting.cpp does not apply here).
@@ -44,6 +46,21 @@ void push_deferred_mapgen_hook( deferred_mapgen_hook h )
     if( !g_has_mapgen_hooks.load( std::memory_order_relaxed ) ) {
         return;
     }
+
+    // Run the threaded hook pre-pass on this worker thread before queuing.
+    // The pre-pass is a no-op when no threaded hooks are registered.
+    if( cata::has_threaded_mapgen_hooks() ) {
+        const auto &omt = h.omt_pos;
+        h.pre_results = cata::run_threaded_hook_pre(
+            "on_mapgen_postprocess",
+            [&omt]( sol::table &params ) {
+                params["pos_x"] = omt.raw().x;
+                params["pos_y"] = omt.raw().y;
+                params["pos_z"] = omt.raw().z;
+            }
+        );
+    }
+
     std::lock_guard<std::mutex> lk( g_hook_mutex );
     g_hooks.push_back( std::move( h ) );
 }
@@ -51,7 +68,8 @@ void push_deferred_mapgen_hook( deferred_mapgen_hook h )
 void refresh_mapgen_postprocess_hook_presence( cata::lua_state &state )
 {
     g_has_mapgen_hooks.store(
-        cata::has_mapgen_postprocess_hooks( state ),
+        cata::has_mapgen_postprocess_hooks( state ) ||
+        cata::has_threaded_mapgen_hooks(),
         std::memory_order_relaxed );
 }
 
@@ -109,16 +127,19 @@ void run_deferred_mapgen_hooks()
         pending.swap( g_hooks );
     }
 
-    // Skip the expensive tinymap construction when no hooks are registered.
-    // Worker threads always push a deferred entry when generating on a worker
-    // thread, regardless of hook registration.  Checking here (on the main
-    // thread, where Lua access is safe) avoids building O(n) tinymaps per turn
-    // just to call a no-op hook loop.
-    if( !cata::has_mapgen_postprocess_hooks( *DynamicDataLoader::get_instance().lua ) ) {
+    if( pending.empty() ) {
         return;
     }
 
-    for( auto &h : pending ) {
+    auto &lua_instance = *DynamicDataLoader::get_instance().lua;
+    const bool has_serial = cata::has_mapgen_postprocess_hooks( lua_instance );
+
+    std::ranges::for_each( pending, [&]( deferred_mapgen_hook &h ) {
+        const bool has_threaded = !h.pre_results.empty();
+        if( !has_serial && !has_threaded ) {
+            return;
+        }
+
         // The submaps are already in the mapbuffer (saven() was called before
         // the hook was deferred).  Load them into a temporary tinymap so the
         // Lua hook receives a live map reference identical in content to what
@@ -128,11 +149,27 @@ void run_deferred_mapgen_hooks()
         tinymap tmp;
         tmp.bind_dimension( h.dim );
         tmp.load_from_mapbuffer( sm_base );
-        cata::run_on_mapgen_postprocess_hooks(
-            *DynamicDataLoader::get_instance().lua,
-            tmp,
-            h.omt_pos.raw(),
-            h.when
-        );
-    }
+
+        if( has_serial ) {
+            cata::run_on_mapgen_postprocess_hooks(
+                lua_instance,
+                tmp,
+                h.omt_pos.raw(),
+                h.when
+            );
+        }
+
+        if( has_threaded ) {
+            map *tmp_as_map = &tmp;
+            cata::run_threaded_hook_post(
+                lua_instance,
+                h.pre_results,
+                [&]( sol::table &params ) {
+                    params["map"]  = tmp_as_map;
+                    params["omt"]  = h.omt_pos.raw();
+                    params["when"] = h.when;
+                }
+            );
+        }
+    } );
 }

--- a/src/mapgen_async.cpp
+++ b/src/mapgen_async.cpp
@@ -52,13 +52,13 @@ void push_deferred_mapgen_hook( deferred_mapgen_hook h )
     if( cata::has_threaded_mapgen_hooks() ) {
         const auto &omt = h.omt_pos;
         h.pre_results = cata::run_threaded_hook_pre(
-            "on_mapgen_postprocess",
-            [&omt]( sol::table &params ) {
-                params["pos_x"] = omt.raw().x;
-                params["pos_y"] = omt.raw().y;
-                params["pos_z"] = omt.raw().z;
-            }
-        );
+                            "on_mapgen_postprocess",
+        [&omt]( sol::table & params ) {
+            params["pos_x"] = omt.raw().x;
+            params["pos_y"] = omt.raw().y;
+            params["pos_z"] = omt.raw().z;
+        }
+                        );
     }
 
     std::lock_guard<std::mutex> lk( g_hook_mutex );
@@ -134,7 +134,7 @@ void run_deferred_mapgen_hooks()
     auto &lua_instance = *DynamicDataLoader::get_instance().lua;
     const bool has_serial = cata::has_mapgen_postprocess_hooks( lua_instance );
 
-    std::ranges::for_each( pending, [&]( deferred_mapgen_hook &h ) {
+    std::ranges::for_each( pending, [&]( deferred_mapgen_hook & h ) {
         const bool has_threaded = !h.pre_results.empty();
         if( !has_serial && !has_threaded ) {
             return;
@@ -164,11 +164,11 @@ void run_deferred_mapgen_hooks()
             cata::run_threaded_hook_post(
                 lua_instance,
                 h.pre_results,
-                [&]( sol::table &params ) {
-                    params["map"]  = tmp_as_map;
-                    params["omt"]  = h.omt_pos.raw();
-                    params["when"] = h.when;
-                }
+            [&]( sol::table & params ) {
+                params["map"]  = tmp_as_map;
+                params["omt"]  = h.omt_pos.raw();
+                params["when"] = h.when;
+            }
             );
         }
     } );

--- a/src/mapgen_async.h
+++ b/src/mapgen_async.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "calendar.h"
+#include "catalua_threaded_hook_types.h"
 #include "coordinates.h"
 
 namespace cata
@@ -28,6 +30,9 @@ struct deferred_mapgen_hook {
     std::string       dim;
     tripoint_abs_omt  omt_pos;
     time_point        when;
+    /// Results from threaded hook pre-passes run on the worker thread.
+    /// Empty when no threaded on_mapgen_postprocess hooks are registered.
+    std::vector<cata::hook_pre_result> pre_results;
 };
 
 /**


### PR DESCRIPTION
## Purpose of change (The Why)

Lua mapgen is inherently serial. Many things are. We're gonna want Lua AI, Lua mapgen, Lua PLANTS.

## Describe the solution (The How)

2 paradigms:
- Pre and Post functions for a hook. Pre phase gets much less context, lives fast, passes the info along, and can block the post phase from occurring to improve performance. Post phase is still serial, but this is useful for stuff that can quickly check before triggering, allowing it to bypass the serial phase entirely.
- Fn function for a hook. This is significantly more constrained. Reads aren't guaranteed to be accurate (could be off by 1 turn) when dealing with the written data of the other threads, and writes are only allowable for this threads context, and *nothing else*. In exchange, this is fully threaded. Lua plants might live here.

Everything about threaded Lua states is explicitly added. We aren't duplicating the global state and blocking incompatible stuff, it requires explicitly adding it. This is effortful, but in many cases likely worth the effort.

## Describe alternatives you've considered

Accepting that Lua will always be serial. This would suck a lot, especially for monster AI. If every monster needs to check for a Lua function even when the vast majority of them do no writes (a.k.a check and pass), that's no good.

## Testing

I compile tested, and nothing crashed.

## Additional context

Consider this an advanced design doc, rather than a complete PR. I wanted to flesh it out because it makes things clearer for this sort of thing. Multi-threading code is finicky and difficult to fully imagine until it's actually there (and even when it is). This allows feedback and scrutiny of the ideas without confusion.