### PR TITLE
feat(mods/Arcana): audit monsterpart drops in Arcana, add drops to a couple monsters I missed

### DIFF
--- a/data/mods/Arcana_BN/modinfo.json
+++ b/data/mods/Arcana_BN/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Chaosvolt" ],
     "description": "Adds a host of craftable magic items and spells, centered around the use of Arcana skill to research and exploit otherworldly monsters and anomalies.",
     "license": "CC-BY-SA-3.0",
-    "version": "BN In-Repo Version, Update 4/27/2026",
+    "version": "BN In-Repo Version, Update 4/28/2026",
     "category": "content",
     "dependencies": [ "bn" ]
   }

--- a/data/mods/Arcana_BN/monsters/monster_drops.json
+++ b/data/mods/Arcana_BN/monsters/monster_drops.json
@@ -1555,10 +1555,7 @@
     "type": "item_group",
     "id": "mon_zhark_death_drops",
     "subtype": "collection",
-    "entries": [
-      { "distribution": [ { "item": "monster_fang", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 10 },
-      { "item": "essence_blood", "prob": 10, "count": [ 2, 4 ] }
-    ]
+    "entries": [ { "distribution": [ { "item": "monster_fang", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 10 } ]
   },
   {
     "type": "item_group",

--- a/data/mods/Arcana_BN/monsters/monster_drops.json
+++ b/data/mods/Arcana_BN/monsters/monster_drops.json
@@ -1553,6 +1553,15 @@
   },
   {
     "type": "item_group",
+    "id": "mon_zhark_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "monster_fang", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 10 },
+      { "item": "essence_blood", "prob": 10, "count": [ 2, 4 ] }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "mon_dog_skeleton_death_drops",
     "subtype": "collection",
     "entries": [

--- a/data/mods/Arcana_BN/monsters/monster_drops.json
+++ b/data/mods/Arcana_BN/monsters/monster_drops.json
@@ -171,18 +171,6 @@
   },
   {
     "type": "item_group",
-    "id": "mon_zombie_ears_death_drops",
-    "subtype": "collection",
-    "entries": [ { "group": "default_zombie_death_drops" }, { "item": "monster_tear", "prob": 10 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_zombie_skull_death_drops",
-    "subtype": "collection",
-    "entries": [ { "group": "default_zombie_death_drops" }, { "item": "monster_tear", "prob": 15 } ]
-  },
-  {
-    "type": "item_group",
     "id": "mon_zombie_smoker_death_drops",
     "subtype": "collection",
     "entries": [ { "item": "iridescent_plate", "prob": 10 }, { "item": "essence_blood", "count": [ 2, 4 ], "prob": 25 } ]
@@ -477,31 +465,7 @@
   },
   {
     "type": "item_group",
-    "id": "mon_bee_death_drops",
-    "subtype": "collection",
-    "entries": [ { "item": "dermatik_sting", "prob": 5 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_wasp_small_death_drops",
-    "subtype": "collection",
-    "entries": [ { "item": "dermatik_sting", "prob": 5 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_wasp_small_guard_death_drops",
-    "subtype": "collection",
-    "entries": [ { "item": "dermatik_sting", "prob": 5 } ]
-  },
-  {
-    "type": "item_group",
     "id": "mon_wasp_queen_death_drops",
-    "subtype": "collection",
-    "entries": [ { "item": "dermatik_sting", "prob": 25 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_wasp_death_drops",
     "subtype": "collection",
     "entries": [ { "item": "dermatik_sting", "prob": 10 } ]
   },
@@ -509,13 +473,13 @@
     "type": "item_group",
     "id": "mon_wasp_guard_death_drops",
     "subtype": "collection",
-    "entries": [ { "item": "dermatik_sting", "prob": 10 } ]
+    "entries": [ { "item": "dermatik_sting", "prob": 5 } ]
   },
   {
     "type": "item_group",
     "id": "mon_wasp_mega_death_drops",
     "subtype": "collection",
-    "entries": [ { "item": "dermatik_sting", "prob": 25 } ]
+    "entries": [ { "item": "dermatik_sting", "prob": 10 } ]
   },
   {
     "type": "item_group",
@@ -534,8 +498,7 @@
     "id": "mon_dark_wyrm_death_drops",
     "subtype": "collection",
     "entries": [
-      { "item": "wyrmskin_piece", "prob": 90 },
-      { "item": "graboid_fang", "prob": 30 },
+      { "distribution": [ { "item": "wyrmskin_piece", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 75 },
       { "item": "essence_blood", "prob": 25, "count": [ 8, 16 ] }
     ]
   },
@@ -552,8 +515,7 @@
     "subtype": "collection",
     "//": "Species is HORROR instead of MUTANT, so allowed to drop essence.",
     "entries": [
-      { "item": "bone_twisted" },
-      { "item": "engraved_stone", "prob": 25 },
+      { "distribution": [ { "item": "bone_twisted", "prob": 75 }, { "item": "engraved_stone", "prob": 25 } ] },
       { "item": "essence", "prob": 25, "count": [ 1, 3 ] }
     ]
   },
@@ -562,8 +524,7 @@
     "id": "mon_thing_death_drops",
     "subtype": "collection",
     "entries": [
-      { "item": "monster_fang", "prob": 90 },
-      { "item": "bone_twisted", "prob": 20 },
+      { "distribution": [ { "item": "monster_fang", "prob": 75 }, { "item": "bone_twisted", "prob": 25 } ], "prob": 90 },
       { "item": "essence", "prob": 25, "count": [ 1, 3 ] }
     ]
   },
@@ -578,8 +539,7 @@
     "id": "mon_twisted_body_death_drops",
     "subtype": "collection",
     "entries": [
-      { "item": "bone_twisted", "prob": 75 },
-      { "item": "vortex_shard", "prob": 10 },
+      { "distribution": [ { "item": "bone_twisted", "prob": 80 }, { "item": "vortex_shard", "prob": 20 } ], "prob": 75 },
       { "item": "essence", "prob": 25, "count": [ 1, 3 ] }
     ]
   },
@@ -594,8 +554,7 @@
     "id": "mon_flying_polyp_death_drops",
     "subtype": "collection",
     "entries": [
-      { "item": "monster_fang", "prob": 90 },
-      { "item": "vortex_shard", "prob": 10 },
+      { "distribution": [ { "item": "monster_fang", "prob": 75 }, { "item": "vortex_shard", "prob": 25 } ], "prob": 75 },
       { "item": "essence", "prob": 50, "count": [ 1, 3 ] }
     ]
   },
@@ -647,8 +606,14 @@
     "id": "mon_yugg_death_drops",
     "subtype": "collection",
     "entries": [
-      { "item": "wyrmskin_piece" },
-      { "item": "dermatik_sting", "prob": 50 },
+      {
+        "distribution": [
+          { "item": "wyrmskin_piece", "prob": 50 },
+          { "item": "dermatik_sting", "prob": 25 },
+          { "item": "graboid_fang", "prob": 25 }
+        ],
+        "prob": 75
+      },
       { "item": "essence", "prob": 50, "count": [ 1, 3 ] }
     ]
   },
@@ -725,7 +690,10 @@
     "type": "item_group",
     "id": "mon_shoggoth_death_drops",
     "subtype": "collection",
-    "entries": [ { "item": "engraved_stone" }, { "item": "blob_gem", "prob": 25 }, { "item": "essence", "count": [ 1, 3 ] } ]
+    "entries": [
+      { "distribution": [ { "item": "engraved_stone", "prob": 75 }, { "item": "blob_gem", "prob": 25 } ] },
+      { "item": "essence", "count": [ 1, 3 ] }
+    ]
   },
   {
     "id": "mon_dementia_death_drops",
@@ -913,9 +881,9 @@
           { "item": "bone_twisted", "prob": 40 },
           { "item": "iridescent_plate", "prob": 10 }
         ],
-        "prob": 10
+        "prob": 5
       },
-      { "item": "essence_blood", "prob": 25, "count": [ 2, 4 ] }
+      { "item": "essence_blood", "prob": 10, "count": [ 2, 4 ] }
     ]
   },
   {
@@ -930,9 +898,9 @@
           { "item": "bone_twisted", "prob": 40 },
           { "item": "iridescent_plate", "prob": 10 }
         ],
-        "prob": 25
+        "prob": 10
       },
-      { "item": "essence_blood", "prob": 50, "count": [ 2, 4 ] }
+      { "item": "essence_blood", "prob": 25, "count": [ 2, 4 ] }
     ]
   },
   {
@@ -960,7 +928,7 @@
       { "group": "default_zombie_items" },
       {
         "distribution": [ { "item": "essence", "prob": 50 }, { "item": "essence_blood", "prob": 50, "count": [ 2, 4 ] } ],
-        "prob": 25
+        "prob": 10
       }
     ]
   },
