### PR TITLE
fix(mods/MagicalNights): Fix manatouched.json referring to non-existent `STR_UP_ALPHA`

### DIFF
--- a/data/mods/MagicalNights/traits/manatouched.json
+++ b/data/mods/MagicalNights/traits/manatouched.json
@@ -100,9 +100,9 @@
     "extend": { "cancels": [ "WEAK" ] }
   },
   {
-    "id": "STR_UP_ALPHA",
+    "id": "STR_ALPHA",
     "type": "mutation",
-    "copy-from": "STR_UP_ALPHA",
+    "copy-from": "STR_ALPHA",
     "extend": { "cancels": [ "WEAK" ] }
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

KorG somehow used two different IDs for the Alpha mutation tree's strength mutation in the same commit
<img width="1228" height="946" alt="image" src="https://github.com/user-attachments/assets/ddd587c7-eaf1-4e42-a76f-58165ecbf982" />

This is obviously incorrect.

## Describe the solution (The How)

Changes the wrong id to the correct id.

## Describe alternatives you've considered

Implode

## Testing

Proofread.

## Additional context

If we don't already have a Weak mutation in vanilla, perhaps we should consider that.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.