### PR TITLE
fix: Retain the state of non-removed bionics when a bionic is removed

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2907,7 +2907,8 @@ void Character::remove_bionic( const bionic_id &b )
     for( bionic &i : *my_bionics ) {
 
         // Remove the specified bionic and any linked bionics
-        if( ( b == i.id || b->is_included( i.id ) || i.id->is_included( b ) ) && !removed_bionics.contains( i.id ) ) {
+        if( ( b == i.id || b->is_included( i.id ) || i.id->is_included( b ) ) &&
+            !removed_bionics.contains( i.id ) ) {
             const units::energy pow_up = i.id->capacity;
             mod_max_power_level( -1 * pow_up );
             if( i.powered ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2286,13 +2286,6 @@ bool Character::uninstall_bionic( const bionic_id &b_id, Character &installer, b
 
     int chance_of_success = bionic_manip_cos( adjusted_skill, difficulty + 2 );
 
-    // Surgery is imminent, retract claws or blade if active
-    for( bionic &bio : *installer.my_bionics ) {
-        if( bio.powered && bio.info().has_flag( flag_BIONIC_WEAPON ) ) {
-            installer.deactivate_bionic( bio );
-        }
-    }
-
     int success = chance_of_success - rng( 1, 100 );
     if( installer.has_trait( trait_DEBUG_BIONICS ) ) {
         perform_uninstall( b_id, difficulty, success, b_id->capacity, pl_skill );
@@ -2912,17 +2905,14 @@ void Character::remove_bionic( const bionic_id &b )
     std::set<spell_id> cbm_spells;
     std::set<bionic_id> removed_bionics;
     for( bionic &i : *my_bionics ) {
-        if( b == i.id && !removed_bionics.contains( i.id ) ) {
-            const units::energy pow_up = i.id->capacity;
-            mod_max_power_level( -1 * pow_up );
-            removed_bionics.emplace( i.id );
-            continue;
-        }
 
-        // Linked bionics: if either is removed, the other is removed as well.
-        if( ( b->is_included( i.id ) || i.id->is_included( b ) ) && !removed_bionics.contains( i.id ) ) {
+        // Remove the specified bionic and any linked bionics
+        if( ( b == i.id || b->is_included( i.id ) || i.id->is_included( b ) ) && !removed_bionics.contains( i.id ) ) {
             const units::energy pow_up = i.id->capacity;
             mod_max_power_level( -1 * pow_up );
+            if( i.powered ) {
+                deactivate_bionic( i, true );
+            }
             removed_bionics.emplace( i.id );
             continue;
         }
@@ -2931,7 +2921,7 @@ void Character::remove_bionic( const bionic_id &b )
             cbm_spells.emplace( spell_pair.first );
         }
 
-        new_my_bionics.push_back( bionic( i.id, i.invlet ) );
+        new_my_bionics.push_back( i );
     }
 
     // any spells you learn from installing a bionic you forget.


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Having a CBM forcefully removed by a nurse bot with a bionic weapon active results in the weapon being deactivated but the item still being wielded, preventing it from being removed. There is a check to prevent this when manually uninstalling, but nurse bots and the debug menu do not use the function the check is in.
When uninstalling a bionic, all non-removed CBMs are replaced with new ones with the same id and invlet. This means that data such as whether they're currently active and how much ammo they have is lost.

This PR fixes both of these problems.

## Describe the solution (The How)

Deactivate bionics as they're removed in Character::remove_bionic() and add the non-removed bionics to new_my_bionics instead of creating new ones. Also combined the checks for removing the selected bionics and linked bionics since they executed the exact same code.

Remove the bionic weapon check in Character::uninstall_bionic() since it is now redundant.

## Describe alternatives you've considered

Force bionic weapon activated to succeed if the weapon is currently wielded.

## Testing

Uninstalled Monofilament Whip CBM while active. Whip was retracted and previously active CBMs remained active.

Uninstalled Power Storage CBM with loaded Shotgun Arm CBM active. Shotgun arm remained active and loaded.

Uninstalled Anti-Glare Compensators CBM while optical dampers were active and loaded Shotgun Arm CBM was inactive. Optical dampers were deactivated and shotgun arm retained ammo.

Had CBM removed by hostile nurse bot while monofilament whip was active. Whip remained active and could be withdrawn.

Debug removed optical dampers while they and Monofilament Whip were active. Optical dampers were deactivated while whip remained active.

Debug removed Monofilament Whip while active. Whip was withdrawn.

## Additional context

I'm not sure why new bionics were created instead of keeping the old ones but it seems to have been that way since bionic removal was added.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
