### PR TITLE
feat: add missing reinforced windshield shape entries

### DIFF
--- a/data/json/vehicleparts/windshields.json
+++ b/data/json/vehicleparts/windshields.json
@@ -255,7 +255,7 @@
     "symbol": "B",
     "type": "vehicle_part"
   },
-    {
+  {
     "copy-from": "reinforced_windshield_abstract",
     "id": "reinforced_windshield",
     "symbol": "T",
@@ -267,7 +267,7 @@
     "symbol": "h",
     "type": "vehicle_part"
   },
-    {
+  {
     "copy-from": "reinforced_windshield_abstract",
     "id": "reinforced_windshield_vertical_left",
     "symbol": "[",

--- a/data/json/vehicleparts/windshields.json
+++ b/data/json/vehicleparts/windshields.json
@@ -80,32 +80,14 @@
     "type": "vehicle_part"
   },
   {
-    "copy-from": "reinforced_windshield_abstract",
-    "id": "reinforced_windshield",
-    "symbol": "\"",
-    "type": "vehicle_part"
-  },
-  {
     "copy-from": "windshield_abstract",
     "id": "windshield_nw",
     "symbol": "y",
     "type": "vehicle_part"
   },
   {
-    "copy-from": "reinforced_windshield_abstract",
-    "id": "reinforced_windshield_nw",
-    "symbol": "y",
-    "type": "vehicle_part"
-  },
-  {
     "copy-from": "windshield_abstract",
     "id": "windshield_ne",
-    "symbol": "u",
-    "type": "vehicle_part"
-  },
-  {
-    "copy-from": "reinforced_windshield_abstract",
-    "id": "reinforced_windshield_ne",
     "symbol": "u",
     "type": "vehicle_part"
   },
@@ -166,12 +148,6 @@
   {
     "copy-from": "windshield_abstract",
     "id": "windshield_horizontal_front",
-    "symbol": "T",
-    "type": "vehicle_part"
-  },
-  {
-    "copy-from": "reinforced_windshield_abstract",
-    "id": "reinforced_windshield_horizontal_front",
     "symbol": "T",
     "type": "vehicle_part"
   },
@@ -277,6 +253,60 @@
     "id": "plastic_windshield_horizontal_rear",
     "looks_like": "windshield_horizontal_rear",
     "symbol": "B",
+    "type": "vehicle_part"
+  },
+    {
+    "copy-from": "reinforced_windshield_abstract",
+    "id": "reinforced_windshield",
+    "symbol": "T",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "reinforced_windshield_abstract",
+    "id": "reinforced_windshield_horizontal_front",
+    "symbol": "h",
+    "type": "vehicle_part"
+  },
+    {
+    "copy-from": "reinforced_windshield_abstract",
+    "id": "reinforced_windshield_vertical_left",
+    "symbol": "[",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "reinforced_windshield_abstract",
+    "id": "reinforced_windshield_vertical_right",
+    "symbol": "]",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "reinforced_windshield_abstract",
+    "id": "reinforced_windshield_horizontal_rear_edge",
+    "symbol": "B",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "reinforced_windshield_abstract",
+    "id": "reinforced_windshield_ne",
+    "symbol": "u",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "reinforced_windshield_abstract",
+    "id": "reinforced_windshield_nw",
+    "symbol": "y",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "reinforced_windshield_abstract",
+    "id": "reinforced_windshield_se_edge",
+    "symbol": "n",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "reinforced_windshield_abstract",
+    "id": "reinforced_windshield_sw_edge",
+    "symbol": "b",
     "type": "vehicle_part"
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Reinforced windshields missing most shapes

## Describe the solution (The How)

Added shapes that were already in normal_vehicle_parts.png and tile_config.json, seems to be all for the existing sprites.
The added UI Symbols for shapes might need changed to conform if there was a consistent pattern to them.
<img width="327" height="254" alt="WS1" src="https://github.com/user-attachments/assets/d1fe07f0-e30e-483b-bb79-6a0f6a03d01a" />
<img width="446" height="199" alt="WS2" src="https://github.com/user-attachments/assets/f057f25d-cf37-476f-9ccc-dfedeedff8f5" />


## Describe alternatives you've considered

Be stuck with barely any reinforced windshield shapes and scream at ugly vehicles

## Testing

Loaded in, spawned vehicle, added reinforced windshield and tested shapes, they exist and match

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--


NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
