### PR TITLE
feat(UI): add user configurable vehicle follow distance

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3097,6 +3097,7 @@ void vehicle::deserialize( JsonIn &jsin )
     pivot_anchor[1] = pivot_anchor[0];
     pivot_rotation[1] = pivot_rotation[0] = fdir_angle;
     data.read( "is_following", is_following );
+    data.read( "follow_distance", follow_distance );
     data.read( "is_patrolling", is_patrolling );
     data.read( "autodrive_local_target", autodrive_local_target );
     data.read( "summon_time_limit", summon_time_limit );
@@ -3277,6 +3278,7 @@ void vehicle::serialize( JsonOut &json ) const
     }
     json.member( "pivot", pivot_anchor[0] );
     json.member( "is_following", is_following );
+    json.member( "follow_distance", follow_distance );
     json.member( "is_patrolling", is_patrolling );
     json.member( "autodrive_local_target", autodrive_local_target );
     json.member( "summon_time_limit", summon_time_limit );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -368,6 +368,7 @@ void vehicle::copy_static_from( const vehicle &source )
     attached = source.attached;
     is_autodriving = source.is_autodriving;
     is_following = source.is_following;
+    follow_distance = source.follow_distance;
     is_patrolling = source.is_patrolling;
     cruise_on = source.cruise_on;
     engine_on = source.engine_on;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -935,6 +935,7 @@ void vehicle::activate_magical_follow()
         if( vp.info().fuel_type == fuel_type_mana ) {
             vp.enabled = true;
             is_following = true;
+            follow_distance = 12 + mount_max.y * 3;
             engine_on = true;
         } else {
             vp.enabled = true;
@@ -952,6 +953,7 @@ void vehicle::activate_animal_follow()
             if( mon && mon->has_effect( effect_harnessed ) ) {
                 vp.enabled = true;
                 is_following = true;
+                follow_distance = 12 + mount_max.y * 3;
                 engine_on = true;
             }
         } else {
@@ -1153,11 +1155,11 @@ void vehicle::drive_to_local_target( const tripoint &target, bool follow_protoco
     }
     if( follow_protocol ) {
         if( ( ( turn_x > 0 || turn_x < 0 ) && velocity > safe_player_follow_speed ) ||
-            rl_dist( vehpos, g->m.getabs( g->u.pos() ) ) < 7 + ( ( mount_max.y * 3 ) + 4 ) ) {
+            rl_dist( vehpos, g->m.getabs( g->u.pos() ) ) < follow_distance - 1 ) {
             accel_y = 1;
         }
         if( ( velocity < std::min( safe_velocity(), safe_player_follow_speed ) && turn_x == 0 &&
-              rl_dist( vehpos, g->m.getabs( g->u.pos() ) ) > 8 + ( ( mount_max.y * 3 ) + 4 ) ) ||
+              rl_dist( vehpos, g->m.getabs( g->u.pos() ) ) > follow_distance ) ||
             velocity < 45 ) {
             accel_y = -1;
         }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1838,6 +1838,7 @@ class vehicle
         // vehicle being driven by player/npc automatically
         bool is_autodriving = false;
         bool is_following = false;
+        int follow_distance = 0;
         bool is_patrolling = false;
         // TODO: change these to a bitset + enum?
         // cruise control on/off

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -641,7 +641,6 @@ void vehicle::toggle_autopilot()
     smenu.addentry_col( STOP, true, 'S', _( "Stop…" ),
                         "", string_format( _( "Stop all autopilot related activities." ) ) );
     smenu.query();
-    auto popup = string_input_popup();
     switch( smenu.ret ) {
         case PATROL:
             autopilot_patrol_check();
@@ -653,21 +652,25 @@ void vehicle::toggle_autopilot()
             autodrive_local_target = tripoint_zero;
             stop_engines();
             break;
-        case FOLLOW:
+        case FOLLOW: {
             autopilot_on = true;
             is_following = true;
             is_patrolling = false;
-            popup.title( _( "What distance?" ) )
-            .text( std::to_string( 12 + mount_max.y * 3 ) )
-            .max_length( 3 )
-            .query();
-            if( popup.canceled() ) {
-                follow_distance = 12 + mount_max.y * 3;
-            } else {
-                follow_distance = std::stoi( popup.text() );
-            }
+            const auto default_follow_distance = 12 + mount_max.y * 3;
+            const auto initial_follow_distance = follow_distance > 0 ? follow_distance :
+                                                 default_follow_distance;
+            const auto requested_follow_distance = string_input_popup()
+                                                   .title( _( "What distance?" ) )
+                                                   .text( std::to_string( initial_follow_distance ) )
+                                                   .only_digits( true )
+                                                   .max_length( 3 )
+                                                   .query_int();
+            follow_distance = requested_follow_distance > 0 ? requested_follow_distance :
+                              default_follow_distance;
             start_engines();
             refresh();
+            break;
+        }
         default:
             return;
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -641,6 +641,7 @@ void vehicle::toggle_autopilot()
     smenu.addentry_col( STOP, true, 'S', _( "Stop…" ),
                         "", string_format( _( "Stop all autopilot related activities." ) ) );
     smenu.query();
+    auto popup = string_input_popup();
     switch( smenu.ret ) {
         case PATROL:
             autopilot_patrol_check();
@@ -656,6 +657,15 @@ void vehicle::toggle_autopilot()
             autopilot_on = true;
             is_following = true;
             is_patrolling = false;
+            popup.title( _( "What distance?" ) )
+            .text( std::to_string( 12 + mount_max.y * 3 ) )
+            .max_length( 3 )
+            .query();
+            if( popup.canceled() ) {
+                follow_distance = 12 + mount_max.y * 3;
+            } else {
+                follow_distance = std::stoi( popup.text() );
+            }
             start_engines();
             refresh();
         default:


### PR DESCRIPTION
## Purpose of change (The Why)
Moving the c++ changes from #8541 to mainline pt 1
This supports close following automated shopping carts

## Describe the solution (The How)
Instead of hardcoded distance
Give users popup and make hardcode distance default

## Describe alternatives you've considered
None

## Testing
Popup works vehicle follows closely

## Additional context
This does allow people to have the vehicle run into them but it only happens once so scrungle

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.