### PR TITLE
fix: prevent crash when opening character preset

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -314,6 +314,45 @@ void avatar::reset_all_missions()
     failed_missions.clear();
 }
 
+auto avatar::sanitize_character_template() -> void
+{
+    setID( character_id(), true );
+    reset_all_missions();
+
+    activity = activity_ptr();
+    stashed_outbounds_activity = activity_ptr();
+    stashed_outbounds_backlog = activity_ptr();
+    backlog.clear();
+    clear_destination_activity();
+    destination_point.reset();
+    get_auto_move_route().clear();
+
+    grab( OBJECT_NONE );
+    in_vehicle = false;
+    controlling_vehicle = false;
+    mounted_creature.reset();
+    mounted_creature_id = 0;
+
+    last_target.reset();
+    last_target_pos.reset();
+    ammo_location = safe_reference<item>();
+    custom_waypoint.reset();
+    follower_ids.clear();
+
+    known_monsters.clear();
+    known_traps.clear();
+    overmap_time.clear();
+    items_identified.clear();
+    warning_record.clear();
+    shadow_npc.reset();
+    omt_path.clear();
+    snippets_read.clear();
+
+    if( player_map_memory ) {
+        player_map_memory->clear();
+    }
+}
+
 tripoint_abs_omt avatar::get_active_mission_target() const
 {
     if( active_mission == nullptr ) {

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -87,6 +87,7 @@ class avatar : public player
         bool load_template( const std::string &template_name, points_left &points );
         void save_template( const std::string &name, const points_left &points );
         void character_to_template( const std::string &name );
+        auto sanitize_character_template() -> void;
 
         bool is_avatar() const override {
             return true;
@@ -339,4 +340,3 @@ class avatar : public player
 };
 
 avatar &get_avatar();
-

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4101,6 +4101,7 @@ void avatar::character_to_template( const std::string &name )
     points.trait_points = 0;
     points.skill_points = 0;
     points.limit = points_left::TRANSFER;
+    sanitize_character_template();
     save_template( name, points );
 }
 
@@ -4177,6 +4178,10 @@ bool avatar::load_template( const std::string &template_name, points_left &point
         }
 
         deserialize( jsin );
+
+        if( points.limit == points_left::TRANSFER ) {
+            sanitize_character_template();
+        }
 
         if( MAP_SHARING::isSharing() ) {
             // just to make sure we have the right name

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -14,11 +14,13 @@
 #include <vector>
 
 #include "avatar.h"
+#include "filesystem.h"
 #include "game.h"
 #include "item.h"
 #include "item_contents.h"
 #include "itype.h"
 #include "newcharacter.h"
+#include "path_info.h"
 #include "pldata.h"
 #include "profession.h"
 #include "ret_val.h"
@@ -191,4 +193,39 @@ TEST_CASE( "starting_items", "[slow]" )
     }
     INFO( failure_messages.str() );
     REQUIRE( failures.empty() );
+}
+
+TEST_CASE( "character_transfer_templates_drop_runtime_state", "[new_character]" )
+{
+    clear_all_state();
+
+    avatar &source = get_avatar();
+    source = get_sanitized_player();
+    source.name = "Template Test";
+    source.focus_pool = 42;
+    source.follower_ids.insert( character_id( 123 ) );
+    source.known_monsters.insert( mtype_id( "mon_zombie" ) );
+    source.last_target_pos = tripoint( 4, 5, 0 );
+    source.destination_point = tripoint( 1, 2, 0 );
+    source.get_auto_move_route().push_back( tripoint( 0, 1, 0 ) );
+    source.grab( OBJECT_VEHICLE, tripoint( 0, 1, 0 ) );
+
+    const auto template_name = std::string( "unit-test-transfer-template" );
+    const auto template_path = PATH_INFO::templatedir() + template_name + ".template";
+    remove_file( template_path );
+
+    source.character_to_template( template_name );
+
+    auto loaded = get_sanitized_player();
+    auto points = points_left();
+    REQUIRE( loaded.load_template( template_name, points ) );
+
+    CHECK( points.limit == points_left::TRANSFER );
+    CHECK( loaded.follower_ids.empty() );
+    CHECK( loaded.get_known_monsters().empty() );
+    CHECK_FALSE( loaded.destination_point.has_value() );
+    CHECK( loaded.get_auto_move_route().empty() );
+    CHECK( loaded.get_grab_type() == OBJECT_NONE );
+
+    CHECK( remove_file( template_path ) );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

closes #8491

Character transfer templates were carrying runtime-only avatar state into preset loading.

## Describe the solution (The How)

- sanitize runtime-only avatar state before saving character transfer templates
- sanitize transfer templates again on load so existing templates stop restoring stale state
- add a regression test for transfer template loading

## Testing

- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[new_character]"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<sup>PR opened by gpt-5.4 high on opencode</sup>