### PR TITLE
feat(mods/Arcana): add Arcana as submodule

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -25,6 +25,7 @@ scopes:
   - balance
   - port
   - lua
+  - mods/Arcana
   - mods/CheesyInnaWoodFixes
   - mods/DinoMod
   - mods/MMA

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
 
       - name: Set up JDK 11 (android)
         uses: actions/setup-java@v4.1.0

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - run: sudo apt-get install astyle ninja-build gettext ccache
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Create VERSION.TXT
         shell: bash

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: install dependencies
         run: |

--- a/.github/workflows/i18n-extraction.yml
+++ b/.github/workflows/i18n-extraction.yml
@@ -22,6 +22,8 @@ jobs:
           sudo pip3 install --break-system-packages polib luaparser
 
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Check that translation template extraction works
         run: lang/update_pot.sh

--- a/.github/workflows/i18n-printf-format.yml
+++ b/.github/workflows/i18n-printf-format.yml
@@ -17,6 +17,8 @@ jobs:
           sudo pip3 install --break-system-packages polib
 
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: "Check printf format string in translations"
         run: ./tools/check_po_printf_format.py

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
       - name: Create release
         run: |
           set +e

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
 
       - name: install dependencies (ubuntu)
         if: ${{ env.SKIP == 'false' }}

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
 
       - name: Setup MSVC environment
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
 
       - name: Install runtime dependencies
         uses: BrettDong/setup-sdl2-frameworks@v1

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#push-to-protected-branches
           token: ${{ secrets.AUTO_COMMIT_PAT }}
+          submodules: recursive
 
       - name: "Get current date"
         id: get-timestamp

--- a/.github/workflows/push-translation-template.yml
+++ b/.github/workflows/push-translation-template.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
 
       - name: "Install gettext tools"
         run: sudo apt-get install -y gettext

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
       yesterday_tag_name: ${{ steps.env_vars.outputs.yesterday_tag_name }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - id: env_vars
         run: |
           TAG_NAME=$(date -u --iso-8601)
@@ -55,6 +57,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Push tag
         if: ${{ steps.tag_check.outputs.exists == 'false' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "external/cdda-arcana-mod"]
+	path = external/cdda-arcana-mod
+	url = https://github.com/chaosvolt/cdda-arcana-mod.git
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -861,6 +861,12 @@ ifeq ($(USE_XDG_DIR),0)
   endif
 endif
 
+ARCANA_BN_MOD_SOURCE = external/cdda-arcana-mod/Arcana_BN
+define copy_arcana_bn_mod
+	rm -rf $(1)/mods/Arcana_BN
+	cp -R $(ARCANA_BN_MOD_SOURCE) $(1)/mods/Arcana_BN
+endef
+
 ifeq ($(LTO), 1)
   # Depending on the compiler version, LTO usually requires all the
   # optimization flags to be specified on the link line, and requires them to
@@ -998,6 +1004,7 @@ install: version $(TARGET)
 	cp -R data/font $(DATA_PREFIX)
 	cp -R data/json $(DATA_PREFIX)
 	cp -R data/mods $(DATA_PREFIX)
+	$(call copy_arcana_bn_mod,$(DATA_PREFIX))
 	cp -R data/names $(DATA_PREFIX)
 	cp -R data/raw $(DATA_PREFIX)
 	cp -R data/motd $(DATA_PREFIX)
@@ -1030,6 +1037,7 @@ install: version $(TARGET)
 	cp -R --no-preserve=ownership data/font $(DATA_PREFIX)
 	cp -R --no-preserve=ownership data/json $(DATA_PREFIX)
 	cp -R --no-preserve=ownership data/mods $(DATA_PREFIX)
+	$(call copy_arcana_bn_mod,$(DATA_PREFIX))
 	cp -R --no-preserve=ownership data/names $(DATA_PREFIX)
 	cp -R --no-preserve=ownership data/raw $(DATA_PREFIX)
 	cp -R --no-preserve=ownership data/motd $(DATA_PREFIX)
@@ -1086,6 +1094,7 @@ endif
 	cp -R data/font $(APPDATADIR)
 	cp -R data/json $(APPDATADIR)
 	cp -R data/mods $(APPDATADIR)
+	$(call copy_arcana_bn_mod,$(APPDATADIR))
 	cp -R data/names $(APPDATADIR)
 	cp -R data/raw $(APPDATADIR)
 	cp -R data/motd $(APPDATADIR)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -193,6 +193,18 @@ unzipDeps.dependsOn makeLocalization
 preBuild.dependsOn unzipDeps
 preBuild.dependsOn unzipSqlite
 
+task prepareAssets(type: Sync) {
+    from('src/main/assets') {
+        exclude 'data/mods/Arcana_BN/**'
+    }
+    from('../../external/cdda-arcana-mod/Arcana_BN') {
+        into 'data/mods/Arcana_BN'
+    }
+    into "$buildDir/generated/assets/main"
+}
+
+preBuild.dependsOn prepareAssets
+
 android {
     namespace "com.cleverraven.cataclysmdda"
     compileSdkVersion override_compileSdkVersion
@@ -336,6 +348,8 @@ android {
             }
         }
     }
+    sourceSets.main.assets.srcDirs = ["$buildDir/generated/assets/main"]
+
     if (!project.hasProperty('EXCLUDE_NATIVE_LIBS')) {
         sourceSets.main {
             jniLibs.srcDir 'libs'

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -4,14 +4,20 @@ if (RELEASE)
                 TYPE DATA
                 PATTERN "CMakeLists.txt" EXCLUDE
                 PATTERN "XDG" EXCLUDE
+                PATTERN "mods/Arcana_BN" EXCLUDE
                 PATTERN "external_tileset/README.md" EXCLUDE
                 PATTERN "mapgen/lab/README.md" EXCLUDE)
+        install(DIRECTORY ${CMAKE_SOURCE_DIR}/external/cdda-arcana-mod/Arcana_BN
+                DESTINATION ${CMAKE_INSTALL_DATADIR}/mods)
     else()
         install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
                 DESTINATION data
                 PATTERN "CMakeLists.txt" EXCLUDE
                 PATTERN "XDG" EXCLUDE
+                PATTERN "mods/Arcana_BN" EXCLUDE
                 PATTERN "external_tileset/README.md" EXCLUDE
                 PATTERN "mapgen/lab/README.md" EXCLUDE)
+        install(DIRECTORY ${CMAKE_SOURCE_DIR}/external/cdda-arcana-mod/Arcana_BN
+                DESTINATION data/mods)
     endif()
 endif ()

--- a/data/mods/Arcana_BN/modinfo.json
+++ b/data/mods/Arcana_BN/modinfo.json
@@ -3,11 +3,11 @@
     "type": "MOD_INFO",
     "id": "Arcana",
     "name": "<color_cyan>Arcana and Magic Items</color>",
-    "authors": ["Chaosvolt"],
+    "authors": [ "Chaosvolt" ],
     "description": "Adds a host of craftable magic items and spells, centered around the use of Arcana skill to research and exploit otherworldly monsters and anomalies.",
     "version": "BN version, update 11/13/2024",
     "category": "content",
-    "dependencies": ["bn"],
+    "dependencies": [ "bn" ],
     "path": "../../../external/cdda-arcana-mod/Arcana_BN"
   }
 ]

