### PR TITLE
refactor(lua): move achievement tracking onto hooks

### DIFF
--- a/data/json/lua/achievement_runtime.lua
+++ b/data/json/lua/achievement_runtime.lua
@@ -1,0 +1,166 @@
+local api = achievement_api
+
+---@class achievement_runtime_time_constraint
+---@field comparison string
+---@field target_turn integer
+
+---@class achievement_runtime_skill_requirement
+---@field skill_id string
+---@field comparison string
+---@field level integer
+
+---@class achievement_runtime_kill_requirement
+---@field kind string
+---@field id? string
+---@field comparison string
+---@field count integer
+
+---@class achievement_runtime_requirement
+---@field statistic_id string
+---@field comparison string
+---@field target? integer
+---@field becomes_false boolean
+
+---@class achievement_runtime_achievement
+---@field id string
+---@field hidden_by string[]
+---@field time_constraint? achievement_runtime_time_constraint
+---@field skill_requirements achievement_runtime_skill_requirement[]
+---@field kill_requirements achievement_runtime_kill_requirement[]
+---@field requirements achievement_runtime_requirement[]
+
+---@param comparison string
+---@param target integer?
+---@param value integer
+---@return boolean
+local compare = function(comparison, target, value)
+  if comparison == ">=" then return value >= target end
+  if comparison == "<=" then return value <= target end
+  return true
+end
+
+---@param requirement achievement_runtime_kill_requirement
+---@return integer
+local kill_count = function(requirement)
+  if requirement.kind == "monster" then return api.monster_kill_count(requirement.id) end
+  if requirement.kind == "species" then return api.species_kill_count(requirement.id) end
+  return api.total_kill_count()
+end
+
+---@param achievement achievement_runtime_achievement
+---@return string
+local time_state = function(achievement)
+  local constraint = achievement.time_constraint
+  if not constraint then return "completed" end
+
+  local now = api.current_turn()
+  if constraint.comparison == "<=" then return now <= constraint.target_turn and "completed" or "failed" end
+  if constraint.comparison == ">=" then return now >= constraint.target_turn and "completed" or "pending" end
+  return "completed"
+end
+
+---@param achievement achievement_runtime_achievement
+---@return string
+local skill_state = function(achievement)
+  local state = "completed"
+  for _, requirement in ipairs(achievement.skill_requirements) do
+    local satisfied = compare(requirement.comparison, requirement.level, api.skill_level(requirement.skill_id))
+    if not satisfied then
+      if requirement.comparison == ">=" then
+        state = "pending"
+      elseif requirement.comparison == "<=" then
+        return "failed"
+      end
+    end
+  end
+  return state
+end
+
+---@param achievement achievement_runtime_achievement
+---@return string
+local kill_state = function(achievement)
+  local state = "completed"
+  for _, requirement in ipairs(achievement.kill_requirements) do
+    local satisfied = compare(requirement.comparison, requirement.count, kill_count(requirement))
+    if not satisfied then
+      if requirement.comparison == ">=" then
+        state = "pending"
+      elseif requirement.comparison == "<=" then
+        return "failed"
+      end
+    end
+  end
+  return state
+end
+
+---@param achievement achievement_runtime_achievement
+---@return boolean
+local requirements_complete = function(achievement)
+  for _, requirement in ipairs(achievement.requirements) do
+    if not compare(requirement.comparison, requirement.target, api.stat_value(requirement.statistic_id)) then
+      return false
+    end
+  end
+  return true
+end
+
+---@param achievement achievement_runtime_achievement
+---@return boolean
+local requirements_failed = function(achievement)
+  for _, requirement in ipairs(achievement.requirements) do
+    if
+      requirement.becomes_false
+      and not compare(requirement.comparison, requirement.target, api.stat_value(requirement.statistic_id))
+    then
+      return true
+    end
+  end
+  return false
+end
+
+---@param achievement achievement_runtime_achievement
+local evaluate = function(achievement)
+  if api.state(achievement.id) ~= "pending" then return end
+
+  local time = time_state(achievement)
+  local skill = skill_state(achievement)
+  local kill = kill_state(achievement)
+
+  if requirements_complete(achievement) and time == "completed" and skill == "completed" and kill == "completed" then
+    api.report(achievement.id, "completed")
+    return
+  end
+
+  if time == "failed" or kill == "failed" or requirements_failed(achievement) then
+    api.report(achievement.id, "failed")
+  end
+end
+
+local M = {}
+---@type achievement_runtime_achievement[]
+local definitions = api.definitions()
+---@type table<string, achievement_runtime_achievement[]>
+local by_statistic = {}
+
+for _, achievement in ipairs(definitions) do
+  local seen_statistics = {}
+  for _, requirement in ipairs(achievement.requirements) do
+    if not seen_statistics[requirement.statistic_id] then
+      seen_statistics[requirement.statistic_id] = true
+      by_statistic[requirement.statistic_id] = by_statistic[requirement.statistic_id] or {}
+      by_statistic[requirement.statistic_id][#by_statistic[requirement.statistic_id] + 1] = achievement
+    end
+  end
+end
+
+---@param params { statistic_id: string }
+M.on_stat_changed = function(params)
+  local achievements = by_statistic[params.statistic_id]
+  if not achievements then return end
+
+  for _, achievement in ipairs(achievements) do
+    evaluate(achievement)
+  end
+end
+
+return M

--- a/data/json/main.lua
+++ b/data/json/main.lua
@@ -3,6 +3,7 @@ local sonar = require("lua/iuse/sonar")
 local slimepit = require("lua/mapgen/slimepit")
 local artifact_analyzer = require("lua/iuse/artifact_analyzer")
 local item_var_viewer = require("lua/iuse/item_var_viewer")
+local achievement_runtime = require("lua/achievement_runtime")
 local lua_traits = require("lua/traits/lua_traits")
 local lab = require("lua/mapgen/lab")
 local cooking = require("lua/cooking")
@@ -15,6 +16,7 @@ mod.slimepit = slimepit
 mod.lab = lab
 mod.artifact_analyzer = artifact_analyzer
 mod.item_var_viewer = item_var_viewer
+mod.achievement_runtime = achievement_runtime
 sonar.register(mod)
 mod.lua_traits = lua_traits
 lua_traits.register(mod)

--- a/data/json/preload.lua
+++ b/data/json/preload.lua
@@ -21,6 +21,9 @@ end)
 
 game.add_hook("on_character_try_move", function(...) return mod.on_character_try_move(...) end)
 game.add_hook("on_craft_result", function(...) return mod.cooking.on_craft_result(...) end)
