### PR TITLE
fix: stop projectiles at map edge

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -476,6 +476,12 @@ auto projectile_attack( const projectile &proj_arg, const tripoint &source,
         prev_point = tp;
         tp = trajectory[i];
 
+        if( !here.inbounds( tp ) ) {
+            traj_len = i;
+            tp = prev_point;
+            break;
+        }
+
         if( tp.z != prev_point.z ) {
             tripoint floor1 = prev_point;
             tripoint floor2 = tp;

--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -83,6 +83,40 @@ TEST_CASE( "projectiles_through_obstacles", "[projectile]" )
     CHECK( projectile_end_point( range, *gun_penetrating, 3 ) == range[0] );
 }
 
+TEST_CASE( "projectiles_stop_at_reality_bubble_edge", "[projectile][ballistics]" )
+{
+    clear_all_state();
+
+    auto &here = get_map();
+    const auto shooter_pos = tripoint( 2, 2, 0 );
+    const auto target_pos = tripoint( -1, 2, 0 );
+    const auto clear_points = std::vector<tripoint> { shooter_pos, tripoint( 1, 2, 0 ), tripoint( 0, 2, 0 ) };
+
+    for( const auto &pt : clear_points ) {
+        REQUIRE( here.inbounds( pt ) );
+        here.ter_set( pt, ter_id( "t_dirt" ) );
+        here.furn_set( pt, furn_id( "f_null" ) );
+    }
+
+    auto &shooter = get_avatar();
+    shooter.setpos( shooter_pos );
+    shooter.set_body();
+
+    auto gun_ptr = item::spawn( itype_id( "m1a" ) );
+    gun_ptr->ammo_set( itype_id( "308" ), 1 );
+    auto &gun = *gun_ptr;
+
+    auto test_proj = projectile {};
+    test_proj.speed = gun.gun_speed();
+    test_proj.range = 20;
+    test_proj.impact = gun.gun_damage();
+
+    const auto attack = projectile_attack(
+                            test_proj, shooter_pos, target_pos, dispersion_sources {}, &shooter, &gun );
+
+    CHECK( here.inbounds( attack.end_point ) );
+}
+
 TEST_CASE( "adjacent_friendly_fire_prevention", "[projectile][ballistics]" )
 {
     clear_all_state();

--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -308,14 +308,15 @@ TEST_CASE( "monster_adjacent_ally_fire_prevention", "[projectile][ballistics]" )
     clear_all_state();
     map &here = get_map();
 
-    // Set up test area: monster shooter at (0,0), allied monster at (1,0), target at (5,0)
-    const auto shooter_pos = tripoint_zero;
-    const auto ally_pos = tripoint_east;
-    const auto target_pos = tripoint( 5, 0, 0 );
+    // Set up test area away from the map edge: monster shooter at (50,60),
+    // allied monster at (51,60), target at (55,60).
+    const auto shooter_pos = tripoint( 50, 60, 0 );
+    const auto ally_pos = tripoint( 51, 60, 0 );
+    const auto target_pos = tripoint( 55, 60, 0 );
 
     // Clear the area
-    for( int x = 0; x <= 5; ++x ) {
-        auto pt = tripoint( x, 0, 0 );
+    for( int x = 50; x <= 55; ++x ) {
+        auto pt = tripoint( x, 60, 0 );
         REQUIRE( here.inbounds( pt ) );
         here.ter_set( pt, ter_id( "t_dirt" ) );
         here.furn_set( pt, furn_id( "f_null" ) );


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #8707.

Projectiles can continue past the currently loaded map/reality-bubble edge and pass out-of-bounds positions into map caches, causing crashes during monster ranged attacks.

## Describe the solution (The How)

Stop projectile map interaction at the first out-of-bounds trajectory point and keep the end point on the last valid tile.

This is a crash fix for the current loaded-map simulation model. It does not add support for weapons to simulate hits beyond the loaded map. Supporting extreme-range weapons independently of reality bubble size would require absolute-coordinate projectile tracing plus loading/simulating intermediate or target submaps.

## Describe alternatives you've considered

Guarding individual map cache readers would leave other projectile effects able to process out-of-bounds positions.

Supporting projectile simulation outside the loaded map would be a larger feature/refactor involving submap loading, terrain/vehicle/creature collision, effects, explosions, and performance concerns.

## Testing

- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "projectiles_stop_at_reality_bubble_edge"`
- ASAN reproduction without the fix: `heap-buffer-overflow` in `map::light_transparency` via `map::shoot` and `projectile_attack`
- ASAN after the fix: `ASAN_OPTIONS=halt_on_error=1:abort_on_error=1 ./out/build/linux-asan/tests/cata_test-tiles "projectiles_stop_at_reality_bubble_edge"`
- `cmake --build --preset linux-full --target astyle`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sup>PR opened by gpt-5.4 high on pi</sup>