--- a/data/mods/Arcana_BN/modinfo.json
+++ b/data/mods/Arcana_BN/modinfo.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "Arcana",
+    "name": "<color_cyan>Arcana and Magic Items</color>",
+    "authors": ["Chaosvolt"],
+    "description": "Adds a host of craftable magic items and spells, centered around the use of Arcana skill to research and exploit otherworldly monsters and anomalies.",
+    "version": "BN version, update 11/13/2024",
+    "category": "content",
+    "dependencies": ["bn"],
+    "path": "../../../external/cdda-arcana-mod/Arcana_BN"
+  }
+]

--- a/doc/src/assets/semantic.json
+++ b/doc/src/assets/semantic.json
@@ -17,6 +17,7 @@
     "i18n",
     "balance",
     "port",
+    "mods/Arcana",
     "mods/CheesyInnaWoodFixes",
     "mods/DinoMod",
     "mods/MMA",

--- a/docs/en/contribute/contributing.md
+++ b/docs/en/contribute/contributing.md
@@ -165,8 +165,14 @@ _(This only needs to be done once.)_
 1. Clone your fork locally.
 
 ```sh
-$ git clone https://github.com/YOUR_USERNAME/Cataclysm-BN.git
-# Clones your fork of the repository into the current directory in terminal
+$ git clone --recurse-submodules https://github.com/YOUR_USERNAME/Cataclysm-BN.git
+# Clones your fork and its submodules into the current directory in terminal
+```
+
+If you already cloned without submodules, initialize them before building or testing:
+
+```sh
+$ git submodule update --init --recursive
 ```
 
 3. Set commit message template.

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -37,12 +37,15 @@ You can obtain the source code tarball for the latest version from
 [git](https://github.com/cataclysmbn/Cataclysm-BN).
 
 ```sh
-git clone --filter=blob:none https://github.com/cataclysmbn/Cataclysm-BN.git
+git clone --filter=blob:none --recurse-submodules https://github.com/cataclysmbn/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 
 > [!TIP]
 > `filter=blob:none` creates a [blobless clone](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/), which makes the initial clone much faster by downloading files on-demand.
+
+If you already cloned without submodules, run `git submodule update --init --recursive` before
+building.
 
 ### UNIX Environment
 

--- a/docs/en/dev/guides/building/cygwin.md
+++ b/docs/en/dev/guides/building/cygwin.md
@@ -83,7 +83,7 @@ testing, you should probably add `--depth=1` (~350MB).
 
 ```bash
 cd /cygdrive/c/dev
-git clone https://github.com/cataclysmbn/Cataclysm-BN.git
+git clone --recurse-submodules https://github.com/cataclysmbn/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 

--- a/docs/en/dev/guides/building/msys.md
+++ b/docs/en/dev/guides/building/msys.md
@@ -100,7 +100,7 @@ PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig:/lib/pkgconfig:/mingw64
 
 ```bash
 cd /c/dev/
-git clone https://github.com/cataclysmbn/Cataclysm-BN.git
+git clone --recurse-submodules https://github.com/cataclysmbn/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 

--- a/docs/en/dev/guides/building/vs_vcpkg.md
+++ b/docs/en/dev/guides/building/vs_vcpkg.md
@@ -56,7 +56,7 @@ vcpkg integrate install
 should probably add `--depth=1`.
 
 ```cmd
-git clone https://github.com/cataclysmbn/Cataclysm-BN.git
+git clone --recurse-submodules https://github.com/cataclysmbn/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 

--- a/docs/ja/contribute/contributing.md
+++ b/docs/ja/contribute/contributing.md
@@ -143,8 +143,14 @@ _(これは一度だけ行う必要があります。)_
 1. フォークしたリポジトリをローカルにクローンします。
 
 ```sh
-$ git clone https://github.com/YOUR_USERNAME/Cataclysm-BN.git
-# ターミナルの現在のディレクトリにリポジトリのフォークをクローンします
+$ git clone --recurse-submodules https://github.com/YOUR_USERNAME/Cataclysm-BN.git
+# ターミナルの現在のディレクトリにリポジトリのフォークとサブモジュールをクローンします
+```
+
+サブモジュールなしで既にクローンした場合は、ビルドまたはテストの前に初期化してください:
+
+```sh
+$ git submodule update --init --recursive
 ```
 
 3. コミットメッセージのテンプレートを設定します。

--- a/docs/ja/dev/guides/building/cmake.md
+++ b/docs/ja/dev/guides/building/cmake.md
@@ -36,12 +36,15 @@ title: CMake
 [git](https://github.com/cataclysmbnteam/Cataclysm-BN)から tarball またはクローンで取得できます。
 
 ```sh
-git clone --filter=blob:none https://github.com/cataclysmbnteam/Cataclysm-BN.git
+git clone --filter=blob:none --recurse-submodules https://github.com/cataclysmbnteam/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 
 > [!TIP]
 > `filter=blob:none` を使用すると、[ブロブなしクローン](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/)が作成されます。これにより、ファイルが必要に応じてダウンロードされるため、最初のクローンがはるかに高速になります。
+
+サブモジュールなしで既にクローンした場合は、ビルド前に
+`git submodule update --init --recursive` を実行してください。
 
 ### UNIX 環境
 

--- a/docs/ja/dev/guides/building/cygwin.md
+++ b/docs/ja/dev/guides/building/cygwin.md
@@ -72,7 +72,7 @@ apt-cyg install astyle ccache gcc-g++ intltool git libSDL2_image-devel libSDL2_m
 
 ```bash
 cd /cygdrive/c/dev
-git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
+git clone --recurse-submodules https://github.com/cataclysmbnteam/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 

--- a/docs/ja/dev/guides/building/msys.md
+++ b/docs/ja/dev/guides/building/msys.md
@@ -91,7 +91,7 @@ PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig:/lib/pkgconfig:/mingw64
 
 ```bash
 cd /c/dev/
-git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
+git clone --recurse-submodules https://github.com/cataclysmbnteam/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 

--- a/docs/ja/dev/guides/building/vs_vcpkg.md
+++ b/docs/ja/dev/guides/building/vs_vcpkg.md
@@ -45,7 +45,7 @@ vcpkg integrate install
 **注釈:** これにより、CBNリポジトリ全体、つまり 3GB 以上のデータがダウンロードされます。テスト目的のみの場合は、`--depth=1`を追加することを推奨します。
 
 ```cmd
-git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
+git clone --recurse-submodules https://github.com/cataclysmbnteam/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 

--- a/docs/ko/contribute/contributing.md
+++ b/docs/ko/contribute/contributing.md
@@ -166,8 +166,14 @@ _(이 과정은 한 번만 하면 됩니다.)_
 2. 포크한 저장소를 로컬에 클론합니다.
 
 ```sh
-$ git clone https://github.com/깃허브_사용자명/Cataclysm-BN.git
-# 터미널에서 현재 디렉토리에 저장소의 포크를 복제합니다.
+$ git clone --recurse-submodules https://github.com/깃허브_사용자명/Cataclysm-BN.git
+# 터미널에서 현재 디렉토리에 저장소의 포크와 서브모듈을 복제합니다.
+```
+
+서브모듈 없이 이미 클론했다면 빌드하거나 테스트하기 전에 초기화합니다:
+
+```sh
+$ git submodule update --init --recursive
 ```
 
 3. 커밋 메시지 템플릿을 설정합니다.

--- a/docs/ko/dev/guides/building/cmake.md
+++ b/docs/ko/dev/guides/building/cmake.md
@@ -35,12 +35,15 @@ CataclysmBN을 빌드하려면 다음 라이브러리와 개발 헤더가 설치
 [git](https://github.com/cataclysmbn/Cataclysm-BN)에서 최신 버전의 소스 코드 tarball을 얻을 수 있습니다.
 
 ```sh
-git clone --filter=blob:none https://github.com/cataclysmbn/Cataclysm-BN.git
+git clone --filter=blob:none --recurse-submodules https://github.com/cataclysmbn/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 
 > [!TIP]
 > `filter=blob:none`은 [blobless clone](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/)을 생성하여 파일을 필요에 따라 다운로드함으로써 초기 클론을 훨씬 빠르게 만듭니다.
+
+서브모듈 없이 이미 클론했다면 빌드하기 전에 `git submodule update --init --recursive`를
+실행하세요.
 
 ### UNIX 환경
 

--- a/docs/ko/dev/guides/building/cygwin.md
+++ b/docs/ko/dev/guides/building/cygwin.md
@@ -69,7 +69,7 @@ apt-cyg install astyle ccache gcc-g++ intltool git libSDL2_image-devel libSDL2_m
 
 ```bash
 cd /cygdrive/c/dev
-git clone https://github.com/cataclysmbn/Cataclysm-BN.git
+git clone --recurse-submodules https://github.com/cataclysmbn/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 

--- a/docs/ko/dev/guides/building/msys.md
+++ b/docs/ko/dev/guides/building/msys.md
@@ -90,7 +90,7 @@ PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig:/lib/pkgconfig:/mingw64
 
 ```bash
 cd /c/dev/
-git clone https://github.com/cataclysmbn/Cataclysm-BN.git
+git clone --recurse-submodules https://github.com/cataclysmbn/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 

--- a/docs/ko/dev/guides/building/vs_vcpkg.md
+++ b/docs/ko/dev/guides/building/vs_vcpkg.md
@@ -42,7 +42,7 @@ vcpkg integrate install
 **참고:** 전체 CBN 저장소, 3GB 이상의 데이터를 다운로드합니다. 테스트만 하는 경우 `--depth=1`을 추가하세요.
 
 ```cmd
-git clone https://github.com/cataclysmbn/Cataclysm-BN.git
+git clone --recurse-submodules https://github.com/cataclysmbn/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 

--- a/msvc-full-features/distribute.bat
+++ b/msvc-full-features/distribute.bat
@@ -2,6 +2,8 @@
 mkdir distribution
 xcopy dll\*.dll distribution\
 xcopy /s /e /i ..\data distribution\data
+if exist distribution\data\mods\Arcana_BN rmdir /s /q distribution\data\mods\Arcana_BN
+xcopy /s /e /i ..\external\cdda-arcana-mod\Arcana_BN distribution\data\mods\Arcana_BN
 xcopy /s /e /i ..\config distribution\config
 xcopy /s /e /i ..\gfx distribution\gfx
 xcopy /s /e /i ..\lang\mo distribution\lang\mo


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/6866b752-4b42-43d5-9921-254f1dad4d22" />

Continuation of #8653.

Adds Arcana and Magic Items from https://github.com/chaosvolt/cdda-arcana-mod without vendoring the full mod contents into this repository.

## Describe the solution (The How)

Adds `chaosvolt/cdda-arcana-mod` as a submodule pinned to `master` and exposes only `Arcana_BN` through `data/mods/Arcana_BN/modinfo.json`.

Updates CI checkouts and clone/build docs to initialize submodules.

## Testing

- `cmake --preset linux-full`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- `./cataclysm-bn-tiles --check-mods Arcana`
- `deno check scripts/semantic.ts`
- `git diff --check`
- Verified installed data contains `data/mods/Arcana_BN` and not `data/mods/Arcana`.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a PR that modifies build process or code organization.
- [x] Please document the changes in the appropriate location in the `docs/` folder.
- [x] This PR adds/removes a mod.
- [x] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
- [x] I have committed the output of `deno task semantic`.

<sup>PR opened by gpt-5.5 on opencode</sup>