### PR TITLE
chore: script to report missing sprites

### DIFF
--- a/scripts/tileset_missing_items.ts
+++ b/scripts/tileset_missing_items.ts
@@ -1,0 +1,622 @@
+#!/usr/bin/env -S deno run --allow-read
+
+/**
+ * @module
+ *
+ * Reports which items do not have a direct sprite in a tileset, and which only
+ * render through an item `looks_like` fallback.
+ *
+ * example usage:
+ *   `deno run -R scripts/tileset_missing_items.ts --limit 50`
+ *   `deno run -R scripts/tileset_missing_items.ts --looks-like --limit 50`
+ *   `deno run -R scripts/tileset_missing_items.ts --tileset gfx/RetroDaysTileset --tileset gfx/BrownLikeBears --limit 50`
+ */
+
+import { Command } from "@cliffy/command"
+import { walk } from "@std/fs"
+import { isAbsolute, join, relative, resolve } from "@std/path"
+import * as jsonMap from "@scarf/json-map"
+
+const REPO_ROOT = resolve(import.meta.dirname!, "..")
+const DEFAULT_TILESETS = [
+  "gfx/MSX++UnDeadPeopleEdition",
+  "data/json/external_tileset",
+  "data/mods",
+]
+const DEFAULT_INPUTS = ["data/json"]
+const SKIP_INPUT_JSON = [/(modinfo|default|replacements|mod_tileset)\.json/]
+
+export const getJsonPathSkips = (source: "input" | "tileset"): RegExp[] =>
+  source === "tileset" ? [] : Array.from(SKIP_INPUT_JSON)
+
+const ITEM_TYPES = new Set([
+  "AMMO",
+  "ARMOR",
+  "BATTERY",
+  "BIONIC_ITEM",
+  "BOOK",
+  "COMESTIBLE",
+  "CONTAINER",
+  "ENGINE",
+  "GENERIC",
+  "GUN",
+  "GUNMOD",
+  "MAGAZINE",
+  "PET_ARMOR",
+  "SPECIES",
+  "TOOL",
+  "TOOLMOD",
+  "TOOL_ARMOR",
+  "WHEEL",
+])
+
+type DefinitionKind = "item" | "abstract"
+
+interface ItemDefinition {
+  id: string
+  kind: DefinitionKind
+  type: string
+  path: string
+  copyFrom?: string
+  looksLike?: string
+  flags: string[]
+}
+
+interface ResolvedItemDefinition extends ItemDefinition {
+  resolvedLooksLike?: string
+  isFake: boolean
+}
+
+interface TileLookup {
+  tileId: string
+  chain: string[]
+}
+
+const TILE_ID_PREFIXES = ["overlay_wielded_", "overlay_worn_"]
+const TILE_ID_SUFFIX_PATTERNS = [
+  /^(.+)_season_(spring|summer|autumn|winter)$/,
+  /^(.+)_harvested$/,
+  /^(.+)_on$/,
+  /^(.+)_off$/,
+  /^(.+)_open$/,
+  /^(.+)_closed$/,
+  /^(.+)_full$/,
+  /^(.+)_empty$/,
+]
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const mapToObject = (value: unknown): unknown =>
+  value instanceof Map
+    ? Object.fromEntries(Array.from(value, ([key, child]) => [key, mapToObject(child)]))
+    : Array.isArray(value)
+    ? value.map(mapToObject)
+    : value
+
+const toDisplayPath = (path: string): string =>
+  path.startsWith(REPO_ROOT) ? relative(REPO_ROOT, path) : path
+
+const resolveRepoPath = (path: string): string => isAbsolute(path) ? path : resolve(REPO_ROOT, path)
+
+const parseProperties = (content: string): Record<string, string> => {
+  const pairs: Record<string, string> = {}
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue
+    }
+
+    const separator = trimmed.indexOf(":")
+    if (separator === -1) {
+      continue
+    }
+
+    const key = trimmed.slice(0, separator).trim()
+    const value = trimmed.slice(separator + 1).trim()
+    if (key && value) {
+      pairs[key] = value
+    }
+  }
+
+  return pairs
+}
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await Deno.stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const resolveTilesetConfigPath = async (tilesetPath: string): Promise<string> => {
+  const resolvedPath = resolveRepoPath(tilesetPath)
+  const stat = await Deno.stat(resolvedPath)
+  if (stat.isFile) {
+    return resolvedPath
+  }
+
+  const propertiesPath = join(resolvedPath, "tileset.txt")
+  try {
+    const properties = parseProperties(await Deno.readTextFile(propertiesPath))
+    return join(resolvedPath, properties.JSON ?? "tile_config.json")
+  } catch {
+    return join(resolvedPath, "tile_config.json")
+  }
+}
+
+const resolveTilesetSourcePaths = async (tilesetPath: string): Promise<string[]> => {
+  const resolvedPath = resolveRepoPath(tilesetPath)
+  const stat = await Deno.stat(resolvedPath)
+  if (stat.isFile) {
+    return [resolvedPath]
+  }
+
+  if (await pathExists(join(resolvedPath, "tileset.txt"))) {
+    return [await resolveTilesetConfigPath(resolvedPath)]
+  }
+
+  const tileConfigPath = join(resolvedPath, "tile_config.json")
+  if (await pathExists(tileConfigPath)) {
+    return [tileConfigPath]
+  }
+
+  return await readJsonPaths([resolvedPath], getJsonPathSkips("tileset"))
+}
+
+const collectTileIdsFromEntries = (entries: unknown[], tileIds: Set<string>): void => {
+  for (const entry of entries) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const { id, additional_tiles: additionalTiles } = entry
+    if (typeof id === "string") {
+      tileIds.add(id)
+    } else if (Array.isArray(id)) {
+      for (const candidate of id) {
+        if (typeof candidate === "string") {
+          tileIds.add(candidate)
+        }
+      }
+    }
+
+    if (Array.isArray(additionalTiles)) {
+      collectTileIdsFromEntries(additionalTiles, tileIds)
+    }
+  }
+}
+
+const collectTileIdsFromConfig = (config: unknown, tileIds: Set<string>): void => {
+  if (Array.isArray(config)) {
+    for (const child of config) {
+      collectTileIdsFromConfig(child, tileIds)
+    }
+    return
+  }
+
+  if (!isRecord(config)) {
+    return
+  }
+
+  if (Array.isArray(config["tiles-new"])) {
+    collectTileIdsFromConfig(config["tiles-new"], tileIds)
+  }
+
+  if (Array.isArray(config.tiles)) {
+    collectTileIdsFromEntries(config.tiles, tileIds)
+  }
+}
+
+export const collectTileIds = (config: unknown): Set<string> => {
+  const tileIds = new Set<string>()
+
+  collectTileIdsFromConfig(config, tileIds)
+  return tileIds
+}
+
+export const collectTileIdsFromConfigs = (configs: readonly unknown[]): Set<string> => {
+  const tileIds = new Set<string>()
+
+  for (const config of configs) {
+    for (const tileId of collectTileIds(config)) {
+      tileIds.add(tileId)
+    }
+  }
+
+  return tileIds
+}
+
+const collectTileIdAliases = (tileId: string, aliases: Set<string>): void => {
+  if (aliases.has(tileId)) {
+    return
+  }
+  aliases.add(tileId)
+
+  for (const prefix of TILE_ID_PREFIXES) {
+    if (tileId.startsWith(prefix)) {
+      collectTileIdAliases(tileId.slice(prefix.length), aliases)
+    }
+  }
+
+  for (const pattern of TILE_ID_SUFFIX_PATTERNS) {
+    const match = tileId.match(pattern)
+    if (match) {
+      collectTileIdAliases(match[1], aliases)
+    }
+  }
+}
+
+export const getTileIdAliases = (tileId: string): Set<string> => {
+  const aliases = new Set<string>()
+  collectTileIdAliases(tileId, aliases)
+  return aliases
+}
+
+export const buildVariantTileLookup = (tileIds: Iterable<string>): Map<string, string> => {
+  const variantTileLookup = new Map<string, string>()
+
+  for (const tileId of Array.from(tileIds).sort()) {
+    for (const alias of getTileIdAliases(tileId)) {
+      if (alias !== tileId && !variantTileLookup.has(alias)) {
+        variantTileLookup.set(alias, tileId)
+      }
+    }
+  }
+
+  return variantTileLookup
+}
+
+const collectExplicitIgnoredItemIdsFromValue = (
+  value: unknown,
+  ignoredItemIds: Set<string>,
+): void => {
+  if (Array.isArray(value)) {
+    for (const child of value) {
+      collectExplicitIgnoredItemIdsFromValue(child, ignoredItemIds)
+    }
+    return
+  }
+
+  if (!isRecord(value)) {
+    return
+  }
+
+  if (typeof value.fake_item === "string") {
+    ignoredItemIds.add(value.fake_item)
+  }
+
+  if (value.type === "gun") {
+    if (typeof value.gun_type === "string") {
+      ignoredItemIds.add(value.gun_type)
+    }
+    if (typeof value.ammo_type === "string") {
+      ignoredItemIds.add(value.ammo_type)
+    }
+  }
+
+  for (const child of Object.values(value)) {
+    collectExplicitIgnoredItemIdsFromValue(child, ignoredItemIds)
+  }
+}
+
+export const collectExplicitIgnoredItemIds = (entries: readonly unknown[]): Set<string> => {
+  const ignoredItemIds = new Set<string>()
+
+  for (const entry of entries) {
+    collectExplicitIgnoredItemIdsFromValue(entry, ignoredItemIds)
+  }
+
+  return ignoredItemIds
+}
+
+const parseJsonMaps = (content: string): unknown[] => {
+  const parsed = jsonMap.parse(content)
+
+  if (Array.isArray(parsed)) {
+    return parsed
+  }
+
+  return [parsed]
+}
+
+export const readJsonPaths = async (
+  inputs: readonly string[],
+  skip: readonly RegExp[] = getJsonPathSkips("input"),
+): Promise<string[]> => {
+  const jsonPaths = new Set<string>()
+  const skipPatterns = Array.from(skip)
+
+  for (const input of inputs) {
+    const resolvedInput = resolveRepoPath(input)
+    const stat = await Deno.lstat(resolvedInput)
+
+    if (stat.isFile) {
+      jsonPaths.add(resolvedInput)
+      continue
+    }
+
+    for await (
+      const entry of walk(resolvedInput, {
+        includeDirs: false,
+        exts: [".json"],
+        skip: skipPatterns,
+      })
+    ) {
+      jsonPaths.add(entry.path)
+    }
+  }
+
+  return Array.from(jsonPaths)
+}
+
+const toDefinition = (value: unknown, path: string): ItemDefinition | null => {
+  if (!isRecord(value) || typeof value.type !== "string" || !ITEM_TYPES.has(value.type)) {
+    return null
+  }
+
+  const id = typeof value.id === "string"
+    ? value.id
+    : typeof value.abstract === "string"
+    ? value.abstract
+    : undefined
+  if (!id) {
+    return null
+  }
+
+  return {
+    id,
+    kind: typeof value.id === "string" ? "item" : "abstract",
+    type: value.type,
+    path,
+    copyFrom: typeof value["copy-from"] === "string" ? value["copy-from"] : undefined,
+    looksLike: typeof value.looks_like === "string" ? value.looks_like : undefined,
+    flags: Array.isArray(value.flags)
+      ? value.flags.filter((flag): flag is string => typeof flag === "string")
+      : typeof value.flags === "string"
+      ? [value.flags]
+      : [],
+  }
+}
+
+const loadDefinitions = async (inputs: readonly string[]) => {
+  const items = new Map<string, ItemDefinition>()
+  const abstracts = new Map<string, ItemDefinition>()
+  const ignoredItemIds = new Set<string>()
+
+  for (const path of await readJsonPaths(inputs)) {
+    const entries = parseJsonMaps(await Deno.readTextFile(path)).map(mapToObject)
+    for (const ignoredItemId of collectExplicitIgnoredItemIds(entries)) {
+      ignoredItemIds.add(ignoredItemId)
+    }
+    for (const rawEntry of entries) {
+      const definition = toDefinition(rawEntry, path)
+      if (!definition) {
+        continue
+      }
+
+      if (definition.kind === "item") {
+        items.set(definition.id, definition)
+      } else {
+        abstracts.set(definition.id, definition)
+      }
+    }
+  }
+
+  return { items, abstracts, ignoredItemIds }
+}
+
+export const resolveItemDefinitions = (
+  items: Map<string, ItemDefinition>,
+  abstracts: Map<string, ItemDefinition>,
+): Map<string, ResolvedItemDefinition> => {
+  const cache = new Map<string, ResolvedItemDefinition>()
+
+  const findDefinition = (id: string): ItemDefinition | undefined =>
+    items.get(id) ?? abstracts.get(id)
+
+  const resolveDefinition = (
+    definition: ItemDefinition,
+    visiting: Set<string> = new Set(),
+  ): ResolvedItemDefinition => {
+    const cacheKey = `${definition.kind}:${definition.id}`
+    const cached = cache.get(cacheKey)
+    if (cached) {
+      return cached
+    }
+
+    if (visiting.has(cacheKey)) {
+      return {
+        ...definition,
+        resolvedLooksLike: definition.looksLike,
+        isFake: definition.id === "fake_item" || definition.flags.includes("PSEUDO"),
+      }
+    }
+
+    visiting.add(cacheKey)
+
+    let resolvedLooksLike = definition.looksLike
+    let isFake = definition.id === "fake_item" || definition.flags.includes("PSEUDO")
+    if (!resolvedLooksLike && definition.copyFrom) {
+      const parent = findDefinition(definition.copyFrom)
+      if (parent?.kind === "item") {
+        resolvedLooksLike = definition.copyFrom
+        isFake = isFake || resolveDefinition(parent, visiting).isFake
+      } else if (parent?.kind === "abstract") {
+        const resolvedParent = resolveDefinition(parent, visiting)
+        resolvedLooksLike = resolvedParent.resolvedLooksLike ?? definition.copyFrom
+        isFake = isFake || resolvedParent.isFake
+      }
+    }
+
+    visiting.delete(cacheKey)
+
+    const resolved = { ...definition, resolvedLooksLike, isFake }
+    cache.set(cacheKey, resolved)
+    return resolved
+  }
+
+  return new Map(
+    Array.from(items.values(), (definition) => [definition.id, resolveDefinition(definition)]),
+  )
+}
+
+export const shouldIgnoreItemDefinition = (
+  item: ResolvedItemDefinition,
+  ignoredItemIds: ReadonlySet<string>,
+): boolean => item.isFake || ignoredItemIds.has(item.id)
+
+export const findTileByLooksLike = (
+  itemId: string,
+  resolvedItems: Map<string, ResolvedItemDefinition>,
+  tileIds: Set<string>,
+  variantTileLookup: ReadonlyMap<string, string>,
+  depth: number = 10,
+  visited: Set<string> = new Set(),
+): TileLookup | null => {
+  if (!itemId || depth <= 0) {
+    return null
+  }
+
+  if (tileIds.has(itemId)) {
+    return { tileId: itemId, chain: [itemId] }
+  }
+
+  const variantTileId = variantTileLookup.get(itemId)
+  if (variantTileId) {
+    return { tileId: variantTileId, chain: [itemId] }
+  }
+
+  if (visited.has(itemId)) {
+    return null
+  }
+  visited.add(itemId)
+
+  const looksLike = resolvedItems.get(itemId)?.resolvedLooksLike
+  if (!looksLike) {
+    return null
+  }
+
+  const lookup = findTileByLooksLike(
+    looksLike,
+    resolvedItems,
+    tileIds,
+    variantTileLookup,
+    depth - 1,
+    visited,
+  )
+  if (!lookup) {
+    return null
+  }
+
+  return {
+    tileId: lookup.tileId,
+    chain: [itemId, ...lookup.chain],
+  }
+}
+
+const printSection = (
+  title: string,
+  rows: string[],
+  limit: number,
+): void => {
+  console.log(`\n${title} (${rows.length})`)
+  if (rows.length === 0) {
+    console.log("  (none)")
+    return
+  }
+
+  const shownRows = limit > 0 ? rows.slice(0, limit) : rows
+  for (const row of shownRows) {
+    console.log(row)
+  }
+
+  if (limit > 0 && rows.length > limit) {
+    console.log(`... ${rows.length - limit} more`)
+  }
+}
+
+if (import.meta.main) {
+  const parsed = await new Command()
+    .description("Report items missing sprites in one or more tilesets")
+    .option("--tileset <path:string>", "Tileset path(s) to inspect", {
+      collect: true,
+      default: DEFAULT_TILESETS,
+    })
+    .option("--input <path:string>", "Item JSON path(s) to inspect", {
+      collect: true,
+      default: DEFAULT_INPUTS,
+    })
+    .option("--looks-like", "Report items that are only covered by looks_like", {
+      default: false,
+    })
+    .option("--limit <count:number>", "Max rows to print per section", { default: 0 })
+    .parse(Deno.args)
+
+  const tilesets = Array.from((parsed.options.tileset ?? DEFAULT_TILESETS) as string[])
+  const input = Array.from((parsed.options.input ?? DEFAULT_INPUTS) as string[])
+  const showLooksLike = Boolean(parsed.options.looksLike ?? false)
+  const limit = Number(parsed.options.limit ?? 0)
+
+  const tilesetSourcePaths = Array.from(
+    new Set((await Promise.all(tilesets.map(resolveTilesetSourcePaths))).flat()),
+  )
+  const tileIds = collectTileIdsFromConfigs(
+    await Promise.all(
+      tilesetSourcePaths.map(async (tilesetSourcePath) => {
+        return mapToObject(jsonMap.parse(await Deno.readTextFile(tilesetSourcePath)))
+      }),
+    ),
+  )
+  const variantTileLookup = buildVariantTileLookup(tileIds)
+  const { items, abstracts, ignoredItemIds } = await loadDefinitions(input)
+  const resolvedItems = resolveItemDefinitions(items, abstracts)
+  const reportableItems = Array.from(resolvedItems.values())
+    .filter((item) => !shouldIgnoreItemDefinition(item, ignoredItemIds))
+    .sort((left, right) => left.id.localeCompare(right.id))
+
+  const direct: string[] = []
+  const variantOnly: string[] = []
+  const fallbackOnly: string[] = []
+  const missing: string[] = []
+
+  for (const item of reportableItems) {
+    if (tileIds.has(item.id)) {
+      direct.push(item.id)
+      continue
+    }
+
+    const variantTileId = variantTileLookup.get(item.id)
+    if (variantTileId) {
+      variantOnly.push(`${item.id}\t${variantTileId}\t${toDisplayPath(item.path)}`)
+      continue
+    }
+
+    const lookup = findTileByLooksLike(item.id, resolvedItems, tileIds, variantTileLookup)
+    if (lookup) {
+      fallbackOnly.push(`${lookup.chain.join(" -> ")}\t${toDisplayPath(item.path)}`)
+      continue
+    }
+
+    missing.push(`${item.id}\t${toDisplayPath(item.path)}`)
+  }
+
+  console.log(`Tilesets: ${tilesets.map(toDisplayPath).join(", ")}`)
+  console.log(`Inputs: ${input.map(toDisplayPath).join(", ")}`)
+  console.log(`Checked items: ${reportableItems.length}`)
+  console.log(`Direct sprites: ${direct.length}`)
+  console.log(`Variant sprites only: ${variantOnly.length}`)
+  if (showLooksLike) {
+    console.log(`Looks_like fallback only: ${fallbackOnly.length}`)
+  }
+  console.log(`Missing entirely: ${missing.length}`)
+
+  printSection("Missing ITEM id (but variant tile exists)", variantOnly, limit)
+  printSection("Missing ITEM", missing, limit)
+  if (showLooksLike) {
+    printSection("Missing ITEM (but looks_like tile exists)", fallbackOnly, limit)
+  }
+}

