### PR TITLE
feat(mods): include Arcana's expansion patchmods for in-repo mods

### DIFF
--- a/data/mods/BN_Arcana_Aftershock_Patch/modinfo.json
+++ b/data/mods/BN_Arcana_Aftershock_Patch/modinfo.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "Arcana_aftershock_Patch",
+    "name": "<color_cyan>Arcana</color>/Aftershock Patchmod",
+    "authors": [ "Chaosvolt" ],
+    "description": "Optional patch mod that allows content in Arcana and Aftershock to interact with each other.",
+    "license": "CC-BY-SA-3.0",
+    "version": "BN In-Repo version, update 4/28/2028",
+    "category": "misc_additions",
+    "dependencies": [ "bn", "Arcana", "aftershock" ]
+  }
+]

--- a/data/mods/BN_Arcana_Aftershock_Patch/monster_drops.json
+++ b/data/mods/BN_Arcana_Aftershock_Patch/monster_drops.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "item_group",
+    "id": "afs_mon_migoturret_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_afs_headless_horror_death_drops",
+    "subtype": "collection",
+    "entries": [ { "group": "default_zombie_death_drops" }, { "item": "monster_tear", "prob": 25 } ]
+  }
+]

--- a/data/mods/BN_Arcana_Aftershock_Patch/monsters.json
+++ b/data/mods/BN_Arcana_Aftershock_Patch/monsters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "afs_mon_migoturret",
+    "copy-from": "afs_mon_migoturret",
+    "type": "MONSTER",
+    "death_drops": "afs_mon_migoturret_death_drops"
+  },
+  {
+    "id": "mon_afs_headless_horror",
+    "copy-from": "mon_afs_headless_horror",
+    "type": "MONSTER",
+    "death_drops": "mon_afs_headless_horror_death_drops"
+  }
+]

--- a/data/mods/BN_Arcana_Aftershock_Patch/recipe_deconstruction.json
+++ b/data/mods/BN_Arcana_Aftershock_Patch/recipe_deconstruction.json
@@ -1,0 +1,56 @@
+[
+  {
+    "result": "afs_bag_of_holding",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "time": "5 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "scrap", 20 ] ], [ [ "essence_dull", 300 ] ] ]
+  },
+  {
+    "result": "vibrating_blaster",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "time": "5 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "resin_chunk", 6 ] ], [ [ "essence_dull", 150 ] ] ]
+  },
+  {
+    "result": "afs_holo_transposition_caster",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "time": "5 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "alloy_sheet", 1 ] ], [ [ "essence_dull", 50 ] ] ]
+  },
+  {
+    "result": "afs_holo_flare_caster",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "time": "5 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "alloy_sheet", 1 ] ], [ [ "essence_dull", 50 ] ] ]
+  },
+  {
+    "result": "afs_holo_decoy_caster",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "time": "5 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "alloy_sheet", 1 ] ], [ [ "essence_dull", 50 ] ] ]
+  },
+  {
+    "result": "afs_holo_field_caster",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "time": "5 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "alloy_sheet", 1 ] ], [ [ "essence_dull", 50 ] ] ]
+  }
+]

--- a/data/mods/BN_Arcana_Crit_Patch/martialarts.json
+++ b/data/mods/BN_Arcana_Crit_Patch/martialarts.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "style_veil_chosen",
+    "copy-from": "style_veil_chosen",
+    "type": "martial_art",
+    "name": { "str": "Ritual Art" },
+    "extend": { "weapons": [ "sword_crt", "blade_crt" ] }
+  }
+]

--- a/data/mods/BN_Arcana_Crit_Patch/modinfo.json
+++ b/data/mods/BN_Arcana_Crit_Patch/modinfo.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "Arcana_Crit_Patch",
+    "name": "<color_cyan>Arcana</color>/<color_red>C.R.I.T.</color> Patchmod",
+    "authors": [ "Chaosvolt" ],
+    "description": "Optional patch mod that allows content in Arcana and C.R.I.T. to interact with each other.",
+    "license": "CC-BY-SA-3.0",
+    "version": "BN In-Repo version, update 4/28/2028",
+    "category": "misc_additions",
+    "dependencies": [ "bn", "Arcana", "crt_expansion" ]
+  }
+]

--- a/data/mods/BN_Arcana_Crit_Patch/monster_drops_modcompat.json
+++ b/data/mods/BN_Arcana_Crit_Patch/monster_drops_modcompat.json
@@ -1,0 +1,101 @@
+[
+  {
+    "type": "item_group",
+    "id": "mon_slasher_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "default_zombie_death_drops" },
+      { "distribution": [ { "item": "bone_twisted", "prob": 50 }, { "item": "iron_thorn", "prob": 50 } ], "prob": 10 },
+      { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_slasher_weak_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "default_zombie_death_drops" },
+      { "distribution": [ { "item": "bone_twisted", "prob": 50 }, { "item": "iron_thorn", "prob": 50 } ], "prob": 5 },
+      { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_waster_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "mon_zombie_cop_death_drops" },
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 50 },
+          { "item": "engraved_stone", "prob": 25 },
+          { "item": "iron_thorn", "prob": 25 }
+        ],
+        "prob": 10
+      },
+      { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_leaper_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "default_zombie_death_drops" },
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 50 },
+          { "item": "monster_fang", "prob": 25 },
+          { "item": "dermatik_sting", "prob": 25 }
+        ],
+        "prob": 10
+      },
+      { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_twitcher_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "default_zombie_death_drops" },
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 50 },
+          { "item": "gracken_knuckles", "prob": 25 },
+          { "item": "dermatik_sting", "prob": 25 }
+        ],
+        "prob": 10
+      },
+      { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_pack_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "default_zombie_clothes" },
+      { "group": "child_items", "prob": 65 },
+      { "item": "bone_twisted", "prob": 5 },
+      { "item": "essence_blood", "count": [ 1, 3 ], "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_puker_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "group": "default_zombie_death_drops" },
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 50 },
+          { "item": "graboid_fang", "prob": 25 },
+          { "item": "wyrmskin_piece", "prob": 25 }
+        ],
+        "prob": 10
+      },
+      { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 }
+    ]
+  }
+]

