### PR TITLE
fix: NPCs no longer segfault when using mutation granting items

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -915,8 +915,10 @@ void npc::move()
             if( elem->has_flag( flag_COMBAT_NPC_USE ) && elem->has_flag( flag_COMBAT_NPC_ON ) ) {
                 if( elem->get_use( "transform" ) ) {
                     invoke_item( elem, "transform" );
+                    recalculate_enchantment_cache();
                 } else if( elem->get_use( "set_transform" ) ) {
                     invoke_item( elem, "set_transform" );
+                    recalculate_enchantment_cache();
                 }
             }
         }
@@ -925,8 +927,10 @@ void npc::move()
             weapon.has_flag( flag_COMBAT_NPC_ON ) ) {
             if( weapon.get_use( "transform" ) ) {
                 invoke_item( &weapon, "transform" );
+                recalculate_enchantment_cache();
             } else if( weapon.get_use( "fireweapon_on" ) ) {
                 invoke_item( &weapon, "fireweapon_on" );
+                recalculate_enchantment_cache();
             }
         }
 


### PR DESCRIPTION
## Purpose of change (The Why)
fix: #8658

## Describe the solution (The How)
Kill enchantments on transform

## Describe alternatives you've considered
Scream

## Testing
Did thing chaos said crash
No crash

## Additional context
Weh

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.