### PR TITLE
feat: make nuclear reactor cores salvageable

### DIFF
--- a/data/json/deconstruction.json
+++ b/data/json/deconstruction.json
@@ -862,6 +862,20 @@
   },
   {
     "type": "construction",
+    "id": "constr_salvage_nuclear_reactor",
+    "//": "Salvages usable compact reactor hardware from a large nuclear reactor core.",
+    "category": "OTHER",
+    "required_skills": [ [ "fabrication", 6 ], [ "electronics", 8 ], [ "mechanics", 6 ] ],
+    "time": "8 h",
+    "using": [ [ "advanced_electronics_high_voltage", 1 ], [ "metal_removal_standard", 1 ], [ "welding_standard", 12 ] ],
+    "pre_terrain": "t_nuclear_reactor",
+    "pre_special": "check_deconstruct",
+    "post_flags": [ "keep_items" ],
+    "post_special": "done_deconstruct",
+    "group": "advanced_object_deconstruction"
+  },
+  {
+    "type": "construction",
     "id": "constr_remove_grid_plut_generator",
     "//": "Removes a Plut Gen from grid.",
     "category": "OTHER",

--- a/data/json/furniture_and_terrain/terrain-mechanisms.json
+++ b/data/json/furniture_and_terrain/terrain-mechanisms.json
@@ -633,6 +633,26 @@
     "symbol": "R",
     "color": "light_green",
     "move_cost": 0,
-    "flags": [ "TRANSPARENT", "CONTAINER", "REDUCE_SCENT", "PERMEABLE", "PLACE_ITEM" ]
+    "flags": [ "TRANSPARENT", "CONTAINER", "REDUCE_SCENT", "PERMEABLE", "PLACE_ITEM", "ADV_DECONSTRUCT" ],
+    "deconstruct": {
+      "ter_set": "t_concrete",
+      "items": [
+        { "item": "compact_reactor_assembly", "count": 2 },
+        { "item": "alloy_plate", "count": [ 4, 6 ] },
+        { "item": "plut_cell", "charges": [ 24, 32 ] },
+        { "item": "lead", "charges": [ 250, 400 ] },
+        { "item": "cable", "charges": [ 60, 90 ] },
+        { "item": "power_supply", "count": [ 16, 20 ] },
+        { "item": "circuit", "count": [ 22, 28 ] },
+        { "item": "amplifier", "count": [ 10, 14 ] },
+        { "item": "RAM", "count": 8 },
+        { "item": "small_lcd_screen", "count": 4 },
+        { "item": "large_lcd_screen", "count": 1 },
+        { "item": "e_scrap", "count": 24 },
+        { "item": "scrap", "count": [ 48, 80 ] },
+        { "item": "steel_lump", "count": [ 20, 35 ] },
+        { "item": "steel_chunk", "count": [ 30, 50 ] }
+      ]
+    }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -2199,7 +2199,27 @@
     "symbol": "R",
     "color": "light_green",
     "move_cost": 0,
-    "flags": [ "TRANSPARENT", "CONTAINER", "REDUCE_SCENT", "PERMEABLE", "PLACE_ITEM" ]
+    "flags": [ "TRANSPARENT", "CONTAINER", "REDUCE_SCENT", "PERMEABLE", "PLACE_ITEM", "ADV_DECONSTRUCT" ],
+    "deconstruct": {
+      "ter_set": "t_concrete",
+      "items": [
+        { "item": "compact_reactor_assembly", "count": 2 },
+        { "item": "alloy_plate", "count": [ 4, 6 ] },
+        { "item": "plut_cell", "charges": [ 24, 32 ] },
+        { "item": "lead", "charges": [ 250, 400 ] },
+        { "item": "cable", "charges": [ 60, 90 ] },
+        { "item": "power_supply", "count": [ 16, 20 ] },
+        { "item": "circuit", "count": [ 22, 28 ] },
+        { "item": "amplifier", "count": [ 10, 14 ] },
+        { "item": "RAM", "count": 8 },
+        { "item": "small_lcd_screen", "count": 4 },
+        { "item": "large_lcd_screen", "count": 1 },
+        { "item": "e_scrap", "count": 24 },
+        { "item": "scrap", "count": [ 48, 80 ] },
+        { "item": "steel_lump", "count": [ 20, 35 ] },
+        { "item": "steel_chunk", "count": [ 30, 50 ] }
+      ]
+    }
   },
   {
     "type": "terrain",

--- a/data/json/items/vehicle/utilities.json
+++ b/data/json/items/vehicle/utilities.json
@@ -35,6 +35,22 @@
   },
   {
     "type": "GENERIC",
+    "id": "compact_reactor_assembly",
+    "name": { "str": "compact reactor assembly" },
+    "description": "A heavily shielded, vehicle-sized reactor package salvaged from a much larger nuclear core.  With enough supporting electronics and fuel, it could become the heart of a minireactor or plutonium generator.",
+    "weight": "38 kg",
+    "to_hit": -4,
+    "color": "light_cyan",
+    "symbol": ":",
+    "material": [ "superalloy", "ceramic", "lead" ],
+    "volume": "60 L",
+    "bashing": 6,
+    "category": "veh_parts",
+    "price": "2 kUSD",
+    "price_postapoc": "100 USD"
+  },
+  {
+    "type": "GENERIC",
     "id": "mountable_cooler",
     "name": { "str": "vehicle cooler" },
     "description": "A vehicle-mounted area cooler.",

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -620,6 +620,32 @@
     ]
   },
   {
+    "type": "recipe",
+    "result": "plut_generator_item",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "electronics",
+    "skills_required": [ [ "mechanics", 7 ], [ "fabrication", 5 ] ],
+    "difficulty": 8,
+    "time": "10 h",
+    "book_learn": [ [ "recipe_lab_elec", 8 ], [ "recipe_mil_augs", 8 ], [ "textbook_robots", 8 ] ],
+    "using": [ [ "advanced_electronics_high_voltage", 1 ], [ "welding_standard", 28 ], [ "soldering_standard", 80 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [
+      [ [ "minireactor", 1 ] ],
+      [ [ "RAM", 8 ] ],
+      [ [ "cable", 16 ] ],
+      [ [ "small_lcd_screen", 4 ] ],
+      [ [ "large_lcd_screen", 1 ] ],
+      [ [ "e_scrap", 24 ] ],
+      [ [ "circuit", 10 ] ],
+      [ [ "power_supply", 8 ] ],
+      [ [ "amplifier", 6 ] ],
+      [ [ "plut_cell", 8 ] ],
+      [ [ "scrap", 16 ] ]
+    ]
+  },
+  {
     "type": "uncraft",
     "result": "plut_generator_item",
     "skill_used": "electronics",

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -49,6 +49,29 @@
   },
   {
     "type": "recipe",
+    "result": "minireactor",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "electronics",
+    "skills_required": [ [ "mechanics", 6 ], [ "fabrication", 5 ] ],
+    "difficulty": 8,
+    "time": "8 h",
+    "book_learn": [ [ "recipe_lab_elec", 8 ], [ "recipe_mil_augs", 8 ], [ "textbook_robots", 8 ] ],
+    "using": [ [ "advanced_electronics_high_voltage", 1 ], [ "welding_standard", 20 ], [ "soldering_standard", 60 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [
+      [ [ "compact_reactor_assembly", 1 ] ],
+      [ [ "plut_cell", 8 ] ],
+      [ [ "alloy_plate", 2 ] ],
+      [ [ "power_supply", 4 ] ],
+      [ [ "circuit", 6 ] ],
+      [ [ "amplifier", 2 ] ],
+      [ [ "cable", 20 ] ],
+      [ [ "scrap", 16 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "result": "embryo_empty",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_OTHER",

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -61,7 +61,6 @@
     "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 }, { "id": "SAW_M", "level": 2 } ],
     "components": [
       [ [ "compact_reactor_assembly", 1 ] ],
-      [ [ "plut_cell", 8 ] ],
       [ [ "alloy_plate", 2 ] ],
       [ [ "power_supply", 4 ] ],
       [ [ "circuit", 6 ] ],


### PR DESCRIPTION
## Purpose of change (The Why)

Nuclear reactor cores are currently decorative terrain. This gives them a late-game salvage use tied to vehicle-scale nuclear power.

## Describe the solution (The How)

- Adds compact reactor assemblies salvaged from nuclear reactor cores.
- Allows advanced deconstruction of nuclear reactor cores for enough reactor hardware and electronics to build a vehicle minireactor and plutonium generator.
- Adds high-skill recipes for `minireactor` and `plut_generator_item`.

## Describe alternatives you've considered

Dropping completed minireactors or plutonium generators directly was considered, but crafting keeps the payoff gated by skills and tools.

## Testing

- Ran `./build-scripts/lint-json.sh`.

## Additional context

Idea source: https://gall.dcinside.com/board/view/?id=rlike&no=516552&page=1

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [ ] I ran the code formatter. The commit hook could not find `json_formatter` in this worktree.
- [x] I linked relevant context in the PR body.