+game.add_hook("on_stat_changed", function(...)
+  if mod.achievement_runtime then return mod.achievement_runtime.on_stat_changed(...) end
+end)
 
 -- Mapgen
 game.mapgen_functions["slimepit"] = function(...) return mod.slimepit.draw(...) end

--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -1,9 +1,10 @@
 #include "achievement.h"
 
-#include <cassert>
+#include "achievement_runtime.h"
+
+#include <algorithm>
 #include <cstdlib>
-#include <set>
-#include <tuple>
+#include <ranges>
 #include <utility>
 
 #include "character.h"
@@ -20,42 +21,27 @@
 #include "stats_tracker.h"
 #include "string_formatter.h"
 
-// Some details about how achievements work
-// ========================================
-//
-// Achievements are built on the stats_tracker, which is in turn built on the
-// event_bus.  Each of these layers involves subscription / callback style
-// interfaces, so the code flow may now be obvious.  Here's a quick outline of
-// the execution flow to help clarify how it all fits together.
-//
-// * Various core game code paths generate events via the event bus.
-// * The stats_tracker subscribes to the event bus, and receives these events.
-// * Events contribute to event_multisets managed by the stats_tracker.
-// * (In the docs, these event_multisets are described as "event streams").
-// * (Optionally) event_transformations transform these event_multisets into
-//   other event_multisets based on json-defined transformation rules.  These
-//   are also managed by stats_tracker.
-// * event_statistics monitor these event_multisets and summarize them into
-//   single values.  These are also managed by stats_tracker.
-// * Each achievement requirement has a corresponding requirement_watcher which
-//   is alerted to statistic changes via the stats_tracker's watch interface.
-// * Each requirement_watcher notifies its achievement_tracker (of which there
-//   is one per achievement) of the requirement's status on each change to a
-//   statistic.
-// * The achievement_tracker keeps track of which requirements are currently
-//   satisfied and which are not.
-// * When all the requirements are satisfied, the achievement_tracker tells the
-//   achievement_tracker (only one of these exists per game).
-// * The achievement_tracker calls the achievement_attained_callback it was
-//   given at construction time.  This hooks into the actual game logic (e.g.
-//   telling the player they just got an achievement).
+// Achievement state transitions are evaluated by the Lua runtime via the
+// on_stat_changed hook.  C++ retains definition loading, UI formatting and the
+// save/load wrapper so the serialized format remains unchanged.
 
 namespace
 {
 
 generic_factory<achievement> achievement_factory( "achievement" );
+achievements_tracker *active_tracker_instance = nullptr;
 
 } // namespace
+
+auto achievement_runtime::set_active_tracker( achievements_tracker *tracker ) -> void
+{
+    active_tracker_instance = tracker;
+}
+
+auto achievement_runtime::active_tracker() -> achievements_tracker *
+{
+    return active_tracker_instance;
+}
 
 /** @relates string_id */
 template<>
@@ -697,50 +683,6 @@ static std::string text_for_requirement( const achievement_requirement &req,
     return colorize( result, c );
 }
 
-class requirement_watcher : stat_watcher
-{
-    public:
-        requirement_watcher( achievement_tracker &tracker, const achievement_requirement &req,
-                             stats_tracker &stats ) :
-            current_value_( req.statistic->value( stats ) ),
-            tracker_( &tracker ),
-            requirement_( &req ) {
-            stats.add_watcher( req.statistic, this );
-        }
-
-        const cata_variant &current_value() const {
-            return current_value_;
-        }
-
-        const achievement_requirement &requirement() const {
-            return *requirement_;
-        }
-
-        void new_value( const cata_variant &new_value, stats_tracker & ) override;
-
-        bool is_satisfied( stats_tracker &stats ) {
-            return requirement_->satisifed_by( requirement_->statistic->value( stats ) );
-        }
-
-        std::string ui_text() const {
-            return text_for_requirement( *requirement_, current_value_ );
-        }
-    private:
-        cata_variant current_value_;
-        achievement_tracker *tracker_;
-        const achievement_requirement *requirement_;
-};
-
-void requirement_watcher::new_value( const cata_variant &new_value, stats_tracker & )
-{
-    if( !tracker_->has_failed() ) {
-        current_value_ = new_value;
-    }
-    // set_requirement can result in this being deleted, so it must be the last
-    // thing in this function
-    tracker_->set_requirement( this, requirement_->satisifed_by( current_value_ ) );
-}
-
 namespace io
 {
 template<>
@@ -808,158 +750,186 @@ void achievement_state::deserialize( JsonIn &jsin )
     jo.read( "last_state_change", last_state_change );
 }
 