@@ -972,7 +940,7 @@
       { "group": "default_zombie_items" },
       {
         "distribution": [ { "item": "essence", "prob": 50 }, { "item": "essence_blood", "prob": 50, "count": [ 2, 4 ] } ],
-        "prob": 25
+        "prob": 10
       }
     ]
   },
@@ -981,10 +949,10 @@
     "id": "mon_zombie_smoker_fungus_death_drops",
     "subtype": "collection",
     "entries": [
-      { "item": "iridescent_plate", "prob": 25 },
+      { "item": "iridescent_plate", "prob": 10 },
       {
         "distribution": [ { "item": "essence", "prob": 50 }, { "item": "essence_blood", "prob": 50, "count": [ 2, 4 ] } ],
-        "prob": 25
+        "prob": 10
       }
     ]
   },
@@ -1002,8 +970,9 @@
         ],
         "prob": 50
       },
-      { "item": "inflorescent_root", "prob": 25 },
-      { "item": "essence_blood", "prob": 50, "count": [ 2, 4 ] }
+      {
+        "distribution": [ { "item": "essence", "prob": 50 }, { "item": "essence_blood", "prob": 50, "count": [ 2, 4 ] } ]
+      }
     ]
   },
   {
@@ -1015,7 +984,7 @@
       { "group": "child_items", "prob": 65 },
       {
         "distribution": [ { "item": "essence", "prob": 50 }, { "item": "essence_blood", "prob": 50, "count": [ 2, 4 ] } ],
-        "prob": 10
+        "prob": 5
       }
     ]
   },
