### PR TITLE
feat(UI): add unload all and pickup menu equip shortcuts

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -265,6 +265,20 @@
   },
   {
     "type": "keybinding",
+    "id": "WEAR",
+    "category": "PICKUP",
+    "name": "Wear selected item",
+    "bindings": [ { "input_method": "keyboard", "key": "W" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "WIELD",
+    "category": "PICKUP",
+    "name": "Wield selected item",
+    "bindings": [ { "input_method": "keyboard", "key": "w" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "EXAMINE",
     "category": "INVENTORY",
     "name": "Examine item",

--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -1955,6 +1955,12 @@
   },
   {
     "type": "keybinding",
+    "name": "Unload All Items",
+    "category": "DEFAULTMODE",
+    "id": "unload_all"
+  },
+  {
+    "type": "keybinding",
     "name": "Throw Item",
     "category": "DEFAULTMODE",
     "id": "throw",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -193,6 +193,8 @@ std::string action_ident( action_id act )
             return "reload_wielded";
         case ACTION_UNLOAD:
             return "unload";
+        case ACTION_UNLOAD_ALL:
+            return "unload_all";
         case ACTION_MEND:
             return "mend";
         case ACTION_THROW:
@@ -931,7 +933,7 @@ action_id handle_action_menu()
             register_actions( {
                 ACTION_DROP, ACTION_COMPARE, ACTION_ORGANIZE, ACTION_USE,
                 ACTION_WEAR, ACTION_TAKE_OFF, ACTION_EAT, ACTION_OPEN_CONSUME,
-                ACTION_READ, ACTION_WIELD, ACTION_UNLOAD
+                ACTION_READ, ACTION_WIELD, ACTION_UNLOAD, ACTION_UNLOAD_ALL
             } );
             register_lua_action_entries( category_id );
         } else if( category_id == "debug" ) {

--- a/src/action.h
+++ b/src/action.h
@@ -157,6 +157,8 @@ enum action_id : int {
     ACTION_RELOAD_WIELDED,
     /** Open the unload item (e.g. firearms) select menu */
     ACTION_UNLOAD,
+    /** Unload every carried item that can be unloaded */
+    ACTION_UNLOAD_ALL,
     /** Open the mending menu (e.g. when using a sewing kit) */
     ACTION_MEND,
     /** Open the throw menu */

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1390,3 +1390,26 @@ void avatar_action::unload( avatar &you )
     }
     avatar_funcs::unload_item( you, *loc );
 }
+
+void avatar_action::unload_all( avatar &you )
+{
+    auto unloaded = 0;
+    while( true ) {
+        auto items = you.all_items();
+        const auto target = std::ranges::find_if( items, []( const auto * it ) {
+            return item_funcs::can_be_unloaded( *it );
+        } );
+
+        if( target == items.end() ) {
+            break;
+        }
+        if( !avatar_funcs::unload_item( you, **target ) ) {
+            break;
+        }
+        ++unloaded;
+    }
+
+    if( unloaded == 0 ) {
+        add_msg( _( "You have nothing to unload." ) );
+    }
+}

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -61,6 +61,7 @@ void reload_weapon( bool try_everything = true );
  * If it's a gun, some gunmods can also be loaded.
  */
 void unload( avatar &you );
+void unload_all( avatar &you );
 
 /**
  * Checks if the weapon is valid and if the player meets certain conditions for firing it.
@@ -110,5 +111,4 @@ void plthrow( avatar &you, item *loc,
 // Use item; also tries E,R,W  'a'
 void use_item( avatar &you, item *loc = nullptr );
 } // namespace avatar_action
-
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2695,6 +2695,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "reload_weapon" );
     ctxt.register_action( "reload_wielded" );
     ctxt.register_action( "unload" );
+    ctxt.register_action( "unload_all" );
     ctxt.register_action( "throw" );
     ctxt.register_action( "fire" );
     ctxt.register_action( "cast_spell" );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "avatar.h"
+#include "avatar_action.h"
 #include "avatar_functions.h"
 #include "bionics.h"
 #include "calendar.h"
@@ -106,6 +107,35 @@ class inventory_filter_preset : public inventory_selector_preset
 
 namespace
 {
+
+class common_inventory_selector : public inventory_pick_selector
+{
+    public:
+        explicit common_inventory_selector( player &p ) : inventory_pick_selector( p ) {
+            ctxt.register_action( "unload_all",
+                                  to_translation( "Unload every carried item that can be unloaded" ) );
+        }
+
+        auto clear_shortcuts() -> void {
+            unload_all_selected = false;
+        }
+
+        [[nodiscard]] auto selected_unload_all() const -> bool {
+            return unload_all_selected;
+        }
+
+    protected:
+        auto handle_action( const std::string &action ) -> bool override {
+            if( action != "unload_all" ) {
+                return false;
+            }
+            unload_all_selected = true;
+            return true;
+        }
+
+    private:
+        bool unload_all_selected = false;
+};
 
 std::string good_bad_none( int value )
 {
@@ -222,7 +252,7 @@ static item *inv_internal( player &u, const inventory_selector_preset &preset,
 
 void game_menus::inv::common( avatar &you )
 {
-    inventory_pick_selector inv_s( you );
+    common_inventory_selector inv_s( you );
 
     inv_s.set_title( _( "Inventory" ) );
     inv_s.set_hint( string_format(
@@ -235,7 +265,14 @@ void game_menus::inv::common( avatar &you )
         inv_s.clear_items();
         inv_s.add_character_items( you );
 
-        item *location = inv_s.execute();
+        inv_s.clear_shortcuts();
+        auto *location = inv_s.execute();
+
+        if( inv_s.selected_unload_all() ) {
+            avatar_action::unload_all( you );
+            started_action = true;
+            continue;
+        }
 
         if( location == nullptr ) {
             if( inv_s.keep_open ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2304,6 +2304,10 @@ bool game::handle_action()
                 avatar_action::unload( u );
                 break;
 
+            case ACTION_UNLOAD_ALL:
+                avatar_action::unload_all( u );
+                break;
+
             case ACTION_MEND:
                 avatar_action::mend( g->u, nullptr );
                 break;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1954,6 +1954,8 @@ item *inventory_pick_selector::execute()
             }
         } else if( input.action == "INVENTORY_FILTER" ) {
             set_filter();
+        } else if( handle_action( input.action ) ) {
+            return nullptr;
         } else {
             on_input( input );
         }

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -660,6 +660,11 @@ class inventory_pick_selector : public inventory_selector
             inventory_selector( p, preset ) {}
 
         item *execute();
+
+    protected:
+        virtual auto handle_action( const std::string &/*action*/ ) -> bool {
+            return false;
+        }
 };
 
 class inventory_multiselector : public inventory_selector

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -151,6 +151,15 @@ enum pickup_answer : int {
     NUM_ANSWERS
 };
 
+struct pick_one_up_options {
+    pickup::pick_drop_selection &selection;
+    bool &got_water;
+    bool &offered_swap;
+    pickup_map &map_pickup;
+    bool autopickup = false;
+    std::optional<pickup_answer> preferred_option;
+};
+
 static pickup_answer handle_problematic_pickup( const item &it, bool &offered_swap,
         bool has_children, const std::string &explain )
 {
@@ -241,10 +250,12 @@ bool pickup::query_thief()
 }
 
 // Returns false if pickup caused a prompt and the player selected to cancel pickup
-static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water,
-                         bool &offered_swap,
-                         pickup_map &map_pickup, bool autopickup )
+static auto pick_one_up( const pick_one_up_options &opts ) -> bool
 {
+    auto &selection = opts.selection;
+    auto &got_water = opts.got_water;
+    auto &offered_swap = opts.offered_swap;
+    auto &map_pickup = opts.map_pickup;
     player &u = get_avatar();
     int moves_taken = 100;
     bool picked_up = false;
@@ -292,7 +303,9 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
     auto with_det = [&]( detached_ptr<item> &&newloc ) {
 
         // Ammo can sometimes be picked up into containers
-        newloc = u.i_add_to_container( std::move( newloc ), false );
+        if( !opts.preferred_option ) {
+            newloc = u.i_add_to_container( std::move( newloc ), false );
+        }
 
         if( !newloc || ( newloc->count_by_charges() && newloc->charges == 0 ) ) {
             // We've picked up everything into containers, skip the options part
@@ -300,8 +313,10 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
             option = NUM_ANSWERS;
         } else if( newloc->made_of( LIQUID ) ) {
             got_water = true;
+        } else if( opts.preferred_option ) {
+            option = *opts.preferred_option;
         } else if( !u.can_pick_weight( newloc->weight() + children_weight, false ) ) {
-            if( !autopickup ) {
+            if( !opts.autopickup ) {
                 const std::string &explain = string_format( _( "The %s is too heavy!" ),
                                              newloc->display_name() );
                 option = handle_problematic_pickup( *newloc, offered_swap, !children.empty(), explain );
@@ -310,7 +325,7 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
                 option = CANCEL;
             }
         } else if( newloc->is_bucket() && !newloc->is_container_empty() ) {
-            if( !autopickup ) {
+            if( !opts.autopickup ) {
                 const std::string &explain = string_format( _( "Can't stash %s while it's not empty" ),
                                              newloc->display_name() );
                 option = handle_problematic_pickup( *newloc, offered_swap, !children.empty(), explain );
@@ -319,7 +334,7 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
                 option = CANCEL;
             }
         } else if( !u.can_pick_volume( newloc->volume() + children_volume ) ) {
-            if( !autopickup ) {
+            if( !opts.autopickup ) {
                 const std::string &explain = string_format( _( "Not enough capacity to stash %s" ),
                                              newloc->display_name() );
                 option = handle_problematic_pickup( *newloc, offered_swap, !children.empty(), explain );
@@ -450,7 +465,12 @@ bool do_pickup( std::vector<pick_drop_selection> &targets, bool autopickup )
         }
 
         // TODO: This invocation is very ugly, should get a proper structure or something
-        problem = !pick_one_up( current_target, got_water, offered_swap, map_pickup, autopickup );
+        problem = !pick_one_up( pick_one_up_options{ .selection = current_target,
+                                .got_water = got_water,
+                                .offered_swap = offered_swap,
+                                .map_pickup = map_pickup,
+                                .autopickup = autopickup,
+                                .preferred_option = std::nullopt } );
     }
 
     if( !map_pickup.empty() ) {
@@ -792,6 +812,8 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
         ctxt.register_action( "ANY_INPUT" );
         ctxt.register_action( "HELP_KEYBINDINGS" );
         ctxt.register_action( "FILTER" );
+        ctxt.register_action( "WEAR", to_translation( "Wear" ) );
+        ctxt.register_action( "WIELD", to_translation( "Wield" ) );
 #if defined(__ANDROID__)
         ctxt.allow_text_entry = true; // allow user to specify pickup amount
 #endif
@@ -1035,6 +1057,49 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                 .edit( new_filter );
                 if( !popup.canceled() ) {
                     filter_changed = true;
+                }
+            } else if( selected >= 0 && selected < static_cast<int>( matches.size() ) &&
+                       ( action == "WEAR" || action == "WIELD" ) ) {
+                const auto true_idx = matches[selected];
+                const auto &selected_item = **stacked_here[true_idx].front();
+                const auto preferred_option = action == "WEAR" ? WEAR : WIELD;
+                const auto can_handle = preferred_option == WEAR ? g->u.can_wear( selected_item ) :
+                                        g->u.can_wield( selected_item );
+                if( !can_handle.success() ) {
+                    add_msg( m_info, "%s", can_handle.c_str() );
+                } else {
+                    auto direct_locations = std::vector<item *> {};
+                    auto direct_quantities = std::vector<int> {};
+                    direct_locations.push_back( *stacked_here[true_idx].front() );
+                    direct_quantities.push_back( 0 );
+                    for( const auto child_index : getitem[true_idx].children ) {
+                        direct_locations.push_back( *stacked_here[child_index].front() );
+                        direct_quantities.push_back( 0 );
+                    }
+
+                    auto direct_targets = pickup::optimize_pickup( direct_locations, direct_quantities );
+                    if( !direct_targets.empty() ) {
+                        auto direct_got_water = false;
+                        auto direct_offered_swap = false;
+                        auto direct_map_pickup = pickup_map{};
+                        auto direct_target = direct_targets.front();
+                        const auto handled = pick_one_up( pick_one_up_options{ .selection = direct_target,
+                                                          .got_water = direct_got_water,
+                                                          .offered_swap = direct_offered_swap,
+                                                          .map_pickup = direct_map_pickup,
+                                                          .autopickup = false,
+                                                          .preferred_option = preferred_option } );
+                        if( !direct_map_pickup.empty() ) {
+                            show_pickup_message( direct_map_pickup );
+                        }
+                        if( direct_got_water ) {
+                            add_msg( m_info, _( "You can't pick up a liquid!" ) );
+                        }
+                        if( handled ) {
+                            g->reenter_fullscreen();
+                            return;
+                        }
+                    }
                 }
             } else if( action == "ANY_INPUT" && raw_input_char == '`' ) {
                 std::string ext = string_input_popup()


### PR DESCRIPTION
## Purpose of change (The Why)

Adds small QoL shortcuts called out by players comparing BN with DDA: equipping loot from the pickup menu and unloading all carried unloadable items.

Source discussion: https://www.reddit.com/r/cataclysmdda/comments/1srb0up/how_about_cbn/

## Describe the solution (The How)

- Adds `W`/`w` pickup-menu actions to wear or wield the selected ground item directly.
- Adds an `unload_all` action exposed in the inventory action menu and directly in the inventory menu via its keybinding.

## Testing

- `cmake --build build --target astyle`
- `cmake --build build --target style-json-parallel`
- `cmake --build --preset linux-curses --target cataclysm-bn`
- `./build-scripts/lint-json.sh`
- `ninja -C out/build/linux-full src/CMakeFiles/cataclysm-bn-tiles-common.dir/inventory_ui.cpp.o src/CMakeFiles/cataclysm-bn-tiles-common.dir/game_inventory.cpp.o src/CMakeFiles/cataclysm-bn-tiles-common.dir/game.cpp.o`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<sup>PR opened by gpt-5.5 on opencode</sup>