--- a/data/mods/BN_Arcana_Crit_Patch/monsters.json
+++ b/data/mods/BN_Arcana_Crit_Patch/monsters.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "mon_slasher",
+    "copy-from": "mon_slasher",
+    "type": "MONSTER",
+    "death_drops": "mon_slasher_death_drops"
+  },
+  {
+    "id": "mon_slasher_weak",
+    "copy-from": "mon_slasher_weak",
+    "type": "MONSTER",
+    "death_drops": "mon_slasher_weak_death_drops"
+  },
+  {
+    "id": "mon_waster",
+    "copy-from": "mon_waster",
+    "type": "MONSTER",
+    "death_drops": "mon_waster_death_drops"
+  },
+  {
+    "id": "mon_leaper",
+    "copy-from": "mon_leaper",
+    "type": "MONSTER",
+    "death_drops": "mon_leaper_death_drops"
+  },
+  {
+    "id": "mon_twitcher",
+    "copy-from": "mon_twitcher",
+    "type": "MONSTER",
+    "death_drops": "mon_twitcher_death_drops"
+  },
+  {
+    "id": "mon_pack",
+    "copy-from": "mon_pack",
+    "type": "MONSTER",
+    "death_drops": "mon_pack_death_drops"
+  },
+  {
+    "id": "mon_puker",
+    "copy-from": "mon_puker",
+    "type": "MONSTER",
+    "death_drops": "mon_puker_death_drops"
+  }
+]

--- a/data/mods/BN_Arcana_Crit_Patch/professions.json
+++ b/data/mods/BN_Arcana_Crit_Patch/professions.json
@@ -1,0 +1,52 @@
+[
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "starting_mana_gem_18_essence",
+    "entries": [ { "item": "essence", "charges": 18 } ]
+  },
+  {
+    "type": "profession",
+    "id": "crt_arcanist",
+    "name": "C.R.I.T. Anomaly Investigator",
+    "description": "You were a specialist in the C.R.I.T. research department, trained and equipped to investigate anomalous activities and local persons of interest.  You developed a small network of contacts from local organizations with suspected ties to anomalous activity, but the end of the world hit before you could follow up on those leads.  Now, all you have to rely on is your training, gear, and limited research into the strange reality you now face.",
+    "points": 9,
+    "traits": [ "MARTIAL_CRT", "PROF_ARCANIST" ],
+    "skills": [
+      { "level": 3, "name": "fabrication" },
+      { "level": 3, "name": "mechanics" },
+      { "level": 3, "name": "electronics" },
+      { "level": 2, "name": "computer" },
+      { "level": 2, "name": "magic" },
+      { "level": 1, "name": "melee" },
+      { "level": 1, "name": "cutting" }
+    ],
+    "items": {
+      "both": {
+        "ammo": 100,
+        "items": [
+          "crt_rec_hat",
+          "crt_aarmor",
+          "crt_jacket",
+          "crt_rec_gloves",
+          "crt_dress_pants",
+          "socks",
+          "crt_boots",
+          "mbag",
+          "lighter",
+          "bowl_pewter",
+          "id_science",
+          "recipe_lab_arcana"
+        ],
+        "entries": [
+          { "item": "mana_gem", "contents-group": "starting_mana_gem_18_essence" },
+          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "knife_crt", "container-item": "crt_belt" },
+          { "item": "sword_crt", "container-item": "scabbard" }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "sports_bra", "boxer_shorts" ]
+    }
+  }
+]

--- a/data/mods/BN_Arcana_Crit_Patch/recipe_deconstruction.json
+++ b/data/mods/BN_Arcana_Crit_Patch/recipe_deconstruction.json
@@ -1,0 +1,20 @@
+[
+  {
+    "result": "sword_crt",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 6,
+    "time": "60 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "scrap", 50 ] ], [ [ "essence_dull", 100 ] ] ]
+  },
+  {
+    "result": "blade_crt",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 7,
+    "time": "70 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "scrap", 1000 ] ], [ [ "essence_dull", 150 ] ] ]
+  }
+]

--- a/data/mods/BN_Arcana_Crit_Patch/scenarios.json
+++ b/data/mods/BN_Arcana_Crit_Patch/scenarios.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "scenario",
+    "id": "arcane_urban",
+    "copy-from": "arcane_urban",
+    "extend": { "professions": [ "crt_arcanist" ] }
+  },
+  {
+    "type": "scenario",
+    "id": "Mine_bottom",
+    "copy-from": "Mine_bottom",
+    "extend": { "professions": [ "crt_arcanist" ] }
+  },
+  {
+    "type": "scenario",
+    "id": "lab_staff",
+    "copy-from": "lab_staff",
+    "extend": { "professions": [ "crt_arcanist" ] }
+  },
+  {
+    "type": "scenario",
+    "id": "heli_crash",
+    "copy-from": "heli_crash",
+    "extend": { "professions": [ "crt_arcanist" ] }
+  },
+  {
+    "type": "scenario",
+    "id": "overrun",
+    "copy-from": "overrun",
+    "extend": { "professions": [ "crt_arcanist" ] }
+  }
+]

--- a/data/mods/BN_Arcana_Dinomod_Patch/modinfo.json
+++ b/data/mods/BN_Arcana_Dinomod_Patch/modinfo.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "Arcana_Dinomod_Patch",
+    "name": "<color_cyan>Arcana</color>/DinoMod Patchmod",
+    "authors": [ "Chaosvolt" ],
+    "description": "Optional patch mod that allows content in Arcana and DinoMod to interact with each other.",
+    "license": "CC-BY-SA-3.0",
+    "version": "BN In-Repo version, update 4/28/2028",
+    "category": "misc_additions",
+    "dependencies": [ "bn", "Arcana", "DinoMod" ]
+  }
+]