-achievement_tracker::achievement_tracker( const achievement &a, achievements_tracker &tracker,
-        stats_tracker &stats ) :
-    achievement_( &a ),
-    tracker_( &tracker )
+namespace
 {
-    for( const achievement_requirement &req : a.requirements() ) {
-        watchers_.push_back( std::make_unique<requirement_watcher>( *this, req, stats ) );
-    }
 
-    for( const std::unique_ptr<requirement_watcher> &watcher : watchers_ ) {
-        bool is_satisfied = watcher->is_satisfied( stats );
-        sorted_watchers_[is_satisfied].insert( watcher.get() );
-    }
+auto current_value_for_requirement( const achievement_requirement &req,
+                                    stats_tracker &stats ) -> cata_variant
+{
+    return req.statistic->value( stats );
 }
 
-void achievement_tracker::set_requirement( requirement_watcher *watcher, bool is_satisfied )
+auto current_values_for_achievement( const achievement &ach,
+                                     stats_tracker &stats ) -> std::vector<cata_variant>
 {
-    if( sorted_watchers_[is_satisfied].insert( watcher ).second ) {
-        // Remove from other; check for completion.
-        sorted_watchers_[!is_satisfied].erase( watcher );
-        assert( sorted_watchers_[0].size() + sorted_watchers_[1].size() == watchers_.size() );
-    }
-
-    achievement_completion time_comp = time_req_completed( *achievement_ );
-    achievement_completion skill_comp = skill_req_completed( *achievement_ );
-    achievement_completion kill_comp = kill_req_completed( *achievement_, *tracker_->kills() );
-    bool all_clear = time_comp == achievement_completion::completed &&
-                     skill_comp == achievement_completion::completed && kill_comp == achievement_completion::completed;
-
-    if( sorted_watchers_[false].empty() && all_clear ) {
-        // report_achievement can result in this being deleted, so it must be
-        // the last thing in the function
-        tracker_->report_achievement( achievement_, achievement_completion::completed );
-        return;
-    }
-
-    if( time_comp == achievement_completion::failed || kill_comp == achievement_completion::failed ||
-        ( !is_satisfied && watcher->requirement().becomes_false ) ) {
-        // report_achievement can result in this being deleted, so it must be
-        // the last thing in the function
-        tracker_->report_achievement( achievement_, achievement_completion::failed );
-    }
+    return ach.requirements()
+    | std::views::transform( [&]( const achievement_requirement & req ) {
+        return current_value_for_requirement( req, stats );
+    } )
+    | std::ranges::to<std::vector>();
 }
 
-bool achievement_tracker::has_failed() const
+auto has_failed_requirement( const achievement &ach, stats_tracker &stats ) -> bool
 {
-    bool failed = time_req_completed( *achievement_ ) == achievement_completion::failed ||
-                  skill_req_completed( *achievement_ ) == achievement_completion::failed ||
-                  kill_req_completed( *achievement_, *tracker_->kills() ) == achievement_completion::failed;
-    return failed;
+    return std::ranges::any_of( ach.requirements(), [&]( const achievement_requirement & req ) {
+        return req.becomes_false && !req.satisifed_by( current_value_for_requirement( req, stats ) );
+    } );
 }
 
-std::vector<cata_variant> achievement_tracker::current_values() const
-{
-    std::vector<cata_variant> result;
-    result.reserve( watchers_.size() );
-    for( const std::unique_ptr<requirement_watcher> &watcher : watchers_ ) {
-        result.push_back( watcher->current_value() );
-    }
-    return result;
-}
-
-std::string achievement_tracker::ui_text() const
-{
-    // Determine overall achievement status
-    if( has_failed() ) {
-        return achievement_state{
-            achievement_completion::failed,
-            calendar::turn,
-            current_values()
-        }. ui_text( achievement_, *tracker_->kills() );
-    }
-
-    // First: the achievement name and description
-    nc_color c = color_from_completion( achievement_completion::pending );
-    std::string result = colorize( achievement_->name(), c ) + "\n";
-    if( !achievement_->description().empty() ) {
-        result += "  " + colorize( achievement_->description(), c ) + "\n";
-    }
-
-    // Next: the time constraint, skill requirements and kill_requirements, if any
-    result += achievement_->ui_text( achievement_completion::pending, *tracker_->kills() );
-
-    // Next: the requirements
-    for( const std::unique_ptr<requirement_watcher> &watcher : watchers_ ) {
-        result += "  " + watcher->ui_text() + "\n";
-    }
-
-    return result;
-}
+} // namespace
 
 achievements_tracker::achievements_tracker(
     stats_tracker &stats, kill_tracker &kt,
     const std::function<void( const achievement * )> &achievement_attained_callback ) :
     stats_( &stats ),
     kill_tracker_( &kt ),
-    achievement_attained_callback_( achievement_attained_callback )
-{}
+    achievement_attained_callback_( achievement_attained_callback ),
+    previous_active_tracker_( achievement_runtime::active_tracker() )
+{
+    achievement_runtime::set_active_tracker( this );
+    activate_statistics();
+}
 
-achievements_tracker::~achievements_tracker() = default;
+achievements_tracker::~achievements_tracker()
+{
+    if( achievement_runtime::active_tracker() == this ) {
+        achievement_runtime::set_active_tracker( previous_active_tracker_ );
+    }
+}
 
-const kill_tracker *achievements_tracker::kills() const
+auto achievements_tracker::stats() -> stats_tracker &
+{
+    return *stats_;
+}
+
+auto achievements_tracker::stats() const -> const stats_tracker &
+{
+    return *stats_;
+}
+
+auto achievements_tracker::kills() const -> const kill_tracker *
 {
     return kill_tracker_;
 }
 
