### PR TITLE
feat: add variations to military camp nested chunks

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/map_extras.json
+++ b/data/json/itemgroups/Locations_MapExtras/map_extras.json
@@ -165,7 +165,7 @@
   {
     "type": "item_group",
     "id": "mass_grave_casings",
-    "items": [ [ "223_casing", 60 ], [ "308_casing", 20 ], [ "shot_hull", 20 ] ]
+    "items": [ [ "9mm_casing", 10 ], [ "223_casing", 50 ], [ "308_casing", 20 ], [ "shot_hull", 20 ] ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -67,6 +67,18 @@
     ]
   },
   {
+    "id": "military_range_guns",
+    "type": "item_group",
+    "subtype": "distribution",
+    "//": "Selection of guns matching the casing spawns used in mass_grave_casings as used at mass graves and military camp firing range",
+    "entries": [
+      { "group": "military_standard_pistols", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1000, 5000 ] },
+      { "group": "military_standard_assault_rifles", "prob": 50, "damage": [ 0, 2 ], "dirt": [ 1000, 5000 ] },
+      { "group": "military_standard_sniper_rifles", "prob": 20, "damage": [ 0, 2 ], "dirt": [ 1000, 5000 ] },
+      { "group": "military_standard_shotguns", "prob": 20, "damage": [ 0, 2 ], "dirt": [ 1000, 5000 ] }
+    ]
+  },
+  {
     "type": "item_group",
     "id": "military_standard_assault_rifles",
     "//": "Mainly the standard rifles that an Army/Marine rifleman, Army TL, or Marine assistant automatic rifleman would use, but allow a handful of Ranger and Delta Force rifles",

--- a/data/json/mapgen/fema/FEMA.json
+++ b/data/json/mapgen/fema/FEMA.json
@@ -89,11 +89,11 @@
       "monster": { "_": { "monster": "mon_turret_searchlight" } },
       "palettes": [ "military_camp" ],
       "nested": {
-        "1": { "chunks": [ "fema_lodging" ] },
+        "1": { "chunks": [ [ "fema_lodging", 75 ], [ "fema_range", 20 ], [ "fema_helipad", 5 ] ] },
         "2": { "chunks": [ "fema_sanitary" ] },
         "3": { "chunks": [ "fema_mess_hall" ] },
         "4": { "chunks": [ "fema_supply" ] },
-        "5": { "chunks": [ "fema_lab" ] }
+        "5": { "chunks": [ "fema_command_center" ] }
       }
     }
   }

--- a/data/json/mapgen/nested/fema_nested.json
+++ b/data/json/mapgen/nested/fema_nested.json
@@ -271,13 +271,10 @@
       "set": [ { "point": "terrain", "id": "t_pit_shallow", "x": [ 2, 17 ], "y": [ 4, 14 ], "repeat": [ 0, 6 ] } ],
       "terrain": { "|": "t_brick_wall", " ": "t_region_groundcover" },
       "furniture": { "A": "f_target", "N": "f_sandbag_wall" },
-
       "//": "Not a mass grave but fits for spawning a distribution of random military casings",
       "items": { " ": { "item": "mass_grave_casings", "chance": 5, "repeat": 2 }, "T": { "item": "military_range_guns", "chance": 5 } }
-
     }
   },
-
   {
     "type": "mapgen",
     "method": "json",
@@ -311,7 +308,6 @@
       "place_vehicles": [ { "vehicle": "helicopters", "x": 9, "y": 7, "chance": 25, "fuel": 0, "status": 1, "rotation": 270 } ]
     }
   },
