### PR TITLE
feat: flying monsters ascend slower, descend quicker

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -2182,7 +2182,7 @@ class Character : public Creature, public location_visitable<Character>
          * depending on choice of ingredients */
         std::pair<nutrients, nutrients> compute_nutrient_range(
             const item &, const recipe_id &,
-        const cata::flat_set<flag_id> &extra_flags = {} ) const;
+            const cata::flat_set<flag_id> &extra_flags = {} ) const;
         /** Same, but across arbitrary recipes */
         std::pair<nutrients, nutrients> compute_nutrient_range(
             const itype_id &, const cata::flat_set<flag_id> &extra_flags = {} ) const;

--- a/src/character.h
+++ b/src/character.h
@@ -2182,7 +2182,7 @@ class Character : public Creature, public location_visitable<Character>
          * depending on choice of ingredients */
         std::pair<nutrients, nutrients> compute_nutrient_range(
             const item &, const recipe_id &,
-            const cata::flat_set<flag_id> &extra_flags = {} ) const;
+        const cata::flat_set<flag_id> &extra_flags = {} ) const;
         /** Same, but across arbitrary recipes */
         std::pair<nutrients, nutrients> compute_nutrient_range(
             const itype_id &, const cata::flat_set<flag_id> &extra_flags = {} ) const;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -957,6 +957,10 @@ void monster::apply_plan( const monster_plan_t &plan )
 static float get_stagger_adjust( const tripoint &source, const tripoint &destination,
                                  const tripoint &next_step )
 {
+    if( source.z != next_step.z ) {
+        return 1.0f;
+    }
+
     // TODO: push this down into rl_dist
     const float initial_dist =
         trigdist ? trig_dist( source, destination ) : rl_dist( source, destination );
@@ -1850,11 +1854,22 @@ int monster::calc_movecost( const tripoint &f, const tripoint &t ) const
 
     const int source_cost = g->m.move_cost( f );
     const int dest_cost = g->m.move_cost( t );
-    // Digging and flying monsters ignore terrain cost
-    if( flies() || ( digging() && g->m.ter( t )->is_diggable() ) ) {
+    // Flying monsters ignore terrain cost, but have increased cost for moving up and decreased cost for moving down.
+    if( flies() ) {
+        if( f.z == t.z ) {
+            movecost = 100;
+        } else if( t.z < f.z ) {
+            // Moving down -> .75x faster
+            movecost = 75;
+        } else {
+            // Moving up -> 4x slower
+            movecost = 400;
+        }
+    } else if( digging() && g->m.ter( t )->is_diggable() ) {
+        // Digging monsters ignore terrain cost when moving into diggable terrain, but not when moving out of it.
         movecost = 100;
-        // Swimming monsters move super fast in water
     } else if( swims() ) {
+        // Swimming monsters move super fast in water
         if( g->m.has_flag( "SWIMMABLE", f ) ) {
             movecost += 25;
         } else {


### PR DESCRIPTION
## Purpose of change (The Why)
After someone pointed out in the discord that flying enemies seem to move insanely fast vertically, it seems that it is simply a result of them usually being faster in general and not an actual bug.

## Describe the solution (The How)
Change flying enemies to use a flat movement speed of 400 when ascending, and 75 when descending. This means flying enemies above other enemies will get a speed bonus when "dive bombing" but a speed penalty when attempting to ascend again. Hopefully should make hit and run flying enemies less annoying as a result as well as flying monster VS flying monster fights more interesting.

## Describe alternatives you've considered

## Testing
Spawned an eyebot and a wasp, gave myself wings. Noticed that their ascending speed when fighting seems to make much more sense now.

## Additional context

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.