### PR TITLE
build: Add explicit cstdint include to cata_libintl.h

### DIFF
--- a/src/cata_libintl.h
+++ b/src/cata_libintl.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 /**
  * Runtime localization system for Cataclysm: Bright Nights.


### PR DESCRIPTION
## Purpose of change (The Why)

Clang 22 doesn't like it otherwise and complains that it can't find uint8_t or uint32_t, which is a fatal error.

## Describe the solution (The How)

Just explicitly `#include <cstdint>`

## Describe alternatives you've considered

Instead go raise the issue with Clang and attempt to change the entire compiler instead of just being more explicit.

## Testing

Latest compiles for me on Nyarch Linux with Clang version 22.1.3 after making this change

## Additional context

First compile I've done since moving to Nyarch xD

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.