### PR TITLE
fix: fix the save loading issue

### DIFF
--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -579,7 +579,7 @@ bool mapbuffer::preload_quad( const tripoint &om_addr )
 bool mapbuffer::generate_quad( const tripoint &om_addr )
 {
     ZoneScoped;
-    const auto base = project_to<coords::sm>( tripoint_abs_om( om_addr ) );
+    const auto base = project_to<coords::sm>( tripoint_abs_omt( om_addr ) );
     const bool all_loaded =
         lookup_submap_in_memory( base.raw() )
         && lookup_submap_in_memory( ( base + tripoint_rel_sm::east() ).raw() )

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -492,7 +492,7 @@ static std::string dim_prefix_path( const std::string &dim_id )
 
 static std::string get_quad_dirname( const std::string &dim_id, const tripoint &om_addr )
 {
-    const auto segment_addr = project_to<coords::seg>( tripoint_abs_om( om_addr ) );
+    const auto segment_addr = project_to<coords::seg>( tripoint_abs_omt( om_addr ) );
     return string_format( "%smaps/%d.%d.%d",
                           dim_prefix_path( dim_id ),
                           segment_addr.x(), segment_addr.y(), segment_addr.z() );


### PR DESCRIPTION
## Purpose of change (The Why)
#8640 used om instead of omt
This caused save loading issues
`omt_to_seg_copy( om_addr );` before
`project_to<coords::seg>( tripoint_abs_omt( om_addr ) );` is thus what it should be

## Describe the solution (The How)
Change to omt

## Describe alternatives you've considered
Rename all _om to something that is less likely to get typoed with _omt
Like I dont know _ws ( world square )
Same thing with sm vs ms
WHY IS EVERYTHING SO TYPOABLE

Rename all the om_addr to omt_addr like a sane person

## Testing
Loaded save
Made sure everything was there

## Additional context
I screm

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.