@@ -1047,8 +1016,7 @@
     "subtype": "collection",
     "entries": [
       { "group": "default_zombie_death_drops" },
-      { "item": "vortex_shard", "prob": 50 },
-      { "item": "blob_gem", "prob": 25 },
+      { "distribution": [ { "item": "vortex_shard", "prob": 75 }, { "item": "blob_gem", "prob": 25 } ], "prob": 75 },
       { "item": "essence_blood", "prob": 75, "count": [ 2, 4 ] }
     ]
   },
@@ -1057,8 +1025,7 @@
     "id": "mon_hound_tindalos_death_drops",
     "subtype": "collection",
     "entries": [
-      { "item": "vortex_shard", "prob": 25 },
-      { "item": "shadow_gem", "prob": 50 },
+      { "distribution": [ { "item": "vortex_shard", "prob": 50 }, { "item": "shadow_gem", "prob": 50 } ], "prob": 75 },
       { "item": "essence", "prob": 75, "count": [ 1, 3 ] }
     ]
   },
@@ -1258,8 +1225,14 @@
     "id": "mon_leech_blossom_death_drops",
     "subtype": "collection",
     "entries": [
-      { "distribution": [ { "item": "inflorescent_root", "prob": 75 }, { "item": "triffid_queen_flower", "prob": 25 } ] },
-      { "distribution": [ { "item": "vortex_shard", "prob": 75 }, { "item": "blob_gem", "prob": 25 } ] },
+      {
+        "distribution": [
+          { "item": "inflorescent_root", "prob": 40 },
+          { "item": "triffid_queen_flower", "prob": 10 },
+          { "item": "vortex_shard", "prob": 40 },
+          { "item": "blob_gem", "prob": 10 }
+        ]
+      },
       { "item": "essence", "count": [ 2, 5 ] }
     ]
   },
