### PR TITLE
feat(balance): reduce fun value of broth and bone broth to be lower than most soups

### DIFF
--- a/data/json/items/comestibles/soup.json
+++ b/data/json/items/comestibles/soup.json
@@ -19,7 +19,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT" ],
-    "fun": 4,
+    "fun": 2,
     "vitamins": [ [ "iron", 3 ], [ "veggy_allergen", 1 ] ]
   },
   {
@@ -44,7 +44,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE", "NO_SALVAGE" ],
-    "fun": 6,
+    "fun": 3,
     "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ], [ "meat_allergen", 1 ] ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Broth was more fun to sippy than the soupy.

Closes https://github.com/cataclysmbn/Cataclysm-BN/issues/8716

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Per suggestion, lowered fun value of bone broth and broth-type broth to 3 and 2 respectively.

## Describe alternatives you've considered

I decided to leave fun values of soup untouched, since that struck me as more subjective than just making it consistent to have plain broth be less fun that stuff made from it. Plus then I'd have to ponder whether to buff curry with meat and clam chowder even more since they're already at 5, plus what to do with other outliers like blood soup (1 fun), mushroom soup or tomato soup (3 for both).

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

4 is a higher number than 3 and 2. :D

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="900" height="196" alt="image" src="https://github.com/user-attachments/assets/4dbd51ba-18fa-4a77-8764-59cbcc5cebc6" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
