### PR TITLE
feat(balance): audit passenger and cargo plane

### DIFF
--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -372,26 +372,25 @@
           "controls",
           "dashboard",
           "vehicle_clock",
-          "vehicle_alarm",
-          "horn_car",
           "roof",
           "programmable_autopilot",
+          "black_box",
           "tracker"
         ]
       },
       { "x": 9, "y": -1, "parts": [ "frame_horizontal_2", "halfboard_nw", "headlight" ] },
-      { "x": 0, "y": 0, "parts": [ "frame_vertical_2", "roof", "aisle_horizontal", "drive_by_wire_controls" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_vertical_2", "roof", "aisle_horizontal" ] },
       { "x": 6, "y": -1, "parts": [ "frame_horizontal_2", "roof", "board_horizontal" ] },
       { "x": 5, "y": 0, "parts": [ "frame_vertical_2", "roof", "trunk_floor" ] },
       { "x": 0, "y": -2, "parts": [ "frame_vertical", "windshield", "v_shutter" ] },
       { "x": 0, "y": 2, "parts": [ "frame_vertical", "windshield_horizontal_front", "v_shutter" ] },
-      { "x": -2, "y": 2, "parts": [ "frame_vertical", "board_vertical", "tank_55gal_drum" ] },
-      { "x": 7, "y": 2, "parts": [ "frame_vertical", "windshield_horizontal_front" ] },
       {
-        "x": 7,
-        "y": 0,
-        "parts": [ "frame_vertical_2", "roof", "veh_table", "vehicle_clock", "aisle_lights", "chimes" ]
+        "x": -2,
+        "y": 2,
+        "parts": [ "frame_vertical", "board_vertical", { "part": "tank_55gal_drum", "fuel": "avgas" } ]
       },
+      { "x": 7, "y": 2, "parts": [ "frame_vertical", "windshield_horizontal_front" ] },
+      { "x": 7, "y": 0, "parts": [ "frame_vertical_2", "roof", "aisle_vertical", "aisle_lights" ] },
       { "x": 7, "y": -2, "parts": [ "frame_vertical", "windshield" ] },
       { "x": 8, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
       {
@@ -438,16 +437,7 @@
       {
         "x": 9,
         "y": 0,
-        "parts": [
-          "frame_cover",
-          "halfboard_cover",
-          "diesel_engine_v6",
-          "battery_car",
-          "wheel_mount_light_steerable",
-          "wheel_small",
-          "alternator_truck",
-          "horn_ship"
-        ]
+        "parts": [ "frame_cover", "halfboard_cover", "wheel_mount_light_steerable", "wheel_small", "horn_ship" ]
       },
       { "x": 8, "y": -2, "parts": [ "frame_horizontal", "windshield_nw_edge" ] },
       {
@@ -470,14 +460,21 @@
       { "x": 3, "y": -4, "part": "wing_metal_external_horizontal" },
       { "x": 3, "y": -3, "part": "wing_metal_external_horizontal" },
       { "x": 4, "y": -3, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
-      { "x": 4, "y": -4, "parts": [ "frame_horizontal", "lit_wing_metal_horizontal" ] },
-      { "x": 4, "y": -5, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
+      { "x": 4, "y": -4, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
+      {
+        "x": 4,
+        "y": -5,
+        "parts": [ "frame_horizontal", "engine_v6", "alternator_truck", "battery_car", "lit_wing_metal_horizontal" ]
+      },
       { "x": 4, "y": -6, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
       { "x": 4, "y": -7, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
-      { "x": 5, "y": -7, "part": "propeller_metal" },
       { "x": 4, "y": 3, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
-      { "x": 4, "y": 4, "parts": [ "frame_horizontal", "lit_wing_metal_horizontal" ] },
-      { "x": 4, "y": 5, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
+      { "x": 4, "y": 4, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
+      {
+        "x": 4,
+        "y": 5,
+        "parts": [ "frame_horizontal", "engine_v6", "alternator_truck", "battery_car", "lit_wing_metal_horizontal" ]
+      },
       { "x": 4, "y": 6, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
       { "x": -3, "y": -1, "parts": [ "frame_cross", "halfboard_horizontal_front" ] },
       { "x": -3, "y": 0, "parts": [ "frame_cross", "halfboard_horizontal_front" ] },
@@ -497,7 +494,6 @@
       { "x": 5, "y": 5, "part": "propeller_metal" },
       { "x": 5, "y": -5, "part": "propeller_metal" },
       { "x": 4, "y": 7, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
-      { "x": 5, "y": 7, "part": "propeller_metal" },
       { "x": 4, "y": 8, "part": "lit_wing_metal_external_horizontal" },
       { "x": 4, "y": -8, "part": "lit_wing_metal_external_horizontal" },
       { "x": 3, "y": -9, "part": "wing_metal_external_horizontal" },
@@ -568,10 +564,9 @@
           "controls",
           "dashboard",
           "vehicle_clock",
-          "vehicle_alarm",
-          "horn_car",
           "roof",
           "programmable_autopilot",
+          "black_box",
           "tracker"
         ]
       },
@@ -581,9 +576,13 @@
       { "x": 5, "y": 0, "parts": [ "frame_vertical_2", "roof", "aisle_horizontal" ] },
       { "x": 0, "y": -2, "parts": [ "frame_vertical", "door_sliding" ] },
       { "x": 0, "y": 2, "parts": [ "frame_vertical", "door_sliding" ] },
-      { "x": -2, "y": 2, "parts": [ "frame_vertical", "board_vertical", "tank_55gal_drum" ] },
+      {
+        "x": -2,
+        "y": 2,
+        "parts": [ "frame_vertical", "board_vertical", { "part": "tank_55gal_drum", "fuel": "avgas" } ]
+      },
       { "x": 7, "y": 2, "parts": [ "frame_vertical", "windshield_horizontal_front" ] },
-      { "x": 7, "y": 0, "parts": [ "frame_vertical_2", "roof", "veh_table", "vehicle_clock", "aisle_lights" ] },
+      { "x": 7, "y": 0, "parts": [ "frame_vertical_2", "roof", "aisle_vertical", "aisle_lights" ] },
       { "x": 7, "y": -2, "parts": [ "frame_vertical", "windshield" ] },
       { "x": 8, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
       { "x": 1, "y": 1, "parts": [ "frame_horizontal_2", "roof", "cargo_space" ] },
@@ -614,16 +613,7 @@
       {
         "x": 9,
         "y": 0,
-        "parts": [
-          "frame_cover",
-          "halfboard_cover",
-          "diesel_engine_v6",
-          "alternator_truck",
-          "battery_car",
-          "wheel_mount_light_steerable",
-          "wheel_small",
-          "horn_ship"
-        ]
+        "parts": [ "frame_cover", "halfboard_cover", "wheel_mount_light_steerable", "wheel_small", "horn_ship" ]
       },
       { "x": 8, "y": -2, "parts": [ "frame_horizontal", "windshield_nw_edge" ] },
       { "x": 2, "y": 1, "parts": [ "frame_horizontal_2", "roof", "cargo_space" ] },
@@ -642,14 +632,21 @@
       { "x": 3, "y": -4, "part": "wing_metal_external_horizontal" },
       { "x": 3, "y": -3, "part": "wing_metal_external_horizontal" },
       { "x": 4, "y": -3, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
-      { "x": 4, "y": -4, "parts": [ "frame_horizontal", "lit_wing_metal_horizontal" ] },
-      { "x": 4, "y": -5, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
+      { "x": 4, "y": -4, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
+      {
+        "x": 4,
+        "y": -5,
+        "parts": [ "frame_horizontal", "engine_v6", "alternator_truck", "battery_car", "lit_wing_metal_horizontal" ]
+      },
       { "x": 4, "y": -6, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
       { "x": 4, "y": -7, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
-      { "x": 5, "y": -7, "part": "propeller_metal" },
       { "x": 4, "y": 3, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
-      { "x": 4, "y": 4, "parts": [ "frame_horizontal", "lit_wing_metal_horizontal" ] },
-      { "x": 4, "y": 5, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
+      { "x": 4, "y": 4, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
+      {
+        "x": 4,
+        "y": 5,
+        "parts": [ "frame_horizontal", "engine_v6", "alternator_truck", "battery_car", "lit_wing_metal_horizontal" ]
+      },
       { "x": 4, "y": 6, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
       { "x": -3, "y": -1, "parts": [ "frame_cross", "halfboard_horizontal_front" ] },
       { "x": -3, "y": 0, "parts": [ "frame_cross", "halfboard_horizontal_front" ] },
@@ -669,7 +666,6 @@
       { "x": 5, "y": 5, "part": "propeller_metal" },
       { "x": 5, "y": -5, "part": "propeller_metal" },
       { "x": 4, "y": 7, "parts": [ "frame_horizontal", "wing_metal_horizontal" ] },
-      { "x": 5, "y": 7, "part": "propeller_metal" },
       { "x": 4, "y": 8, "part": "lit_wing_metal_external_horizontal" },
       { "x": 4, "y": -8, "part": "lit_wing_metal_external_horizontal" },
       { "x": 3, "y": -9, "part": "wing_metal_external_horizontal" },

--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -339,7 +339,11 @@
         "y": 1,
         "parts": [ "frame_horizontal_2", "roof", "reclining_seat_leather", "seatbelt", "aisle_lights" ]
       },
-      { "x": 0, "y": 1, "parts": [ "frame_horizontal_2", "roof", "folding_seat", "controls_electronic", "cargo_space" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "frame_horizontal_2", "roof", "folding_seat", "controls_electronic", "cargo_space" ]
+      },
       { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "roof", "door_internal" ] },
       {
         "x": 3,

--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -339,7 +339,7 @@
         "y": 1,
         "parts": [ "frame_horizontal_2", "roof", "reclining_seat_leather", "seatbelt", "aisle_lights" ]
       },
-      { "x": 0, "y": 1, "parts": [ "frame_horizontal_2", "roof", "folding_seat", "cargo_space" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_horizontal_2", "roof", "folding_seat", "controls_electronic", "cargo_space" ] },
       { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "roof", "door_internal" ] },
       {
         "x": 3,
@@ -408,7 +408,7 @@
         "parts": [ "frame_horizontal_2", "roof", "reclining_seat_leather", "seatbelt", "aisle_lights" ]
       },
       { "x": -2, "y": -2, "parts": [ "frame_vertical", "board_vertical" ] },
-      { "x": 7, "y": 1, "parts": [ "frame_vertical_2", "roof", "seat", "controls_electronic" ] },
+      { "x": 7, "y": 1, "parts": [ "frame_vertical_2", "roof", "seat", "drive_by_wire_controls" ] },
       { "x": 2, "y": -2, "parts": [ "frame_vertical", "windshield", "v_shutter" ] },
       { "x": 6, "y": -2, "parts": [ "frame_vertical", "board_vertical" ] },
       { "x": 4, "y": 2, "parts": [ "frame_vertical", "windshield", "v_shutter" ] },
@@ -592,7 +592,7 @@
       { "x": 1, "y": -2, "parts": [ "frame_horizontal", "wheel_mount_medium", "wheel", "door_sliding" ] },
       { "x": 2, "y": -1, "parts": [ "frame_horizontal_2", "roof", "cargo_space" ] },
       { "x": -2, "y": -2, "parts": [ "frame_vertical", "board_vertical" ] },
-      { "x": 7, "y": 1, "parts": [ "frame_vertical_2", "roof", "seat", "controls_electronic" ] },
+      { "x": 7, "y": 1, "parts": [ "frame_vertical_2", "roof", "seat", "drive_by_wire_controls" ] },
       { "x": 2, "y": -2, "parts": [ "frame_vertical", "door_sliding" ] },
       { "x": 6, "y": -2, "parts": [ "frame_vertical", "board_vertical" ] },
       { "x": 4, "y": 2, "parts": [ "frame_vertical", "board_vertical" ] },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This does a bit of sanity-checking of passenger and cargo plane layouts to be consistent with other planes.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Switched up propeller and engine placement for both heavy planes, giving both two propellers instead of four, and with two V6 engines on the wings instead of a single V6 diesel engine slapped in the middle (in the vein of cargo planes such as the DC-3/C-47, Cessna 408, etc).
2. Moved the lit wing spots to where the propellers are.
3. Set tanks to be able to spawn with avgas.
4. Removed several extraneous electronic parts, added a black box.
5. Per feedback in the discord, swapped around the drive-by-wire controls and electronics controls, so the copilot can also take control of the plane while the steward in the back can operate electronics.
6. Removed table hindering movement in and out of the cockpit in favor of an aisle.

## Describe alternatives you've considered

Also overhauling the position logic so 0, 0 is actually the pilot's position, but that's effort weh.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Ported changes to playthrough build and load-tested.

Passenger plane went from a takeoff speed of 61 MPH and max safe airspeed of 192 MPH, to 63 MPH and 207 MPH respectively.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