--- a/data/mods/BN_Arcana_Dinomod_Patch/monster_drops.json
+++ b/data/mods/BN_Arcana_Dinomod_Patch/monster_drops.json
@@ -1,0 +1,37 @@
+[
+  {
+    "type": "item_group",
+    "id": "zombie_dino_fungal_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "item": "inflorescent_root", "prob": 10 },
+      {
+        "distribution": [ { "item": "essence", "prob": 50 }, { "item": "essence_blood", "prob": 50, "count": [ 1, 3 ] } ],
+        "prob": 25
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "zombie_dino_shady_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "shadow_gem", "prob": 10 }, { "item": "essence_blood", "count": [ 1, 3 ], "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "zombie_dino_skeletal_death_drops",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bone_twisted", "prob": 25 },
+          { "item": "gracken_knuckles", "prob": 25 },
+          { "item": "graboid_fang", "prob": 25 },
+          { "item": "monster_fang", "prob": 25 }
+        ],
+        "prob": 10
+      },
+      { "item": "essence_blood", "prob": 25, "count": [ 1, 3 ] }
+    ]
+  }
+]

--- a/data/mods/BN_Arcana_Dinomod_Patch/monsters.json
+++ b/data/mods/BN_Arcana_Dinomod_Patch/monsters.json
@@ -1,0 +1,968 @@
+[
+  {
+    "id": "mon_silophosaurus",
+    "copy-from": "mon_silophosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_seratosaurus",
+    "copy-from": "mon_seratosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_skinosaurus",
+    "copy-from": "mon_skinosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sorvosaurus",
+    "copy-from": "mon_sorvosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sallosaurus",
+    "copy-from": "mon_sallosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sacrocanthosaurus",
+    "copy-from": "mon_sacrocanthosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_skiats",
+    "copy-from": "mon_skiats",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sryptosaurus",
+    "copy-from": "mon_sryptosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sappalachiosaurus",
+    "copy-from": "mon_sappalachiosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sorgosaurus",
+    "copy-from": "mon_sorgosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_salbertosaurus",
+    "copy-from": "mon_salbertosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sianzhousaurus",
+    "copy-from": "mon_sianzhousaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sanuqsaurus",
+    "copy-from": "mon_sanuqsaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_saspletosaurus",
+    "copy-from": "mon_saspletosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_syrannosaurus",
+    "copy-from": "mon_syrannosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sallimimus",
+    "copy-from": "mon_sallimimus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sktruthiomimus",
+    "copy-from": "mon_sktruthiomimus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sornithomimus",
+    "copy-from": "mon_sornithomimus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sothronychus",
+    "copy-from": "mon_sothronychus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sanzu",
+    "copy-from": "mon_sanzu",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_seinonychus",
+    "copy-from": "mon_seinonychus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sutahraptor",
+    "copy-from": "mon_sutahraptor",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sissi",
+    "copy-from": "mon_sissi",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_samargasaurus",
+    "copy-from": "mon_samargasaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sapatosaurus",
+    "copy-from": "mon_sapatosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_srontosaurus",
+    "copy-from": "mon_srontosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_siplodocus",
+    "copy-from": "mon_siplodocus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_samarasaurus",
+    "copy-from": "mon_samarasaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_srachiosaurus",
+    "copy-from": "mon_srachiosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_salamosaurus",
+    "copy-from": "mon_salamosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sktegosaurus",
+    "copy-from": "mon_sktegosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_syoplosaurus",
+    "copy-from": "mon_syoplosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sankylosaurus",
+    "copy-from": "mon_sankylosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sodosaurus",
+    "copy-from": "mon_sodosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sedmontonia",
+    "copy-from": "mon_sedmontonia",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_samptosaurus",
+    "copy-from": "mon_samptosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sadrosaurus",
+    "copy-from": "mon_sadrosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sarasaurolophus",
+    "copy-from": "mon_sarasaurolophus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sorythosaurus",
+    "copy-from": "mon_sorythosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_saiasaura",
+    "copy-from": "mon_saiasaura",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sedmontosaurus",
+    "copy-from": "mon_sedmontosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sachycephalosaurus",
+    "copy-from": "mon_sachycephalosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sachyrhinosaurus",
+    "copy-from": "mon_sachyrhinosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sentaceratops",
+    "copy-from": "mon_sentaceratops",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sosmoceratops",
+    "copy-from": "mon_sosmoceratops",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sorosaurus",
+    "copy-from": "mon_sorosaurus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sriceratops",
+    "copy-from": "mon_sriceratops",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_silophosaurus_brute",
+    "copy-from": "mon_silophosaurus_brute",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_silophosaurus_hulk",
+    "copy-from": "mon_silophosaurus_hulk",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_skinosaurus_brute",
+    "copy-from": "mon_skinosaurus_brute",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_skinosaurus_hulk",
+    "copy-from": "mon_skinosaurus_hulk",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sorvosaurus_brute",
+    "copy-from": "mon_sorvosaurus_brute",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sorvosaurus_hulk",
+    "copy-from": "mon_sorvosaurus_hulk",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sallosaurus_brute",
+    "copy-from": "mon_sallosaurus_brute",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sallosaurus_hulk",
+    "copy-from": "mon_sallosaurus_hulk",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_syrannosaurus_brute",
+    "copy-from": "mon_syrannosaurus_brute",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_syrannosaurus_hulk",
+    "copy-from": "mon_syrannosaurus_hulk",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sallimimus_brute",
+    "copy-from": "mon_sallimimus_brute",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sallimimus_hulk",
+    "copy-from": "mon_sallimimus_hulk",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sothronychus_brute",
+    "copy-from": "mon_sothronychus_brute",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sothronychus_hulk",
+    "copy-from": "mon_sothronychus_hulk",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sanzu_brute",
+    "copy-from": "mon_sanzu_brute",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sanzu_hulk",
+    "copy-from": "mon_sanzu_hulk",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sutahraptor_brute",
+    "copy-from": "mon_sutahraptor_brute",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_sutahraptor_hulk",
+    "copy-from": "mon_sutahraptor_hulk",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_skeletal_death_drops"
+  },
+  {
+    "id": "mon_zilophosaurus_shady",
+    "copy-from": "mon_zilophosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zeratosaurus_shady",
+    "copy-from": "mon_zeratosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zpinosaurus_shady",
+    "copy-from": "mon_zpinosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zorvosaurus_shady",
+    "copy-from": "mon_zorvosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zallosaurus_shady",
+    "copy-from": "mon_zallosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zacrocanthosaurus_shady",
+    "copy-from": "mon_zacrocanthosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_ziats_shady",
+    "copy-from": "mon_ziats_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zryptosaurus_shady",
+    "copy-from": "mon_zryptosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zappalachiosaurus_shady",
+    "copy-from": "mon_zappalachiosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zorgosaurus_shady",
+    "copy-from": "mon_zorgosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zalbertosaurus_shady",
+    "copy-from": "mon_zalbertosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zianzhousaurus_shady",
+    "copy-from": "mon_zianzhousaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zanuqsaurus_shady",
+    "copy-from": "mon_zanuqsaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zaspletosaurus_shady",
+    "copy-from": "mon_zaspletosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zyrannosaurus_shady",
+    "copy-from": "mon_zyrannosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zallimimus_shady",
+    "copy-from": "mon_zallimimus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_ztruthiomimus_shady",
+    "copy-from": "mon_ztruthiomimus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zornithomimus_shady",
+    "copy-from": "mon_zornithomimus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zothronychus_shady",
+    "copy-from": "mon_zothronychus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zanzu_shady",
+    "copy-from": "mon_zanzu_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zeinonychus_shady",
+    "copy-from": "mon_zeinonychus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zutahraptor_shady",
+    "copy-from": "mon_zutahraptor_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zankylosaurus_shady",
+    "copy-from": "mon_zankylosaurus_shady",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zilophosaurus_nightstalker",
+    "copy-from": "mon_zilophosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zeratosaurus_nightstalker",
+    "copy-from": "mon_zeratosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zpinosaurus_nightstalker",
+    "copy-from": "mon_zpinosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zorvosaurus_nightstalker",
+    "copy-from": "mon_zorvosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zallosaurus_nightstalker",
+    "copy-from": "mon_zallosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zacrocanthosaurus_nightstalker",
+    "copy-from": "mon_zacrocanthosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_ziats_nightstalker",
+    "copy-from": "mon_ziats_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zryptosaurus_nightstalker",
+    "copy-from": "mon_zryptosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zappalachiosaurus_nightstalker",
+    "copy-from": "mon_zappalachiosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zorgosaurus_nightstalker",
+    "copy-from": "mon_zorgosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zalbertosaurus_nightstalker",
+    "copy-from": "mon_zalbertosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zianzhousaurus_nightstalker",
+    "copy-from": "mon_zianzhousaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zanuqsaurus_nightstalker",
+    "copy-from": "mon_zanuqsaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zaspletosaurus_nightstalker",
+    "copy-from": "mon_zaspletosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zyrannosaurus_nightstalker",
+    "copy-from": "mon_zyrannosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zallimimus_nightstalker",
+    "copy-from": "mon_zallimimus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_ztruthiomimus_nightstalker",
+    "copy-from": "mon_ztruthiomimus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zornithomimus_nightstalker",
+    "copy-from": "mon_zornithomimus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zothronychus_nightstalker",
+    "copy-from": "mon_zothronychus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zanzu_nightstalker",
+    "copy-from": "mon_zanzu_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zeinonychus_nightstalker",
+    "copy-from": "mon_zeinonychus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zutahraptor_nightstalker",
+    "copy-from": "mon_zutahraptor_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zankylosaurus_nightstalker",
+    "copy-from": "mon_zankylosaurus_nightstalker",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_shady_death_drops"
+  },
+  {
+    "id": "mon_zilophosaurus_fungus",
+    "copy-from": "mon_zilophosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zeratosaurus_fungus",
+    "copy-from": "mon_zeratosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zpinosaurus_fungus",
+    "copy-from": "mon_zpinosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zorvosaurus_fungus",
+    "copy-from": "mon_zorvosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zallosaurus_fungus",
+    "copy-from": "mon_zallosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zacrocanthosaurus_fungus",
+    "copy-from": "mon_zacrocanthosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_ziats_fungus",
+    "copy-from": "mon_ziats_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zryptosaurus_fungus",
+    "copy-from": "mon_zryptosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zappalachiosaurus_fungus",
+    "copy-from": "mon_zappalachiosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zorgosaurus_fungus",
+    "copy-from": "mon_zorgosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zalbertosaurus_fungus",
+    "copy-from": "mon_zalbertosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zianzhousaurus_fungus",
+    "copy-from": "mon_zianzhousaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zanuqsaurus_fungus",
+    "copy-from": "mon_zanuqsaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zaspletosaurus_fungus",
+    "copy-from": "mon_zaspletosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zyrannosaurus_fungus",
+    "copy-from": "mon_zyrannosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zallimimus_fungus",
+    "copy-from": "mon_zallimimus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_ztruthiomimus_fungus",
+    "copy-from": "mon_ztruthiomimus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zornithomimus_fungus",
+    "copy-from": "mon_zornithomimus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zothronychus_fungus",
+    "copy-from": "mon_zothronychus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zanzu_fungus",
+    "copy-from": "mon_zanzu_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zeinonychus_fungus",
+    "copy-from": "mon_zeinonychus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zutahraptor_fungus",
+    "copy-from": "mon_zutahraptor_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zissi_fungus",
+    "copy-from": "mon_zissi_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zamargasaurus_fungus",
+    "copy-from": "mon_zamargasaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zapatosaurus_fungus",
+    "copy-from": "mon_zapatosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zrontosaurus_fungus",
+    "copy-from": "mon_zrontosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_ziplodocus_fungus",
+    "copy-from": "mon_ziplodocus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zamarasaurus_fungus",
+    "copy-from": "mon_zamarasaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zrachiosaurus_fungus",
+    "copy-from": "mon_zrachiosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zalamosaurus_fungus",
+    "copy-from": "mon_zalamosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_ztegosaurus_fungus",
+    "copy-from": "mon_ztegosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zyoplosaurus_fungus",
+    "copy-from": "mon_zyoplosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zankylosaurus_fungus",
+    "copy-from": "mon_zankylosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zodosaurus_fungus",
+    "copy-from": "mon_zodosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zedmontonia_fungus",
+    "copy-from": "mon_zedmontonia_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zamptosaurus_fungus",
+    "copy-from": "mon_zamptosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zadrosaurus_fungus",
+    "copy-from": "mon_zadrosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zarasaurolophus_fungus",
+    "copy-from": "mon_zarasaurolophus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zorythosaurus_fungus",
+    "copy-from": "mon_zorythosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zaiasaura_fungus",
+    "copy-from": "mon_zaiasaura_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zedmontosaurus_fungus",
+    "copy-from": "mon_zedmontosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zachycephalosaurus_fungus",
+    "copy-from": "mon_zachycephalosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zachyrhinosaurus_fungus",
+    "copy-from": "mon_zachyrhinosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zentaceratops_fungus",
+    "copy-from": "mon_zentaceratops_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zosmoceratops_fungus",
+    "copy-from": "mon_zosmoceratops_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zorosaurus_fungus",
+    "copy-from": "mon_zorosaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zriceratops_fungus",
+    "copy-from": "mon_zriceratops_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zteranodon_fungus",
+    "copy-from": "mon_zteranodon_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zuetzalcoatlus_fungus",
+    "copy-from": "mon_zuetzalcoatlus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  },
+  {
+    "id": "mon_zosasaurus_fungus",
+    "copy-from": "mon_zosasaurus_fungus",
+    "type": "MONSTER",
+    "death_drops": "zombie_dino_fungal_death_drops"
+  }
+]

--- a/data/mods/BN_Arcana_MagicalNights_Patch/crafting_requirements.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/crafting_requirements.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "arcana_blood_standard",
+    "type": "requirement",
+    "//": "Any available sort of blood, ideally human blood.",
+    "components": [ [ [ "blood", 1 ], [ "dragon_blood", 1 ], [ "animal_blood", 3 ], [ "mutant_blood", 4 ] ] ]
+  },
+  {
+    "id": "arcana_flesh_standard",
+    "type": "requirement",
+    "//": "Flesh suitable for blood sacrifice, human meat is preferable.",
+    "components": [ [ [ "human_flesh", 1 ], [ "meat_dragon", 1 ], [ "mutant_human_flesh", 2 ], [ "meat", 3 ], [ "mutant_meat", 4 ] ] ]
+  }
+]

