### PR TITLE
fix: metal wings use steel to repair

### DIFF
--- a/data/json/vehicleparts/wings.json
+++ b/data/json/vehicleparts/wings.json
@@ -27,7 +27,7 @@
       "repair": {
         "skills": [ [ "mechanics", 5 ] ],
         "time": "10 m",
-        "using": [ [ "welding_standard", 5 ], [ "vehicle_repair_aluminium", 1 ] ]
+        "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ]
       }
     },
     "flags": [ "WING", "SHOCK_RESISTANT" ],

--- a/data/json/vehicleparts/wings.json
+++ b/data/json/vehicleparts/wings.json
@@ -24,11 +24,7 @@
     "requirements": {
       "install": { "skills": [ [ "mechanics", 4 ] ], "time": "40 m", "using": [ [ "welding_standard", 20 ] ] },
       "removal": { "skills": [ [ "mechanics", 4 ] ], "qualities": [ { "id": "SAW_M", "level": 1 } ] },
-      "repair": {
-        "skills": [ [ "mechanics", 5 ] ],
-        "time": "10 m",
-        "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ]
-      }
+      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
     },
     "flags": [ "WING", "SHOCK_RESISTANT" ],
     "damage_reduction": { "all": 28 }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Metal wings are made from steel foldable frames (or pipes) and sheet metal, but for some reason I derped when adding them and they use aluminum to repair.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Changed metal wings from using `vehicle_repair_aluminium` for repairs to `steel_tiny`.

## Describe alternatives you've considered

Adding aluminum wings while I'm at it?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Used my fucking eyes for once.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Behold! Aluminumiumium I guess, according to Past Me.

<img width="459" height="91" alt="image" src="https://github.com/user-attachments/assets/09acec6b-21b6-4380-8a67-66662cc98e31" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
