### PR TITLE
fix: fire should no longer spread upward while sealed

### DIFF
--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1259,7 +1259,7 @@ auto process_fields_in_submap( submap &sm,
                 }
 
                 // --- Z-rise: level-3 fire spreads upward ---
-                if( pos.z() < OVERMAP_HEIGHT && cur.get_field_intensity() == 3 ) {
+                if( can_spread && pos.z() < OVERMAP_HEIGHT && cur.get_field_intensity() == 3 ) {
                     const tripoint_abs_sm above_pos( pos.raw() + tripoint{ 0, 0, 1 } );
                     auto *above_sm = mb.lookup_submap_in_memory( above_pos.raw() );
                     if( above_sm ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Resolves part 2 of: #8726

## Describe the solution (The How)
Before rising fire, check if can spread

## Describe alternatives you've considered
None

## Testing
I could not replicate the issue in the first place
But it appears that it would be caused by this
And I used my eyes to determine everything else uses it

## Additional context
I screm

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.