--- a/data/mods/BN_Arcana_MagicalNights_Patch/item_groups_modcompat.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/item_groups_modcompat.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "chalice_cult_books_postapoc",
+    "type": "item_group",
+    "items": [ [ "wizard_beginner", 3 ], [ "wizard_advanced", 2 ] ]
+  },
+  {
+    "id": "sanguine_cult_books_postapoc",
+    "type": "item_group",
+    "items": [ { "group": "dragon_books", "prob": 5 } ]
+  },
+  {
+    "id": "cleansing_flame_books_postapoc",
+    "type": "item_group",
+    "items": [ [ "priest_beginner", 2 ], [ "priest_advanced", 2 ], [ "techno_fundamentals", 1 ] ]
+  },
+  {
+    "id": "unaligned_arcanist_books_postapoc",
+    "type": "item_group",
+    "items": [
+      { "group": "magic_recipe_basic", "prob": 2 },
+      { "group": "magic_recipe_advanced", "prob": 1 },
+      { "group": "spellbook_loot_0", "prob": 1 },
+      { "group": "spellbook_loot_1", "prob": 1 }
+    ]
+  },
+  {
+    "id": "magic_books_postapoc",
+    "type": "item_group",
+    "items": [
+      { "group": "magic_recipe_basic", "prob": 2 },
+      { "group": "magic_recipe_advanced", "prob": 1 },
+      { "group": "spellbook_loot_0", "prob": 1 },
+      { "group": "spellbook_loot_1", "prob": 1 }
+    ]
+  }
+]