-
   {
     "type": "mapgen",
     "method": "json",

--- a/data/json/mapgen/nested/fema_nested.json
+++ b/data/json/mapgen/nested/fema_nested.json
@@ -242,6 +242,79 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "fema_range",
+    "object": {
+      "mapgensize": [ 20, 20 ],
+      "rows": [
+        "....................",
+        ".||||||||||||||||||.",
+        ".|NNNNNNNNNNNNNNNN|.",
+        ".%!A!A!A!!!!A!A!A!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%!!!!!!!!!!!!!!!!%.",
+        ".%TTTTTTT!!TTTTTTT%.",
+        ".%                %.",
+        ".%                %.",
+        ".%%%%%%%%..%%%%%%%%.",
+        "...................."
+      ],
+      "palettes": [ "military_camp" ],
+      "set": [ { "point": "terrain", "id": "t_pit_shallow", "x": [ 2, 17 ], "y": [ 4, 14 ], "repeat": [ 0, 6 ] } ],
+      "terrain": { "|": "t_brick_wall", " ": "t_region_groundcover" },
+      "furniture": { "A": "f_target", "N": "f_sandbag_wall" },
+
+      "//": "Not a mass grave but fits for spawning a distribution of random military casings",
+      "items": { " ": { "item": "mass_grave_casings", "chance": 5, "repeat": 2 }, "T": { "item": "military_range_guns", "chance": 5 } }
+
+    }
+  },
+
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fema_helipad",
+    "object": {
+      "mapgensize": [ 20, 20 ],
+      "rows": [
+        "....................",
+        ".ffffffFFFFFFFfffff.",
+        ".f                f.",
+        ".f                f.",
+        ".f                f.",
+        ".f                f.",
+        ".f    ~~    ~~    f.",
+        ".F    ~~    ~~    F.",
+        ".F    ~~    ~~    F.",
+        ".F    ~~~~~~~~    F.",
+        ".F    ~~~~~~~~    F.",
+        ".F    ~~    ~~    F.",
+        ".F    ~~    ~~    F.",
+        ".f    ~~    ~~    f.",
+        ".f                f.",
+        ".f                f.",
+        ".f                f.",
+        ".f                f.",
+        ".ffffffFFFFFFffffff.",
+        "...................."
+      ],
+      "palettes": [ "military_camp" ],
+      "terrain": { " ": "t_pavement", "~": "t_pavement_y" },
+      "place_vehicles": [ { "vehicle": "helicopters", "x": 9, "y": 7, "chance": 25, "fuel": 0, "status": 1, "rotation": 270 } ]
+    }
+  },
+
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "fema_mess_hall",
     "object": {
       "mapgensize": [ 20, 20 ],
@@ -493,6 +566,51 @@
         "C": { "item": "dissection", "chance": 90, "repeat": [ 0, 3 ] }
       },
       "monsters": { ",": { "monster": "GROUP_LAB_FEMA", "chance": 1, "density": 0.002 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fema_command_center",
+    "object": {
+      "mapgensize": [ 20, 20 ],
+      "rows": [
+        "....................",
+        "....................",
+        "..|-----9[[------|..",
+        "..|              |..",
+        "..|              |..",
+        "..|-[----++----+-|..",
+        "..|l  |      |   |..",
+        "..|l  | cTTc |   |..",
+        "..|XX | cTTc |   |..",
+        "..|XX |      |   |..",
+        "..|---||@@@@||-+-|..",
+        "..|8             |..",
+        "..|8             |..",
+        "..|8 ??????????  |..",
+        "..|8 DDD6666DDD  |..",
+        "..|8             |..",
+        "..|8 7777777777  |..",
+        "..|--------------|..",
+        "....................",
+        "...................."
+      ],
+      "palettes": [ "military_camp", "military_camp_interior" ],
+      "terrain": {
+        "9": "t_card_military",
+        "7": "t_floor",
+        "8": "t_floor",
+        "?": "t_floor",
+        "l": "t_floor",
+        "[": "t_door_metal_locked",
+        "+": "t_door_metal_c",
+        "-": "t_concrete_wall",
+        "|": "t_concrete_wall"
+      },
+      "furniture": { "?": [ [ "f_null", 2 ], "f_chair" ], "7": "f_control_station", "8": "f_server" },
+      "items": { "X": { "item": "mil_armor", "chance": 50, "repeat": 2 }, "T": { "item": "maps_milspec", "chance": 10 } },
+      "monsters": { " ": { "monster": "GROUP_MIL_BASE", "chance": 1, "density": 0.002 } }
     }
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This adds a bit more variety to the new military camps.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added two new chunks that can sometimes spawn in place of the tents: a small firing range with backstop, spawning cases on the ground and sometimes a random (potentially damaged or fouled) firearm on the tables, and a helipad that has a random civilian heli/wrekc 50% of the time. Ranges show up 20% of the time, helipads 5%.
2. Set it so the lab in military camps is replaced with a command center building, which can rarely provide operations maps, as well as some extra equipment in a locked storage room the player needs to be able to break into.
3. Defined a fitting itemgroup for the gun range spawns. Mainly standard assault rifles, snipers, pistols, and shotguns to match the casings used below.
3. Misc: Added a small weight of 9mm casings to `mass_grave_casings`, to imply some use of pistols at places that use it, due to reusing the itemgroup as a conveinent military casing spawn for the gun range chunk.

## Describe alternatives you've considered

1. Making it choose between the command center and lab at random instead of always a command center.
2. Renaming `mass_grave_casings` to fit its use elsewhere?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Load-tested in compiled test build.
2. Spawned the various mapgen tiles, confirmed they look okay to me.
3. Swiped ID card to confirm the door to the storage room isn't also in range.

<img width="725" height="709" alt="image" src="https://github.com/user-attachments/assets/d78835ec-2aab-4297-8dbe-fafd31e2170c" />
<img width="677" height="705" alt="image" src="https://github.com/user-attachments/assets/acb8bc6a-53c3-4293-940a-0b63df564755" />
<img width="777" height="665" alt="image" src="https://github.com/user-attachments/assets/3253506a-669a-4057-aeab-399aeedf03cb" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