@@ -1269,10 +1242,14 @@
     "subtype": "collection",
     "entries": [
       {
-        "distribution": [ { "item": "inflorescent_root", "prob": 75 }, { "item": "triffid_queen_flower", "prob": 25 } ],
+        "distribution": [
+          { "item": "inflorescent_root", "prob": 40 },
+          { "item": "triffid_queen_flower", "prob": 10 },
+          { "item": "vortex_shard", "prob": 40 },
+          { "item": "blob_gem", "prob": 10 }
+        ],
         "prob": 10
       },
-      { "distribution": [ { "item": "vortex_shard", "prob": 75 }, { "item": "blob_gem", "prob": 25 } ], "prob": 10 },
       { "item": "essence", "prob": 15 }
     ]
   },
@@ -1282,10 +1259,14 @@
     "subtype": "collection",
     "entries": [
       {
-        "distribution": [ { "item": "inflorescent_root", "prob": 75 }, { "item": "triffid_queen_flower", "prob": 25 } ],
+        "distribution": [
+          { "item": "inflorescent_root", "prob": 40 },
+          { "item": "triffid_queen_flower", "prob": 10 },
+          { "item": "vortex_shard", "prob": 40 },
+          { "item": "blob_gem", "prob": 10 }
+        ],
         "prob": 5
       },
-      { "distribution": [ { "item": "vortex_shard", "prob": 75 }, { "item": "blob_gem", "prob": 25 } ], "prob": 5 },
       { "item": "essence", "prob": 10 }
     ]
   },
@@ -1294,8 +1275,14 @@
     "id": "mon_leech_root_runner_death_drops",
     "subtype": "collection",
     "entries": [
-      { "item": "inflorescent_root", "prob": 5 },
-      { "distribution": [ { "item": "vortex_shard", "prob": 75 }, { "item": "blob_gem", "prob": 25 } ], "prob": 5 },
+      {
+        "distribution": [
+          { "item": "inflorescent_root", "prob": 50 },
+          { "item": "vortex_shard", "prob": 40 },
+          { "item": "blob_gem", "prob": 10 }
+        ],
+        "prob": 5
+      },
       { "item": "essence", "prob": 10 }
     ]
   },
@@ -1304,8 +1291,14 @@
     "id": "mon_leech_root_drone_death_drops",
     "subtype": "collection",
     "entries": [
-      { "item": "inflorescent_root", "prob": 2 },
-      { "distribution": [ { "item": "vortex_shard", "prob": 75 }, { "item": "blob_gem", "prob": 25 } ], "prob": 2 },
+      {
+        "distribution": [
+          { "item": "inflorescent_root", "prob": 50 },
+          { "item": "vortex_shard", "prob": 40 },
+          { "item": "blob_gem", "prob": 10 }
+        ],
+        "prob": 2
+      },
       { "item": "essence", "prob": 5 }
     ]
   },
