### PR TITLE
fix: update lighting when toggling bionics/mutations

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1171,6 +1171,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
     // Recalculate stats (strength, mods from pain etc.) that could have been affected
     reset_encumbrance();
     reset();
+    here.invalidate_lightmap_caches();
 
     // Also reset crafting inventory cache if this bionic spawned a fake item
     if( !bio.info().fake_item.is_empty() ) {
@@ -1256,6 +1257,7 @@ bool Character::deactivate_bionic( bionic &bio, bool eff_only )
     // Recalculate stats (strength, mods from pain etc.) that could have been affected
     reset_encumbrance();
     reset();
+    get_map().invalidate_lightmap_caches();
     if( !bio.id->enchantments.empty() ) {
         recalculate_enchantment_cache();
     }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -561,6 +561,7 @@ void Character::activate_mutation( const trait_id &mut )
     if( !mut->enchantments.empty() ) {
         recalculate_enchantment_cache();
     }
+    get_map().invalidate_lightmap_caches();
 
     if( mdata.transform ) {
         const cata::value_ptr<mut_transform> trans = mdata.transform;
@@ -686,6 +687,7 @@ void Character::deactivate_mutation( const trait_id &mut )
     // Handle stat changes from deactivation
     apply_mods( mut, false );
     recalc_sight_limits();
+    get_map().invalidate_lightmap_caches();
     const mutation_branch &mdata = mut.obj();
     if( mdata.transform ) {
         const cata::value_ptr<mut_transform> trans = mdata.transform;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This fixes some more lighting delay bugs.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In bionics.cpp, `Character::activate_bionic` and `Character::deactivate_bionic` now correctly call `invalidate_lightmap_caches` at a proper point.
2. In mutation_ui.cpp, added calls to `invalidate_lightmap_caches` to `Character::activate_mutation` and `Character::deactivate_mutation`.

## Describe alternatives you've considered

Casting Testicular Torsion on AzmodiusX until they fix it for me.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in with cranial flashlight, turning it on and off works right now.
3. Gave myself photophore, also works now.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