-std::vector<const achievement *> achievements_tracker::valid_achievements() const
+auto achievements_tracker::valid_achievements() const -> std::vector<const achievement *>
 {
-    std::vector<const achievement *> result;
-    for( const achievement &ach : achievement::get_all() ) {
-        result.push_back( &ach );
+    return achievement::get_all()
+    | std::views::transform( []( const achievement & ach ) {
+        return &ach;
+    } )
+    | std::ranges::to<std::vector>();
+}
+
+auto achievements_tracker::current_values_for( const achievement &ach ) const ->
+std::vector<cata_variant>
+{
+    return current_values_for_achievement( ach, *stats_ );
+}
+
+auto achievements_tracker::activate_statistics() -> void
+{
+    auto tracked_statistics = achievement::get_all()
+    | std::views::transform( []( const achievement & ach ) {
+        return ach.requirements()
+        | std::views::transform( []( const achievement_requirement & req ) {
+            return req.statistic;
+        } );
+    } )
+    | std::views::join;
+
+    for( const string_id<event_statistic> &statistic : tracked_statistics ) {
+        stats_->activate_stat( statistic );
     }
+}
+
+auto achievements_tracker::has_failed( const achievement &ach ) const -> bool
+{
+    return time_req_completed( ach ) == achievement_completion::failed ||
+           skill_req_completed( ach ) == achievement_completion::failed ||
+           kill_req_completed( ach, *kill_tracker_ ) == achievement_completion::failed ||
+           has_failed_requirement( ach, *stats_ );
+}
+
+auto achievements_tracker::pending_ui_text_for( const achievement &ach ) const -> std::string
+{
+    if( has_failed( ach ) ) {
+        return achievement_state{
+            achievement_completion::failed,
+            calendar::turn,
+            current_values_for( ach )
+        }.ui_text( &ach, *kill_tracker_ );
+    }
+
+    auto result = colorize( ach.name(),
+                            color_from_completion( achievement_completion::pending ) ) + "\n";
+    if( !ach.description().empty() ) {
+        result += "  " + colorize( ach.description(), c_yellow ) + "\n";
+    }
+
+    result += ach.ui_text( achievement_completion::pending, *kill_tracker_ );
+    for( const achievement_requirement &req : ach.requirements() ) {
+        result += "  " + text_for_requirement( req, current_value_for_requirement( req, *stats_ ) ) + "\n";
+    }
+
     return result;
 }
 
-void achievements_tracker::report_achievement( const achievement *a,
-        achievement_completion comp )
+auto achievements_tracker::report_achievement( const achievement *a,
+        achievement_completion comp ) -> void
 {
-    assert( comp != achievement_completion::pending );
-    assert( !achievements_status_.count( a->id ) );
+    if( comp == achievement_completion::pending || achievements_status_.contains( a->id ) ) {
+        return;
+    }
 
-    auto tracker_it = trackers_.find( a->id );
     achievements_status_.emplace(
         a->id,
     achievement_state{
         comp,
         calendar::turn,
-        tracker_it->second.current_values()
+        current_values_for( *a )
     }
     );
+
     if( comp == achievement_completion::completed ) {
         achievement_attained_callback_( a );
     }
-    trackers_.erase( tracker_it );
 }
 
-achievement_completion achievements_tracker::is_completed( const string_id<achievement> &id )
-const
+auto achievements_tracker::report_achievement( const string_id<achievement> &id,
+        achievement_completion comp ) -> void
 {
-    auto it = achievements_status_.find( id );
-    if( it == achievements_status_.end() ) {
-        // It might still have failed; check for other criteria
-        auto tracker_it = trackers_.find( id );
-        if( tracker_it != trackers_.end() && tracker_it->second.has_failed() ) {
-            return achievement_completion::failed;
-        }
-        return achievement_completion::pending;
+    if( !id.is_valid() ) {
+        return;
     }
-    return it->second.completion;
+
+    report_achievement( &id.obj(), comp );
 }
 
-bool achievements_tracker::is_hidden( const achievement *ach ) const
+auto achievements_tracker::recorded_completion( const string_id<achievement> &id ) const ->
+achievement_completion
+{
+    const auto iter = achievements_status_.find( id );
+    return iter == achievements_status_.end() ? achievement_completion::pending :
+           iter->second.completion;
+}
+
+auto achievements_tracker::is_completed( const string_id<achievement> &id ) const ->
+achievement_completion
+{
+    const auto recorded = recorded_completion( id );
+    if( recorded != achievement_completion::pending ) {
+        return recorded;
+    }
+
+    if( id.is_valid() && has_failed( id.obj() ) ) {
+        return achievement_completion::failed;
+    }
+
+    return achievement_completion::pending;
+}
+
+auto achievements_tracker::is_hidden( const achievement *ach ) const -> bool
 {
     if( is_completed( ach->id ) == achievement_completion::completed ) {
         return false;
@@ -970,61 +940,38 @@ bool achievements_tracker::is_hidden( const achievement *ach ) const
             return true;
         }
     }
+
     return false;
 }
 
-std::string achievements_tracker::ui_text_for( const achievement *ach ) const
+auto achievements_tracker::ui_text_for( const achievement *ach ) const -> std::string
 {
-    auto state_it = achievements_status_.find( ach->id );
-    if( state_it != achievements_status_.end() ) {
-        return state_it->second.ui_text( ach, *kills() );
+    const auto iter = achievements_status_.find( ach->id );
+    if( iter != achievements_status_.end() ) {
+        return iter->second.ui_text( ach, *kill_tracker_ );
     }
-    auto tracker_it = trackers_.find( ach->id );
-    if( tracker_it == trackers_.end() ) {
-        return colorize( ach->description() + _( "\nInternal error: achievement lacks watcher." ),
-                         c_red );
-    }
-    return tracker_it->second.ui_text();
+
+    return pending_ui_text_for( *ach );
 }
 
-void achievements_tracker::clear()
+auto achievements_tracker::clear() -> void
 {
-    trackers_.clear();
     achievements_status_.clear();
+    activate_statistics();
 }
 
-void achievements_tracker::notify( const cata::event &e )
-{
-    if( e.type() == event_type::game_start ) {
-        init_watchers();
-    }
-}
-
-void achievements_tracker::serialize( JsonOut &jsout ) const
+auto achievements_tracker::serialize( JsonOut &jsout ) const -> void
 {
     jsout.start_object();
     jsout.member( "achievements_status", achievements_status_ );
     jsout.end_object();
 }
 
-void achievements_tracker::deserialize( JsonIn &jsin )
+auto achievements_tracker::deserialize( JsonIn &jsin ) -> void
 {
     JsonObject jo = jsin.get_object();
     jo.read( "achievements_status", achievements_status_ );
-
-    init_watchers();
-}
-
-void achievements_tracker::init_watchers()
-{
-    for( const achievement *a : valid_achievements() ) {
-        if( achievements_status_.contains( a->id ) ) {
-            continue;
-        }
-        trackers_.emplace(
-            std::piecewise_construct, std::forward_as_tuple( a->id ),
-            std::forward_as_tuple( *a, *this, *stats_ ) );
-    }
+    activate_statistics();
 }
 
 void achievement_requirement::deserialize( JsonIn &jin )

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -1,18 +1,15 @@
 #pragma once
 
-#include <array>
 #include <functional>
-#include <memory>
+#include <map>
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "calendar.h"
 #include "cata_variant.h"
 #include "enums.h"
-#include "event_bus.h"
 #include "event_statistics.h"
 #include "json.h"
 #include "string_id.h"
@@ -22,13 +19,8 @@ class JsonIn;
 class JsonObject;
 class JsonOut;
 class achievements_tracker;
-class requirement_watcher;
 class stats_tracker;
 class kill_tracker;
-namespace cata
-{
-class event;
-}  // namespace cata
 struct achievement_requirement;
 template <typename E> struct enum_traits;
 
@@ -149,7 +141,7 @@ class achievement
 struct achievement_requirement {
     string_id<event_statistic> statistic;
     achievement_comparison comparison;
-    int target;
+    int target = 0;
     bool becomes_false = false;
 
     void deserialize( JsonIn &jin );
@@ -182,72 +174,49 @@ struct achievement_state {
     void deserialize( JsonIn & );
 };
 
-class achievement_tracker
+class achievements_tracker
 {
     public:
-        // Non-movable because requirement_watcher stores a pointer to us
-        achievement_tracker( const achievement_tracker & ) = delete;
-        achievement_tracker &operator=( const achievement_tracker & ) = delete;
-
-        achievement_tracker( const achievement &a, achievements_tracker &tracker,
-                             stats_tracker &stats );
-
-        void set_requirement( requirement_watcher *watcher, bool is_satisfied );
-
-        bool has_failed() const;
-        std::vector<cata_variant> current_values() const;
-        std::string ui_text() const;
-    private:
-        const achievement *achievement_;
-        achievements_tracker *tracker_;
-        std::vector<std::unique_ptr<requirement_watcher>> watchers_;
-
-        // sorted_watchers_ maintains two sets of watchers, categorised by
-        // whether they watch a satisfied or unsatisfied requirement.  This
-        // allows us to check whether the achievment is met on each new stat
-        // value in O(1) time.
-        std::array<std::unordered_set<requirement_watcher *>, 2> sorted_watchers_;
-};
-
-class achievements_tracker : public event_subscriber
-{
-    public:
-        // Non-movable because achievement_tracker stores a pointer to us
         achievements_tracker( const achievements_tracker & ) = delete;
         achievements_tracker &operator=( const achievements_tracker & ) = delete;
 
         achievements_tracker(
             stats_tracker &, kill_tracker &,
             const std::function<void( const achievement * )> &achievement_attained_callback );
-        ~achievements_tracker() override;
+        ~achievements_tracker();
+
+        auto stats() -> stats_tracker &; // *NOPAD*
+        auto stats() const -> const stats_tracker &; // *NOPAD*
 
         // Return kill tracker pointer (only matters for testing)
-        const kill_tracker *kills() const;
+        auto kills() const -> const kill_tracker *; // *NOPAD*
 
         // Return all scores which are valid now and existed at game start
-        std::vector<const achievement *> valid_achievements() const;
+        auto valid_achievements() const -> std::vector<const achievement *>;
 
-        void report_achievement( const achievement *, achievement_completion );
+        auto report_achievement( const achievement *, achievement_completion ) -> void;
+        auto report_achievement( const string_id<achievement> &, achievement_completion ) -> void;
 
-        achievement_completion is_completed( const string_id<achievement> & ) const;
-        bool is_hidden( const achievement * ) const;
-        std::string ui_text_for( const achievement * ) const;
+        auto recorded_completion( const string_id<achievement> & ) const -> achievement_completion;
+        auto is_completed( const string_id<achievement> & ) const -> achievement_completion;
+        auto is_hidden( const achievement * ) const -> bool;
+        auto ui_text_for( const achievement * ) const -> std::string;
 
-        void clear();
-        void notify( const cata::event & ) override;
+        auto clear() -> void;
 
-        void serialize( JsonOut & ) const;
-        void deserialize( JsonIn & );
+        auto serialize( JsonOut & ) const -> void;
+        auto deserialize( JsonIn & ) -> void;
     private:
-        void init_watchers();
+        auto activate_statistics() -> void;
+        auto current_values_for( const achievement & ) const -> std::vector<cata_variant>;
+        auto has_failed( const achievement & ) const -> bool;
+        auto pending_ui_text_for( const achievement & ) const -> std::string;
 
         stats_tracker *stats_ = nullptr;
         kill_tracker *kill_tracker_ = nullptr;
         std::function<void( const achievement * )> achievement_attained_callback_;
+        achievements_tracker *previous_active_tracker_ = nullptr;
 
-        // Class invariant: each valid achievement has exactly one of a watcher
-        // (if it's pending) or a status (if it's completed or failed).
-        std::unordered_map<string_id<achievement>, achievement_tracker> trackers_;
         std::unordered_map<string_id<achievement>, achievement_state> achievements_status_;
 };
 
@@ -260,4 +229,3 @@ achievement_completion skill_req_completed( const achievement &ach );
 
 /** Uses comparator supplied to compare target and supplied value. Only works on integers.*/
 bool ach_compare( const achievement_comparison symbol, const int target, const int to_compare );
-

--- a/src/achievement_runtime.h
+++ b/src/achievement_runtime.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class achievements_tracker;
+
+namespace achievement_runtime
+{
+
+auto set_active_tracker( achievements_tracker *tracker ) -> void;
+auto active_tracker() -> achievements_tracker *; // *NOPAD*
+
+} // namespace achievement_runtime

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -550,6 +550,12 @@ void cata::detail::reg_hooks_examples( sol::state &lua )
     DOC( "Called when the game has first started." );
     luna::set_fx( lib, "on_game_started", []() {} );
 
+    DOC( "Called when an event statistic changes.  " );
+    DOC( "The hook receives a table with keys:  " );
+    DOC( "* `statistic_id` (string): The changed event statistic id  " );
+    DOC_PARAMS( "params" );
+    luna::set_fx( lib, "on_stat_changed", []( const sol::table & ) {} );
+
     DOC( "Called when the weather has changed.  " );
     DOC( "The hook receives a table with keys:  " );
     DOC( "* `weather_id` (string): Current weather ID  " );
@@ -994,6 +1000,7 @@ void cata::reg_all_bindings( sol::state &lua )
 
     override_default_print( lua );
     forbid_unsafe_functions( lua );
+    reg_achievement_api( lua );
     reg_debug_api( lua );
     reg_game_api( lua );
     reg_locale_api( lua );

--- a/src/catalua_bindings.h
+++ b/src/catalua_bindings.h
@@ -13,6 +13,7 @@ void override_default_print( sol::state &lua );
 void forbid_unsafe_functions( sol::state &lua );
 
 void reg_avatar( sol::state &lua );
+void reg_achievement_api( sol::state &lua );
 void reg_bionics( sol::state &lua );
 void mod_bionic_data( sol::state &lua );
 void reg_character( sol::state &lua );

--- a/src/catalua_bindings_achievement.cpp
+++ b/src/catalua_bindings_achievement.cpp
@@ -1,0 +1,263 @@
+#include "catalua_bindings.h"
+#include "catalua_bindings_utils.h"
+
+#include "achievement.h"
+#include "achievement_runtime.h"
+#include "calendar.h"
+#include "catalua_luna.h"
+#include "catalua_luna_doc.h"
+#include "character.h"
+#include "debug.h"
+#include "event_statistics.h"
+#include "kill_tracker.h"
+#include "skill.h"
+#include "stats_tracker.h"
+#include "type_id.h"
+
+namespace
+{
+
+auto comparison_string( const achievement_comparison comparison ) -> std::string
+{
+    switch( comparison ) {
+        case achievement_comparison::less_equal:
+            return "<=";
+        case achievement_comparison::greater_equal:
+            return ">=";
+        case achievement_comparison::anything:
+            return "anything";
+        case achievement_comparison::last:
+            break;
+    }
+    debugmsg( "Invalid achievement_comparison" );
+    return "anything";
+}
+
+auto completion_string( const achievement_completion completion ) -> std::string
+{
+    switch( completion ) {
+        case achievement_completion::pending:
+            return "pending";
+        case achievement_completion::completed:
+            return "completed";
+        case achievement_completion::failed:
+            return "failed";
+        case achievement_completion::last:
+            break;
+    }
+    debugmsg( "Invalid achievement_completion" );
+    return "pending";
+}
+
+auto completion_from_string( const std::string &completion ) -> achievement_completion
+{
+    if( completion == "completed" ) {
+        return achievement_completion::completed;
+    }
+    if( completion == "failed" ) {
+        return achievement_completion::failed;
+    }
+    if( completion == "pending" ) {
+        return achievement_completion::pending;
+    }
+
+    debugmsg( "Invalid achievement completion string: %s", completion );
+    return achievement_completion::pending;
+}
+
+auto tracker() -> achievements_tracker *
+{
+    return achievement_runtime::active_tracker();
+}
+
+auto add_hidden_by( sol::state_view lua, sol::table &entry,
+                    const achievement &ach ) -> void
+{
+    auto hidden_by = lua.create_table();
+    auto index = 1;
+    for( const string_id<achievement> &hidden_id : ach.hidden_by() ) {
+        hidden_by[index++] = hidden_id.str();
+    }
+    entry["hidden_by"] = hidden_by;
+}
+
+auto add_time_constraint( sol::state_view lua, sol::table &entry,
+                          const achievement &ach ) -> void
+{
+    if( !ach.time_constraint() ) {
+        return;
+    }
+
+    entry["time_constraint"] = lua.create_table_with(
+                                   "comparison", comparison_string( ach.time_constraint()->comparison() ),
+                                   "target_turn", to_turn<int>( ach.time_constraint()->target() )
+                               );
+}
+
+auto add_skill_requirements( sol::state_view lua, sol::table &entry,
+                             const achievement &ach ) -> void
+{
+    auto requirements = lua.create_table();
+    auto index = 1;
+    for( const auto &[skill_id, requirement] : ach.skill_requirements() ) {
+        const auto &[comparison, level] = requirement;
+        requirements[index++] = lua.create_table_with(
+                                    "skill_id", skill_id.str(),
+                                    "comparison", comparison_string( comparison ),
+                                    "level", level
+                                );
+    }
+    entry["skill_requirements"] = requirements;
+}
+
+auto add_kill_requirements( sol::state_view lua, sol::table &entry,
+                            const achievement &ach ) -> void
+{
+    auto requirements = lua.create_table();
+    auto index = 1;
+    for( const auto &[monster_id, requirement] : ach.kill_requirements() ) {
+        const auto &[comparison, count] = requirement;
+        auto row = lua.create_table_with(
+                       "comparison", comparison_string( comparison ),
+                       "count", count,
+                       "kind", monster_id == mtype_id::NULL_ID() ? "all" : "monster"
+                   );
+        if( monster_id != mtype_id::NULL_ID() ) {
+            row["id"] = monster_id.str();
+        }
+        requirements[index++] = row;
+    }
+    for( const auto &[species_id, requirement] : ach.species_kill_requirements() ) {
+        const auto &[comparison, count] = requirement;
+        requirements[index++] = lua.create_table_with(
+                                    "id", species_id.str(),
+                                    "comparison", comparison_string( comparison ),
+                                    "count", count,
+                                    "kind", "species"
+                                );
+    }
+    entry["kill_requirements"] = requirements;
+}
+
+auto add_requirements( sol::state_view lua, sol::table &entry,
+                       const achievement &ach ) -> void
+{
+    auto requirements = lua.create_table();
+    auto index = 1;
+    for( const achievement_requirement &req : ach.requirements() ) {
+        auto row = lua.create_table_with(
+                       "statistic_id", req.statistic.str(),
+                       "comparison", comparison_string( req.comparison ),
+                       "becomes_false", req.becomes_false
+                   );
+        if( req.comparison != achievement_comparison::anything ) {
+            row["target"] = req.target;
+        }
+        requirements[index++] = row;
+    }
+    entry["requirements"] = requirements;
+}
+
+} // namespace
+
+void cata::detail::reg_achievement_api( sol::state &lua )
+{
+    DOC( "Achievement runtime helpers for Lua-driven tracking." );
+    auto lib = luna::begin_lib( lua, "achievement_api" );
+
+    luna::set_fx( lib, "definitions", []( sol::this_state lua_this ) {
+        sol::state_view lua_state( lua_this );
+        auto out = lua_state.create_table();
+        auto index = 1;
+        for( const achievement &ach : achievement::get_all() ) {
+            auto entry = lua_state.create_table_with( "id", ach.id.str() );
+            add_hidden_by( lua_state, entry, ach );
+            add_time_constraint( lua_state, entry, ach );
+            add_skill_requirements( lua_state, entry, ach );
+            add_kill_requirements( lua_state, entry, ach );
+            add_requirements( lua_state, entry, ach );
+            out[index++] = entry;
+        }
+        return out;
+    } );
+
+    luna::set_fx( lib, "state", []( const std::string & achievement_id ) -> std::string {
+        const auto *active = tracker();
+        if( active == nullptr )
+        {
+            return completion_string( achievement_completion::pending );
+        }
+        return completion_string( active->recorded_completion( string_id<achievement>( achievement_id ) ) );
+    } );
+
+    luna::set_fx( lib, "report", []( const std::string & achievement_id,
+    const std::string & completion ) -> void {
+        auto *active = tracker();
+        if( active == nullptr )
+        {
+            return;
+        }
+        active->report_achievement( string_id<achievement>( achievement_id ),
+                                    completion_from_string( completion ) );
+    } );
+
+    luna::set_fx( lib, "stat_value", []( const std::string & statistic_id ) -> int {
+        auto *active = tracker();
+        if( active == nullptr )
+        {
+            return 0;
+        }
+        const auto id = string_id<event_statistic>( statistic_id );
+        if( !id.is_valid() )
+        {
+            return 0;
+        }
+        return active->stats().value_of( id ).get<int>();
+    } );
+
+    luna::set_fx( lib, "skill_level", []( const std::string & skill_name ) -> int {
+        const auto id = skill_id( skill_name );
+        if( !id.is_valid() )
+        {
+            return 0;
+        }
+        return get_player_character().get_skill_level( id );
+    } );
+
+    luna::set_fx( lib, "total_kill_count", []() -> int {
+        const auto *active = tracker();
+        return active == nullptr ? 0 : active->kills()->monster_kill_count();
+    } );
+
+    luna::set_fx( lib, "monster_kill_count", []( const std::string & monster_name ) -> int {
+        const auto *active = tracker();
+        const auto id = mtype_id( monster_name );
+        if( active == nullptr || !id.is_valid() )
+        {
+            return 0;
+        }
+        return active->kills()->kill_count( id );
+    } );
+
+    luna::set_fx( lib, "species_kill_count", []( const std::string & species_name ) -> int {
+        const auto *active = tracker();
+        const auto id = species_id( species_name );
+        if( active == nullptr || !id.is_valid() || id.is_null() )
+        {
+            return 0;
+        }
+        return active->kills()->kill_count( id );
+    } );
+
+    luna::set_fx( lib, "current_turn", []() -> int {
+        return to_turn<int>( calendar::turn );
+    } );
+    luna::set_fx( lib, "game_start_turn", []() -> int {
+        return to_turn<int>( calendar::start_of_game );
+    } );
+    luna::set_fx( lib, "cataclysm_start_turn", []() -> int {
+        return to_turn<int>( calendar::start_of_cataclysm );
+    } );
+
+    luna::finalize_lib( lib );
+}

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -9,6 +9,7 @@ constexpr auto hook_names = std::array
     "on_game_load",
     "on_game_save",
     "on_game_started",
+    "on_stat_changed",
     "on_weather_changed",
     "on_weather_updated",
     "on_try_npc_interaction",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -427,7 +427,6 @@ game::game() :
     events().subscribe( &*kill_tracker_ptr );
     events().subscribe( &*stats_tracker_ptr );
     events().subscribe( &*memorial_logger_ptr );
-    events().subscribe( &*achievements_tracker_ptr );
     events().subscribe( &*spell_events_ptr );
     world_generator = std::make_unique<worldfactory>();
     // do nothing, everything that was in here is moved to init_data() which is called immediately after g = new game; in main.cpp

--- a/src/stats_tracker.cpp
+++ b/src/stats_tracker.cpp
@@ -5,8 +5,11 @@
 #include <map>
 #include <utility>
 
+#include "catalua_hooks.h"
+#include "catalua_sol.h"
 #include "debug.h"
 #include "event_statistics.h"
+#include "init.h"
 
 static bool event_data_matches( const cata::event::data_type &data,
                                 const cata::event::data_type &criteria )
@@ -156,6 +159,14 @@ cata_variant stats_tracker::value_of( const string_id<event_statistic> &stat )
     return stat->value( *this );
 }
 
+void stats_tracker::activate_stat( const string_id<event_statistic> &id )
+{
+    std::unique_ptr<stats_tracker_state> &state = stat_states[ id ];
+    if( !state ) {
+        state = id->watch( *this );
+    }
+}
+
 void stats_tracker::add_watcher( event_type type, event_multiset_watcher *watcher )
 {
     event_type_watchers[type].insert( watcher );
@@ -177,10 +188,7 @@ void stats_tracker::add_watcher( const string_id<event_statistic> &id, stat_watc
 {
     stat_watchers[id].insert( watcher );
     watcher->on_subscribe( this );
-    std::unique_ptr<stats_tracker_state> &state = stat_states[ id ];
-    if( !state ) {
-        state = id->watch( *this );
-    }
+    activate_stat( id );
 }
 
 void stats_tracker::unwatch( base_watcher *watcher )
@@ -230,6 +238,12 @@ void stats_tracker::stat_value_changed( const string_id<event_statistic> &id,
     auto it = stat_watchers.find( id );
     if( it != stat_watchers.end() ) {
         it->second.send_to_all( &stat_watcher::new_value, new_value, *this );
+    }
+
+    if( DynamicDataLoader::get_instance().lua ) {
+        cata::run_hooks( "on_stat_changed", [&]( auto & params ) {
+            params["statistic_id"] = id.str();
+        }, { .state = DynamicDataLoader::get_instance().lua.get() } );
     }
 }
 

--- a/src/stats_tracker.h
+++ b/src/stats_tracker.h
@@ -154,6 +154,7 @@ class stats_tracker : public event_subscriber
         event_multiset get_events( const string_id<event_transformation> & );
 
         cata_variant value_of( const string_id<event_statistic> & );
+        void activate_stat( const string_id<event_statistic> & );
 
         void add_watcher( event_type, event_multiset_watcher * );
         void add_watcher( const string_id<event_transformation> &, event_multiset_watcher * );
@@ -192,5 +193,4 @@ class stats_tracker : public event_subscriber
 
         std::unordered_set<string_id<score>> initial_scores;
 };
-
 

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 
 #include "achievement.h"
@@ -16,6 +17,7 @@
 #include "event_statistics.h"
 #include "game.h"
 #include "game_constants.h"
+#include "json.h"
 #include "kill_tracker.h"
 #include "options_helpers.h"
 #include "stats_tracker.h"
@@ -472,7 +474,6 @@ TEST_CASE( "achievements_tracker", "[stats]" )
     achievements_tracker a( s, k, [&]( const achievement * a ) {
         achievements_completed.emplace( a->id, a );
     } );
-    b.subscribe( &a );
 
     SECTION( "time" ) {
         calendar::turn = calendar::start_of_game;
@@ -716,6 +717,32 @@ TEST_CASE( "achievements_tracker", "[stats]" )
                 }
             }
         }
+    }
+
+    SECTION( "serialize_format" ) {
+        const character_id u_id = g->u.getID();
+        const mtype_id mon_zombie( "mon_zombie" );
+        const cata::event avatar_zombie_kill =
+            cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie );
+        const string_id<achievement> a_kill_zombie( "achievement_kill_zombie" );
+
+        b.send<event_type::game_start>( u_id );
+        b.send( avatar_zombie_kill );
+
+        std::ostringstream serialized;
+        JsonOut jsout( serialized );
+        a.serialize( jsout );
+
+        CHECK( serialized.str().find( "\"achievements_status\"" ) != std::string::npos );
+        CHECK( serialized.str().find( "\"achievement_kill_zombie\"" ) != std::string::npos );
+        CHECK( serialized.str().find( "\"completion\":\"completed\"" ) != std::string::npos );
+
+        achievements_tracker loaded( s, k, [&]( const achievement * ) {} );
+        std::istringstream input( serialized.str() );
+        JsonIn jsin( input );
+        loaded.deserialize( jsin );
+
+        CHECK( loaded.recorded_completion( a_kill_zombie ) == achievement_completion::completed );
     }
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Achievement tracking duplicated the existing Lua hook pipeline. Moving transition logic to Lua keeps the save payload unchanged while removes the per-achievement C++ watcher layer.

## Describe the solution (The How)
- add an `on_stat_changed` hook and a core Lua achievement runtime that evaluates completion and failure
- keep `achievements_tracker` as the save/UI wrapper and pre-activate the required statistics without per-achievement watcher objects
- add regression coverage for achievement completion and serialized tracker state

## Testing
- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[stats]"`
- `./out/build/linux-full/src/cataclysm-bn-tiles --check-mods` (fails on unrelated local `Backrooms-CBN-mod` external option parsing error)

## Checklist

### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines.md).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've committed my changes to new branch that isn't `main` so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This PR modifies lua scripts or the lua API.
- [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
- [x] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<sup>PR opened by gpt-5.4 high on opencode</sup>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [db99a3b](https://github.com/cataclysmbn/Cataclysm-BN/commit/db99a3b07b3aed568c2c156f9ba558bd5cfe2000) (refactor(lua): move achievement tracking onto hooks) on 2026-05-28 19:19:45

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589995848/artifacts/7273562420)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589995848/artifacts/7273506417)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589995848/artifacts/7273556282)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589995848/artifacts/7275170269)
<!-- END artifact comment -->