### PR TITLE
perf: Reduce pinyin search slowdown on long text matches

### DIFF
--- a/src/pinyin.cpp
+++ b/src/pinyin.cpp
@@ -12,7 +12,7 @@
 namespace
 {
 
-constexpr auto max_pinyin_combinations = size_t{ 64 };
+constexpr auto max_pinyin_combinations = size_t { 64 };
 
 auto indexed_pinyin_map() -> const std::unordered_map<char32_t, std::vector<std::u32string>> &
 {

--- a/src/pinyin.cpp
+++ b/src/pinyin.cpp
@@ -5,11 +5,14 @@
 #include <algorithm>
 #include <ranges>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
 namespace
 {
+
+constexpr auto max_pinyin_combinations = size_t{ 64 };
 
 auto indexed_pinyin_map() -> const std::unordered_map<char32_t, std::vector<std::u32string>> &
 {
@@ -32,26 +35,26 @@ auto indexed_pinyin_map() -> const std::unordered_map<char32_t, std::vector<std:
     return indexed_map;
 }
 
-} // namespace
-
-namespace pinyin
+auto query_window_char_limit( const size_t query_length ) -> size_t
 {
+    return std::max<size_t>( 1, ( query_length + 1 ) / 2 );
+}
 
-auto pinyin_match( const std::u32string &text, const std::u32string &query ) -> bool
+auto window_matches_query(
+    const std::u32string_view text_window, const std::u32string &query,
+    const std::unordered_map<char32_t, std::vector<std::u32string>> &pinyin_index ) -> bool
 {
-    const auto &pinyin_index = indexed_pinyin_map();
-
     auto combination_index = size_t{ 0 };
     auto all_combinations_tested = false;
 
     while( !all_combinations_tested ) {
         auto current_combination = std::u32string{};
-        current_combination.reserve( text.length() * 6 );
+        current_combination.reserve( text_window.length() * 6 );
 
         auto current_combination_index = combination_index;
         auto total_combinations = size_t{ 1 };
 
-        for( const auto current_char : text ) {
+        for( const auto current_char : text_window ) {
             const auto found = pinyin_index.find( current_char );
             if( found == pinyin_index.end() ) {
                 current_combination += current_char;
@@ -62,6 +65,10 @@ auto pinyin_match( const std::u32string &text, const std::u32string &query ) -> 
             current_combination += current_char_pinyin_list.at(
                                        current_combination_index % current_char_pinyin_list.size() );
             current_combination_index /= current_char_pinyin_list.size();
+
+            if( total_combinations > max_pinyin_combinations / current_char_pinyin_list.size() ) {
+                return false;
+            }
             total_combinations *= current_char_pinyin_list.size();
         }
 
@@ -71,6 +78,32 @@ auto pinyin_match( const std::u32string &text, const std::u32string &query ) -> 
 
         ++combination_index;
         all_combinations_tested = combination_index >= total_combinations;
+    }
+
+    return false;
+}
+
+} // namespace
+
+namespace pinyin
+{
+
+auto pinyin_match( const std::u32string &text, const std::u32string &query ) -> bool
+{
+    const auto &pinyin_index = indexed_pinyin_map();
+    const auto max_window_chars = std::min( text.length(), query_window_char_limit( query.length() ) );
+    const auto text_view = std::u32string_view( text );
+
+    for( const auto window_start : std::views::iota( size_t{ 0 }, text.length() ) ) {
+        const auto remaining_chars = text.length() - window_start;
+        const auto current_window_limit = std::min( max_window_chars, remaining_chars );
+
+        for( const auto window_size : std::views::iota( size_t{ 1 }, current_window_limit + 1 ) ) {
+            if( window_matches_query(
+                    text_view.substr( window_start, window_size ), query, pinyin_index ) ) {
+                return true;
+            }
+        }
     }
 
     return false;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

In BN, unlike DDA, construction menu search covers not only construction group names but also result-related text. With the current full-string pinyin expansion approach, this cause the game to freeze when filtering construction entries.

## Describe the solution (The How)

This changes pinyin matching so it no longer expands the whole candidate string at once. Instead, it only checks smaller local windows based on query length. I also added a cap to stop the search from blowing up on multi-pronunciation characters.

## Describe alternatives you've considered

Disable pinyin search for the construction menu

## Testing

- Tested in English with pinyin search disabled. Search behavior was unchanged.
- Tested in Chinese with pinyin search disabled. Search behavior was unchanged.
- Tested in Chinese with pinyin search enabled. Construction menu search no longer stalled. Also tested the debug menu and crafting menu, and pinyin search still worked normally there.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
