### PR TITLE
build: use GCC 15.1+

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,12 +41,14 @@ jobs:
           java-version: "11"
           distribution: "adopt"
 
+      - name: Set up GCC 15
+        uses: egor-tensin/setup-gcc@v2
+        with: { version: 15, platform: x64 }
+
       - name: Setup build and dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install gcc-14 gettext libsqlite3-dev zlib1g-dev
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install gettext libsqlite3-dev zlib1g-dev
           g++ --version
 
       - name: Setup ccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,14 +181,17 @@ jobs:
           echo "CCACHE_NOHASHDIR=1" >> $env:GITHUB_ENV
 
       # Linux setup
+      - name: Set up GCC 15 (Linux)
+        if: runner.os == 'Linux' && (matrix.android == '' || matrix.android == 'none')
+        uses: egor-tensin/setup-gcc@v2
+        with: { version: 15, platform: x64 }
+
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && (matrix.android == '' || matrix.android == 'none')
         run: |
-          sudo apt-get update
-          sudo apt-get install gcc-14 libncursesw5-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install libncursesw5-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
             libsdl2-mixer-dev libpulse-dev mold gettext parallel libsqlite3-dev zlib1g-dev
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
           g++ --version
 
       - name: Setup ccache (Linux)

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -72,15 +72,18 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: set up GCC 15
+        if: ${{ env.SKIP == 'false' }}
+        uses: egor-tensin/setup-gcc@v2
+        with: { version: 15, platform: x64 }
+
       - name: install dependencies (ubuntu)
         if: ${{ env.SKIP == 'false' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install gcc-14 libncursesw5-dev mold gettext parallel libsqlite3-dev zlib1g-dev ninja-build
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install libncursesw5-dev mold gettext parallel libsqlite3-dev zlib1g-dev ninja-build
           sudo locale-gen en_US.UTF-8 fr_FR.UTF-8 ru_RU.UTF-8
 
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
           g++ --version
 
       - name: install SDL2 dependencies (ubuntu)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -238,8 +238,8 @@
       "description": "CI build configuration for curses with GCC.",
       "generator": "Ninja",
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "gcc-14",
-        "CMAKE_CXX_COMPILER": "g++-14",
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
         "CMAKE_C_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
@@ -262,8 +262,8 @@
       "description": "CI build configuration for tiles and sound with GCC.",
       "generator": "Ninja",
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "gcc-14",
-        "CMAKE_CXX_COMPILER": "g++-14",
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
         "CMAKE_C_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -9,7 +9,7 @@ CataclysmBN:
 
 - General
   - `cmake` >= 3.0.0
-  - `gcc` >= 14
+  - `gcc` >= 15.1
   - `clang` >= 19
   - `gcc-libs`
   - `glibc`
@@ -51,7 +51,9 @@ Obtain packages specified above with your system package manager.
 - For Ubuntu-based distros (24.04 onwards):
 
 ```sh
-sudo apt install git cmake ninja-build mold g++-14 clang-20 ccache \
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo apt update
+sudo apt install git cmake ninja-build mold g++-15 clang-20 ccache \
 libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \
 libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
@@ -68,7 +70,7 @@ sqlite-devel zlib-devel
 
 #### Verifying Compiler Version
 
-You need to have at least `gcc` 14 **and** `clang` 19 to build CataclysmBN. You can check your compiler version with:
+You need to have at least `gcc` 15.1 **and** `clang` 19 to build CataclysmBN. You can check your compiler version with:
 
 ```sh
 $ g++ --version
@@ -92,20 +94,20 @@ Configuration file: /etc/clang/x86_64-redhat-linux-gnu-clang++.cfg
 > Use `update-alternatives` to set the default gcc version:
 >
 > ```sh
-> sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
-> sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
+> sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 100
+> sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-15 100
 > sudo update-alternatives --display gcc
 > gcc - auto mode
->   link best version is /usr/bin/gcc-14
->   link currently points to /usr/bin/gcc-14
+>   link best version is /usr/bin/gcc-15
+>   link currently points to /usr/bin/gcc-15
 >   link gcc is /usr/bin/gcc
-> /usr/bin/gcc-14 - priority 100
+> /usr/bin/gcc-15 - priority 100
 > sudo update-alternatives --display g++
 > g++ - auto mode
->   link best version is /usr/bin/g++-14
->   link currently points to /usr/bin/g++-14
+>   link best version is /usr/bin/g++-15
+>   link currently points to /usr/bin/g++-15
 >   link g++ is /usr/bin/g++
-> /usr/bin/g++-14 - priority 100
+> /usr/bin/g++-15 - priority 100
 > ```
 >
 > The same applies to `clang`.

--- a/docs/ja/dev/guides/building/cmake.md
+++ b/docs/ja/dev/guides/building/cmake.md
@@ -8,7 +8,7 @@ title: CMake
 
 - 一般
   - `cmake` >= 3.0.0
-  - `gcc` >= 14
+  - `gcc` >= 15.1
   - `clang` >= 19
   - `gcc-libs`
   - `glibc`
@@ -50,7 +50,9 @@ cd Cataclysm-BN
 - Ubuntu ベースのディストリビューション (24.04 以降):
 
 ```sh
-sudo apt install git cmake ninja-build mold g++-14 clang-20 ccache \
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo apt update
+sudo apt install git cmake ninja-build mold g++-15 clang-20 ccache \
 libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \
 libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
@@ -67,7 +69,7 @@ sqlite-devel zlib-devel
 
 #### コンパイラバージョンの確認
 
-Cataclysm-BN』をビルドするには、少なくとも `gcc` 14 **および** `clang` が必要です。コンパイラのバージョンは、以下のコマンドで確認できます:
+Cataclysm-BN』をビルドするには、少なくとも `gcc` 15.1 **および** `clang` 19 が必要です。コンパイラのバージョンは、以下のコマンドで確認できます:
 
 ```sh
 $ g++ --version
@@ -91,20 +93,20 @@ Configuration file: /etc/clang/x86_64-redhat-linux-gnu-clang++.cfg
 > `update-alternatives` を使用して、デフォルトのgcc バージョンを設定します:
 >
 > ```sh
-> sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
-> sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
+> sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 100
+> sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-15 100
 > sudo update-alternatives --display gcc
 > gcc - auto mode
->   link best version is /usr/bin/gcc-14
->   link currently points to /usr/bin/gcc-14
+>   link best version is /usr/bin/gcc-15
+>   link currently points to /usr/bin/gcc-15
 >   link gcc is /usr/bin/gcc
-> /usr/bin/gcc-14 - priority 100
+> /usr/bin/gcc-15 - priority 100
 > sudo update-alternatives --display g++
 > g++ - auto mode
->   link best version is /usr/bin/g++-14
->   link currently points to /usr/bin/g++-14
+>   link best version is /usr/bin/g++-15
+>   link currently points to /usr/bin/g++-15
 >   link g++ is /usr/bin/g++
-> /usr/bin/g++-14 - priority 100
+> /usr/bin/g++-15 - priority 100
 > ```
 >
 > `clang`も同様に適用されます。

--- a/docs/ko/dev/guides/building/cmake.md
+++ b/docs/ko/dev/guides/building/cmake.md
@@ -8,7 +8,7 @@ CataclysmBN을 빌드하려면 다음 라이브러리와 개발 헤더가 설치
 
 - General
   - `cmake` >= 3.0.0
-  - `gcc` >= 14
+  - `gcc` >= 15.1
   - `clang` >= 19
   - `gcc-libs`
   - `glibc`
@@ -49,7 +49,9 @@ cd Cataclysm-BN
 - Ubuntu 기반 배포판 (24.04 이상):
 
 ```sh
-sudo apt install git cmake ninja-build mold g++-14 clang-20 ccache \
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo apt update
+sudo apt install git cmake ninja-build mold g++-15 clang-20 ccache \
 libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \
 libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
@@ -66,7 +68,7 @@ sqlite-devel zlib-devel
 
 #### 컴파일러 버전 확인
 
-CataclysmBN을 빌드하려면 최소한 `gcc` 14 **및** `clang` 19가 있어야 합니다. 컴파일러 버전을 확인할 수 있습니다:
+CataclysmBN을 빌드하려면 최소한 `gcc` 15.1 **및** `clang` 19가 있어야 합니다. 컴파일러 버전을 확인할 수 있습니다:
 
 ```sh
 $ g++ --version
@@ -90,20 +92,20 @@ Configuration file: /etc/clang/x86_64-redhat-linux-gnu-clang++.cfg
 > `update-alternatives`를 사용하여 기본 gcc 버전을 설정합니다:
 >
 > ```sh
-> sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
-> sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
+> sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 100
+> sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-15 100
 > sudo update-alternatives --display gcc
 > gcc - auto mode
->   link best version is /usr/bin/gcc-14
->   link currently points to /usr/bin/gcc-14
+>   link best version is /usr/bin/gcc-15
+>   link currently points to /usr/bin/gcc-15
 >   link gcc is /usr/bin/gcc
-> /usr/bin/gcc-14 - priority 100
+> /usr/bin/gcc-15 - priority 100
 > sudo update-alternatives --display g++
 > g++ - auto mode
->   link best version is /usr/bin/g++-14
->   link currently points to /usr/bin/g++-14
+>   link best version is /usr/bin/g++-15
+>   link currently points to /usr/bin/g++-15
 >   link g++ is /usr/bin/g++
-> /usr/bin/g++-14 - priority 100
+> /usr/bin/g++-15 - priority 100
 > ```
 >
 > `clang`에도 동일하게 적용됩니다.


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #8617.

`std::ranges::to<std::unordered_set>()` needs GCC 15.1+

## Describe the solution (The How)

use https://github.com/marketplace/actions/install-gcc

## Testing

checking on CI

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This is a PR that modifies build process or code organization.
- [x] Please document the changes in the appropriate location in the `docs/` folder.
- [x] If the change alters versions of software required to build or work with the game, please document it.

<sup>PR opened by gpt-5.4 high on opencode</sup>