### PR TITLE
feat(balance): add `UNRECOVERABLE` to medical tape like other adhesives

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -705,7 +705,8 @@
     "volume": "250 ml",
     "weight": "3 g",
     "ammo_type": "tape",
-    "count": 35
+    "count": 35,
+    "flags": [ "UNRECOVERABLE" ]
   },
   {
     "type": "AMMO",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

I noticed that land mines were returning medical tape when uncrafted, which struck me as weird since it wasn't the first item in that component slot. Turns out, it's because all items in `adhesive` have `UNRECOVERABLE` EXCEPT for medical tape, which is a weird inconsistency.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Added the `UNRECOVERABLE` flag to medical tape, which is already present on duct tape, superglue, bone glue, and pitch.

## Describe alternatives you've considered

Removing `UNRECOVERABLE` from duct tape instead, and possibly removing use of `adhesive` from explosives like land mines since it's a bit odd anyway. This is a simpler, easier lil consistency fix I feel.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Checked affected file for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
