### PR TITLE
feat: allow monster groups to have included evolution cycles

### DIFF
--- a/docs/en/mod/json/reference/creatures/monster_spawning.md
+++ b/docs/en/mod/json/reference/creatures/monster_spawning.md
@@ -17,8 +17,8 @@ title: Monster Spawning System
 | `monsters`      | To choose a monster for spawning, the game creates 1000 entries and picks one. Each monster will have a number of entries equal to it's "freq" and the default monster will fill in the remaining. See the table below for how to build the single monster definitions. |
 | `is_safe`       | (bool) Check to not trigger safe-mode warning.                                                                                                                                                                                                                          |
 | `is_animal`     | (bool) Check if that group has only normal animals.                                                                                                                                                                                                                     |
-| `evolve_repeat` | (int) Number of attempts for extra default evolutions. 0 means off
-| `evolve_chance` | (int) Chance for extra evolutions from 0-100
+| `evolve_repeat` | (int) Number of attempts for extra default evolutions. 0 means off                                                                                                                                                                                                      |
+| `evolve_chance` | (int) Chance for extra evolutions from 0-100                                                                                                                                                                                                                            |
 
 #### Monster definition
 

--- a/docs/en/mod/json/reference/creatures/monster_spawning.md
+++ b/docs/en/mod/json/reference/creatures/monster_spawning.md
@@ -10,13 +10,15 @@ title: Monster Spawning System
 
 #### Group definition
 
-| Identifier  | Description                                                                                                                                                                                                                                                             |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`      | Unique ID. Must be one continuous word, use underscores if necessary.                                                                                                                                                                                                   |
-| `default`   | Default monster, automatically fills in any remaining spawn chances.                                                                                                                                                                                                    |
-| `monsters`  | To choose a monster for spawning, the game creates 1000 entries and picks one. Each monster will have a number of entries equal to it's "freq" and the default monster will fill in the remaining. See the table below for how to build the single monster definitions. |
-| `is_safe`   | (bool) Check to not trigger safe-mode warning.                                                                                                                                                                                                                          |
-| `is_animal` | (bool) Check if that group has only normal animals.                                                                                                                                                                                                                     |
+| Identifier      | Description                                                                                                                                                                                                                                                             |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`          | Unique ID. Must be one continuous word, use underscores if necessary.                                                                                                                                                                                                   |
+| `default`       | Default monster, automatically fills in any remaining spawn chances.                                                                                                                                                                                                    |
+| `monsters`      | To choose a monster for spawning, the game creates 1000 entries and picks one. Each monster will have a number of entries equal to it's "freq" and the default monster will fill in the remaining. See the table below for how to build the single monster definitions. |
+| `is_safe`       | (bool) Check to not trigger safe-mode warning.                                                                                                                                                                                                                          |
+| `is_animal`     | (bool) Check if that group has only normal animals.                                                                                                                                                                                                                     |
+| `evolve_repeat` | (int) Number of attempts for extra default evolutions. 0 means off
+| `evolve_chance` | (int) Chance for extra evolutions from 0-100
 
 #### Monster definition
 

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -104,6 +104,26 @@ MonsterGroupResult MonsterGroupManager::GetResultFromGroup(
     //Our spawn details specify, by default, a single instance of the default monster
     MonsterGroupResult spawn_details = MonsterGroupResult( group.defaultMonster, 1 );
 
+    if( group.defaultMonster != mtype_id::NULL_ID() ) {
+        int count = 0;
+        auto montype = group.defaultMonster;
+        while( count < group.evolve_repeat ) {
+            if( rng( 0, 100 ) < group.evolve_chance ) {
+                if( montype->upgrade_into ) {
+                    //If we upgrade into a blacklisted monster, treat it as though we are non-upgradeable
+                    if( MonsterGroupManager::monster_is_blacklisted( montype->upgrade_into ) ) {
+                        count = group.evolve_repeat;
+                    }
+                    montype = montype->upgrade_into;
+                } else {
+                    montype = MonsterGroupManager::GetRandomMonsterFromGroup( montype->upgrade_group );
+                }
+            }
+            count++;
+        }
+        spawn_details = MonsterGroupResult( montype, 1 );
+    }
+
     bool monster_found = false;
     // Loop invariant values
     const time_point sunset = ::sunset( calendar::turn );
@@ -178,7 +198,23 @@ MonsterGroupResult MonsterGroupManager::GetResultFromGroup(
                 if( use_pack_size || it->pack_maximum > 1 ) {
                     pack_size = rng( it->pack_minimum, it->pack_maximum );
                 }
-                spawn_details = MonsterGroupResult( it->name, pack_size );
+                int count = 0;
+                auto montype = it->name;
+                while( count < group.evolve_repeat ) {
+                    if( rng( 0, 100 ) < group.evolve_chance ) {
+                        if( montype->upgrade_into ) {
+                            //If we upgrade into a blacklisted monster, treat it as though we are non-upgradeable
+                            if( MonsterGroupManager::monster_is_blacklisted( montype->upgrade_into ) ) {
+                                count = group.evolve_repeat;
+                            }
+                            montype = montype->upgrade_into;
+                        } else {
+                            montype = MonsterGroupManager::GetRandomMonsterFromGroup( montype->upgrade_group );
+                        }
+                    }
+                    count++;
+                }
+                spawn_details = MonsterGroupResult( montype, pack_size );
                 //And if a quantity pointer with remaining value was passed, will modify the external value as a side effect
                 //We will reduce it by the spawn rule's cost multiplier
                 if( quantity ) {
@@ -393,6 +429,8 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
     g.new_monster_group = mongroup_id( jo.get_string( "new_monster_group_id",
                                        mongroup_id::NULL_ID().str() ) );
     assign( jo, "replacement_time", g.monster_group_time, false, 1_days );
+    assign( jo, "evolve_chance", g.evolve_chance, false, 0 );
+    assign( jo, "evolve_repeat", g.evolve_repeat, false, 0 );
     g.is_safe = jo.get_bool( "is_safe", false );
 
     g.freq_total = jo.get_int( "freq_total", ( extending ? g.freq_total : 1000 ) );

--- a/src/mongroup.h
+++ b/src/mongroup.h
@@ -66,6 +66,8 @@ struct MonsterGroup {
     mongroup_id name;
     mtype_id defaultMonster;
     FreqDef  monsters;
+    int evolve_chance;
+    int evolve_repeat;
     bool IsMonsterInGroup( const mtype_id &id ) const;
     bool is_animal = false;
     // replaces this group after a period of


### PR DESCRIPTION
## Purpose of change (The Why)
Moving the c++ changes from https://github.com/cataclysmbn/Cataclysm-BN/pull/8541 to mainline pt 5
This supports monster groups having integrated evolutions

## Describe the solution (The How)
Add 2 fields `evolve_chance` and `evolve_repeat` to support innate evolutions

## Describe alternatives you've considered
Manually do this for every monster group
I believe as we get further and have more monsters this will get to be too tedious
Especially if we have things like regions with the wildlife being mutated and such

## Testing
Once again tested in #8541 
Alternative is adding the 2 fields to basic zombies and behold as they are much more evolved then normal

## Additional context
Only one part left...

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.