### PR TITLE
feat(balance): photophore becomes more esthetic

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -16,12 +16,11 @@
     "id": "BIOLUM1",
     "name": { "str": "Weak Photophore" },
     "points": 1,
-    "description": "A photophore has grown from your head; you can make it glow softly.  This will make you very visible in the dark, ideal for attracting a partner during mating season.",
+    "description": "A photophore has grown under the skin of your cheeks; you can make them glow softly.  This will make you very visible in the dark, ideal for attracting a partner during mating season.",
     "active": true,
     "cost": 1,
     "time": 810000,
     "hunger": true,
-    "encumbrance_covered": [ [ "head", 5 ] ],
     "changes_to": [ "BIOLUM2" ],
     "category": [ "ELFA", "INSECT", "FISH" ],
     "lumination": [ [ "head", 8 ] ]
@@ -36,7 +35,6 @@
     "cost": 1,
     "time": 405000,
     "hunger": true,
-    "encumbrance_covered": [ [ "head", 5 ] ],
     "prereqs": [ "BIOLUM1" ],
     "category": [ "ELFA", "INSECT", "FISH" ],
     "lumination": [ [ "head", 20 ] ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Photophore has a utility as a flashlight you don't need to carry, that helps you read and craft anywhere any time and just feeds off your stored calories.

Current photophore is based on the anglerfish photophore. This means it's a protrusion sticking out of the head. Players might not want to take this otherwise harmless utility mutation, because of the esthetics.


## Describe the solution (The How)

<!-- e.g nerfs monster A -->

I made a simple change that turns the photophore from a head protrusion, to a cheek-based subdermal. In essence, you go from a light-up teletubby, to a charge-up pikachu.

The head encumbrance was removed as this no longer sticks out anywhere.

I felt like this would be a much more appealing presentation of this mutation that would go well with almost any mutation line.

Plus, it is based on real-world fish.

<img width="292" height="357" alt="photophore" src="https://github.com/user-attachments/assets/a93c12e7-2c0e-4d8c-b104-4c977ebde276" />


## Describe alternatives you've considered

Honestly, there's also photophores that go along what would in a human be the tummy, or the sides. Considering these regions are almost always covered in thick, opaque armor, it wouldn't make a lot of sense to be able to see light radiating here.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Simple description change and removal of encumbrance. No testing needed.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

While this isn't a _necessary_ change by any means, I feel it's important to make beneficial mutations appealing to the player so they'll both keep and use them.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