--- a/data/mods/BN_Arcana_MagicalNights_Patch/martialarts.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/martialarts.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "style_veil_chosen",
+    "copy-from": "style_veil_chosen",
+    "type": "martial_art",
+    "name": { "str": "Ritual Art" },
+    "//": "No, the generic D&D +1/+2 weapons don't really count as anomalous enough.",
+    "extend": {
+      "weapons": [
+        "magi_staff_minor",
+        "rune_biomancer_weapon",
+        "rune_technomancer_weapon",
+        "rune_magus_weapon",
+        "rune_kelvinist_weapon",
+        "rune_stormshaper_weapon",
+        "rune_animist_weapon",
+        "flaming_fist",
+        "flaming_fist_plus_one",
+        "flaming_fist_plus_two",
+        "gauntlet_pounding",
+        "rune_earthshaper_weapon",
+        "stonefist",
+        "stormhammer",
+        "tentacle_whip",
+        "mjolnir",
+        "gungnir",
+        "gram",
+        "laevateinn"
+      ]
+    }
+  }
+]

--- a/data/mods/BN_Arcana_MagicalNights_Patch/modinfo.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/modinfo.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "Arcana_MagiclalNights_Patch",
+    "name": "<color_cyan>Arcana</color>/Magical Nights Patchmod",
+    "authors": [ "Chaosvolt" ],
+    "description": "Optional patch mod that allows content in Arcana and Magical Nights to interact with each other.",
+    "license": "CC-BY-SA-3.0",
+    "version": "BN In-Repo version, update 4/28/2028",
+    "category": "misc_additions",
+    "dependencies": [ "bn", "Arcana", "MagicalNights" ]
+  }
+]

