### PR TITLE
feat(balance): buff feral black ops and guarantee hover vehicle in blacksite

### DIFF
--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -844,7 +844,7 @@
     "vision_night": 20,
     "path_settings": { "max_dist": 40, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "emit_fields": [ { "emit_id": "emit_shadow_field_darkfield", "delay": "1 s" } ],
-    "starting_ammo": { "5x50dart": 100 },
+    "starting_ammo": { "5x50dart": 200 },
     "special_attacks": [
       [ "PARROT_AT_DANGER", 0 ],
       {
@@ -856,9 +856,9 @@
         "fake_skills": [ [ "gun", 8 ], [ "smg", 8 ] ],
         "fake_dex": 10,
         "fake_per": 10,
-        "ranges": [ [ 0, 30, "SINGLE" ] ],
+        "ranges": [ [ 0, 5, "AUTO" ], [ 5, 30, "SINGLE" ] ],
         "require_targeting_player": false,
-        "description": "The feral black-ops fires their smg!",
+        "description": "The feral black-ops fires their SPIW!",
         "no_crits": true
       }
     ],
@@ -911,7 +911,6 @@
     "dodge": 8,
     "harvest": "CBM_OP_BOSS_FERAL",
     "vision_night": 20,
-    "path_settings": { "max_dist": 40, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "emit_fields": [ { "emit_id": "emit_shadow_field_darkfield", "delay": "1 s" } ],
     "special_attacks": [ [ "PARROT_AT_DANGER", 0 ], [ "BIO_OP_BIOJUTSU", 10 ] ],
     "special_when_hit": [ "ZAPBACK", 75 ],
@@ -1039,7 +1038,7 @@
     "vision_night": 30,
     "path_settings": { "max_dist": 40, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "emit_fields": [ { "emit_id": "emit_shadow_field_darkfield", "delay": "1 s" } ],
-    "starting_ammo": { "8mm_caseless": 25 },
+    "starting_ammo": { "8mm_hvp": 50 },
     "special_attacks": [
       [ "PARROT_AT_DANGER", 0 ],
       {
@@ -1047,7 +1046,7 @@
         "cooldown": 60,
         "move_cost": 200,
         "gun_type": "rm11b_sniper_rifle",
-        "ammo_type": "8mm_caseless",
+        "ammo_type": "8mm_hvp",
         "fake_skills": [ [ "gun", 10 ], [ "rifle", 10 ] ],
         "fake_dex": 10,
         "fake_per": 12,

--- a/data/json/overmap/overmap_special/mil_blacksite_multitile.json
+++ b/data/json/overmap/overmap_special/mil_blacksite_multitile.json
@@ -442,7 +442,7 @@
       ],
       "place_vehicles": [
         { "vehicle": "experimental_military_vehicles", "x": 20, "y": 15, "chance": 100, "rotation": 90, "status": 0 },
-        { "vehicle": "experimental_military_vehicles", "x": 51, "y": 15, "chance": 100, "rotation": 90, "status": 0 }
+        { "vehicle": "hover_military_vehicles", "x": 51, "y": 15, "chance": 100, "rotation": 90, "status": 0 }
       ],
       "mapping": {
         "r": { "items": [ { "item": "supplies_mechanics_milspec", "chance": 25 }, { "item": "mil_food_nodrugs", "chance": 25 } ] }
@@ -493,7 +493,6 @@
     "sym": "M",
     "color": "dark_gray",
     "see_cost": 5,
-    "extras": "build",
     "mondensity": 2
   }
 ]

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -490,6 +490,11 @@
     "type": "vehicle_group",
     "id": "experimental_military_vehicles",
     "vehicles": [ [ "tank_xm7_elec", 50 ], [ "tank_xm_hover", 30 ], [ "xapc_hover", 40 ] ]
+  },  
+  {
+    "type": "vehicle_group",
+    "id": "hover_military_vehicles",
+    "vehicles": [ [ "tank_xm_hover", 30 ], [ "xapc_hover", 40 ] ]
   },
   {
     "type": "vehicle_group",

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -490,7 +490,7 @@
     "type": "vehicle_group",
     "id": "experimental_military_vehicles",
     "vehicles": [ [ "tank_xm7_elec", 50 ], [ "tank_xm_hover", 30 ], [ "xapc_hover", 40 ] ]
-  },  
+  },
   {
     "type": "vehicle_group",
     "id": "hover_military_vehicles",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
After further playtesting, the feral black ops are underwhelming when using heavy power armor. Also, it's really lame to do the blacksite and not even get a hover vehicle.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Buffs the feral blackops: lets the commander full auto at close range, make the bioop much more aggressive, the sniper shoots hvp instead of normal caseless. Adds a dedicated hover vehicle group and makes it so that one of the spawned vehicles in the blacksite will always be a hover vehicle
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Really underwhelming boss fight and reward

## Testing
Debug spawned and teleported, everything looks correct
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.