--- a/scripts/tileset_missing_items.ts
+++ b/scripts/tileset_missing_items.ts
@@ -16,6 +16,8 @@ import { Command } from "@cliffy/command"
 import { walk } from "@std/fs"
 import { isAbsolute, join, relative, resolve } from "@std/path"
 import * as jsonMap from "@scarf/json-map"
+import { partition } from "jsr:@std/collections@^1.1.3"
+import * as v from "jsr:@valibot/valibot@^1.1.0"
 
 const REPO_ROOT = resolve(import.meta.dirname!, "..")
 const DEFAULT_TILESETS = [
@@ -25,11 +27,7 @@ const DEFAULT_TILESETS = [
 ]
 const DEFAULT_INPUTS = ["data/json"]
 const SKIP_INPUT_JSON = [/(modinfo|default|replacements|mod_tileset)\.json/]
-
-export const getJsonPathSkips = (source: "input" | "tileset"): RegExp[] =>
-  source === "tileset" ? [] : Array.from(SKIP_INPUT_JSON)
-
-const REPORTABLE_TYPES = new Set([
+const REPORTABLE_TYPES = [
   "AMMO",
   "ARMOR",
   "BATTERY",
@@ -48,9 +46,14 @@ const REPORTABLE_TYPES = new Set([
   "TOOLMOD",
   "TOOL_ARMOR",
   "WHEEL",
-])
+] as const
+const OUTPUT_FORMATS = ["text", "json", "md"] as const
+
+export const getJsonPathSkips = (source: "input" | "tileset"): RegExp[] =>
+  source === "tileset" ? [] : Array.from(SKIP_INPUT_JSON)
 
 type DefinitionKind = "item" | "abstract"
+type OutputFormat = (typeof OUTPUT_FORMATS)[number]
 
 interface ItemDefinition {
   id: string
@@ -71,8 +74,6 @@ interface TileLookup {
   tileId: string
   chain: string[]
 }
-
-type OutputFormat = "text" | "json" | "md"
 
 interface VariantOnlyEntry {
   id: string
@@ -116,7 +117,6 @@ interface MissingTilesetReport {
 }
 
 const TILE_ID_PREFIXES = ["overlay_wielded_", "overlay_worn_"]
-const OUTPUT_FORMATS = new Set<OutputFormat>(["text", "json", "md"])
 const TILE_ID_SUFFIX_PATTERNS = [
   /^(.+)_season_(spring|summer|autumn|winter)$/,
   /^(.+)_harvested$/,
@@ -127,9 +127,41 @@ const TILE_ID_SUFFIX_PATTERNS = [
   /^(.+)_full$/,
   /^(.+)_empty$/,
 ]
+const OutputFormatSchema = v.picklist(OUTPUT_FORMATS)
+const TileEntrySchema = v.looseObject({
+  id: v.optional(v.union([v.string(), v.array(v.unknown())])),
+  additional_tiles: v.optional(v.array(v.unknown())),
+})
+const TileConfigSchema = v.looseObject({
+  "tiles-new": v.optional(v.array(v.unknown())),
+  tiles: v.optional(v.array(v.unknown())),
+})
+const DefinitionSchema = v.looseObject({
+  type: v.picklist(REPORTABLE_TYPES),
+  id: v.optional(v.string()),
+  abstract: v.optional(v.string()),
+  "copy-from": v.optional(v.string()),
+  looks_like: v.optional(v.string()),
+  flags: v.optional(v.union([v.string(), v.array(v.unknown())])),
+})
+const IgnoredItemValueSchema = v.looseObject({
+  fake_item: v.optional(v.string()),
+  type: v.optional(v.string()),
+  gun_type: v.optional(v.string()),
+  ammo_type: v.optional(v.string()),
+})
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isDefined = <T>(value: T | undefined): value is T => value !== undefined
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : typeof value === "string"
+    ? [value]
+    : []
 
 const mapToObject = (value: unknown): unknown =>
   value instanceof Map
@@ -143,29 +175,24 @@ const toDisplayPath = (path: string): string =>
 
 const resolveRepoPath = (path: string): string => isAbsolute(path) ? path : resolve(REPO_ROOT, path)
 
-const parseProperties = (content: string): Record<string, string> => {
-  const pairs: Record<string, string> = {}
+const parseProperties = (content: string): Record<string, string> =>
+  Object.fromEntries(
+    content.split("\n").flatMap((line) => {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith("#")) {
+        return []
+      }
 
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim()
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue
-    }
+      const separator = trimmed.indexOf(":")
+      if (separator === -1) {
+        return []
+      }
 
-    const separator = trimmed.indexOf(":")
-    if (separator === -1) {
-      continue
-    }
-
-    const key = trimmed.slice(0, separator).trim()
-    const value = trimmed.slice(separator + 1).trim()
-    if (key && value) {
-      pairs[key] = value
-    }
-  }
-
-  return pairs
-}
+      const key = trimmed.slice(0, separator).trim()
+      const value = trimmed.slice(separator + 1).trim()
+      return key && value ? [[key, value] as const] : []
+    }),
+  )
 
 const pathExists = async (path: string): Promise<boolean> => {
   try {
@@ -211,68 +238,41 @@ const resolveTilesetSourcePaths = async (tilesetPath: string): Promise<string[]>
   return await readJsonPaths([resolvedPath], getJsonPathSkips("tileset"))
 }
 
-const collectTileIdsFromEntries = (entries: unknown[], tileIds: Set<string>): void => {
-  for (const entry of entries) {
-    if (!isRecord(entry)) {
-      continue
-    }
-
-    const { id, additional_tiles: additionalTiles } = entry
-    if (typeof id === "string") {
-      tileIds.add(id)
-    } else if (Array.isArray(id)) {
-      for (const candidate of id) {
-        if (typeof candidate === "string") {
-          tileIds.add(candidate)
-        }
-      }
-    }
-
-    if (Array.isArray(additionalTiles)) {
-      collectTileIdsFromEntries(additionalTiles, tileIds)
-    }
+const tileIdsFromEntry = (entry: unknown): string[] => {
+  const parsedEntry = v.safeParse(TileEntrySchema, entry)
+  if (!parsedEntry.success) {
+    return []
   }
+
+  const { id, additional_tiles: additionalTiles } = parsedEntry.output
+  return [
+    ...asStringArray(id),
+    ...(additionalTiles?.flatMap(tileIdsFromEntry) ?? []),
+  ]
 }
 
-const collectTileIdsFromConfig = (config: unknown, tileIds: Set<string>): void => {
+const tileIdsFromConfig = (config: unknown): string[] => {
   if (Array.isArray(config)) {
-    for (const child of config) {
-      collectTileIdsFromConfig(child, tileIds)
-    }
-    return
+    return config.flatMap(tileIdsFromConfig)
   }
 
-  if (!isRecord(config)) {
-    return
+  const parsedConfig = v.safeParse(TileConfigSchema, config)
+  if (!parsedConfig.success) {
+    return []
   }
 
-  if (Array.isArray(config["tiles-new"])) {
-    collectTileIdsFromConfig(config["tiles-new"], tileIds)
-  }
-
-  if (Array.isArray(config.tiles)) {
-    collectTileIdsFromEntries(config.tiles, tileIds)
-  }
+  return [
+    ...(parsedConfig.output["tiles-new"]
+      ? tileIdsFromConfig(parsedConfig.output["tiles-new"])
+      : []),
+    ...(parsedConfig.output.tiles?.flatMap(tileIdsFromEntry) ?? []),
+  ]
 }
 
-export const collectTileIds = (config: unknown): Set<string> => {
-  const tileIds = new Set<string>()
+export const collectTileIds = (config: unknown): Set<string> => new Set(tileIdsFromConfig(config))
 
-  collectTileIdsFromConfig(config, tileIds)
-  return tileIds
-}
-
-export const collectTileIdsFromConfigs = (configs: readonly unknown[]): Set<string> => {
-  const tileIds = new Set<string>()
-
-  for (const config of configs) {
-    for (const tileId of collectTileIds(config)) {
-      tileIds.add(tileId)
-    }
-  }
-
-  return tileIds
-}
+export const collectTileIdsFromConfigs = (configs: readonly unknown[]): Set<string> =>
+  new Set(configs.flatMap(tileIdsFromConfig))
 
 const collectTileIdAliases = (tileId: string, aliases: Set<string>): void => {
   if (aliases.has(tileId)) {
@@ -315,55 +315,39 @@ export const buildVariantTileLookup = (tileIds: Iterable<string>): Map<string, s
 }
 
 export const parseOutputFormat = (format: string): OutputFormat => {
-  if (OUTPUT_FORMATS.has(format as OutputFormat)) {
-    return format as OutputFormat
+  const parsedFormat = v.safeParse(OutputFormatSchema, format)
+  if (parsedFormat.success) {
+    return parsedFormat.output
   }
 
   throw new Error(`Unsupported --format '${format}'. Use one of: text, json, md.`)
 }
 
-const collectExplicitIgnoredItemIdsFromValue = (
-  value: unknown,
-  ignoredItemIds: Set<string>,
-): void => {
+const explicitIgnoredItemIdsFromValue = (value: unknown): string[] => {
   if (Array.isArray(value)) {
-    for (const child of value) {
-      collectExplicitIgnoredItemIdsFromValue(child, ignoredItemIds)
-    }
-    return
+    return value.flatMap(explicitIgnoredItemIdsFromValue)
   }
 
   if (!isRecord(value)) {
-    return
+    return []
   }
 
-  if (typeof value.fake_item === "string") {
-    ignoredItemIds.add(value.fake_item)
-  }
+  const parsedValue = v.safeParse(IgnoredItemValueSchema, value)
+  const explicitItemIds = !parsedValue.success ? [] : [
+    parsedValue.output.fake_item,
+    ...(parsedValue.output.type === "gun"
+      ? [parsedValue.output.gun_type, parsedValue.output.ammo_type]
+      : []),
+  ].filter(isDefined)
 
-  if (value.type === "gun") {
-    if (typeof value.gun_type === "string") {
-      ignoredItemIds.add(value.gun_type)
-    }
-    if (typeof value.ammo_type === "string") {
-      ignoredItemIds.add(value.ammo_type)
-    }
-  }
-
-  for (const child of Object.values(value)) {
-    collectExplicitIgnoredItemIdsFromValue(child, ignoredItemIds)
-  }
+  return [
+    ...explicitItemIds,
+    ...Object.values(value).flatMap(explicitIgnoredItemIdsFromValue),
+  ]
 }
 
-export const collectExplicitIgnoredItemIds = (entries: readonly unknown[]): Set<string> => {
-  const ignoredItemIds = new Set<string>()
-
-  for (const entry of entries) {
-    collectExplicitIgnoredItemIdsFromValue(entry, ignoredItemIds)
-  }
-
-  return ignoredItemIds
-}
+export const collectExplicitIgnoredItemIds = (entries: readonly unknown[]): Set<string> =>
+  new Set(entries.flatMap(explicitIgnoredItemIdsFromValue))
 
 const parseJsonMaps = (content: string): unknown[] => {
   const parsed = jsonMap.parse(content)
@@ -406,59 +390,55 @@ export const readJsonPaths = async (
 }
 
 const toDefinition = (value: unknown, path: string): ItemDefinition | null => {
-  if (!isRecord(value) || typeof value.type !== "string" || !REPORTABLE_TYPES.has(value.type)) {
+  const parsedDefinition = v.safeParse(DefinitionSchema, value)
+  if (!parsedDefinition.success) {
     return null
   }
 
-  const id = typeof value.id === "string"
-    ? value.id
-    : typeof value.abstract === "string"
-    ? value.abstract
-    : undefined
-  if (!id) {
+  const { abstract, flags, id, looks_like: looksLike, type } = parsedDefinition.output
+  const definitionId = id ?? abstract
+  if (!definitionId) {
     return null
   }
 
   return {
-    id,
-    kind: typeof value.id === "string" ? "item" : "abstract",
-    type: value.type,
+    id: definitionId,
+    kind: id ? "item" : "abstract",
+    type,
     path,
-    copyFrom: typeof value["copy-from"] === "string" ? value["copy-from"] : undefined,
-    looksLike: typeof value.looks_like === "string" ? value.looks_like : undefined,
-    flags: Array.isArray(value.flags)
-      ? value.flags.filter((flag): flag is string => typeof flag === "string")
-      : typeof value.flags === "string"
-      ? [value.flags]
-      : [],
+    copyFrom: parsedDefinition.output["copy-from"],
+    looksLike,
+    flags: asStringArray(flags),
   }
 }
 
 const loadDefinitions = async (inputs: readonly string[]) => {
-  const items = new Map<string, ItemDefinition>()
-  const abstracts = new Map<string, ItemDefinition>()
-  const ignoredItemIds = new Set<string>()
-
-  for (const path of await readJsonPaths(inputs)) {
-    const entries = parseJsonMaps(await Deno.readTextFile(path)).map(mapToObject)
-    for (const ignoredItemId of collectExplicitIgnoredItemIds(entries)) {
-      ignoredItemIds.add(ignoredItemId)
-    }
-    for (const rawEntry of entries) {
-      const definition = toDefinition(rawEntry, path)
-      if (!definition) {
-        continue
+  const loaded = await Promise.all(
+    (await readJsonPaths(inputs)).map(async (path) => {
+      const entries = parseJsonMaps(await Deno.readTextFile(path)).map(mapToObject)
+      return {
+        ignoredItemIds: Array.from(collectExplicitIgnoredItemIds(entries)),
+        definitions: entries.flatMap((rawEntry) => {
+          const definition = toDefinition(rawEntry, path)
+          return definition ? [definition] : []
+        }),
       }
+    }),
+  )
 
-      if (definition.kind === "item") {
-        items.set(definition.id, definition)
-      } else {
-        abstracts.set(definition.id, definition)
-      }
-    }
+  const definitions = loaded.flatMap(({ definitions }) => definitions)
+  const [itemDefinitions, abstractDefinitions] = partition(
+    definitions,
+    (definition) => definition.kind === "item",
+  )
+
+  return {
+    items: new Map(itemDefinitions.map((definition) => [definition.id, definition] as const)),
+    abstracts: new Map(
+      abstractDefinitions.map((definition) => [definition.id, definition] as const),
+    ),
+    ignoredItemIds: new Set(loaded.flatMap(({ ignoredItemIds }) => ignoredItemIds)),
   }
-
-  return { items, abstracts, ignoredItemIds }
 }
 
 export const resolveItemDefinitions = (
@@ -587,6 +567,27 @@ const formatMissingEntry = (entry: MissingEntry): string => `${entry.id}\t${entr
 const formatLooksLikeEntry = (entry: LooksLikeEntry): string =>
   `${entry.chain.join(" -> ")}\t${entry.path}`
 
+const renderTextSectionLines = (section: RenderedReportSection): string[] => [
+  "",
+  `${section.title} (${section.rows.length})`,
+  ...(section.rows.length === 0 ? ["  (none)"] : [
+    ...section.shownRows,
+    ...(section.hiddenCount > 0 ? [`... ${section.hiddenCount} more`] : []),
+  ]),
+]
+
+const renderMarkdownSectionLines = (section: RenderedReportSection): string[] => [
+  "",
+  `## ${section.title} (${section.rows.length})`,
+  "",
+  ...(section.rows.length === 0 ? ["(none)"] : [
+    "```text",
+    ...section.shownRows,
+    ...(section.hiddenCount > 0 ? [`... ${section.hiddenCount} more`] : []),
+    "```",
+  ]),
+]
+
 const getReportSections = (report: MissingTilesetReport): ReportSection[] => [
   {
     title: "Missing id (but variant tile exists)",
@@ -615,37 +616,20 @@ const limitEntries = <T>(entries: readonly T[], limit: number, total: number = e
 }
 
 export const renderTextReport = (report: MissingTilesetReport, limit: number): string => {
-  const lines = [
+  return [
     `Tilesets: ${report.tilesets.join(", ")}`,
     `Inputs: ${report.inputs.join(", ")}`,
     `Checked ids: ${report.checkedIds}`,
     `Direct sprites: ${report.directSprites}`,
     `Variant sprites only: ${report.variantSpritesOnly}`,
-  ]
-
-  if (report.looksLikeOnly !== undefined) {
-    lines.push(`Looks_like fallback only: ${report.looksLikeFallbackOnly}`)
-  }
-
-  lines.push(`Missing entirely: ${report.missingEntirely}`)
-
-  for (const section of getReportSections(report).map((section) => renderSection(section, limit))) {
-    lines.push("", `${section.title} (${section.rows.length})`)
-    if (section.rows.length === 0) {
-      lines.push("  (none)")
-      continue
-    }
-
-    for (const row of section.shownRows) {
-      lines.push(row)
-    }
-
-    if (section.hiddenCount > 0) {
-      lines.push(`... ${section.hiddenCount} more`)
-    }
-  }
-
-  return lines.join("\n")
+    ...(report.looksLikeOnly !== undefined
+      ? [`Looks_like fallback only: ${report.looksLikeFallbackOnly}`]
+      : []),
+    `Missing entirely: ${report.missingEntirely}`,
+    ...getReportSections(report)
+      .map((section) => renderSection(section, limit))
+      .flatMap(renderTextSectionLines),
+  ].join("\n")
 }
 
 export const renderJsonReport = (report: MissingTilesetReport, limit: number): string => {
@@ -694,7 +678,7 @@ export const renderJsonReport = (report: MissingTilesetReport, limit: number): s
 }
 
 export const renderMarkdownReport = (report: MissingTilesetReport, limit: number): string => {
-  const lines = [
+  return [
     "# Tileset Missing Sprites",
     "",
     `- Tilesets: ${report.tilesets.map((path) => `\`${path}\``).join(", ")}`,
@@ -702,29 +686,14 @@ export const renderMarkdownReport = (report: MissingTilesetReport, limit: number
     `- Checked ids: ${report.checkedIds}`,
     `- Direct sprites: ${report.directSprites}`,
     `- Variant sprites only: ${report.variantSpritesOnly}`,
-  ]
-
-  if (report.looksLikeOnly !== undefined) {
-    lines.push(`- Looks_like fallback only: ${report.looksLikeFallbackOnly}`)
-  }
-
-  lines.push(`- Missing entirely: ${report.missingEntirely}`)
-
-  for (const section of getReportSections(report).map((section) => renderSection(section, limit))) {
-    lines.push("", `## ${section.title} (${section.rows.length})`, "")
-    if (section.rows.length === 0) {
-      lines.push("(none)")
-      continue
-    }
-
-    lines.push("```text", ...section.shownRows)
-    if (section.hiddenCount > 0) {
-      lines.push(`... ${section.hiddenCount} more`)
-    }
-    lines.push("```")
-  }
-
-  return lines.join("\n")
+    ...(report.looksLikeOnly !== undefined
+      ? [`- Looks_like fallback only: ${report.looksLikeFallbackOnly}`]
+      : []),
+    `- Missing entirely: ${report.missingEntirely}`,
+    ...getReportSections(report)
+      .map((section) => renderSection(section, limit))
+      .flatMap(renderMarkdownSectionLines),
+  ].join("\n")
 }
 
 export const renderReport = (
@@ -742,104 +711,100 @@ export const renderReport = (
   }
 }
 
-const run = async (): Promise<void> => {
-  const parsed = await new Command()
-    .description("Report items and monsters missing sprites in one or more tilesets")
-    .option("--tileset <path:string>", "Tileset path(s) to inspect", {
-      collect: true,
-      default: DEFAULT_TILESETS,
-    })
-    .option("--input <path:string>", "JSON path(s) with items and monsters to inspect", {
-      collect: true,
-      default: DEFAULT_INPUTS,
-    })
-    .option("--looks-like", "Report items that are only covered by looks_like", {
-      default: false,
-    })
-    .option("--format <format:string>", "Output format: text, json, or md", {
-      default: "text",
-      value: parseOutputFormat,
-    })
-    .option("--limit <count:number>", "Max rows to print per section", { default: 0 })
-    .parse(Deno.args)
+const main = new Command()
+  .description("Report items and monsters missing sprites in one or more tilesets")
+  .option("--tileset <path:string>", "Tileset path(s) to inspect", {
+    collect: true,
+    default: DEFAULT_TILESETS,
+  })
+  .option("--input <path:string>", "JSON path(s) with items and monsters to inspect", {
+    collect: true,
+    default: DEFAULT_INPUTS,
+  })
+  .option("--looks-like", "Report items that are only covered by looks_like", {
+    default: false,
+  })
+  .option("--format <format:string>", "Output format: text, json, or md", {
+    default: "text",
+    value: parseOutputFormat,
+  })
+  .option("--limit <count:number>", "Max rows to print per section", { default: 0 })
+  .action(async ({ format, input, limit, looksLike, tileset }) => {
+    const tilesets = Array.from((tileset ?? DEFAULT_TILESETS) as string[])
+    const inputs = Array.from((input ?? DEFAULT_INPUTS) as string[])
+    const showLooksLike = Boolean(looksLike ?? false)
+    const outputFormat = format as OutputFormat
+    const rowLimit = Number(limit ?? 0)
 
-  const tilesets = Array.from((parsed.options.tileset ?? DEFAULT_TILESETS) as string[])
-  const input = Array.from((parsed.options.input ?? DEFAULT_INPUTS) as string[])
-  const showLooksLike = Boolean(parsed.options.looksLike ?? false)
-  const format = parsed.options.format as OutputFormat
-  const limit = Number(parsed.options.limit ?? 0)
+    const tilesetSourcePaths = Array.from(
+      new Set((await Promise.all(tilesets.map(resolveTilesetSourcePaths))).flat()),
+    )
+    const tileIds = collectTileIdsFromConfigs(
+      await Promise.all(
+        tilesetSourcePaths.map(async (tilesetSourcePath) => {
+          return mapToObject(jsonMap.parse(await Deno.readTextFile(tilesetSourcePath)))
+        }),
+      ),
+    )
+    const variantTileLookup = buildVariantTileLookup(tileIds)
+    const { items, abstracts, ignoredItemIds } = await loadDefinitions(inputs)
+    const resolvedItems = resolveItemDefinitions(items, abstracts)
+    const reportableItems = Array.from(resolvedItems.values())
+      .filter((item) => !shouldIgnoreItemDefinition(item, ignoredItemIds))
+      .sort((left, right) => left.id.localeCompare(right.id))
+    const [directItems, unresolvedItems] = partition(
+      reportableItems,
+      (item) => tileIds.has(item.id),
+    )
 
-  const tilesetSourcePaths = Array.from(
-    new Set((await Promise.all(tilesets.map(resolveTilesetSourcePaths))).flat()),
-  )
-  const tileIds = collectTileIdsFromConfigs(
-    await Promise.all(
-      tilesetSourcePaths.map(async (tilesetSourcePath) => {
-        return mapToObject(jsonMap.parse(await Deno.readTextFile(tilesetSourcePath)))
-      }),
-    ),
-  )
-  const variantTileLookup = buildVariantTileLookup(tileIds)
-  const { items, abstracts, ignoredItemIds } = await loadDefinitions(input)
-  const resolvedItems = resolveItemDefinitions(items, abstracts)
-  const reportableItems = Array.from(resolvedItems.values())
-    .filter((item) => !shouldIgnoreItemDefinition(item, ignoredItemIds))
-    .sort((left, right) => left.id.localeCompare(right.id))
+    const variantOnly: VariantOnlyEntry[] = []
+    const fallbackOnly: LooksLikeEntry[] = []
+    const missing: MissingEntry[] = []
 
-  const direct: string[] = []
-  const variantOnly: VariantOnlyEntry[] = []
-  const fallbackOnly: LooksLikeEntry[] = []
-  const missing: MissingEntry[] = []
+    for (const item of unresolvedItems) {
+      const variantTileId = variantTileLookup.get(item.id)
+      if (variantTileId) {
+        variantOnly.push({
+          id: item.id,
+          tileId: variantTileId,
+          path: toDisplayPath(item.path),
+        })
+        continue
+      }
 
-  for (const item of reportableItems) {
-    if (tileIds.has(item.id)) {
-      direct.push(item.id)
-      continue
+      const lookup = findTileByLooksLike(item.id, resolvedItems, tileIds, variantTileLookup)
+      if (lookup) {
+        fallbackOnly.push({
+          id: item.id,
+          tileId: lookup.tileId,
+          chain: lookup.chain,
+          path: toDisplayPath(item.path),
+        })
+        continue
+      }
+
+      missing.push({ id: item.id, path: toDisplayPath(item.path) })
     }
 
-    const variantTileId = variantTileLookup.get(item.id)
-    if (variantTileId) {
-      variantOnly.push({
-        id: item.id,
-        tileId: variantTileId,
-        path: toDisplayPath(item.path),
-      })
-      continue
+    const report: MissingTilesetReport = {
+      tilesets: tilesets.map(toDisplayPath),
+      inputs: inputs.map(toDisplayPath),
+      checkedIds: reportableItems.length,
+      directSprites: directItems.length,
+      variantSpritesOnly: variantOnly.length,
+      looksLikeFallbackOnly: fallbackOnly.length,
+      missingEntirely: missing.length,
+      variantOnly,
+      missing,
+      looksLikeOnly: showLooksLike ? fallbackOnly : undefined,
     }
 
-    const lookup = findTileByLooksLike(item.id, resolvedItems, tileIds, variantTileLookup)
-    if (lookup) {
-      fallbackOnly.push({
-        id: item.id,
-        tileId: lookup.tileId,
-        chain: lookup.chain,
-        path: toDisplayPath(item.path),
-      })
-      continue
-    }
-
-    missing.push({ id: item.id, path: toDisplayPath(item.path) })
-  }
-
-  const report: MissingTilesetReport = {
-    tilesets: tilesets.map(toDisplayPath),
-    inputs: input.map(toDisplayPath),
-    checkedIds: reportableItems.length,
-    directSprites: direct.length,
-    variantSpritesOnly: variantOnly.length,
-    looksLikeFallbackOnly: fallbackOnly.length,
-    missingEntirely: missing.length,
-    variantOnly,
-    missing,
-    looksLikeOnly: showLooksLike ? fallbackOnly : undefined,
-  }
-
-  console.log(renderReport(report, format, limit))
-}
+    console.log(renderReport(report, outputFormat, rowLimit))
+  })
 
 if (import.meta.main) {
   try {
-    await run()
+    await main.parse(Deno.args)
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error))
     Deno.exit(1)

--- a/scripts/tileset_missing_items.ts
+++ b/scripts/tileset_missing_items.ts
@@ -3,8 +3,8 @@
 /**
  * @module
  *
- * Reports which items do not have a direct sprite in a tileset, and which only
- * render through an item `looks_like` fallback.
+ * Reports which items and monsters do not have a direct sprite in a tileset,
+ * and which only render through a `looks_like` fallback.
  *
  * example usage:
  *   `deno run -R scripts/tileset_missing_items.ts --limit 50`
@@ -29,7 +29,7 @@ const SKIP_INPUT_JSON = [/(modinfo|default|replacements|mod_tileset)\.json/]
 export const getJsonPathSkips = (source: "input" | "tileset"): RegExp[] =>
   source === "tileset" ? [] : Array.from(SKIP_INPUT_JSON)
 
-const ITEM_TYPES = new Set([
+const REPORTABLE_TYPES = new Set([
   "AMMO",
   "ARMOR",
   "BATTERY",
@@ -42,8 +42,8 @@ const ITEM_TYPES = new Set([
   "GUN",
   "GUNMOD",
   "MAGAZINE",
+  "MONSTER",
   "PET_ARMOR",
-  "SPECIES",
   "TOOL",
   "TOOLMOD",
   "TOOL_ARMOR",
@@ -72,7 +72,51 @@ interface TileLookup {
   chain: string[]
 }
 
+type OutputFormat = "text" | "json" | "md"
+
+interface VariantOnlyEntry {
+  id: string
+  tileId: string
+  path: string
+}
+
+interface MissingEntry {
+  id: string
+  path: string
+}
+
+interface LooksLikeEntry {
+  id: string
+  tileId: string
+  chain: string[]
+  path: string
+}
+
+interface ReportSection {
+  title: string
+  rows: string[]
+}
+
+interface RenderedReportSection extends ReportSection {
+  shownRows: string[]
+  hiddenCount: number
+}
+
+interface MissingTilesetReport {
+  tilesets: string[]
+  inputs: string[]
+  checkedIds: number
+  directSprites: number
+  variantSpritesOnly: number
+  looksLikeFallbackOnly: number
+  missingEntirely: number
+  variantOnly: VariantOnlyEntry[]
+  missing: MissingEntry[]
+  looksLikeOnly?: LooksLikeEntry[]
+}
+
 const TILE_ID_PREFIXES = ["overlay_wielded_", "overlay_worn_"]
+const OUTPUT_FORMATS = new Set<OutputFormat>(["text", "json", "md"])
 const TILE_ID_SUFFIX_PATTERNS = [
   /^(.+)_season_(spring|summer|autumn|winter)$/,
   /^(.+)_harvested$/,
@@ -270,6 +314,14 @@ export const buildVariantTileLookup = (tileIds: Iterable<string>): Map<string, s
   return variantTileLookup
 }
 
+export const parseOutputFormat = (format: string): OutputFormat => {
+  if (OUTPUT_FORMATS.has(format as OutputFormat)) {
+    return format as OutputFormat
+  }
+
+  throw new Error(`Unsupported --format '${format}'. Use one of: text, json, md.`)
+}
+
 const collectExplicitIgnoredItemIdsFromValue = (
   value: unknown,
   ignoredItemIds: Set<string>,
@@ -354,7 +406,7 @@ export const readJsonPaths = async (
 }
 
 const toDefinition = (value: unknown, path: string): ItemDefinition | null => {
-  if (!isRecord(value) || typeof value.type !== "string" || !ITEM_TYPES.has(value.type)) {
+  if (!isRecord(value) || typeof value.type !== "string" || !REPORTABLE_TYPES.has(value.type)) {
     return null
   }
 
@@ -518,40 +570,195 @@ export const findTileByLooksLike = (
   }
 }
 
-const printSection = (
-  title: string,
-  rows: string[],
-  limit: number,
-): void => {
-  console.log(`\n${title} (${rows.length})`)
-  if (rows.length === 0) {
-    console.log("  (none)")
-    return
-  }
-
-  const shownRows = limit > 0 ? rows.slice(0, limit) : rows
-  for (const row of shownRows) {
-    console.log(row)
-  }
-
-  if (limit > 0 && rows.length > limit) {
-    console.log(`... ${rows.length - limit} more`)
+const renderSection = (section: ReportSection, limit: number): RenderedReportSection => {
+  const shownRows = limit > 0 ? section.rows.slice(0, limit) : section.rows
+  return {
+    ...section,
+    shownRows,
+    hiddenCount: section.rows.length - shownRows.length,
   }
 }
 
-if (import.meta.main) {
+const formatVariantOnlyEntry = (entry: VariantOnlyEntry): string =>
+  `${entry.id}\t${entry.tileId}\t${entry.path}`
+
+const formatMissingEntry = (entry: MissingEntry): string => `${entry.id}\t${entry.path}`
+
+const formatLooksLikeEntry = (entry: LooksLikeEntry): string =>
+  `${entry.chain.join(" -> ")}\t${entry.path}`
+
+const getReportSections = (report: MissingTilesetReport): ReportSection[] => [
+  {
+    title: "Missing id (but variant tile exists)",
+    rows: report.variantOnly.map(formatVariantOnlyEntry),
+  },
+  {
+    title: "Missing id",
+    rows: report.missing.map(formatMissingEntry),
+  },
+  ...(report.looksLikeOnly
+    ? [{
+      title: "Missing id (but looks_like tile exists)",
+      rows: report.looksLikeOnly.map(formatLooksLikeEntry),
+    }]
+    : []),
+]
+
+const limitEntries = <T>(entries: readonly T[], limit: number, total: number = entries.length) => {
+  const shownEntries = limit > 0 ? entries.slice(0, limit) : entries
+  return {
+    total,
+    shown: shownEntries.length,
+    hidden: total - shownEntries.length,
+    entries: shownEntries,
+  }
+}
+
+export const renderTextReport = (report: MissingTilesetReport, limit: number): string => {
+  const lines = [
+    `Tilesets: ${report.tilesets.join(", ")}`,
+    `Inputs: ${report.inputs.join(", ")}`,
+    `Checked ids: ${report.checkedIds}`,
+    `Direct sprites: ${report.directSprites}`,
+    `Variant sprites only: ${report.variantSpritesOnly}`,
+  ]
+
+  if (report.looksLikeOnly !== undefined) {
+    lines.push(`Looks_like fallback only: ${report.looksLikeFallbackOnly}`)
+  }
+
+  lines.push(`Missing entirely: ${report.missingEntirely}`)
+
+  for (const section of getReportSections(report).map((section) => renderSection(section, limit))) {
+    lines.push("", `${section.title} (${section.rows.length})`)
+    if (section.rows.length === 0) {
+      lines.push("  (none)")
+      continue
+    }
+
+    for (const row of section.shownRows) {
+      lines.push(row)
+    }
+
+    if (section.hiddenCount > 0) {
+      lines.push(`... ${section.hiddenCount} more`)
+    }
+  }
+
+  return lines.join("\n")
+}
+
+export const renderJsonReport = (report: MissingTilesetReport, limit: number): string => {
+  const looksLikeOnlyEntries = report.looksLikeOnly?.map((entry) => ({
+    id: entry.id,
+    tile_id: entry.tileId,
+    chain: entry.chain,
+    path: entry.path,
+  })) ?? []
+
+  return JSON.stringify(
+    {
+      tilesets: report.tilesets,
+      inputs: report.inputs,
+      counts: {
+        checked_ids: report.checkedIds,
+        direct_sprites: report.directSprites,
+        variant_sprites_only: report.variantSpritesOnly,
+        looks_like_fallback_only: report.looksLikeFallbackOnly,
+        missing_entirely: report.missingEntirely,
+      },
+      variant_only: limitEntries(
+        report.variantOnly.map((entry) => ({
+          id: entry.id,
+          tile_id: entry.tileId,
+          path: entry.path,
+        })),
+        limit,
+      ),
+      missing: limitEntries(
+        report.missing.map((entry) => ({
+          id: entry.id,
+          path: entry.path,
+        })),
+        limit,
+      ),
+      looks_like_only: limitEntries(
+        looksLikeOnlyEntries,
+        limit,
+        report.looksLikeFallbackOnly,
+      ),
+    },
+    null,
+    2,
+  )
+}
+
+export const renderMarkdownReport = (report: MissingTilesetReport, limit: number): string => {
+  const lines = [
+    "# Tileset Missing Sprites",
+    "",
+    `- Tilesets: ${report.tilesets.map((path) => `\`${path}\``).join(", ")}`,
+    `- Inputs: ${report.inputs.map((path) => `\`${path}\``).join(", ")}`,
+    `- Checked ids: ${report.checkedIds}`,
+    `- Direct sprites: ${report.directSprites}`,
+    `- Variant sprites only: ${report.variantSpritesOnly}`,
+  ]
+
+  if (report.looksLikeOnly !== undefined) {
+    lines.push(`- Looks_like fallback only: ${report.looksLikeFallbackOnly}`)
+  }
+
+  lines.push(`- Missing entirely: ${report.missingEntirely}`)
+
+  for (const section of getReportSections(report).map((section) => renderSection(section, limit))) {
+    lines.push("", `## ${section.title} (${section.rows.length})`, "")
+    if (section.rows.length === 0) {
+      lines.push("(none)")
+      continue
+    }
+
+    lines.push("```text", ...section.shownRows)
+    if (section.hiddenCount > 0) {
+      lines.push(`... ${section.hiddenCount} more`)
+    }
+    lines.push("```")
+  }
+
+  return lines.join("\n")
+}
+
+export const renderReport = (
+  report: MissingTilesetReport,
+  format: OutputFormat,
+  limit: number,
+): string => {
+  switch (format) {
+    case "json":
+      return renderJsonReport(report, limit)
+    case "md":
+      return renderMarkdownReport(report, limit)
+    default:
+      return renderTextReport(report, limit)
+  }
+}
+
+const run = async (): Promise<void> => {
   const parsed = await new Command()
-    .description("Report items missing sprites in one or more tilesets")
+    .description("Report items and monsters missing sprites in one or more tilesets")
     .option("--tileset <path:string>", "Tileset path(s) to inspect", {
       collect: true,
       default: DEFAULT_TILESETS,
     })
-    .option("--input <path:string>", "Item JSON path(s) to inspect", {
+    .option("--input <path:string>", "JSON path(s) with items and monsters to inspect", {
       collect: true,
       default: DEFAULT_INPUTS,
     })
     .option("--looks-like", "Report items that are only covered by looks_like", {
       default: false,
+    })
+    .option("--format <format:string>", "Output format: text, json, or md", {
+      default: "text",
+      value: parseOutputFormat,
     })
     .option("--limit <count:number>", "Max rows to print per section", { default: 0 })
     .parse(Deno.args)
@@ -559,6 +766,7 @@ if (import.meta.main) {
   const tilesets = Array.from((parsed.options.tileset ?? DEFAULT_TILESETS) as string[])
   const input = Array.from((parsed.options.input ?? DEFAULT_INPUTS) as string[])
   const showLooksLike = Boolean(parsed.options.looksLike ?? false)
+  const format = parsed.options.format as OutputFormat
   const limit = Number(parsed.options.limit ?? 0)
 
   const tilesetSourcePaths = Array.from(
@@ -579,9 +787,9 @@ if (import.meta.main) {
     .sort((left, right) => left.id.localeCompare(right.id))
 
   const direct: string[] = []
-  const variantOnly: string[] = []
-  const fallbackOnly: string[] = []
-  const missing: string[] = []
+  const variantOnly: VariantOnlyEntry[] = []
+  const fallbackOnly: LooksLikeEntry[] = []
+  const missing: MissingEntry[] = []
 
   for (const item of reportableItems) {
     if (tileIds.has(item.id)) {
@@ -591,32 +799,49 @@ if (import.meta.main) {
 
     const variantTileId = variantTileLookup.get(item.id)
     if (variantTileId) {
-      variantOnly.push(`${item.id}\t${variantTileId}\t${toDisplayPath(item.path)}`)
+      variantOnly.push({
+        id: item.id,
+        tileId: variantTileId,
+        path: toDisplayPath(item.path),
+      })
       continue
     }
 
     const lookup = findTileByLooksLike(item.id, resolvedItems, tileIds, variantTileLookup)
     if (lookup) {
-      fallbackOnly.push(`${lookup.chain.join(" -> ")}\t${toDisplayPath(item.path)}`)
+      fallbackOnly.push({
+        id: item.id,
+        tileId: lookup.tileId,
+        chain: lookup.chain,
+        path: toDisplayPath(item.path),
+      })
       continue
     }
 
-    missing.push(`${item.id}\t${toDisplayPath(item.path)}`)
+    missing.push({ id: item.id, path: toDisplayPath(item.path) })
   }
 
-  console.log(`Tilesets: ${tilesets.map(toDisplayPath).join(", ")}`)
-  console.log(`Inputs: ${input.map(toDisplayPath).join(", ")}`)
-  console.log(`Checked items: ${reportableItems.length}`)
-  console.log(`Direct sprites: ${direct.length}`)
-  console.log(`Variant sprites only: ${variantOnly.length}`)
-  if (showLooksLike) {
-    console.log(`Looks_like fallback only: ${fallbackOnly.length}`)
+  const report: MissingTilesetReport = {
+    tilesets: tilesets.map(toDisplayPath),
+    inputs: input.map(toDisplayPath),
+    checkedIds: reportableItems.length,
+    directSprites: direct.length,
+    variantSpritesOnly: variantOnly.length,
+    looksLikeFallbackOnly: fallbackOnly.length,
+    missingEntirely: missing.length,
+    variantOnly,
+    missing,
+    looksLikeOnly: showLooksLike ? fallbackOnly : undefined,
   }
-  console.log(`Missing entirely: ${missing.length}`)
 
-  printSection("Missing ITEM id (but variant tile exists)", variantOnly, limit)
-  printSection("Missing ITEM", missing, limit)
-  if (showLooksLike) {
-    printSection("Missing ITEM (but looks_like tile exists)", fallbackOnly, limit)
+  console.log(renderReport(report, format, limit))
+}
+
+if (import.meta.main) {
+  try {
+    await run()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    Deno.exit(1)
   }
 }

--- a/scripts/tileset_missing_items_test.ts
+++ b/scripts/tileset_missing_items_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert"
+import { assertEquals, assertThrows } from "@std/assert"
 
 import {
   buildVariantTileLookup,
@@ -6,6 +6,10 @@ import {
   collectTileIdsFromConfigs,
   getJsonPathSkips,
   getTileIdAliases,
+  parseOutputFormat,
+  renderJsonReport,
+  renderMarkdownReport,
+  renderTextReport,
   resolveItemDefinitions,
   shouldIgnoreItemDefinition,
 } from "./tileset_missing_items.ts"
@@ -142,4 +146,92 @@ Deno.test("shouldIgnoreItemDefinition() ignores fake_item inheritance and explic
     shouldIgnoreItemDefinition(resolvedItems.get("acid_artillery")!, new Set(["acid_artillery"])),
     true,
   )
+})
+
+Deno.test("parseOutputFormat() accepts text, json, and md", () => {
+  assertEquals(parseOutputFormat("text"), "text")
+  assertEquals(parseOutputFormat("json"), "json")
+  assertEquals(parseOutputFormat("md"), "md")
+})
+
+Deno.test("parseOutputFormat() rejects unsupported formats", () => {
+  assertThrows(
+    () => parseOutputFormat("yaml"),
+    Error,
+    "Unsupported --format 'yaml'. Use one of: text, json, md.",
+  )
+})
+
+Deno.test("renderers format the report consistently", () => {
+  const report = {
+    tilesets: ["gfx/MSX++UnDeadPeopleEdition", "data/json/external_tileset"],
+    inputs: ["data/json"],
+    checkedIds: 10,
+    directSprites: 7,
+    variantSpritesOnly: 1,
+    looksLikeFallbackOnly: 1,
+    missingEntirely: 1,
+    variantOnly: [
+      {
+        id: "seatbelt",
+        tileId: "overlay_worn_seatbelt",
+        path: "data/json/items/generic/string.json",
+      },
+    ],
+    missing: [{ id: "missing_thing", path: "data/json/items/generic.json" }],
+    looksLikeOnly: [{
+      id: "manual_luty",
+      tileId: "pocket_firearms",
+      chain: ["manual_luty", "pocket_firearms"],
+      path: "data/json/items/book/gun.json",
+    }],
+  }
+
+  assertEquals(
+    renderTextReport(report, 0).includes("Looks_like fallback only: 1"),
+    true,
+  )
+  assertEquals(
+    renderMarkdownReport(report, 1).includes("# Tileset Missing Sprites"),
+    true,
+  )
+
+  const jsonReport = JSON.parse(renderJsonReport(report, 1)) as {
+    counts: { looks_like_fallback_only: number }
+    variant_only: { entries: Array<{ id: string; tile_id: string }>; shown: number; hidden: number }
+    looks_like_only: { entries: Array<{ id: string; tile_id: string; chain: string[] }> }
+  }
+  assertEquals(jsonReport.counts.looks_like_fallback_only, 1)
+  assertEquals(jsonReport.variant_only.entries[0].id, "seatbelt")
+  assertEquals(jsonReport.variant_only.entries[0].tile_id, "overlay_worn_seatbelt")
+  assertEquals(jsonReport.variant_only.shown, 1)
+  assertEquals(jsonReport.variant_only.hidden, 0)
+  assertEquals(jsonReport.looks_like_only.entries[0].id, "manual_luty")
+  assertEquals(jsonReport.looks_like_only.entries[0].tile_id, "pocket_firearms")
+  assertEquals(jsonReport.looks_like_only.entries[0].chain[0], "manual_luty")
+})
+
+Deno.test("renderJsonReport() keeps looks_like schema without detailed entries", () => {
+  const report = {
+    tilesets: ["gfx/MSX++UnDeadPeopleEdition"],
+    inputs: ["data/json"],
+    checkedIds: 4,
+    directSprites: 2,
+    variantSpritesOnly: 1,
+    looksLikeFallbackOnly: 3,
+    missingEntirely: 1,
+    variantOnly: [],
+    missing: [{ id: "missing_thing", path: "data/json/items/generic.json" }],
+  }
+
+  const jsonReport = JSON.parse(renderJsonReport(report, 0)) as {
+    counts: { looks_like_fallback_only: number }
+    looks_like_only: { total: number; shown: number; hidden: number; entries: unknown[] }
+  }
+
+  assertEquals(jsonReport.counts.looks_like_fallback_only, 3)
+  assertEquals(jsonReport.looks_like_only.total, 3)
+  assertEquals(jsonReport.looks_like_only.shown, 0)
+  assertEquals(jsonReport.looks_like_only.hidden, 3)
+  assertEquals(jsonReport.looks_like_only.entries, [])
 })

--- a/scripts/tileset_missing_items_test.ts
+++ b/scripts/tileset_missing_items_test.ts
@@ -1,0 +1,145 @@
+import { assertEquals } from "@std/assert"
+
+import {
+  buildVariantTileLookup,
+  collectExplicitIgnoredItemIds,
+  collectTileIdsFromConfigs,
+  getJsonPathSkips,
+  getTileIdAliases,
+  resolveItemDefinitions,
+  shouldIgnoreItemDefinition,
+} from "./tileset_missing_items.ts"
+
+Deno.test("collectTileIdsFromConfigs() merges tile ids across tilesets", () => {
+  const firstConfig = {
+    "tiles-new": [{
+      tiles: [
+        { id: "item_a" },
+        { id: ["item_b", "item_c"] },
+      ],
+    }],
+  }
+  const secondConfig = [{
+    type: "mod_tileset",
+    "tiles-new": [{
+      tiles: [
+        {
+          id: "item_d",
+          additional_tiles: [{ id: "item_e" }],
+        },
+        { id: "item_b" },
+      ],
+    }],
+  }]
+
+  assertEquals(
+    Array.from(collectTileIdsFromConfigs([firstConfig, secondConfig])).sort(),
+    ["item_a", "item_b", "item_c", "item_d", "item_e"],
+  )
+})
+
+Deno.test("getJsonPathSkips() keeps mod_tileset for tileset sources", () => {
+  assertEquals(getJsonPathSkips("tileset"), [])
+  assertEquals(
+    getJsonPathSkips("input").some((pattern) => pattern.test("mod_tileset.json")),
+    true,
+  )
+})
+
+Deno.test("getTileIdAliases() strips common item tile variants", () => {
+  assertEquals(
+    Array.from(getTileIdAliases("fern_harvested_season_winter")).sort(),
+    ["fern", "fern_harvested", "fern_harvested_season_winter"],
+  )
+  assertEquals(
+    Array.from(getTileIdAliases("overlay_wielded_bullet_vibrator_on")).sort(),
+    [
+      "bullet_vibrator",
+      "bullet_vibrator_on",
+      "overlay_wielded_bullet_vibrator",
+      "overlay_wielded_bullet_vibrator_on",
+    ],
+  )
+})
+
+Deno.test("buildVariantTileLookup() resolves base ids from variant-only tiles", () => {
+  const variantTileLookup = buildVariantTileLookup([
+    "fern_harvested_season_winter",
+    "overlay_wielded_bullet_vibrator_on",
+  ])
+
+  assertEquals(variantTileLookup.get("fern"), "fern_harvested_season_winter")
+  assertEquals(variantTileLookup.get("bullet_vibrator"), "overlay_wielded_bullet_vibrator_on")
+})
+
+Deno.test("collectExplicitIgnoredItemIds() collects explicit fake item references", () => {
+  const ignoredItemIds = collectExplicitIgnoredItemIds([
+    { fake_item: "bio_wire_weapon" },
+    {
+      type: "gun",
+      gun_type: "acid_artillery",
+      ammo_type: "acid_artillery_shell",
+    },
+  ])
+
+  assertEquals(Array.from(ignoredItemIds).sort(), [
+    "acid_artillery",
+    "acid_artillery_shell",
+    "bio_wire_weapon",
+  ])
+})
+
+Deno.test("shouldIgnoreItemDefinition() ignores fake_item inheritance and explicit ids", () => {
+  const items = new Map<string, {
+    id: string
+    kind: "item"
+    type: string
+    path: string
+    copyFrom?: string
+    looksLike?: string
+    flags: string[]
+  }>([
+    ["fake_tool", {
+      id: "fake_tool",
+      kind: "item",
+      type: "TOOL",
+      path: "items/fake.json",
+      copyFrom: "fake_item",
+      looksLike: undefined,
+      flags: [],
+    }],
+    ["acid_artillery", {
+      id: "acid_artillery",
+      kind: "item",
+      type: "GUN",
+      path: "monster_attacks.json",
+      looksLike: undefined,
+      flags: [],
+    }],
+  ])
+  const abstracts = new Map<string, {
+    id: string
+    kind: "abstract"
+    type: string
+    path: string
+    copyFrom?: string
+    looksLike?: string
+    flags: string[]
+  }>([
+    ["fake_item", {
+      id: "fake_item",
+      kind: "abstract",
+      type: "GENERIC",
+      path: "items/fake.json",
+      looksLike: undefined,
+      flags: [],
+    }],
+  ])
+  const resolvedItems = resolveItemDefinitions(items, abstracts)
+
+  assertEquals(shouldIgnoreItemDefinition(resolvedItems.get("fake_tool")!, new Set()), true)
+  assertEquals(
+    shouldIgnoreItemDefinition(resolvedItems.get("acid_artillery")!, new Set(["acid_artillery"])),
+    true,
+  )
+})


### PR DESCRIPTION

## Why

per request in https://discord.com/channels/830879262763909202/830916451517857894/1495201595523076117

## What

<details><summary>Details</summary>

# Tileset Missing Sprites

- Tilesets: `gfx/MSX++UnDeadPeopleEdition`, `data/json/external_tileset`, `data/mods`
- Inputs: `data/json`
- Checked ids: 6364
- Direct sprites: 5724
- Variant sprites only: 3
- Missing entirely: 101

## Missing id (but variant tile exists) (3)

```text
cuirass_bone	overlay_worn_cuirass_bone	data/json/items/armor/torso_armor.json
seatbelt	overlay_worn_seatbelt	data/json/items/generic/string.json
stockings_snake_tail	overlay_worn_stockings_snake_tail	data/json/items/armor/boots.json
```

## Missing id (101)

```text
155mm_nuke	data/json/items/ammo/tankammo.json
25mm_autocannon_sawn	data/json/items/gun/tankguns.json
25mm_cannon_crude	data/json/items/gun/tankguns.json
airship_balloon_item	data/json/items/vehicle/balloon.json
ammo_satchel_leg	data/json/items/armor/ammo_pouch.json
assorted_bugs	data/json/items/comestibles/carnivore.json
assorted_bugs_fried	data/json/items/comestibles/meat_dishes.json
atlatl	data/json/items/ranged/slings.json
aug_nato_conversion	data/json/items/gunmod/mechanism.json
badge_IRS	data/json/items/armor/jewelry.json
ballmachine	data/json/items/furniture.json
bio_atomic_battery	data/json/items/bionics.json
bio_atomic_battery_upgrade	data/json/items/bionics.json
bio_cable_upgrade	data/json/items/bionics.json
blank_card	data/json/items/generic.json
bola_cartridge	data/json/items/ranged/throwing.json
bossam	data/json/items/comestibles/meat_dishes.json
bot_turret_antimateriel	data/json/items/corpses/inactive_bots.json
bot_turret_mark19	data/json/items/corpses/inactive_bots.json
bot_unstable_grub	data/json/monster_attacks.json
brew_sake	data/json/items/comestibles/brewing.json
broken_dissector	data/json/items/generic.json
buchimgae_veggy	data/json/items/comestibles/veggy_dishes.json
bullet_vibrator	data/json/items/tool/electronics.json
bullet_vibrator_on	data/json/items/tool/electronics.json
c_hydrogen_gas	data/json/items/ammo.json
carbon_plate	data/json/items/vehicle/plating.json
carbonmag_223	data/json/items/magazine/223.json
chair_folding	data/json/items/tool/deployable.json
chaos_dagger	data/json/artifact/premade_artifacts.json
chaos_dagger_on	data/json/artifact/premade_artifacts.json
clam	data/json/items/comestibles/carnivore.json
clam_fried	data/json/items/comestibles/meat_dishes.json
cola_syrup	data/json/items/comestibles/drink.json
colamdew_syrup	data/json/items/comestibles/drink.json
creamsoda_syrup	data/json/items/comestibles/drink.json
dehydrator_tray	data/json/items/containers.json
dp12_aux_shotgun	data/json/items/gunmod/underbarrel.json
drink_sewersoda	data/json/items/comestibles/mutagen.json
dry_lobster	data/json/obsoletion/items.json
drying_fish	data/json/items/tool/cooking.json
drying_fruit	data/json/items/tool/cooking.json
drying_meat	data/json/items/tool/cooking.json
drying_taint	data/json/items/tool/cooking.json
drying_veg	data/json/items/tool/cooking.json
energy_drink_atomic_syrup	data/json/items/comestibles/drink.json
energy_drink_syrup	data/json/items/comestibles/drink.json
fluted_grip	data/json/items/gunmod/grip.json
g36_stanag_adapter	data/json/items/gunmod/mechanism.json
gas_sac_buoyancy_cell	data/json/items/vehicle/boat.json
glockswitch	data/json/items/gunmod/mechanism.json
horn_ship	data/json/items/tool/misc.json
howitzer_gun_crude	data/json/items/gun/tankguns.json
iv_mutagen_rabbit	data/json/items/comestibles/mutagen.json
iv_mutagen_serpent	data/json/items/comestibles/mutagen.json
jellied_insects_petfood	data/json/items/comestibles/other.json
laser_source	data/json/items/generic.json
lemonlime_syrup	data/json/items/comestibles/drink.json
lobster	data/json/obsoletion/items.json
lobster_canned	data/json/obsoletion/items.json
lobster_cooked	data/json/obsoletion/items.json
lobster_pickled	data/json/obsoletion/items.json
lobster_roll	data/json/obsoletion/items.json
lobster_salted	data/json/obsoletion/items.json
lobster_smoked	data/json/obsoletion/items.json
makeshift_sled_runners_item	data/json/items/vehicle/wheel.json
movie_poster	data/json/items/newspaper.json
mutagen_rabbit	data/json/items/comestibles/mutagen.json
mutagen_serpent	data/json/items/comestibles/mutagen.json
NBC_seal	data/json/items/vehicle/armor.json
net_cartridge	data/json/items/ranged/throwing.json
noodles_kimchi	data/json/items/comestibles/wheat.json
orangesoda_syrup	data/json/items/comestibles/drink.json
pack_basket	data/json/items/armor/storage.json
pine_soda	data/json/items/comestibles/drink.json
pistol_lanyard	data/json/items/gunmod/sling.json
pocket_dimension_key	data/json/items/tool/dimensional_travel.json
pouch_cheese	data/json/items/comestibles/junkfood.json
power_armor_ammo_satchel_leg	data/json/items/armor/power_armor.json
power_portal_key	data/json/items/tool/electronics.json
purple_drink_syrup	data/json/items/comestibles/drink.json
radiation_triangle	data/json/artifact/premade_artifacts.json
rehydrated_lobster	data/json/obsoletion/items.json
rice_bran	data/json/items/comestibles/raw_veggy.json
rootbeer_syrup	data/json/items/comestibles/drink.json
sake	data/json/items/comestibles/alcohol.json
samhap	data/json/items/comestibles/meat_dishes.json
sandwich_generic	data/json/items/comestibles/sandwich.json
sewing_machine	data/json/items/tool/tailoring.json
sheet_carbon	data/json/items/vehicle/plating.json
shot_crafted_suppressor	data/json/items/gunmod/muzzle.json
sikhye	data/json/items/comestibles/drink.json
sonar_device	data/json/items/tool/electronics.json
soup_lobster	data/json/obsoletion/items.json
tank_gun_crude	data/json/items/gun/tankguns.json
tank_gun_crude_105mm	data/json/items/gun/tankguns.json
turret_autoloader	data/json/items/vehicle/turrets.json
unstable_grub_bomb	data/json/monster_attacks.json
unstable_grub_bomb_act	data/json/monster_attacks.json
wheel_mount_skateboard	data/json/items/vehicle/wheel.json
wheel_skateboard	data/json/items/vehicle/wheel.json
```


</details> 