--- a/data/mods/BN_Arcana_MagicalNights_Patch/monster_drops.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/monster_drops.json
@@ -1,0 +1,173 @@
+[
+  {
+    "type": "item_group",
+    "id": "mon_demon_spiderling_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence", "prob": 10 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_demon_spider_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "dermatik_sting", "prob": 50 }, { "item": "iridescent_plate", "prob": 50 } ], "prob": 10 },
+      { "item": "essence", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_demon_spider_queen_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "dermatik_sting", "prob": 50 }, { "item": "iridescent_plate", "prob": 50 } ] },
+      { "item": "essence", "count": [ 2, 5 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_dragon_black_wyrmling_death_drops",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "graboid_fang", "prob": 40 },
+          { "item": "monster_fang", "prob": 10 },
+          { "item": "wyrmskin_piece", "prob": 40 },
+          { "item": "iridescent_plate", "prob": 10 }
+        ],
+        "prob": 5
+      },
+      { "item": "essence", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_dragon_black_young_death_drops",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "graboid_fang", "prob": 40 },
+          { "item": "monster_fang", "prob": 10 },
+          { "item": "wyrmskin_piece", "prob": 40 },
+          { "item": "iridescent_plate", "prob": 10 }
+        ],
+        "prob": 10
+      },
+      { "item": "essence", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_dragon_black_adult_death_drops",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "graboid_fang", "prob": 40 },
+          { "item": "monster_fang", "prob": 10 },
+          { "item": "wyrmskin_piece", "prob": 40 },
+          { "item": "iridescent_plate", "prob": 10 }
+        ],
+        "prob": 25
+      },
+      { "item": "essence", "prob": 50 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_claygolem_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "engraved_stone", "prob": 50 }, { "item": "monster_tear", "prob": 50 } ], "prob": 10 },
+      { "item": "essence_dull", "prob": 25, "count": [ 10, 20 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_plasticgolem_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "monster_tear", "prob": 10 }, { "item": "essence_dull", "prob": 25, "count": [ 10, 20 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_stonegolem_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "engraved_stone", "prob": 50 }, { "item": "monster_tear", "prob": 50 } ], "prob": 10 },
+      { "item": "essence_dull", "prob": 25, "count": [ 10, 20 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_irongolem_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "iron_thorn", "prob": 50 }, { "item": "monster_tear", "prob": 50 } ], "prob": 10 },
+      { "item": "essence_dull", "prob": 25, "count": [ 10, 20 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_owlbear_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "prob": 25, "count": [ 2, 4 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_black_pudding_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "blob_gem", "prob": 50 }, { "item": "wyrmskin_piece", "prob": 50 } ], "prob": 10 },
+      { "item": "essence", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_krabgek_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "monster_tear", "prob": 10 }, { "item": "essence", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_owlbear_cub_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence_blood", "prob": 10, "count": [ 2, 4 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_bulette_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "iridescent_plate", "prob": 50 }, { "item": "wyrmskin_piece", "prob": 50 } ], "prob": 10 },
+      { "item": "essence_blood", "prob": 25, "count": [ 2, 4 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_troll_death_drops",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "item": "monster_fang", "prob": 25 }, { "item": "bone_twisted", "prob": 75 } ], "prob": 10 },
+      { "item": "essence_blood", "prob": 25, "count": [ 2, 4 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_stirge_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_shrieker_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "inflorescent_root", "prob": 10 }, { "item": "essence", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mon_lemure_death_drops",
+    "subtype": "collection",
+    "entries": [ { "item": "essence", "prob": 25 } ]
+  }
+]

--- a/data/mods/BN_Arcana_MagicalNights_Patch/monsters.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/monsters.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "mon_demon_spiderling",
+    "copy-from": "mon_demon_spiderling",
+    "type": "MONSTER",
+    "death_drops": "mon_demon_spiderling_death_drops"
+  },
+  {
+    "id": "mon_demon_spider",
+    "copy-from": "mon_demon_spider",
+    "type": "MONSTER",
+    "death_drops": "mon_demon_spider_death_drops"
+  },
+  {
+    "id": "mon_demon_spider_queen",
+    "copy-from": "mon_demon_spider_queen",
+    "type": "MONSTER",
+    "death_drops": "mon_demon_spider_queen_death_drops"
+  },
+  {
+    "id": "mon_dragon_black_wyrmling",
+    "copy-from": "mon_dragon_black_wyrmling",
+    "type": "MONSTER",
+    "death_drops": "mon_dragon_black_wyrmling_death_drops"
+  },
+  {
+    "id": "mon_dragon_black_young",
+    "copy-from": "mon_dragon_black_young",
+    "type": "MONSTER",
+    "death_drops": "mon_dragon_black_young_death_drops"
+  },
+  {
+    "id": "mon_dragon_black_adult",
+    "copy-from": "mon_dragon_black_adult",
+    "type": "MONSTER",
+    "death_drops": "mon_dragon_black_adult_death_drops"
+  },
+  {
+    "id": "mon_claygolem",
+    "copy-from": "mon_claygolem",
+    "type": "MONSTER",
+    "death_drops": "mon_claygolem_death_drops"
+  },
+  {
+    "id": "mon_plasticgolem",
+    "copy-from": "mon_plasticgolem",
+    "type": "MONSTER",
+    "death_drops": "mon_plasticgolem_death_drops"
+  },
+  {
+    "id": "mon_stonegolem",
+    "copy-from": "mon_stonegolem",
+    "type": "MONSTER",
+    "death_drops": "mon_stonegolem_death_drops"
+  },
+  {
+    "id": "mon_irongolem",
+    "copy-from": "mon_irongolem",
+    "type": "MONSTER",
+    "death_drops": "mon_irongolem_death_drops"
+  },
+  {
+    "id": "mon_owlbear",
+    "copy-from": "mon_owlbear",
+    "type": "MONSTER",
+    "death_drops": "mon_owlbear_death_drops"
+  },
+  {
+    "id": "mon_black_pudding",
+    "copy-from": "mon_black_pudding",
+    "type": "MONSTER",
+    "death_drops": "mon_black_pudding_death_drops"
+  },
+  {
+    "id": "mon_krabgek",
+    "copy-from": "mon_krabgek",
+    "type": "MONSTER",
+    "death_drops": "mon_krabgek_death_drops"
+  },
+  {
+    "id": "mon_owlbear_cub",
+    "copy-from": "mon_owlbear_cub",
+    "type": "MONSTER",
+    "death_drops": "mon_owlbear_cub_death_drops"
+  },
+  {
+    "id": "mon_bulette",
+    "copy-from": "mon_bulette",
+    "type": "MONSTER",
+    "death_drops": "mon_bulette_death_drops"
+  },
+  {
+    "id": "mon_troll",
+    "copy-from": "mon_troll",
+    "type": "MONSTER",
+    "death_drops": "mon_troll_death_drops"
+  },
+  {
+    "id": "mon_stirge",
+    "copy-from": "mon_stirge",
+    "type": "MONSTER",
+    "death_drops": "mon_stirge_death_drops"
+  },
+  {
+    "id": "mon_shrieker",
+    "copy-from": "mon_shrieker",
+    "type": "MONSTER",
+    "death_drops": "mon_shrieker_death_drops"
+  },
+  {
+    "id": "mon_lemure",
+    "copy-from": "mon_lemure",
+    "type": "MONSTER",
+    "death_drops": "mon_lemure_death_drops"
+  }
+]

--- a/data/mods/BN_Arcana_MagicalNights_Patch/recipe_deconstruction.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/recipe_deconstruction.json
@@ -1,0 +1,319 @@
+[
+  {
+    "result": "spell_scroll_acid_resistance",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 1,
+    "skills_required": [ "spellcraft", 1 ],
+    "time": "10 m",
+    "using": [ [ "arcana_purification_standard", 1 ] ],
+    "components": [ [ [ "essence_dull", 40 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "mana_dust",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 0,
+    "time": "5 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "essence_dull", 50 ] ] ]
+  },
+  {
+    "result": "crystallized_mana",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 0,
+    "time": "5 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "essence_dull", 50 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "helmet_demonchitin",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "chitin_piece", 17 ] ], [ [ "essence_dull", 85 ] ] ]
+  },
+  {
+    "result": "armguard_demonchitin",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "chitin_piece", 18 ] ], [ [ "essence_dull", 90 ] ] ]
+  },
+  {
+    "result": "armor_demonchitin",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "chitin_piece", 70 ] ], [ [ "essence_dull", 350 ] ] ]
+  },
+  {
+    "result": "boots_demonchitin",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "chitin_piece", 17 ] ], [ [ "essence_dull", 10 ] ] ]
+  },
+  {
+    "result": "gauntlets_demonchitin",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "chitin_piece", 10 ] ], [ [ "essence_dull", 50 ] ] ]
+  },
+  {
+    "result": "demonchitin_armor_horse",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "chitin_piece", 84 ] ], [ [ "essence_dull", 420 ] ] ]
+  },
+  {
+    "result": "demonchitin_harness_dog",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "chitin_piece", 12 ] ], [ [ "essence_dull", 60 ] ] ]
+  },
+  {
+    "result": "alumentum",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 2,
+    "skills_required": [ "spellcraft", 2 ],
+    "time": "20 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "ash", 10 ] ], [ [ "essence_dull", 10 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "suit_black_dragon_hide",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 2,
+    "skills_required": [ "spellcraft", 2 ],
+    "time": "20 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 240 ] ], [ [ "essence_dull", 600 ] ] ]
+  },
+  {
+    "result": "suit_black_dragon_scale",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "skills_required": [ "spellcraft", 4 ],
+    "time": "40 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 240 ] ], [ [ "essence_dull", 600 ] ] ]
+  },
+  {
+    "result": "boots_black_dragon_hide",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 2,
+    "skills_required": [ "spellcraft", 2 ],
+    "time": "20 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 24 ] ], [ [ "essence_dull", 80 ] ] ]
+  },
+  {
+    "result": "boots_black_dragon_scale",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "skills_required": [ "spellcraft", 4 ],
+    "time": "40 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 36 ] ], [ [ "essence_dull", 160 ] ] ]
+  },
+  {
+    "result": "helmet_black_dragon_hide",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 2,
+    "skills_required": [ "spellcraft", 2 ],
+    "time": "20 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 18 ] ], [ [ "essence_dull", 80 ] ] ]
+  },
+  {
+    "result": "helmet_black_dragon_scale",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "skills_required": [ "spellcraft", 4 ],
+    "time": "40 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 6 ] ], [ [ "essence_dull", 160 ] ] ]
+  },
+  {
+    "result": "gloves_black_dragon_hide",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 2,
+    "skills_required": [ "spellcraft", 2 ],
+    "time": "20 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 18 ] ], [ [ "essence_dull", 120 ] ] ]
+  },
+  {
+    "result": "gauntlets_black_dragon_scale",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 4,
+    "skills_required": [ "spellcraft", 4 ],
+    "time": "40 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 24 ] ], [ [ "essence_dull", 200 ] ] ]
+  },
+  {
+    "result": "suit_xlblack_dragon_hide",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 3,
+    "skills_required": [ "spellcraft", 3 ],
+    "time": "30 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 360 ] ], [ [ "essence_dull", 800 ] ] ]
+  },
+  {
+    "result": "suit_xlblack_dragon_scale",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 360 ] ], [ [ "essence_dull", 1000 ] ] ]
+  },
+  {
+    "result": "boots_xlblack_dragon_hide",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 3,
+    "skills_required": [ "spellcraft", 3 ],
+    "time": "30 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 36 ] ], [ [ "essence_dull", 120 ] ] ]
+  },
+  {
+    "result": "boots_xlblack_dragon_scale",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 48 ] ], [ [ "essence_dull", 240 ] ] ]
+  },
+  {
+    "result": "helmet_xlblack_dragon_hide",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 3,
+    "skills_required": [ "spellcraft", 3 ],
+    "time": "30 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 24 ] ], [ [ "essence_dull", 120 ] ] ]
+  },
+  {
+    "result": "helmet_xlblack_dragon_scale",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 12 ] ], [ [ "essence_dull", 240 ] ] ]
+  },
+  {
+    "result": "gloves_xlblack_dragon_hide",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 3,
+    "skills_required": [ "spellcraft", 3 ],
+    "time": "30 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 24 ] ], [ [ "essence_dull", 160 ] ] ]
+  },
+  {
+    "result": "gauntlets_xlblack_dragon_scale",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 5,
+    "skills_required": [ "spellcraft", 5 ],
+    "time": "50 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "leather", 36 ] ], [ [ "essence_dull", 280 ] ] ]
+  },
+  {
+    "result": "magic_suppressor",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 3,
+    "skills_required": [ "spellcraft", 3 ],
+    "time": "30 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [ [ [ "scrap", 12 ] ], [ [ "essence_dull", 50 ] ] ]
+  },
+  {
+    "result": "mana_dot_sight",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 6,
+    "skills_required": [ "spellcraft", 6 ],
+    "time": "60 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [
+      [ [ "plastic_chunk", 2 ] ],
+      [ [ "amplifier", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "scrap", 3 ] ],
+      [ [ "silver_small", 10 ] ],
+      [ [ "gold_small", 10 ] ],
+      [ [ "material_sand", 1 ] ],
+      [ [ "essence_dull", 750 ] ]
+    ]
+  },
+  {
+    "result": "mana_laser_under",
+    "type": "uncraft",
+    "skill_used": "magic",
+    "difficulty": 3,
+    "skills_required": [ "spellcraft", 3 ],
+    "time": "30 m",
+    "tools": [ [ [ "hexenhammer", -1 ] ] ],
+    "components": [
+      [ [ "amplifier", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "material_sand", 1 ] ],
+      [ [ "scrap", 2 ] ],
+      [ [ "cable", 5 ] ],
+      [ [ "essence_dull", 50 ] ]
+    ]
+  }
+]

