### PR TITLE
fix(mods/MonsterGirls): monster girls nested categories compat

### DIFF
--- a/data/mods/Monster_Girls/nested.json
+++ b/data/mods/Monster_Girls/nested.json
@@ -1,0 +1,38 @@
+[
+    {
+    "type": "nested_category",
+    "id": "nested_mutagens_strains",
+    "nested_name": "strain mutagens",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_NESTED",
+    "description": "Animal and specialty strains with their IV versions.",
+    "nested_category_data": [
+      "mutagen_neko",
+      "iv_mutagen_neko",
+      "mutagen_doggirl",
+      "iv_mutagen_doggirl",
+      "mutagen_cowgirl",
+      "iv_mutagen_cowgirl",
+      "mutagen_beargirl",
+      "iv_mutagen_beargirl",
+      "mutagen_mousegirl",
+      "iv_mutagen_mousegirl",
+      "mutagen_spidergirl",
+      "iv_mutagen_spidergirl",
+      "mutagen_harpy",
+      "iv_mutagen_harpy",
+      "mutagen_dryad",
+      "iv_mutagen_dryad",
+      "mutagen_slimegirl",
+      "iv_mutagen_slimegirl",
+      "mutagen_elf",
+      "iv_mutagen_elf",
+      "mutagen_kitsune",
+      "iv_mutagen_kitsune",
+      "mutagen_lamia",
+      "iv_mutagen_lamia",
+      "mutagen_bunnygirl",
+      "iv_mutagen_bunnygirl"
+    ]
+  },
+]

--- a/data/mods/Monster_Girls/nested.json
+++ b/data/mods/Monster_Girls/nested.json
@@ -1,5 +1,5 @@
 [
-    {
+  {
     "type": "nested_category",
     "id": "nested_mutagens_strains",
     "nested_name": "strain mutagens",
@@ -34,5 +34,5 @@
       "mutagen_bunnygirl",
       "iv_mutagen_bunnygirl"
     ]
-  },
+  }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)
Resolves #8562

## Describe the solution (The How)
Redefine with the new recipes

## Describe alternatives you've considered
Have anyone else fix these things

## Testing
Load tested
Debug all recipies
Nested looks fine

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.