@@ -1560,24 +1553,6 @@
   },
   {
     "type": "item_group",
-    "id": "mon_zhark_death_drops",
-    "subtype": "collection",
-    "entries": [
-      { "distribution": [ { "item": "monster_fang", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 10 },
-      { "item": "essence_blood", "prob": 10, "count": [ 2, 4 ] }
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_dog_zombie_rot_death_drops",
-    "subtype": "collection",
-    "entries": [
-      { "distribution": [ { "item": "monster_fang", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 5 },
-      { "item": "essence_blood", "prob": 5, "count": [ 2, 4 ] }
-    ]
-  },
-  {
-    "type": "item_group",
     "id": "mon_dog_skeleton_death_drops",
     "subtype": "collection",
     "entries": [
@@ -1590,33 +1565,6 @@
         ],
         "prob": 5
       },
-      { "item": "essence_blood", "prob": 5, "count": [ 2, 4 ] }
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_zolf_death_drops",
-    "subtype": "collection",
-    "entries": [
-      { "distribution": [ { "item": "monster_fang", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 5 },
-      { "item": "essence_blood", "prob": 5, "count": [ 2, 4 ] }
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_zombear_death_drops",
-    "subtype": "collection",
-    "entries": [
-      { "distribution": [ { "item": "monster_fang", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 10 },
-      { "item": "essence_blood", "prob": 10, "count": [ 2, 4 ] }
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "mon_zougar_death_drops",
-    "subtype": "collection",
-    "entries": [
-      { "distribution": [ { "item": "monster_fang", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 5 },
       { "item": "essence_blood", "prob": 5, "count": [ 2, 4 ] }
     ]
   },
@@ -1718,8 +1666,7 @@
     "subtype": "collection",
     "entries": [
       { "group": "default_zombie_death_drops" },
-      { "item": "vortex_shard", "prob": 50 },
-      { "item": "blob_gem", "prob": 25 },
+      { "distribution": [ { "item": "vortex_shard", "prob": 50 }, { "item": "blob_gem", "prob": 50 } ], "prob": 50 },
       { "item": "essence_blood", "prob": 75, "count": [ 2, 4 ] }
     ]
   },
@@ -1824,8 +1771,25 @@
     "subtype": "collection",
     "entries": [
       { "group": "mon_zombie_miner_death_drops" },
-      { "item": "iridescent_plate", "prob": 10 },
+      { "item": "shadow_gem", "prob": 10 },
       { "item": "essence_blood", "count": [ 2, 4 ], "prob": 25 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_zombie_miner_evolved_moleman_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "mon_zombie_miner_death_drops" },
+      { "item": "gracken_knuckles", "prob": 5 },
+      { "item": "essence_blood", "count": [ 2, 4 ], "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_shade_boss_death_drops",
+    "//": "Adds to existing group, high chance of a shadow gem and nether-tier essence drop",
+    "subtype": "collection",
+    "entries": [ { "item": "shadow_gem" }, { "item": "essence", "count": [ 1, 3 ] } ]
   }
 ]

--- a/data/mods/Arcana_BN/monsters/monster_overrides.json
+++ b/data/mods/Arcana_BN/monsters/monster_overrides.json
@@ -778,6 +778,12 @@
     "extend": { "categories": [ "CLASSIC" ] }
   },
   {
+    "id": "mon_zhark",
+    "copy-from": "mon_zhark",
+    "type": "MONSTER",
+    "death_drops": "mon_zhark_death_drops"
+  },
+  {
     "id": "mon_dog_skeleton",
     "copy-from": "mon_dog_skeleton",
     "type": "MONSTER",

--- a/data/mods/Arcana_BN/monsters/monster_overrides.json
+++ b/data/mods/Arcana_BN/monsters/monster_overrides.json
@@ -96,18 +96,6 @@
     "death_drops": "mon_zombie_mancroc_death_drops"
   },
   {
-    "id": "mon_zombie_ears",
-    "copy-from": "mon_zombie_ears",
-    "type": "MONSTER",
-    "death_drops": "mon_zombie_ears_death_drops"
-  },
-  {
-    "id": "mon_zombie_skull",
-    "copy-from": "mon_zombie_skull",
-    "type": "MONSTER",
-    "death_drops": "mon_zombie_skull_death_drops"
-  },
-  {
     "id": "mon_zombie_necro",
     "copy-from": "mon_zombie_necro",
     "type": "MONSTER",
@@ -274,30 +262,6 @@
     "type": "MONSTER",
     "death_drops": "mon_rat_king_death_drops",
     "extend": { "categories": [ "CLASSIC" ] }
-  },
-  {
-    "id": "mon_bee",
-    "copy-from": "mon_bee",
-    "type": "MONSTER",
-    "death_drops": "mon_bee_death_drops"
-  },
-  {
-    "id": "mon_wasp",
-    "copy-from": "mon_wasp",
-    "type": "MONSTER",
-    "death_drops": "mon_wasp_death_drops"
-  },
-  {
-    "id": "mon_wasp_small",
-    "copy-from": "mon_wasp_small",
-    "type": "MONSTER",
-    "death_drops": "mon_wasp_small_death_drops"
-  },
-  {
-    "id": "mon_wasp_small_guard",
-    "copy-from": "mon_wasp_small_guard",
-    "type": "MONSTER",
-    "death_drops": "mon_wasp_small_guard_death_drops"
   },
   {
     "id": "mon_wasp_queen",
@@ -814,40 +778,10 @@
     "extend": { "categories": [ "CLASSIC" ] }
   },
   {
-    "id": "mon_zhark",
-    "copy-from": "mon_zhark",
-    "type": "MONSTER",
-    "death_drops": "mon_zhark_death_drops"
-  },
-  {
     "id": "mon_dog_skeleton",
     "copy-from": "mon_dog_skeleton",
     "type": "MONSTER",
     "death_drops": "mon_dog_skeleton_death_drops"
-  },
-  {
-    "id": "mon_dog_zombie_rot",
-    "copy-from": "mon_dog_zombie_rot",
-    "type": "MONSTER",
-    "death_drops": "mon_dog_zombie_rot_death_drops"
-  },
-  {
-    "id": "mon_zolf",
-    "copy-from": "mon_zolf",
-    "type": "MONSTER",
-    "death_drops": "mon_zolf_death_drops"
-  },
-  {
-    "id": "mon_zombear",
-    "copy-from": "mon_zombear",
-    "type": "MONSTER",
-    "death_drops": "mon_zombear_death_drops"
-  },
-  {
-    "id": "mon_zougar",
-    "copy-from": "mon_zougar",
-    "type": "MONSTER",
-    "death_drops": "mon_zougar_death_drops"
   },
   {
     "id": "mon_cat_mutant_prism",
@@ -956,6 +890,12 @@
     "copy-from": "mon_zombie_smoker_evolved_toxic",
     "type": "MONSTER",
     "death_drops": "mon_zombie_smoker_evolved_toxic_death_drops"
+  },
+  {
+    "id": "mon_zombie_miner_evolved_moleman",
+    "copy-from": "mon_zombie_miner_evolved_moleman",
+    "type": "MONSTER",
+    "death_drops": "mon_zombie_miner_evolved_moleman_death_drops"
   },
   {
     "id": "mon_zombie_miner_evolved_shady",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This updates monsterpart drops in Arcana.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Belatedly add monsterpart and essence drop to shaded figure, it's a miniboss-type entity that gives me the impression of being inhabited/possesed by something moreso than being aregular zombie so gave it regular essence instead of the standard blood essence zombies get.
2. Audited monsterpart drops, phased out monsters that can drop two or more different monsterparts in favor of distributions used by other monsters that can drop a variety of parts.
3. Phased out a few drops from low-level zeds where it felt ill-fitting, since we have a lot more weird critters to target these days: headless zombies didn't really seem logical to drop crystallized tears since how do you cry with no eyes, giant wasps/bees were pared down to only allowing the biggest variants to have monsterparts (and at a lower rate), mundane zombie wildlife had their drops revoked.
4. Couple monster types kept their drops but had chances reduced: Skeletons had drop rates reduced for lower-tier variants, essence drops for fungal zombies reduced.
5. Misc: fixed subterranean haunts dropping iridescent plates instead of intended shadow gem, added small chance of cracked knucklebones for zombie tunnelers.
## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
