### PR TITLE
feat: add tileset sprite editor and mask composition

### DIFF
--- a/docs/en/dev/reference/tileset_web_tool.md
+++ b/docs/en/dev/reference/tileset_web_tool.md
@@ -22,6 +22,23 @@ Use this page to compose/decompose a **small tileset** directly in your browser.
     <button id="tileset-download" type="button" disabled>Download ZIP</button>
   </p>
   <pre id="tileset-log" style="white-space: pre-wrap; max-height: 22rem; overflow: auto;"></pre>
+  <hr />
+  <p>
+    <label>
+      PNG:
+      <input id="sprite-editor-input" type="file" accept="image/png" />
+    </label>
+  </p>
+  <p>
+    <label>W <input id="sprite-editor-width" type="number" min="1" max="256" value="16" /></label>
+    <label>H <input id="sprite-editor-height" type="number" min="1" max="256" value="16" /></label>
+    <button id="sprite-editor-new" type="button">New</button>
+    <label><input id="sprite-editor-color" type="color" value="#ffffff" /></label>
+    <label><input type="radio" name="sprite-editor-tool" value="pen" checked /> Pen</label>
+    <label><input type="radio" name="sprite-editor-tool" value="erase" /> Erase</label>
+    <button id="sprite-editor-download" type="button">Download PNG</button>
+  </p>
+  <canvas id="sprite-editor-canvas" style="image-rendering: pixelated; touch-action: none;"></canvas>
 </div>
 
 <script type="module" src="/tools/tileset_web_tool.js"></script>

--- a/docs/tools/tileset_web_tool.js
+++ b/docs/tools/tileset_web_tool.js
@@ -197,6 +197,23 @@ const convertTileEntry = (entry, prefix, context) => {
     }
   }
 
+  if (Array.isArray(converted.masks)) {
+    converted.masks = converted.masks.map((mask) => {
+      const convertedMask = structuredClone(mask)
+      if (convertedMask.fg) {
+        convertedMask.fg = listOrFirst(convertLayer(convertedMask.fg, context))
+      } else {
+        delete convertedMask.fg
+      }
+      if (convertedMask.bg) {
+        convertedMask.bg = listOrFirst(convertLayer(convertedMask.bg, context))
+      } else {
+        delete convertedMask.bg
+      }
+      return convertedMask
+    })
+  }
+
   const additionalTiles = Array.isArray(converted.additional_tiles)
     ? converted.additional_tiles
     : []
@@ -449,9 +466,30 @@ const convertEntryToNames = (entry, indexToName) => {
     delete converted.bg
   }
 
+  if (Array.isArray(converted.masks)) {
+    converted.masks = converted.masks
+      .map((mask) => {
+        const convertedMask = structuredClone(mask)
+        const maskFg = convertLayerToNames(convertedMask.fg, indexToName)
+        const maskBg = convertLayerToNames(convertedMask.bg, indexToName)
+        if (maskFg.length > 0) {
+          convertedMask.fg = listOrFirst(maskFg)
+        } else {
+          delete convertedMask.fg
+        }
+        if (maskBg.length > 0) {
+          convertedMask.bg = listOrFirst(maskBg)
+        } else {
+          delete convertedMask.bg
+        }
+        return maskFg.length > 0 || maskBg.length > 0 ? convertedMask : null
+      })
+      .filter(Boolean)
+  }
+
   if (Array.isArray(converted.additional_tiles)) {
     converted.additional_tiles = converted.additional_tiles
-      .map((additional) => convertEntryToNames(additional, indexToName))
+      .map((additional) => convertEntryToNames(additional, indexToName)[1])
       .filter(Boolean)
   }
 
