### PR TITLE
feat: add deployer monster attack actor

### DIFF
--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -195,7 +195,16 @@
     "vision_night": 3,
     "harvest": "exempt",
     "starting_ammo": { "bot_c4_hack": 2, "bot_flashbang_hack": 3, "bot_gasbomb_hack": 3, "bot_grenade_hack": 10 },
-    "special_attacks": [ [ "GRENADIER", 6 ] ],
+    "special_attacks": [ {
+      "type": "deployer",
+      "deployables": {
+        "bot_c4_hack": { "message": "The zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.5, "range": 10 },
+        "bot_flashbang_hack": { "message": "The zombie grenadier deploys a flashbang hack", "chance": 1, "ammo_percentage": 0.75, "range": 10 },
+        "bot_gasbomb_hack": { "message": "The zombie grenadier deploys a gasbomb hack", "chance": 1, "ammo_percentage": 0.5, "range": 10 },
+        "bot_grenade_hack": { "message": "The zombie grenadier deploys a grenade hack", "chance": 1, "ammo_percentage": 1.0, "range": 10 },
+      },
+      "cooldown": 6
+    } ],
     "death_drops": { "subtype": "collection", "groups": [ [ "mon_zombie_soldier_death_drops", 100 ], [ "mon_zombie_grenadier", 100 ] ] },
     "death_function": [ "DETONATE" ],
     "burn_into": "mon_zombie_scorched",
@@ -231,7 +240,17 @@
     "vision_night": 3,
     "harvest": "exempt",
     "starting_ammo": { "bot_c4_hack": 10, "bot_flashbang_hack": 10, "bot_gasbomb_hack": 10, "bot_grenade_hack": 20, "bot_mininuke_hack": 1 },
-    "special_attacks": [ [ "GRENADIER_ELITE", 3 ] ],
+    "special_attacks": [ {
+      "type": "deployer",
+      "deployables": {
+        "bot_c4_hack": { "message": "The elite zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.6, "range": 10 },
+        "bot_flashbang_hack": { "message": "The elite zombie grenadier deploys a flashbang hack", "chance": 1, "ammo_percentage": 0.8, "range": 10 },
+        "bot_gasbomb_hack": { "message": "The elite zombie grenadier deploys a gasbomb hack", "chance": 1, "ammo_percentage": 0.7, "range": 10 },
+        "bot_grenade_hack": { "message": "The elite zombie grenadier deploys a grenade hack", "chance": 1, "ammo_percentage": 1.0, "range": 10 },
+        "bot_mininuke_hack": { "message": "A klaxon blares from the elite zombie grenadier and you see a mininuke hack come out", "chance": 50, "ammo_percentage": 0.5, "range": 10 }
+      },
+      "cooldown": 3
+    } ],
     "death_drops": {
       "subtype": "collection",
       "groups": [ [ "mon_zombie_soldier_death_drops", 100 ], [ "mon_zombie_grenadier_elite", 100 ] ]

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -195,16 +195,18 @@
     "vision_night": 3,
     "harvest": "exempt",
     "starting_ammo": { "bot_c4_hack": 2, "bot_flashbang_hack": 3, "bot_gasbomb_hack": 3, "bot_grenade_hack": 10 },
-    "special_attacks": [ {
-      "type": "deployer",
-      "deployables": {
-        "bot_c4_hack": { "message": "The zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.5, "range": 10 },
-        "bot_flashbang_hack": { "message": "The zombie grenadier deploys a flashbang hack", "chance": 1, "ammo_percentage": 0.75, "range": 10 },
-        "bot_gasbomb_hack": { "message": "The zombie grenadier deploys a gasbomb hack", "chance": 1, "ammo_percentage": 0.5, "range": 10 },
-        "bot_grenade_hack": { "message": "The zombie grenadier deploys a grenade hack", "chance": 1, "ammo_percentage": 1.0, "range": 10 },
-      },
-      "cooldown": 6
-    } ],
+    "special_attacks": [
+      {
+        "type": "deployer",
+        "deployables": {
+          "bot_c4_hack": { "message": "The zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.5, "range": 10 },
+          "bot_flashbang_hack": { "message": "The zombie grenadier deploys a flashbang hack", "chance": 1, "ammo_percentage": 0.75, "range": 10 },
+          "bot_gasbomb_hack": { "message": "The zombie grenadier deploys a gasbomb hack", "chance": 1, "ammo_percentage": 0.5, "range": 10 },
+          "bot_grenade_hack": { "message": "The zombie grenadier deploys a grenade hack", "chance": 1, "ammo_percentage": 1.0, "range": 10 }
+        },
+        "cooldown": 6
+      }
+    ],
     "death_drops": { "subtype": "collection", "groups": [ [ "mon_zombie_soldier_death_drops", 100 ], [ "mon_zombie_grenadier", 100 ] ] },
     "death_function": [ "DETONATE" ],
     "burn_into": "mon_zombie_scorched",
@@ -240,17 +242,24 @@
     "vision_night": 3,
     "harvest": "exempt",
     "starting_ammo": { "bot_c4_hack": 10, "bot_flashbang_hack": 10, "bot_gasbomb_hack": 10, "bot_grenade_hack": 20, "bot_mininuke_hack": 1 },
-    "special_attacks": [ {
-      "type": "deployer",
-      "deployables": {
-        "bot_c4_hack": { "message": "The elite zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.6, "range": 10 },
-        "bot_flashbang_hack": { "message": "The elite zombie grenadier deploys a flashbang hack", "chance": 1, "ammo_percentage": 0.8, "range": 10 },
-        "bot_gasbomb_hack": { "message": "The elite zombie grenadier deploys a gasbomb hack", "chance": 1, "ammo_percentage": 0.7, "range": 10 },
-        "bot_grenade_hack": { "message": "The elite zombie grenadier deploys a grenade hack", "chance": 1, "ammo_percentage": 1.0, "range": 10 },
-        "bot_mininuke_hack": { "message": "A klaxon blares from the elite zombie grenadier and you see a mininuke hack come out", "chance": 50, "ammo_percentage": 0.5, "range": 10 }
-      },
-      "cooldown": 3
-    } ],
+    "special_attacks": [
+      {
+        "type": "deployer",
+        "deployables": {
+          "bot_c4_hack": { "message": "The elite zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.6, "range": 10 },
+          "bot_flashbang_hack": { "message": "The elite zombie grenadier deploys a flashbang hack", "chance": 1, "ammo_percentage": 0.8, "range": 10 },
+          "bot_gasbomb_hack": { "message": "The elite zombie grenadier deploys a gasbomb hack", "chance": 1, "ammo_percentage": 0.7, "range": 10 },
+          "bot_grenade_hack": { "message": "The elite zombie grenadier deploys a grenade hack", "chance": 1, "ammo_percentage": 1.0, "range": 10 },
+          "bot_mininuke_hack": {
+            "message": "A klaxon blares from the elite zombie grenadier and you see a mininuke hack come out",
+            "chance": 50,
+            "ammo_percentage": 0.5,
+            "range": 10
+          }
+        },
+        "cooldown": 3
+      }
+    ],
     "death_drops": {
       "subtype": "collection",
       "groups": [ [ "mon_zombie_soldier_death_drops", 100 ], [ "mon_zombie_grenadier_elite", 100 ] ]

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -199,7 +199,7 @@
       {
         "type": "deployer",
         "deployables": {
-          "bot_c4_hack": { "message": "The zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.5, "range": 10 },
+          "bot_c4_hack": { "message": "The zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.5, "range": 5 },
           "bot_flashbang_hack": { "message": "The zombie grenadier deploys a flashbang hack", "chance": 1, "ammo_percentage": 0.75, "range": 10 },
           "bot_gasbomb_hack": { "message": "The zombie grenadier deploys a gasbomb hack", "chance": 1, "ammo_percentage": 0.5, "range": 10 },
           "bot_grenade_hack": { "message": "The zombie grenadier deploys a grenade hack", "chance": 1, "ammo_percentage": 1.0, "range": 10 }

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -254,7 +254,7 @@
             "message": "A klaxon blares from the elite zombie grenadier and you see a mininuke hack come out",
             "chance": 50,
             "ammo_percentage": 0.5,
-            "range": 10
+            "range": 2
           }
         },
         "cooldown": 3

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -246,7 +246,7 @@
       {
         "type": "deployer",
         "deployables": {
-          "bot_c4_hack": { "message": "The elite zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.6, "range": 10 },
+          "bot_c4_hack": { "message": "The elite zombie grenadier deploys a c4 hack", "chance": 1, "ammo_percentage": 0.6, "range": 5 },
           "bot_flashbang_hack": { "message": "The elite zombie grenadier deploys a flashbang hack", "chance": 1, "ammo_percentage": 0.8, "range": 10 },
           "bot_gasbomb_hack": { "message": "The elite zombie grenadier deploys a gasbomb hack", "chance": 1, "ammo_percentage": 0.7, "range": 10 },
           "bot_grenade_hack": { "message": "The elite zombie grenadier deploys a grenade hack", "chance": 1, "ammo_percentage": 1.0, "range": 10 },

--- a/docs/en/mod/json/reference/creatures/monsters.md
+++ b/docs/en/mod/json/reference/creatures/monsters.md
@@ -855,15 +855,14 @@ Description of the sound made when out of ammo.
 ```json
 {
   "type": "deployer",
-  "deployables": { 
-    "bot_c4_hack": {                                             // Item Id of ammo to deploy
+  "deployables": {
+    "bot_c4_hack": { // Item Id of ammo to deploy
       "message": "The elite zombie grenadier deploys a c4 hack", // Message to display when deploying
-      "chance": 1,                                               // Chance to use ( sum of all active deployables )
-      "ammo_percentage": 0.6,                                    // Percentage of ammo spent to use it
-      "range": 10                                                // How far can it throw this ( note it will throw it unfocused on a target )
-    },
+      "chance": 1, // Chance to use ( sum of all active deployables )
+      "ammo_percentage": 0.6, // Percentage of ammo spent to use it
+      "range": 10 // How far can it throw this ( note it will throw it unfocused on a target )
+    }
   },
-  "cooldown": 3                                                  // Turns between deployments
+  "cooldown": 3 // Turns between deployments
 }
 ```
-

--- a/docs/en/mod/json/reference/creatures/monsters.md
+++ b/docs/en/mod/json/reference/creatures/monsters.md
@@ -858,9 +858,9 @@ Description of the sound made when out of ammo.
   "deployables": {
     "bot_c4_hack": { // Item Id of ammo to deploy
       "message": "The elite zombie grenadier deploys a c4 hack", // Message to display when deploying
-      "chance": 1, // Chance to use ( sum of all active deployables )
-      "ammo_percentage": 0.6, // Percentage of ammo spent to use it
-      "range": 10 // How far can it throw this ( note it will throw it unfocused on a target )
+      "chance": 1, // Spawn weight, randomly selected based on total weight of available deployables
+      "ammo_percentage": 0.6, // Threshold for when it will add this deployable to the pool for random selection, e.g. won't start deploying this until 40% of total deployables have already been used up.
+      "range": 10 // Spawn radius when deploying
     }
   },
   "cooldown": 3 // Turns between deployments

--- a/docs/en/mod/json/reference/creatures/monsters.md
+++ b/docs/en/mod/json/reference/creatures/monsters.md
@@ -849,3 +849,21 @@ Volume of the sound made when targeting.
 #### "no_ammo_sound"
 
 Description of the sound made when out of ammo.
+
+### "deployer"
+
+```json
+{
+  "type": "deployer",
+  "deployables": { 
+    "bot_c4_hack": {                                             // Item Id of ammo to deploy
+      "message": "The elite zombie grenadier deploys a c4 hack", // Message to display when deploying
+      "chance": 1,                                               // Chance to use ( sum of all active deployables )
+      "ammo_percentage": 0.6,                                    // Percentage of ammo spent to use it
+      "range": 10                                                // How far can it throw this ( note it will throw it unfocused on a target )
+    },
+  },
+  "cooldown": 3                                                  // Turns between deployments
+}
+```
+

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -17,6 +17,8 @@
 #include "generic_factory.h"
 #include "gun_mode.h"
 #include "int_id.h"
+#include "itype.h"
+#include "iuse_actor.h"
 #include "item.h"
 #include "json.h"
 #include "line.h"
@@ -225,6 +227,98 @@ bool mon_spellcasting_actor::call( monster &mon ) const
     }
 
     spell_data.cast_all_effects( mon, target );
+
+    return true;
+}
+
+std::unique_ptr<mattack_actor> deployer_actor::clone() const
+{
+    return std::make_unique<deployer_actor>( *this );
+}
+
+void deployer_actor::load_internal( const JsonObject &obj, const std::string & )
+{
+    for( const JsonMember member : obj.get_object( "deployables" ) ) {
+        const JsonObject jo = member.get_object();
+        grenades[itype_id( member.name() )] = {
+            _( jo.get_string( "message" ) ),
+            jo.get_int( "chance" ),
+            jo.get_float( "ammo_percentage" ),
+            jo.get_int( "range" )
+        };
+    }
+}
+
+bool deployer_actor::call( monster &mon ) const
+{
+    if( !mon.can_act() ) {
+        return false;
+    }
+    bool has_attack_target = mon.attack_target();
+    has_attack_target = has_attack_target || ( !mon.friendly && mon.sees( g->u ) );
+    if( !has_attack_target ) {
+        // this is an attack. there is no reason to attack if there isn't a real target.
+        return false;
+    }
+
+    int total_ammo = 0;
+    for( const auto &ammo_entry : mon.type->starting_ammo ) {
+        total_ammo += ammo_entry.second;
+    }
+    if( total_ammo == 0 ) {
+        // Should never happen, but protect us from a div/0 if it does.
+        return false;
+    }
+
+    // Find how much ammo we currently have to get the total ratio
+    int curr_ammo = 0;
+    for( const auto &amm : mon.ammo ) {
+        curr_ammo += amm.second;
+    }
+    float rat = curr_ammo / static_cast<float>( total_ammo );
+
+    weighted_float_list<itype_id> possible_attacks;
+    for( const auto &amm : mon.ammo ) {
+        if( amm.second > 0 && grenades.at( amm.first ).ammo_percentage >= rat ) {
+            possible_attacks.add( amm.first, 1.0 / grenades.at( amm.first ).chance );
+        }
+    }
+    if( possible_attacks.empty() ) {
+        return false;
+    }
+
+    itype_id att = *possible_attacks.pick();
+
+    std::vector<tripoint> empty_points_in_rad;
+
+    auto points_in_rad = g->m.points_in_radius( mon.pos(), grenades.at( att ).range );
+    for( tripoint p : points_in_rad ) {
+        if( g->is_empty( p ) ) {
+            empty_points_in_rad.push_back( p );
+        }
+    }
+
+    // Get our monster type
+    const use_function *usage = att->get_use( "place_monster" );
+    if( usage == nullptr ) {
+        // Invalid bomb item usage, Toggle this special off so we stop processing
+        add_msg( m_debug, "Invalid bomb item usage in deployer special for %s.", mon.name() );
+        return false;
+    }
+    auto *actor = dynamic_cast<const place_monster_iuse *>( usage->get_actor_ptr() );
+    if( actor == nullptr ) {
+        // Invalid bomb item, Toggle this special off so we stop processing
+        add_msg( m_debug, "Invalid bomb type in deployer special for %s.", mon.name() );
+        return false;
+    }
+
+    const tripoint where = empty_points_in_rad[ rng( 0, empty_points_in_rad.size() - 1 ) ];
+
+    if( monster *const hack = g->place_critter_at( actor->mtypeid, where ) ) {
+        mon.ammo[att]--;
+        hack->make_ally( mon );
+        add_msg( m_bad, grenades.at( att ).message );
+    }
 
     return true;
 }

--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -198,4 +198,27 @@ class gun_actor : public mattack_actor
         std::unique_ptr<mattack_actor> clone() const override;
 };
 
+class deployer_actor : public mattack_actor
+{
+    public:
+        struct deployer_helper_struct {
+            // Print this on deployment
+            std::string message;
+            // Chance from 0 to 100 of deployment
+            int chance = 1;
+            // At what percent of ammo remaining should this be considered
+            double ammo_percentage = 1;
+            // At what range can this be deployed ( 0 being in melee )
+            int range = 0;
+
+        };
+        std::map<itype_id, deployer_helper_struct> grenades;
+
+        deployer_actor() = default;
+        ~deployer_actor() override = default;
+
+        void load_internal( const JsonObject &obj, const std::string &src ) override;
+        bool call( monster & ) const override;
+        std::unique_ptr<mattack_actor> clone() const override;
+};
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1350,6 +1350,8 @@ mtype_special_attack MonsterGenerator::create_actor( const JsonObject &obj,
         new_attack = std::make_unique<gun_actor>();
     } else if( attack_type == "spell" ) {
         new_attack = std::make_unique<mon_spellcasting_actor>();
+    } else if( attack_type == "deployer" ) {
+        new_attack = std::make_unique<deployer_actor>();
     } else {
         obj.throw_error( "unknown monster attack", "attack_type" );
     }


### PR DESCRIPTION
## Purpose of change (The Why)
Moving the c++ changes from https://github.com/cataclysmbn/Cataclysm-BN/pull/8541 to mainline pt 4
This supports configurable grenadier attack actions

## Describe the solution (The How)
Add a new mattack actor: deployer
It does everything the monattack did but jsonized

## Describe alternatives you've considered
Make it do more then the monattack did?

## Testing
Grenadiers work

## Additional context
Getting close to no more new hardcode in CRIT lab PR

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.