--- a/data/mods/BN_Arcana_MagicalNights_Patch/scenarios.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/scenarios.json
@@ -1,0 +1,77 @@
+[
+  {
+    "type": "scenario",
+    "id": "lost_faith",
+    "copy-from": "lost_faith",
+    "extend": {
+      "professions": [ "arcanist_magehunter", "arcanist_dark_priest", "arcanist_purifier", "arcanist_operator", "arcanist_mendicant" ],
+      "traits": [
+        "SPELL_CLAIRVOYANCE",
+        "SPELL_CLARITY",
+        "SPELL_CONFUSE",
+        "SPELL_STRENGTH",
+        "SPELL_AGILE",
+        "SPELL_INSIGHT",
+        "SPELL_LIGHT",
+        "SPELL_DAYLIGHT",
+        "SPELL_LOCKPICK",
+        "SPELL_POISONARMOR"
+      ]
+    }
+  },
+  {
+    "type": "scenario",
+    "id": "magic_basement",
+    "copy-from": "magic_basement",
+    "extend": {
+      "traits": [
+        "SPELL_HEAL",
+        "SPELL_SHADOWSNAKES",
+        "SPELL_CLERIC",
+        "SPELL_STRENGTH",
+        "SPELL_AGILE",
+        "SPELL_INSIGHT",
+        "SPELL_LIGHT",
+        "SPELL_FIRE",
+        "SPELL_DAMPENING",
+        "SPELL_SUMMONDOG"
+      ]
+    }
+  },
+  {
+    "type": "scenario",
+    "id": "lake_retreat",
+    "copy-from": "lake_retreat",
+    "extend": {
+      "traits": [
+        "SPELL_HEAL",
+        "SPELL_SHADOWSNAKES",
+        "SPELL_CLERIC",
+        "SPELL_STRENGTH",
+        "SPELL_AGILE",
+        "SPELL_INSIGHT",
+        "SPELL_LIGHT",
+        "SPELL_FIRE",
+        "SPELL_DAMPENING",
+        "SPELL_SUMMONDOG"
+      ]
+    }
+  },
+  {
+    "type": "scenario",
+    "id": "arcane_seeker",
+    "copy-from": "arcane_seeker",
+    "extend": {
+      "professions": [ "novice_necromancer", "novice_stormshaper", "novice_earthshaper", "novice_technomancer", "novice_kelvinist" ]
+    }
+  },
+  {
+    "type": "scenario",
+    "id": "arcane_urban",
+    "copy-from": "arcane_urban",
+    "extend": {
+      "professions": [ "priest_magic2", "shinto_priest_magic2", "imam_magic2", "rabbi_magic2", "guru_magic2", "preacher_magic2" ]
+    },
+    "delete": { "professions": [ "priest", "shinto_priest", "imam", "rabbi", "guru", "preacher" ] }
+  }
+]

