### PR TITLE
feat: add recipe for ear plugs

### DIFF
--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1546,6 +1546,18 @@
     "components": [ [ [ "scrap_bronze", 7 ] ], [ [ "fabric_hides_proper", 4, "LIST" ] ] ]
   },
   {
+    "result": "ear_plugs",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "10 m",
+    "autolearn": true,
+    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 15, "LIST" ] ] ],
+    "components": [ [ [ "chunk_rubber", 1 ], [ "wax", 1 ] ] ]
+  },
+  {
     "result": "attached_ear_plugs_off",
     "type": "recipe",
     "category": "CC_ARMOR",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Smol idea I mused upon in alternatives section of https://github.com/cataclysmbn/Cataclysm-BN/pull/8720

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Adds a recipe for ear plugs, making them from 1 chunk of rubber or wax. Uses basic surface heating and a plastic mold, along with fabrication 1 (compare noise-canceling headgear taking 1 tailoring).

## Describe alternatives you've considered

Adding a dedicated improvised version for making them out of wax instead. Not really important unless level of deafness starts mattering.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Checked affected file for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
