### PR TITLE
fix: prevent winter mornings from appearing sunlit before sunrise

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -395,9 +395,11 @@ void map::build_sunlight_cache( int pzlev )
     //    ↓
     // when fully below ground: fully_outside=false, fully_inside=true  (fast fill)
 
-    // Rebuild the directional sunlight cache once per in-game hour (expensive path only).
+    // Rebuild the directional sunlight cache once per absolute in-game hour (expensive path only).
+    // Sunrise and sunset vary by date, so comparing only the hour of day can reuse stale
+    // sun state when a later day has a different dawn or dusk time.
     if( fov_3d_occlusion ) {
-        const auto current_hour = to_hours<int>( time_past_midnight( calendar::turn ) );
+        const auto current_hour = to_hours<int>( calendar::turn - calendar::turn_zero );
         if( current_hour != m_solar.last_built_hour ) {
             update_solar_params();
             std::ranges::for_each(

--- a/src/map.h
+++ b/src/map.h
@@ -2412,7 +2412,7 @@ class map : public submap_load_listener
         // forces a seen_cache rebuild regardless of whether the player moved.
         tripoint_bub_ms m_last_seen_cache_origin = tripoint_bub_ms( tripoint_min );
 
-        // State for the directional sunlight system.  Rebuilt once per in-game hour by
+        // State for the directional sunlight system.  Rebuilt once per absolute in-game hour by
         // update_solar_params() and build_angled_sunlight_cache().
         struct solar_params {
             // Sun ray horizontal displacement per z-level.
@@ -2423,7 +2423,7 @@ class map : public submap_load_listener
             float dy_per_z     = 0.f;
             // False at night; true for all daylight hours (day/night boundary only).
             bool  direct_active  = false;
-            // Game-hour when the cache was last rebuilt; -1 forces a rebuild on first use.
+            // Absolute game-hour when the cache was last rebuilt; -1 forces a rebuild on first use.
             int   last_built_hour = -1;
         };
         solar_params m_solar;

--- a/tests/zlevel_visibility_cache_test.cpp
+++ b/tests/zlevel_visibility_cache_test.cpp
@@ -3,12 +3,54 @@
 
 #include "avatar.h"
 #include "calendar.h"
+#include "cata_utility.h"
 #include "coordinates.h"
 #include "game.h"
 #include "map.h"
 #include "options_helpers.h"
 #include "state_helpers.h"
 #include "type_id.h"
+
+TEST_CASE( "solar_cache_uses_date_sensitive_hour", "[vision][zlevel][sun]" )
+{
+    clear_all_state();
+
+    override_option fov3d( "FOV_3D", "true" );
+    override_option fov3d_occlusion( "FOV_3D_OCCLUSION", "true" );
+    const auto restore_fov_3d = restore_on_out_of_scope<bool>( fov_3d );
+    const auto restore_fov_3d_occlusion = restore_on_out_of_scope<bool>( fov_3d_occlusion );
+    fov_3d = true;
+    fov_3d_occlusion = true;
+
+    auto &here = get_map();
+    const auto one_season = calendar::season_length();
+    const auto summer_after_sunrise = calendar::turn_zero + one_season + 5_hours + 30_minutes;
+    const auto winter_before_sunrise = calendar::turn_zero + one_season * 3 + 5_hours + 30_minutes;
+    const auto sample = tripoint_bub_ms( 60, 60, OVERMAP_HEIGHT );
+
+    REQUIRE( time_past_midnight( summer_after_sunrise ) ==
+             time_past_midnight( winter_before_sunrise ) );
+    REQUIRE( summer_after_sunrise > sunrise( summer_after_sunrise ) );
+    REQUIRE( summer_after_sunrise < sunset( summer_after_sunrise ) );
+    REQUIRE( winter_before_sunrise < sunrise( winter_before_sunrise ) );
+
+    calendar::turn = summer_after_sunrise;
+    g->reset_light_level();
+    here.invalidate_map_cache( sample.z() );
+    here.build_map_cache( sample.z() );
+
+    const auto &summer_cache = here.access_cache( sample.z() );
+    const auto sample_idx = static_cast<size_t>( summer_cache.idx( sample.x(), sample.y() ) );
+    REQUIRE( summer_cache.angled_sunlight_cache[sample_idx] );
+
+    calendar::turn = winter_before_sunrise;
+    g->reset_light_level();
+    here.invalidate_lightmap_caches();
+    here.build_map_cache( sample.z() );
+
+    const auto &winter_cache = here.access_cache( sample.z() );
+    CHECK_FALSE( winter_cache.angled_sunlight_cache[sample_idx] );
+}
 
 TEST_CASE( "opening_floor_invalidates_below_seen_cache", "[vision][zlevel]" )
 {


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="1062" height="290" alt="image" src="https://github.com/user-attachments/assets/669ba2b8-ea70-44e9-b6d3-65eb9b02dcf4" />

> "There are a lot of light-related errors popping up."
> "What is happening with this? Is there an overall issue for it?"
> "It is winter, 5 AM before sunrise, but the area is bright. Then at exactly 7 AM it suddenly gets dark, and the light slowly rises again."
> "I think I know the rough cause now. Season-specific sunrise/sunset times were newly added, but old code paths may not have been cleaned up. Sunrise handling may be duplicated."
> "Default summer sunrise is 5 AM, winter sunrise is 7 AM, and it is winter now."

https://discord.com/channels/830879262763909202/1093580823351001098/1500712298879123567

Related to #8465 and #8535.

The game caches expensive directional sunlight calculations for the current hour. That cache used only the clock hour, like "5 AM". If the cache was built on a date where 5 AM already had sunlight, the same cached sun state could be reused on a winter 5 AM before sunrise.

This made pre-sunrise winter tiles look sunlit until the next hourly refresh.

## Describe the solution (The How)

Store the cache timestamp as an absolute in-game hour instead of only the hour of the day.

That keeps the hourly cache, but makes different dates use different cache keys. When the date or season changes, sunrise/sunset is recalculated for the current date before reusing sunlight state.

## Describe alternatives you've considered

Rebuilding every turn would also avoid stale state, but this keeps the existing hourly cache behavior.

## Testing

- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "solar_cache_uses_date_sensitive_hour"`
- `./out/build/linux-full/tests/cata_test-tiles "[vision][zlevel]"`
- `cmake --build --preset linux-full --target format`
- Temporarily restored the old hour-of-day cache key and verified `solar_cache_uses_date_sensitive_hour` fails on the winter 5:30 assertion.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] No matching open issue exists; related PRs are linked above.

<sup>PR opened by gpt-5.4 high on pi</sup>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9095739](https://github.com/cataclysmbn/Cataclysm-BN/commit/9095739b5db8717f315a691e10d97bc0bc539309) (test: cover date-sensitive solar cache) on 2026-06-07 18:38:54

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27095542298/artifacts/7465133972)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27095542298/artifacts/7466758572)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27095542298/artifacts/7465128748)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27095542298/artifacts/7465250445)
<!-- END artifact comment -->