--- a/data/mods/BN_Arcana_MagicalNights_Patch/snippets.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/snippets.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "snippet",
+    "category": "note_grove",
+    "text": [
+      {
+        "id": "note_grove_arcana_magiclysm_1",
+        "text": "\"Those who came before us are in decline, but they too will face what awaits those who shall take our place.  What they will make of all they have learned, only time will tell.\""
+      }
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "note_chalice",
+    "text": [
+      {
+        "id": "note_chalice_arcana_magiclysm_1",
+        "text": "\"The power He has granted our Chosen, who wield the Shrouded King's relics, draws from the spirit much like that of the fallen arts.  But it draws forth a divine power with it, strengthened by The Beyond…\""
+      }
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "note_soa_journal",
+    "text": [
+      {
+        "id": "note_soa_journal_arcana_magiclysm_1",
+        "text": "\"Local activity shows no connection to any suspected remnant of previous anomalous research, probable connection to current outbreak of anomalies falling under our purview.  Sustain observation until confirmation received.\""
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This PR includes the small patchmods for Arcana for those mods that're already in-repo, optional mods that use Arcana and another mod as prerequisites and expand on the interactions between the two, such as adding monster drops to anomalous monsters specific to them, allowing dismantling unusual items for essence, or other relevant interactions.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Adds Arcana/Aftershock patchmod, adding essence/part drops to mi-go turrets and headless horrors, and consecration uncrafts for anomalous items such as the bag of holding, mi-go blaster, and holocaster items.
2. Adds Arcana/C.R.I.T. patchmod, containing injection of reso-blade and Dragonslayer into Ritual Art, death drops for necromorphs, C.R.I.T. Anomaly Investigator profession and associated scenario injections, and consecration uncrafts for the reso-blade and Dragonslayer.
3. Adds Arcana/Dinomod patchmod, injecting monsterpart drops into associated anomalous zombie dinos.
4. Adds Arcana/Magical Nights patchmod, contains injection of dragon blood into relevant crafting requirements in Arcana, injection of MN books to certain appropriate Arcana itemgroups (the inverse is handled in Arcana itself without any fuss), injection of relevant magical weapons into Ritual Art's weapon list (excludes basic +1/+2 enchanted weapons due to how many there are), injection of monsterpart drops into appropriate MN monsters, consecration uncrafts for relevant MN items, injection of Arcana professions and/or chargen spells into associated MN scenarios and injection of MN professions into Arcana scenarios (including replacing vanilla religious professions from Urban Awakening with MN's versions), and a snippet injection to Arcana lore notes alluding to the existence of other magical orders.

Arcana/Cataclysm++ patchmod to be moved to Cataclysm++'s repo.

## Describe alternatives you've considered

Obsoleting some of these interactions via adding empty death drops to relevant monsters so the itemgroup is already implemented for Arcana to inject them into. It'd look weird and some content would still nessecitate patchmods to exist.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Load-tested a world with all patchmods in playthrough save.
2. Confirmed that Urban Awakening with Arcana+MN patchmod indeed correctly deletes the vanilla religious professions from its list and replaces them with MN's versions, since never tried deleting professions from a scenaro profession list before.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