@@ -503,17 +541,27 @@ const decomposeSmallTileset = async (files) => {
 
   const safeId = (value) => String(value ?? "tile").replaceAll("/", "_")
 
-  for (const entry of composeSheet.tiles) {
-    const indices = new Set()
+  const collectEntryIndices = (entry, indices) => {
     collectIndicesFromLayer(entry.fg, indices)
     collectIndicesFromLayer(entry.bg, indices)
 
-    if (Array.isArray(entry.additional_tiles)) {
-      for (const additional of entry.additional_tiles) {
-        collectIndicesFromLayer(additional.fg, indices)
-        collectIndicesFromLayer(additional.bg, indices)
+    if (Array.isArray(entry.masks)) {
+      for (const mask of entry.masks) {
+        collectIndicesFromLayer(mask.fg, indices)
+        collectIndicesFromLayer(mask.bg, indices)
       }
     }
+
+    if (Array.isArray(entry.additional_tiles)) {
+      for (const additional of entry.additional_tiles) {
+        collectEntryIndices(additional, indices)
+      }
+    }
+  }
+
+  for (const entry of composeSheet.tiles) {
+    const indices = new Set()
+    collectEntryIndices(entry, indices)
 
     const ids = Array.isArray(entry.id) ? entry.id : [entry.id]
     const baseName = safeId(ids[0])
@@ -601,6 +649,130 @@ const createZipBlob = (files) => {
   return zip.generateAsync({ type: "blob" })
 }
 
+const setupSpriteEditor = () => {
+  const input = document.getElementById("sprite-editor-input")
+  const widthInput = document.getElementById("sprite-editor-width")
+  const heightInput = document.getElementById("sprite-editor-height")
+  const newButton = document.getElementById("sprite-editor-new")
+  const colorInput = document.getElementById("sprite-editor-color")
+  const downloadButton = document.getElementById("sprite-editor-download")
+  const canvas = document.getElementById("sprite-editor-canvas")
+
+  if (
+    !input || !widthInput || !heightInput || !newButton || !colorInput || !downloadButton || !canvas
+  ) {
+    return
+  }
+
+  const context = canvas.getContext("2d")
+  const backingCanvas = document.createElement("canvas")
+  const backingContext = backingCanvas.getContext("2d")
+  let scale = 16
+  let painting = false
+
+  const clampDimension = (value) => Math.max(1, Math.min(256, Number.parseInt(value, 10) || 16))
+  const currentTool = () =>
+    document.querySelector("input[name='sprite-editor-tool']:checked")?.value ?? "pen"
+  const syncSizeInputs = () => {
+    widthInput.value = String(backingCanvas.width)
+    heightInput.value = String(backingCanvas.height)
+  }
+  const redraw = () => {
+    scale = Math.max(1, Math.floor(Math.min(512 / backingCanvas.width, 512 / backingCanvas.height)))
+    canvas.width = backingCanvas.width * scale
+    canvas.height = backingCanvas.height * scale
+    context.imageSmoothingEnabled = false
+    context.clearRect(0, 0, canvas.width, canvas.height)
+    context.drawImage(backingCanvas, 0, 0, canvas.width, canvas.height)
+    context.strokeStyle = "rgba(128,128,128,0.35)"
+    context.lineWidth = 1
+    for (let x = 0; x <= backingCanvas.width; x += 1) {
+      context.beginPath()
+      context.moveTo(x * scale + 0.5, 0)
+      context.lineTo(x * scale + 0.5, canvas.height)
+      context.stroke()
+    }
+    for (let y = 0; y <= backingCanvas.height; y += 1) {
+      context.beginPath()
+      context.moveTo(0, y * scale + 0.5)
+      context.lineTo(canvas.width, y * scale + 0.5)
+      context.stroke()
+    }
+  }
+  const resizeBacking = (width, height) => {
+    const previous = document.createElement("canvas")
+    previous.width = backingCanvas.width
+    previous.height = backingCanvas.height
+    previous.getContext("2d").drawImage(backingCanvas, 0, 0)
+    backingCanvas.width = width
+    backingCanvas.height = height
+    backingContext.clearRect(0, 0, width, height)
+    backingContext.drawImage(previous, 0, 0)
+    syncSizeInputs()
+    redraw()
+  }
+  const drawAt = (event) => {
+    const bounds = canvas.getBoundingClientRect()
+    const x = Math.floor((event.clientX - bounds.left) / scale)
+    const y = Math.floor((event.clientY - bounds.top) / scale)
+    if (x < 0 || y < 0 || x >= backingCanvas.width || y >= backingCanvas.height) {
+      return
+    }
+    backingContext.clearRect(x, y, 1, 1)
+    if (currentTool() === "pen") {
+      backingContext.fillStyle = colorInput.value
+      backingContext.fillRect(x, y, 1, 1)
+    }
+    redraw()
+  }
+
+  resizeBacking(clampDimension(widthInput.value), clampDimension(heightInput.value))
+
+  input.addEventListener("change", async () => {
+    const file = input.files?.[0]
+    if (!file) {
+      return
+    }
+    const image = await readImageData(file)
+    backingCanvas.width = image.width
+    backingCanvas.height = image.height
+    backingContext.putImageData(image.imageData, 0, 0)
+    syncSizeInputs()
+    redraw()
+  })
+  newButton.addEventListener("click", () =>
+    resizeBacking(
+      clampDimension(widthInput.value),
+      clampDimension(heightInput.value),
+    ))
+  canvas.addEventListener("pointerdown", (event) => {
+    painting = true
+    canvas.setPointerCapture(event.pointerId)
+    drawAt(event)
+  })
+  canvas.addEventListener("pointermove", (event) => {
+    if (painting) {
+      drawAt(event)
+    }
+  })
+  canvas.addEventListener("pointerup", (event) => {
+    painting = false
+    canvas.releasePointerCapture(event.pointerId)
+  })
+  canvas.addEventListener("pointercancel", () => {
+    painting = false
+  })
+  downloadButton.addEventListener("click", async () => {
+    const blob = await canvasToPngBlob(backingCanvas)
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = "sprite.png"
+    anchor.click()
+    URL.revokeObjectURL(url)
+  })
+}
+
 const setupWebTool = () => {
   const input = document.getElementById("tileset-input")
   const runButton = document.getElementById("tileset-run")
@@ -671,3 +843,4 @@ const setupWebTool = () => {
 }
 
 setupWebTool()
+setupSpriteEditor()

--- a/scripts/tileset.ts
+++ b/scripts/tileset.ts
@@ -71,10 +71,25 @@ interface TileSheetConfig {
   filler?: boolean
 }
 
+type TileLayer =
+  | number
+  | number[]
+  | string
+  | string[]
+  | Record<string, unknown>[]
+  | Record<string, unknown>
+
+interface TileMaskEntry {
+  fg?: TileLayer
+  bg?: TileLayer
+  [key: string]: unknown
+}
+
 interface TileEntry {
   id: string | string[]
-  fg?: number | number[] | Record<string, unknown>[] | Record<string, unknown>
-  bg?: number | number[] | Record<string, unknown>[] | Record<string, unknown>
+  fg?: TileLayer
+  bg?: TileLayer
+  masks?: TileMaskEntry[]
   additional_tiles?: TileEntry[]
   [key: string]: unknown
 }
@@ -693,6 +708,11 @@ class TileEntryHandler {
       delete entry.bg
     }
 
+    const maskEntries = entry.masks ?? []
+    for (const maskEntry of maskEntries) {
+      this.convertMaskEntry(maskEntry)
+    }
+
     const additionalEntries = entry.additional_tiles ?? []
     for (const additionalEntry of additionalEntries) {
       this.convert(additionalEntry, `${idArray[0]}_`)
@@ -724,15 +744,21 @@ class TileEntryHandler {
     return null
   }
 
-  convertEntryLayer(
-    entryLayer:
-      | number
-      | number[]
-      | Record<string, unknown>[]
-      | Record<string, unknown>
-      | string
-      | string[],
-  ): (number | Record<string, unknown>)[] {
+  convertMaskEntry(maskEntry: TileMaskEntry): void {
+    if (maskEntry.fg) {
+      maskEntry.fg = listOrFirst(this.convertEntryLayer(maskEntry.fg))
+    } else {
+      delete maskEntry.fg
+    }
+
+    if (maskEntry.bg) {
+      maskEntry.bg = listOrFirst(this.convertEntryLayer(maskEntry.bg))
+    } else {
+      delete maskEntry.bg
+    }
+  }
+
+  convertEntryLayer(entryLayer: TileLayer): (number | Record<string, unknown>)[] {
     const output: (number | Record<string, unknown>)[] = []
 
     if (Array.isArray(entryLayer)) {
@@ -938,7 +964,7 @@ class TileSheetData {
   }
 
   parseIndex(
-    readPngnums: number | number[] | Record<string, unknown> | Record<string, unknown>[],
+    readPngnums: TileLayer,
     allPngnums: number[],
     refs: PngRefs,
   ): number[] {
@@ -983,6 +1009,16 @@ class TileSheetData {
     const bgId = tileEntry.bg
     if (bgId !== undefined) {
       allPngnums = this.parseIndex(bgId, allPngnums, refs)
+    }
+
+    const maskEntries = tileEntry.masks ?? []
+    for (const maskEntry of maskEntries) {
+      if (maskEntry.fg !== undefined) {
+        allPngnums = this.parseIndex(maskEntry.fg, allPngnums, refs)
+      }
+      if (maskEntry.bg !== undefined) {
+        allPngnums = this.parseIndex(maskEntry.bg, allPngnums, refs)
+      }
     }
 
     const addTileEntries = tileEntry.additional_tiles ?? []
@@ -1232,7 +1268,7 @@ class PngRefs {
   }
 
   convertIndex(
-    readPngnums: number | number[] | Record<string, unknown> | Record<string, unknown>[],
+    readPngnums: TileLayer,
     newIndex: (string | Record<string, unknown>)[],
   ): void {
     if (Array.isArray(readPngnums)) {
@@ -1286,6 +1322,38 @@ class PngRefs {
     const bgId = tileEntry.bg
     if (bgId !== undefined) {
       this.convertIndex(bgId, newBg)
+    }
+
+    const maskEntries = tileEntry.masks ?? []
+    const convertedMasks = []
+    for (const maskEntry of maskEntries) {
+      const newMaskFg: (string | Record<string, unknown>)[] = []
+      if (maskEntry.fg !== undefined) {
+        this.convertIndex(maskEntry.fg, newMaskFg)
+      }
+      const newMaskBg: (string | Record<string, unknown>)[] = []
+      if (maskEntry.bg !== undefined) {
+        this.convertIndex(maskEntry.bg, newMaskBg)
+      }
+
+      if (newMaskFg.length > 0) {
+        maskEntry.fg = listOrFirst(newMaskFg)
+      } else {
+        delete maskEntry.fg
+      }
+      if (newMaskBg.length > 0) {
+        maskEntry.bg = listOrFirst(newMaskBg)
+      } else {
+        delete maskEntry.bg
+      }
+      if (newMaskFg.length > 0 || newMaskBg.length > 0) {
+        convertedMasks.push(maskEntry)
+      }
+    }
+    if (convertedMasks.length > 0) {
+      tileEntry.masks = convertedMasks
+    } else {
+      delete tileEntry.masks
     }
 
     const addTileEntries = tileEntry.additional_tiles ?? []

--- a/scripts/tileset_test.ts
+++ b/scripts/tileset_test.ts
@@ -161,6 +161,64 @@ const writeSolidPng = async (
   }).png().toFile(pathname)
 }
 
+const createMaskFixtureTileset = async (sourceDir: string): Promise<void> => {
+  await ensureDir(sourceDir)
+  await Deno.writeTextFile(join(sourceDir, "tileset.txt"), "JSON: tile_config.json\n")
+  await Deno.writeTextFile(
+    join(sourceDir, "tile_info.json"),
+    JSON.stringify(
+      [
+        { width: 2, height: 2 },
+        { "main.png": { sprites_across: 4 } },
+        { "fallback.png": { fallback: true } },
+      ],
+      null,
+      2,
+    ),
+  )
+
+  const mainDir = join(sourceDir, "pngs_main_2x2", "images0")
+  await ensureDir(mainDir)
+  await writeSolidPng(join(mainDir, "alpha.png"), 2, 2, {
+    r: 255,
+    g: 0,
+    b: 0,
+    alpha: 255,
+  })
+  await writeSolidPng(join(mainDir, "alpha_tint_mask.png"), 2, 2, {
+    r: 255,
+    g: 255,
+    b: 255,
+    alpha: 255,
+  })
+  await writeSolidPng(join(mainDir, "open_tint_mask.png"), 2, 2, {
+    r: 0,
+    g: 0,
+    b: 0,
+    alpha: 255,
+  })
+
+  await Deno.writeTextFile(
+    join(mainDir, "entries.json"),
+    JSON.stringify(
+      {
+        id: "t_alpha",
+        fg: "alpha",
+        masks: [{ type: "tint", fg: "alpha_tint_mask" }, { type: "tint", fg: "missing_mask" }, {
+          type: "tint",
+        }],
+        additional_tiles: [{
+          id: "open",
+          fg: "alpha",
+          masks: [{ type: "tint", fg: "open_tint_mask" }],
+        }],
+      },
+      null,
+      2,
+    ),
+  )
+}
+
 const createFixtureTileset = async (sourceDir: string): Promise<void> => {
   await ensureDir(sourceDir)
   await Deno.writeTextFile(join(sourceDir, "tileset.txt"), "JSON: tile_config.json\n")
@@ -317,6 +375,30 @@ const collectReferencedSpriteIndexes = (
   }
 }
 
+const collectTileEntryReferencedSpriteIndexes = (
+  tile: Record<string, unknown>,
+  target: Set<number>,
+): void => {
+  collectReferencedSpriteIndexes(tile.fg, target)
+  collectReferencedSpriteIndexes(tile.bg, target)
+
+  const masks = tile.masks
+  if (Array.isArray(masks)) {
+    for (const mask of masks) {
+      const maskEntry = mask as Record<string, unknown>
+      collectReferencedSpriteIndexes(maskEntry.fg, target)
+      collectReferencedSpriteIndexes(maskEntry.bg, target)
+    }
+  }
+
+  const additionalTiles = tile.additional_tiles
+  if (Array.isArray(additionalTiles)) {
+    for (const additionalTile of additionalTiles) {
+      collectTileEntryReferencedSpriteIndexes(additionalTile as Record<string, unknown>, target)
+    }
+  }
+}
+
 const compareReferencedSpritesOnly = async (
   leftPath: string,
   rightPath: string,
@@ -420,6 +502,53 @@ const compareDecomposedOutputs = async (leftDir: string, rightDir: string): Prom
 }
 
 Deno.test({
+  name: "tileset: compose and decompose preserve tint mask sprites",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const tempRoot = await Deno.makeTempDir({ prefix: "tileset_mask_compose_" })
+
+    try {
+      const sourceDir = join(tempRoot, "fixture_source")
+      const outputDir = join(tempRoot, "packed")
+      await createMaskFixtureTileset(sourceDir)
+
+      await runTypescriptCompose(sourceDir, outputDir)
+
+      const tileConfig = await readJson(join(outputDir, "tile_config.json")) as {
+        "tiles-new": Array<{ tiles?: Array<Record<string, unknown>> }>
+      }
+      const firstTile = tileConfig["tiles-new"][0]?.tiles?.[0] as {
+        fg: number
+        masks: Array<{ type: string; fg: number }>
+        additional_tiles: Array<{ masks: Array<{ type: string; fg: number }> }>
+      }
+
+      assertEquals(firstTile.fg, 2)
+      assertEquals(firstTile.masks, [{ type: "tint", fg: 1 }, { type: "tint", fg: [] }, {
+        type: "tint",
+      }])
+      assertEquals(firstTile.additional_tiles[0].masks, [{ type: "tint", fg: 3 }])
+
+      await runTypescriptDecompose(outputDir)
+      const decomposedEntry = await readJson(
+        join(outputDir, "pngs_main_2x2", "images0", "t_alpha_0.json"),
+      ) as {
+        masks: Array<{ type: string; fg: string }>
+        additional_tiles: Array<{ masks: Array<{ type: string; fg: string }> }>
+      }
+
+      assertEquals(decomposedEntry.masks[0].type, "tint")
+      assertEquals(typeof decomposedEntry.masks[0].fg, "string")
+      assertEquals(decomposedEntry.additional_tiles[0].masks[0].type, "tint")
+      assertEquals(typeof decomposedEntry.additional_tiles[0].masks[0].fg, "string")
+    } finally {
+      await Deno.remove(tempRoot, { recursive: true })
+    }
+  },
+})
+
+Deno.test({
   name: "tileset: compose output matches compose.py pixel-perfect",
   sanitizeOps: false,
   sanitizeResources: false,
@@ -472,17 +601,7 @@ Deno.test({
           const referencedIndexes = new Set<number>()
 
           for (const tile of sheet.tiles) {
-            collectReferencedSpriteIndexes(tile.fg, referencedIndexes)
-            collectReferencedSpriteIndexes(tile.bg, referencedIndexes)
-
-            const additionalTiles = tile.additional_tiles
-            if (Array.isArray(additionalTiles)) {
-              for (const additionalTile of additionalTiles) {
-                const entry = additionalTile as Record<string, unknown>
-                collectReferencedSpriteIndexes(entry.fg, referencedIndexes)
-                collectReferencedSpriteIndexes(entry.bg, referencedIndexes)
-              }
-            }
+            collectTileEntryReferencedSpriteIndexes(tile, referencedIndexes)
           }
 
           const spriteWidth = sheet.sprite_width ?? defaultWidth


### PR DESCRIPTION
## Purpose of change (The Why)

Continuation of #8151.

## Describe the solution (The How)

- Supports `masks[].fg` and `masks[].bg` sprite name conversion in `scripts/tileset.ts` compose output, matching the attached companion `compose.py` mask behavior.
- Preserves mask sprite references in TypeScript decompose and browser compose/decompose.
- Adds a minimal PNG sprite editor to the docs tileset web tool page.

## Testing

- `deno test --allow-read --allow-write --allow-env --allow-run --allow-ffi scripts/tileset_test.ts`
- `deno lint docs/tools/tileset_web_tool.js`
- `deno task --cwd docs build`
- Playwright screenshot: `/tmp/tileset-web-tool.png`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sup>gpt-5.4 high on pi</sup>
