### PR TITLE
feat(balance): reduce ammo belt link weight and crafting cost

### DIFF
--- a/data/json/items/ammo/tankammo.json
+++ b/data/json/items/ammo/tankammo.json
@@ -25,8 +25,8 @@
     "copy-from": "ammolink",
     "type": "GENERIC",
     "name": { "str": "25x137mm autocannon belt linkage" },
-    "weight": "6 g",
-    "volume": "10ml",
+    "weight": "20 g",
+    "volume": "20 ml",
     "stackable": true,
     "use_action": { "type": "ammobelt", "belt": "belt25mm" }
   },

--- a/data/json/items/generic/ammolink.json
+++ b/data/json/items/generic/ammolink.json
@@ -25,6 +25,8 @@
     "copy-from": "ammolink",
     "type": "GENERIC",
     "name": { "str": "7.62x51mm ammo belt linkage" },
+    "weight": "4 g",
+    "volume": "4 ml",
     "use_action": { "type": "ammobelt", "belt": "belt308" }
   },
   {
@@ -32,8 +34,8 @@
     "copy-from": "ammolink",
     "type": "GENERIC",
     "name": { "str": "40mm grenade belt linkage" },
-    "weight": "10 g",
-    "volume": "10 ml",
+    "weight": "20 g",
+    "volume": "20 ml",
     "use_action": { "type": "ammobelt", "belt": "belt40mm" }
   },
   {
@@ -41,6 +43,8 @@
     "copy-from": "ammolink",
     "type": "GENERIC",
     "name": { "str": ".50 ammo belt linkage" },
+    "weight": "10 g",
+    "volume": "10 ml",
     "use_action": { "type": "ammobelt", "belt": "belt50" }
   }
 ]

--- a/data/json/recipes/weapon/magazines.json
+++ b/data/json/recipes/weapon/magazines.json
@@ -417,56 +417,53 @@
   {
     "type": "recipe",
     "result": "ammolink223",
-    "byproducts": [ [ "scrap", 50 ] ],
-    "charges": 10,
+    "charges": 25,
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_MAGAZINES",
     "skill_used": "fabrication",
     "difficulty": 4,
     "skills_required": [ "gun", 1 ],
-    "time": "20 m",
+    "time": "30 m",
     "batch_time_factors": [ 50, 3 ],
     "autolearn": [ [ "fabrication", 5 ], [ "gun", 2 ] ],
     "book_learn": [ [ "manual_rifle", 3 ], [ "recipe_bullets", 3 ] ],
     "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
-    "using": [ [ "forging_standard", 3 ] ],
-    "components": [ [ [ "sheet_metal", 1 ], [ "sheet_metal_small", 24 ] ] ]
+    "using": [ [ "forging_standard", 1 ] ],
+    "components": [ [ [ "scrap", 1 ] ] ]
   },
   {
     "type": "recipe",
     "result": "ammolink308",
-    "byproducts": [ [ "scrap", 50 ] ],
-    "charges": 10,
+    "charges": 25,
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_MAGAZINES",
     "skill_used": "fabrication",
     "difficulty": 4,
     "skills_required": [ "gun", 1 ],
-    "time": "20 m",
+    "time": "30 m",
     "batch_time_factors": [ 50, 3 ],
     "autolearn": [ [ "fabrication", 5 ], [ "gun", 2 ] ],
     "book_learn": [ [ "manual_rifle", 3 ], [ "recipe_bullets", 3 ] ],
     "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
-    "using": [ [ "forging_standard", 3 ] ],
-    "components": [ [ [ "sheet_metal", 1 ], [ "sheet_metal_small", 24 ] ] ]
+    "using": [ [ "forging_standard", 2 ] ],
+    "components": [ [ [ "scrap", 2 ] ] ]
   },
   {
     "type": "recipe",
     "result": "ammolink50",
-    "byproducts": [ [ "scrap", 50 ] ],
-    "charges": 10,
+    "charges": 25,
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_MAGAZINES",
     "skill_used": "fabrication",
     "difficulty": 4,
     "skills_required": [ "gun", 2 ],
-    "time": "20 m",
+    "time": "45 m",
     "batch_time_factors": [ 50, 3 ],
     "autolearn": [ [ "fabrication", 5 ], [ "gun", 2 ] ],
     "book_learn": [ [ "manual_rifle", 3 ], [ "recipe_bullets", 3 ] ],
     "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
-    "using": [ [ "forging_standard", 3 ] ],
-    "components": [ [ [ "sheet_metal", 1 ], [ "sheet_metal_small", 24 ] ] ]
+    "using": [ [ "forging_standard", 5 ] ],
+    "components": [ [ [ "scrap", 5 ], [ "sheet_metal_small", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -478,13 +475,13 @@
     "skill_used": "fabrication",
     "difficulty": 4,
     "skills_required": [ "gun", 2 ],
-    "time": "25 m",
+    "time": "60 m",
     "batch_time_factors": [ 50, 3 ],
     "autolearn": [ [ "fabrication", 6 ], [ "gun", 2 ] ],
     "book_learn": [ [ "recipe_bullets", 4 ] ],
     "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
-    "using": [ [ "forging_standard", 4 ] ],
-    "components": [ [ [ "sheet_metal", 2 ], [ "sheet_metal_small", 48 ] ] ]
+    "using": [ [ "forging_standard", 10 ] ],
+    "components": [ [ [ "scrap", 10 ], [ "sheet_metal_small", 2 ] ] ]
   },
   {
     "result": "nailmag",
@@ -1687,18 +1684,18 @@
   {
     "type": "recipe",
     "result": "ammolink25mm",
-    "charges": 10,
+    "charges": 25,
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_MAGAZINES",
     "skill_used": "fabrication",
     "difficulty": 4,
     "skills_required": [ "gun", 2 ],
-    "time": "25 m",
+    "time": "60 m",
     "batch_time_factors": [ 50, 3 ],
     "autolearn": [ [ "fabrication", 6 ], [ "gun", 2 ] ],
     "book_learn": [ [ "textbook_launcher", 4 ], [ "recipe_bullets", 4 ] ],
-    "using": [ [ "forging_standard", 4 ] ],
+    "using": [ [ "forging_standard", 10 ] ],
     "qualities": [ { "id": "SWAGING", "level": 1 }, { "id": "GRIP_HOT", "level": 2 } ],
-    "components": [ [ [ "sheet_metal", 2 ], [ "sheet_metal_small", 48 ] ] ]
+    "components": [ [ [ "scrap", 10 ], [ "sheet_metal_small", 2 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Why in the fuck does it take 6 kilograms of small metal sheet to make 20 grams of ammo link AAAAAAAAAAAAAAAA

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Sanity-checked recipes for ammo links a bit, set to use scrap metal and produce batches of 25 at a time, in exchange for increasing time required to 30-60 minutes depending on the item. 5.56mm ammo links require only 1 scrap metal, 7.62x51mm ammo links require 2 scrap metal, .50 ammo links 5 scrap metal or 1 small metal sheet, 40mm and 25mm links 10 scrap metal or 2 small metal sheets.
2. As the above implies, tweaked weights of ammo links a bit. Increased 7.62 ammo link to 4 grams, .50 links to 10 grams, 25mm links to and 40mm and 25mm links to 20 grams.

## Describe alternatives you've considered

Going the fuck to sleep, it's like 6:40 AM at the moment.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported to playthrough build and load-tested.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
