### PR TITLE
fix: reassign utility part slots

### DIFF
--- a/data/json/vehicleparts/balloons.json
+++ b/data/json/vehicleparts/balloons.json
@@ -2,7 +2,7 @@
   {
     "abstract": "balloon",
     "type": "vehicle_part",
-    "location": "anywhere",
+    "location": "on_roof",
     "symbol": "|",
     "color": "light_blue",
     "looks_like": "inflatable_airbag",

--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -476,7 +476,7 @@
     "type": "vehicle_part",
     "name": { "str": "bike rack" },
     "item": "bike_rack",
-    "location": "anywhere",
+    "location": "on_roof",
     "symbol": "=",
     "broken_symbol": "#",
     "color": "light_gray",

--- a/data/json/vehicleparts/crafting.json
+++ b/data/json/vehicleparts/crafting.json
@@ -441,7 +441,7 @@
     "durability": 200,
     "description": "A water purifier, powered by the vehicle's batteries.  You can use it to purify water in a container or in the vehicle's tanks.  'e'xamine the tile with the purifier to use it.",
     "item": "water_purifier",
-    "location": "anywhere",
+    "location": "on_ceiling",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_screw", 1 ] ] },

--- a/data/json/vehicleparts/misc.json
+++ b/data/json/vehicleparts/misc.json
@@ -108,7 +108,7 @@
     "damage_modifier": 50,
     "durability": 120,
     "item": "NBC_seal",
-    "location": "anywhere",
+    "location": "on_ceiling",
     "flags": [ "NOFIELDS", "SHOCK_IMMUNE", "ON_ROOF" ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "adhesive", 1 ] ] },

--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -134,7 +134,7 @@
     "description": "A crude seat, too uncomfortable to sleep in.",
     "item": "sheet",
     "folded_volume": "2500 ml",
-    "location": "anywhere",
+    "location": "center",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 5 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -608,6 +608,9 @@ void vpart_info::finalize()
         } else if( info.location == "on_cargo" ) {
             info.z_order = 8;
             info.list_order = 6;
+        } else if( info.location == "on_ceiling" ) {
+            info.z_order = 8;
+            info.list_order = 5;
         } else if( info.location == "center" ) {
             info.z_order = 7;
             info.list_order = 7;

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -15,3 +15,14 @@ TEST_CASE( "verify_copy_from_gets_damage_reduction", "[vehicle]" )
     const vpart_info &vp = vpart_id( "halfboard_horizontal" ).obj();
     CHECK( vp.damage_reduction.type_resist( DT_BASH ) != 0 );
 }
+
+TEST_CASE( "vehicle_part_utility_slots_are_not_anywhere", "[vehicle]" )
+{
+    clear_all_state();
+
+    CHECK( vpart_id( "folding_seat" ).obj().location == "center" );
+    CHECK( vpart_id( "bike_rack" ).obj().location == "on_roof" );
+    CHECK( vpart_id( "water_purifier" ).obj().location == "on_ceiling" );
+    CHECK( vpart_id( "NBC_seal" ).obj().location == "on_ceiling" );
+    CHECK( vpart_id( "airship_balloon" ).obj().location == "on_roof" );
+}

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -370,6 +370,22 @@ TEST_CASE( "horde_spawns_skip_owned_vehicle_tiles", "[horde][vehicle][monster]" 
     }
 }
 
+TEST_CASE( "folding_seat_tile_accepts_other_utility_parts", "[vehicle]" )
+{
+    clear_all_state();
+    const auto origin = tripoint_bub_ms( 60, 60, 0 );
+    auto *veh_ptr = get_map().add_vehicle( vproto_id( "bicycle" ), origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    const auto mount = tripoint_mnt_veh::north();
+    REQUIRE( veh_ptr->install_part( mount, vpart_id( "frame_vertical" ) ) >= 0 );
+    REQUIRE( veh_ptr->install_part( mount, vpart_id( "roof" ) ) >= 0 );
+    REQUIRE( veh_ptr->install_part( mount, vpart_id( "folding_seat" ) ) >= 0 );
+
+    CHECK( veh_ptr->can_mount( mount, vpart_id( "NBC_seal" ) ) );
+    CHECK( veh_ptr->can_mount( mount, vpart_id( "inboard_mirror" ) ) );
+}
+
 TEST_CASE( "add_item_to_broken_vehicle_part" )
 {
     clear_all_state();


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #8489.
Vehicle utility parts were still sharing the legacy `anywhere` slot, which blocked combinations like foldable seats with NBC seals on the same tile.

## Describe the solution (The How)

Reassign former `anywhere` parts to more specific layers (`center`, `on_ceiling`, `on_roof`) and give `on_ceiling` explicit ordering.
Add regression tests for the slot remap and for installing utility parts on a folding-seat tile.

## Testing

- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target style-json-parallel`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "vehicle_part_utility_slots_are_not_anywhere"`
- `./out/build/linux-full/tests/cata_test-tiles "folding_seat_tile_accepts_other_utility_parts"`
- `./build-scripts/lint-json.sh`

## Additional context

No existing docs appear to cover vehicle part slot layering.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
- [ ] I have documented the changes in the appropriate location in the `docs/` folder.
- [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.

<sup>PR opened by gpt-5.4 high on opencode</sup>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [da4a608](https://github.com/cataclysmbn/Cataclysm-BN/commit/da4a60880d64c6a527c9a0efb08628195e275ba5) (fix: reassign utility part slots) on 2026-05-28 19:14:51

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589860752)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589860752/artifacts/7273437701)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589860752/artifacts/7272593676)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26589860752/artifacts/7272941332)
<!-- END artifact comment -->