### PR TITLE
fix: handle stored ammo recovery correctly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,8 @@ auto print_button( const catacurses::window &w, const button_options &opts ) -> 
 
 - **SHOULD NOT** modify existing headers with >10 usages. Create new header with pure functions.
 - **MUST** use modern C++23 features.
-- **MUST** use options struct for functions with more than 3 parameters. Use designated initializers at call sites.
-- **MUST NOT** manually write an options/struct type at a call site when the function parameter type makes it inferable; use `{ .field = value }` instead of `options_type{ .field = value }`.
+- **MUST** use options struct for functions with more than 3 parameters.
+- **MUST NOT** spell an options struct type at call sites when the callee parameter can infer it. Prefer `foo( { .bar = baz } )` over `foo( foo_options{ .bar = baz } )`.
 - **SHOULD** search for existing solution because it's a large, legacy codebase.
 
 ## Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,12 @@ deno task docs:gen
 - Do not call PO/printf errors pre-existing to skip them when the task touches that locale or validation path.
 - If a mistake is found during the task, update AGENTS/skill immediately and fix the current branch before summarizing.
 
+## WHEN updating docs
+
+- If an English doc under `docs/en/` has matching localized files under `docs/ko/` or `docs/ja/`, update those localized files in the same change.
+- Before committing docs, check matching localized paths with `fd "$(basename <file>)" docs/ko docs/ja` or `git ls-files 'docs/*/<relative-path-after-docs/en>'`.
+- If a localized update is intentionally skipped, state the reason in the final response and PR body.
+
 ## WHEN translating docs
 
 When translating, MUST search for correct glossary, e.g

--- a/docs/en/dev/guides/items.md
+++ b/docs/en/dev/guides/items.md
@@ -1,16 +1,162 @@
-# Items Cookbook
+# Items and Ammo Cookbook
 
-Here are some common tasks that you might want to do with items.
-[For more on item(game objects), check here.](../explanation/game_objects.md)
+Here are common item tasks and the rules that keep item, ammo, magazine, and charge handling
+consistent. For more on item game objects, see [Game Objects](../explanation/game_objects.md).
+For JSON item fields, see the modding references for
+[item creation](../../mod/json/reference/items/item_creation.md),
+[item spawning](../../mod/json/reference/items/item_spawn.md), and
+[recipes](../../mod/json/reference/items/recipes.md).
+
+## Mental model
+
+An `item` can represent several different concepts:
+
+- A normal object, such as a screwdriver or backpack.
+- A count-by-charges stack, such as ammo, food portions, liquid, or components.
+- A gun or tool with stored ammo/energy.
+- A magazine that stores ammo as contained ammo items.
+- A container that happens to hold other items.
+
+Do not assume that `item::charges` always means the same thing. Depending on the item type, charges
+may be stack count, tool energy, ammo remaining, or irrelevant. Prefer the higher-level item APIs
+listed below.
+
+## Choosing the right API
+
+| Task                                  | Preferred API                                    | Avoid                                      |
+| ------------------------------------- | ------------------------------------------------ | ------------------------------------------ |
+| Query loaded ammo type                | `item::ammo_current()`                           | Reading `curammo` directly                 |
+| Query loaded amount                   | `item::ammo_remaining()`                         | Reading `charges` directly                 |
+| Query capacity                        | `item::ammo_capacity()`                          | Recalculating from JSON fields             |
+| Load ammo into gun/tool/magazine      | `item::ammo_set()`                               | Manually setting `charges` and ammo fields |
+| Empty gun/tool/magazine               | `item::ammo_unset()` or `recover_stored_ammo()`  | Clearing only `charges`                    |
+| Consume ammo from a loaded item       | `item::ammo_consume()`                           | Subtracting from `charges`                 |
+| Consume inventory/map charges         | `Character::use_charges()`, `map::use_charges()` | Manual inventory scans                     |
+| Consume whole item components         | `Character::use_amount()`, `map::use_amount()`   | Manual detach loops                        |
+| Turn stored ammo into inventory items | `stored_ammo.h` helpers                          | `item::spawn()` plus ad-hoc charge math    |
+
+Use direct field access only in low-level item implementation code where the invariant is local and
+obvious.
 
 ## Moving items from one tripoint to another
 
 ```cpp
 auto move_item( map &here, const tripoint &src, const tripoint &dest ) -> void
 {
-    map_stack items_src = here.i_at( src );
-    map_stack items_dest = here.i_at( dest );
+    auto items_src = here.i_at( src );
+    auto items_dest = here.i_at( dest );
 
     items_src.move_all_to( &items_dest );
 }
 ```
+
+## Spawning items with ammo or charges
+
+For a plain count-by-charges item, spawning with charges is fine:
+
+```cpp
+auto nails = item::spawn( "nail", calendar::turn, 50 );
+```
+
+For guns, tools, and magazines, prefer `ammo_set()` after spawning. It knows whether the target uses
+integral ammo storage or a contained magazine/ammo item.
+
+```cpp
+auto cell = item::spawn( "medium_battery_cell" );
+cell->ammo_set( itype_id( "battery" ), 500 );
+```
+
+Do not initialize loaded ammo by manually writing `charges` unless you are in item internals and
+also maintain all related ammo invariants.
+
+## Guns, tools, and magazines
+
+Use the same public queries for all loaded items:
+
+```cpp
+auto describe_loaded_ammo( const item &it ) -> std::string
+{
+    if( it.ammo_current().is_null() || it.ammo_remaining() <= 0 ) {
+        return "empty";
+    }
+    return string_format( "%s: %d", it.ammo_current().str(), it.ammo_remaining() );
+}
+```
+
+The storage layout differs by item type:
+
+- Integral guns/tools often store ammo amount in `charges` and ammo type separately.
+- Guns/tools with detachable magazines forward ammo queries to the magazine.
+- Magazines store ammo as contained ammo items.
+
+That is why callers should use `ammo_current()`, `ammo_remaining()`, `ammo_set()`, `ammo_unset()`,
+and `ammo_consume()` instead of inspecting the layout.
+
+## Recovering ammo or charges stored inside items
+
+Some items store ammo as abstract charges, while the physical item that appears in the inventory may
+use different units. Plutonium fuel is the important special case: tools and vehicle parts store it
+in `PLUTONIUM_CHARGES` units, but inventory fuel cells are whole items. Partial plutonium charges
+must not be converted with raw `item::spawn` plus manual `charges` assignment, because that can
+create zero-charge ghost items.
+
+Use `stored_ammo.h` whenever code turns stored ammo from guns, tools, magazines, or vehicle fuel
+stores into physical items:
+
+```cpp
+for( auto &ammo : recover_stored_ammo( source_item, stored_ammo_remainder_handling::discard ) ) {
+    drop_or_handle( std::move( ammo ), who );
+}
+```
+
+Choose the remainder policy explicitly:
+
+- `stored_ammo_remainder_handling::discard`: use when the source item is being destroyed, such as
+  crafting, disassembly, or salvage. Recover complete ammo items and clear unitemizable remainders.
+- `stored_ammo_remainder_handling::preserve`: use when the source remains in the world, such as
+  unloading complete fuel items from a vehicle while leaving partial fuel in the part.
+
+For code that only needs to inspect or spawn the physical representation, use
+`stored_ammo_item_charges`, `stored_ammo_charges_for_items`, and `spawn_stored_ammo`. This keeps
+charge-to-item conversion in one documented path and prevents each caller from reimplementing
+plutonium rounding rules.
+
+## Vehicle fuel stores
+
+Vehicle parts have their own ammo/fuel storage. Use vehicle APIs such as `vehicle::fuel_left()`,
+`vehicle::fuels_left()`, `vehicle::drain()`, and part ammo APIs instead of reading part internals.
+
+When unloading solid vehicle fuel into inventory items, still use `stored_ammo.h` for the final
+stored-charge to item-charge conversion. This preserves partial fuel that cannot be represented as a
+complete item.
+
+```cpp
+const auto stored_charges = veh.fuel_left( fuel );
+auto fuel_item = spawn_stored_ammo( fuel, stored_charges );
+if( fuel_item ) {
+    veh.drain( fuel, stored_ammo_charges_for_items( fuel, fuel_item->charges ) );
+}
+```
+
+## `NO_UNLOAD` and recovery policy
+
+`NO_UNLOAD` on an item means the player should not be able to unload it through normal unload UI.
+It does not automatically answer what should happen when the containing item is destroyed by
+crafting, disassembly, or salvage. In those paths, make the policy explicit and add a test:
+
+- If the source item survives, preserve unitemizable remainders.
+- If the source item is consumed, recover complete ammo items and discard any remainder that cannot
+  exist as an inventory item.
+
+## Testing checklist
+
+When changing item, ammo, or fuel code, include tests for the storage layout and edge cases:
+
+- A tool or gun with integral ammo.
+- A magazine with contained ammo, such as a rechargeable battery cell.
+- A source item that is consumed as a crafting/disassembly component.
+- A source item that remains in the world after unloading.
+- Zero ammo and partial ammo below one physical item, especially plutonium fuel.
+- Multiple complete physical items plus a partial remainder.
+
+Prefer checking both sides of the operation: the recovered item stack and the remaining source ammo.

--- a/docs/en/dev/guides/items.md
+++ b/docs/en/dev/guides/items.md
@@ -112,9 +112,14 @@ for( auto &ammo : recover_stored_ammo( source_item, stored_ammo_remainder_handli
 Choose the remainder policy explicitly:
 
 - `stored_ammo_remainder_handling::discard`: use when the source item is being destroyed, such as
-  crafting, disassembly, or salvage. Recover complete ammo items and clear unitemizable remainders.
+  disassembly or salvage. Recover complete ammo items and clear unitemizable remainders.
 - `stored_ammo_remainder_handling::preserve`: use when the source remains in the world, such as
   unloading complete fuel items from a vehicle while leaving partial fuel in the part.
+
+Crafting is a two-stage case: preserve stored ammo while the in-progress craft owns the components,
+then on completion load that ammo into a compatible result before recovering any leftovers as
+physical items. This prevents charged battery-cell components from turning into loose `battery`
+items when the recipe result is another battery cell.
 
 For code that only needs to inspect or spawn the physical representation, use
 `stored_ammo_item_charges`, `stored_ammo_charges_for_items`, and `spawn_stored_ammo`. This keeps

--- a/docs/ja/dev/guides/items.md
+++ b/docs/ja/dev/guides/items.md
@@ -1,16 +1,164 @@
-# アイテム クックブック
+# アイテムと弾薬のクックブック
 
-ここでは、アイテムを使って実行したい一般的なタスクをいくつか紹介します。
-[アイテム(ゲームオブジェクト)の詳細については、こちらを確認してください](../explanation/game_objects.md)。
+ここでは、アイテムを扱うときによく使う作業と、アイテム、弾薬、マガジン、チャージの
+処理を一貫させるための規則を説明します。アイテムのゲームオブジェクトについては
+[ゲームオブジェクト](../explanation/game_objects.md)を参照してください。JSON のアイテム
+フィールドについては、Mod 用リファレンスの
+[アイテム作成](../../mod/json/reference/items/item_creation.md)、
+[アイテム生成](../../mod/json/reference/items/item_spawn.md)、
+[レシピ](../../mod/json/reference/items/recipes.md)を参照してください。
 
-## あるtripointから別のtripointへのアイテムの移動
+## 基本モデル
+
+`item` は複数の概念を表すことがあります。
+
+- ドライバーやバックパックのような通常の物体。
+- 弾薬、食料の一部、液体、部品のような charge で数えるスタック。
+- 弾薬やエネルギーを保持している銃や道具。
+- 弾薬を中身の弾薬アイテムとして保持するマガジン。
+- 他のアイテムを入れているコンテナ。
+
+`item::charges` が常に同じ意味だと仮定しないでください。アイテムの種類によって、
+charges はスタック数、道具のエネルギー、残弾数、または意味のない値になります。
+下にある高水準のアイテム API を優先して使ってください。
+
+## 適切な API を選ぶ
+
+| 作業                                           | 推奨 API                                            | 避けるもの                                 |
+| ---------------------------------------------- | --------------------------------------------------- | ------------------------------------------ |
+| 装填中の弾薬タイプを調べる                     | `item::ammo_current()`                              | `curammo` を直接読む                       |
+| 装填量を調べる                                 | `item::ammo_remaining()`                            | `charges` を直接読む                       |
+| 容量を調べる                                   | `item::ammo_capacity()`                             | JSON フィールドから再計算する              |
+| 銃/道具/マガジンへ装填する                     | `item::ammo_set()`                                  | `charges` と弾薬フィールドを直接設定する   |
+| 銃/道具/マガジンを空にする                     | `item::ammo_unset()` または `recover_stored_ammo()` | `charges` だけを消す                       |
+| 装填済みアイテムから弾薬を消費する             | `item::ammo_consume()`                              | `charges` から直接引く                     |
+| インベントリ/マップの charges を消費する       | `Character::use_charges()`, `map::use_charges()`    | インベントリを手動で走査する               |
+| 個数指定の部品アイテムを消費する               | `Character::use_amount()`, `map::use_amount()`      | 手動の detach ループを書く                 |
+| 保持された弾薬をインベントリアイテムへ変換する | `stored_ammo.h` のヘルパー                          | `item::spawn()` と場当たり的な charge 計算 |
+
+直接のフィールドアクセスは、不変条件がその場で明確な低水準のアイテム実装コードだけで
+使ってください。
+
+## ある tripoint から別の tripoint へアイテムを移動する
 
 ```cpp
 auto move_item( map &here, const tripoint &src, const tripoint &dest ) -> void
 {
-    map_stack items_src = here.i_at( src );
-    map_stack items_dest = here.i_at( dest );
+    auto items_src = here.i_at( src );
+    auto items_dest = here.i_at( dest );
 
     items_src.move_all_to( &items_dest );
 }
 ```
+
+## 弾薬や charges つきのアイテムを生成する
+
+通常の count-by-charges アイテムであれば、charges を指定して生成してかまいません。
+
+```cpp
+auto nails = item::spawn( "nail", calendar::turn, 50 );
+```
+
+銃、道具、マガジンでは、生成後に `ammo_set()` を使うことを優先してください。この関数は、
+対象が内蔵弾薬ストレージを使うのか、中身のマガジン/弾薬アイテムを使うのかを把握しています。
+
+```cpp
+auto cell = item::spawn( "medium_battery_cell" );
+cell->ammo_set( itype_id( "battery" ), 500 );
+```
+
+アイテム内部の実装で関連する弾薬の不変条件をすべて同時に保つ場合を除き、`charges` を
+直接書き換えて装填済み弾薬を初期化しないでください。
+
+## 銃、道具、マガジン
+
+装填済みアイテムには同じ公開クエリを使ってください。
+
+```cpp
+auto describe_loaded_ammo( const item &it ) -> std::string
+{
+    if( it.ammo_current().is_null() || it.ammo_remaining() <= 0 ) {
+        return "empty";
+    }
+    return string_format( "%s: %d", it.ammo_current().str(), it.ammo_remaining() );
+}
+```
+
+保存方法はアイテムの種類ごとに異なります。
+
+- 内蔵式の銃/道具は、多くの場合、弾薬量を `charges` に保存し、弾薬タイプは別に保存します。
+- 着脱式マガジンを使う銃/道具は、弾薬の問い合わせをマガジンへ転送します。
+- マガジンは弾薬を中身の弾薬アイテムとして保存します。
+
+そのため、呼び出し側は保存レイアウトを調べず、`ammo_current()`、`ammo_remaining()`、
+`ammo_set()`、`ammo_unset()`、`ammo_consume()` を使うべきです。
+
+## アイテム内に保持された弾薬や charges を回収する
+
+一部のアイテムは弾薬を抽象的な charges として保持しますが、インベントリに現れる物理
+アイテムは別の単位を使うことがあります。重要な特殊例はプルトニウム燃料です。道具と車両
+部品はプルトニウムを `PLUTONIUM_CHARGES` 単位で保存しますが、インベントリの燃料電池は
+完全なアイテムです。部分的なプルトニウム charges を生の `item::spawn` と手動の `charges`
+代入で変換してはいけません。0-charge のゴーストアイテムを作る可能性があります。
+
+銃、道具、マガジン、車両燃料ストアの保持弾薬を物理アイテムへ変換するコードでは、
+`stored_ammo.h` を使ってください。
+
+```cpp
+for( auto &ammo : recover_stored_ammo( source_item, stored_ammo_remainder_handling::discard ) ) {
+    drop_or_handle( std::move( ammo ), who );
+}
+```
+
+余りの扱いを明示的に選んでください。
+
+- `stored_ammo_remainder_handling::discard`: クラフト、分解、解体のように元アイテムが破壊される
+  ときに使います。完全な弾薬アイテムを回収し、アイテムとして存在できない余りを消します。
+- `stored_ammo_remainder_handling::preserve`: 車両から完全な燃料アイテムだけを取り出し、部分燃料を
+  部品に残す場合のように、元のものが世界に残るときに使います。
+
+物理表現を調べる、または生成するだけのコードでは、`stored_ammo_item_charges`、
+`stored_ammo_charges_for_items`、`spawn_stored_ammo` を使ってください。これにより、charge から
+アイテムへの変換が文書化された 1 つの経路にまとまり、呼び出し側がプルトニウムの丸め規則を
+再実装しなくて済みます。
+
+## 車両燃料ストア
+
+車両部品には独自の弾薬/燃料ストレージがあります。部品内部を直接読まず、
+`vehicle::fuel_left()`、`vehicle::fuels_left()`、`vehicle::drain()`、部品の弾薬 API などの
+車両 API を使ってください。
+
+固体の車両燃料をインベントリアイテムとして取り出す場合も、最後の保持 charge から
+アイテム charge への変換には `stored_ammo.h` を使ってください。これにより、完全なアイテムで
+表せない部分燃料を保持できます。
+
+```cpp
+const auto stored_charges = veh.fuel_left( fuel );
+auto fuel_item = spawn_stored_ammo( fuel, stored_charges );
+if( fuel_item ) {
+    veh.drain( fuel, stored_ammo_charges_for_items( fuel, fuel_item->charges ) );
+}
+```
+
+## `NO_UNLOAD` と回収ポリシー
+
+アイテムの `NO_UNLOAD` は、通常の unload UI でプレイヤーがそのアイテムを空にできないという
+意味です。クラフト、分解、解体でそのアイテムを含むものが破壊されるときに何が起きるべきかは
+自動的には決まりません。そのような経路ではポリシーを明示し、テストを追加してください。
+
+- 元アイテムが残る場合は、アイテムとして表せない余りを保持します。
+- 元アイテムが消費される場合は、完全な弾薬アイテムを回収し、インベントリアイテムとして
+  存在できない余りを捨てます。
+
+## テストチェックリスト
+
+アイテム、弾薬、燃料コードを変更するときは、保存レイアウトと境界条件をテストしてください。
+
+- 内蔵弾薬を使う道具または銃。
+- 充電式バッテリーセルのような、中身の弾薬を持つマガジン。
+- クラフト/分解の部品として消費される元アイテム。
+- unload 後も世界に残る元アイテム。
+- 弾薬なし、および物理アイテム 1 個未満の部分弾薬、特にプルトニウム燃料。
+- 複数の完全な物理アイテムと部分的な余りが同時にある場合。
+
+回収されたアイテムスタックと、元に残った弾薬の両方を確認するテストを推奨します。

--- a/docs/ja/dev/guides/items.md
+++ b/docs/ja/dev/guides/items.md
@@ -112,10 +112,15 @@ for( auto &ammo : recover_stored_ammo( source_item, stored_ammo_remainder_handli
 
 余りの扱いを明示的に選んでください。
 
-- `stored_ammo_remainder_handling::discard`: クラフト、分解、解体のように元アイテムが破壊される
-  ときに使います。完全な弾薬アイテムを回収し、アイテムとして存在できない余りを消します。
+- `stored_ammo_remainder_handling::discard`: 分解や解体のように元アイテムが破壊されるときに
+  使います。完全な弾薬アイテムを回収し、アイテムとして存在できない余りを消します。
 - `stored_ammo_remainder_handling::preserve`: 車両から完全な燃料アイテムだけを取り出し、部分燃料を
   部品に残す場合のように、元のものが世界に残るときに使います。
+
+クラフトは 2 段階で扱います。進行中クラフトが部品を所有している間は保持弾薬を保存し、完了時に
+互換性のある完成品へ先に装填してから、残りだけを物理アイテムとして回収します。これにより、
+充電済みバッテリーセル部品が別のバッテリーセル完成品ではなく、裸の `battery` アイテムとして
+出てくることを防ぎます。
 
 物理表現を調べる、または生成するだけのコードでは、`stored_ammo_item_charges`、
 `stored_ammo_charges_for_items`、`spawn_stored_ammo` を使ってください。これにより、charge から

--- a/docs/ko/dev/guides/items.md
+++ b/docs/ko/dev/guides/items.md
@@ -110,10 +110,15 @@ for( auto &ammo : recover_stored_ammo( source_item, stored_ammo_remainder_handli
 
 나머지 처리 정책을 명시적으로 선택하세요.
 
-- `stored_ammo_remainder_handling::discard`: 제작, 분해, 해체처럼 원본 아이템이 파괴될 때
-  사용합니다. 온전한 탄약 아이템은 회수하고, 아이템으로 존재할 수 없는 나머지는 지웁니다.
+- `stored_ammo_remainder_handling::discard`: 분해나 해체처럼 원본 아이템이 파괴될 때 사용합니다.
+  온전한 탄약 아이템은 회수하고, 아이템으로 존재할 수 없는 나머지는 지웁니다.
 - `stored_ammo_remainder_handling::preserve`: 차량에서 온전한 연료 아이템만 빼고 부분 연료는
   부품에 남기는 경우처럼 원본이 세계에 남을 때 사용합니다.
+
+제작은 두 단계로 처리합니다. 진행 중 제작 아이템이 재료를 소유하는 동안에는 저장 탄약을
+보존하고, 완료 시 호환되는 결과물에 먼저 장전한 뒤 남은 것만 물리 아이템으로 회수합니다. 이렇게
+해야 충전된 배터리 셀 재료가 다른 배터리 셀 제작 결과 대신 느슨한 `battery` 아이템으로 나오지
+않습니다.
 
 물리 표현을 검사하거나 스폰하기만 하는 코드에는 `stored_ammo_item_charges`,
 `stored_ammo_charges_for_items`, `spawn_stored_ammo`를 사용하세요. 이렇게 하면 charge에서

--- a/docs/ko/dev/guides/items.md
+++ b/docs/ko/dev/guides/items.md
@@ -1,16 +1,162 @@
-# 아이템 쿡북
+# 아이템과 탄약 쿡북
 
-아이템과 관련하여 자주 수행하는 작업들입니다.
-[아이템(게임 객체)에 대한 자세한 내용은 여기를 확인하세요.](../explanation/game_objects.md)
+아이템 작업에서 자주 쓰는 패턴과, 아이템/탄약/탄창/충전량 처리를 일관되게 유지하는
+규칙입니다. 아이템 게임 객체에 대한 자세한 내용은 [게임 객체](../explanation/game_objects.md)를
+참고하세요. JSON 아이템 필드는 모딩 문서의
+[아이템 생성](../../mod/json/reference/items/item_creation.md),
+[아이템 스폰](../../mod/json/reference/items/item_spawn.md),
+[제작법](../../mod/json/reference/items/recipes.md)을 참고하세요.
+
+## 기본 모델
+
+`item`은 여러 개념을 나타낼 수 있습니다.
+
+- 드라이버나 배낭 같은 일반 물체.
+- 탄약, 음식 일부, 액체, 부품처럼 charges로 개수를 세는 스택.
+- 탄약이나 에너지를 저장한 총기 또는 도구.
+- 탄약을 내용물 아이템으로 저장하는 탄창.
+- 다른 아이템을 담고 있는 컨테이너.
+
+`item::charges`가 항상 같은 뜻이라고 가정하지 마세요. 아이템 타입에 따라 charges는
+스택 개수, 도구 에너지, 남은 탄약, 또는 의미 없는 값일 수 있습니다. 아래의 상위 수준
+아이템 API를 우선 사용하세요.
+
+## 알맞은 API 선택하기
+
+| 작업                                   | 권장 API                                          | 피할 것                            |
+| -------------------------------------- | ------------------------------------------------- | ---------------------------------- |
+| 장전된 탄약 타입 확인                  | `item::ammo_current()`                            | `curammo` 직접 읽기                |
+| 장전량 확인                            | `item::ammo_remaining()`                          | `charges` 직접 읽기                |
+| 용량 확인                              | `item::ammo_capacity()`                           | JSON 필드로 직접 재계산            |
+| 총기/도구/탄창에 탄약 장전             | `item::ammo_set()`                                | `charges`와 탄약 필드 직접 설정    |
+| 총기/도구/탄창 비우기                  | `item::ammo_unset()` 또는 `recover_stored_ammo()` | `charges`만 지우기                 |
+| 장전된 아이템에서 탄약 소비            | `item::ammo_consume()`                            | `charges`에서 직접 빼기            |
+| 인벤토리/맵 charges 소비               | `Character::use_charges()`, `map::use_charges()`  | 직접 인벤토리 순회                 |
+| 온전한 아이템 재료 소비                | `Character::use_amount()`, `map::use_amount()`    | 직접 detach 루프 작성              |
+| 저장된 탄약을 인벤토리 아이템으로 변환 | `stored_ammo.h` 헬퍼                              | `item::spawn()`과 임시 charge 계산 |
+
+직접 필드 접근은 불변식이 해당 위치에서 명확한 저수준 아이템 구현 코드에서만 사용하세요.
 
 ## 한 tripoint에서 다른 tripoint로 아이템 이동하기
 
 ```cpp
 auto move_item( map &here, const tripoint &src, const tripoint &dest ) -> void
 {
-    map_stack items_src = here.i_at( src );
-    map_stack items_dest = here.i_at( dest );
+    auto items_src = here.i_at( src );
+    auto items_dest = here.i_at( dest );
 
     items_src.move_all_to( &items_dest );
 }
 ```
+
+## 탄약이나 charges가 있는 아이템 스폰하기
+
+일반 count-by-charges 아이템은 charges를 지정해서 스폰해도 됩니다.
+
+```cpp
+auto nails = item::spawn( "nail", calendar::turn, 50 );
+```
+
+총기, 도구, 탄창은 스폰한 뒤 `ammo_set()`을 우선 사용하세요. 이 함수는 대상이 내부
+탄약 저장소를 쓰는지, 내용물 탄창/탄약 아이템을 쓰는지 알고 있습니다.
+
+```cpp
+auto cell = item::spawn( "medium_battery_cell" );
+cell->ammo_set( itype_id( "battery" ), 500 );
+```
+
+아이템 내부 구현에서 관련 탄약 불변식을 모두 함께 유지하는 경우가 아니라면, `charges`를
+직접 써서 장전된 탄약을 초기화하지 마세요.
+
+## 총기, 도구, 탄창
+
+장전된 아이템은 같은 공개 질의 함수를 사용하세요.
+
+```cpp
+auto describe_loaded_ammo( const item &it ) -> std::string
+{
+    if( it.ammo_current().is_null() || it.ammo_remaining() <= 0 ) {
+        return "empty";
+    }
+    return string_format( "%s: %d", it.ammo_current().str(), it.ammo_remaining() );
+}
+```
+
+저장 방식은 아이템 타입마다 다릅니다.
+
+- 내부 저장식 총기/도구는 보통 탄약량을 `charges`에 저장하고 탄약 타입은 따로 저장합니다.
+- 탈착식 탄창을 쓰는 총기/도구는 탄약 질의를 탄창으로 전달합니다.
+- 탄창은 탄약을 내용물 탄약 아이템으로 저장합니다.
+
+따라서 호출자는 저장 구조를 검사하지 말고 `ammo_current()`, `ammo_remaining()`,
+`ammo_set()`, `ammo_unset()`, `ammo_consume()`을 사용해야 합니다.
+
+## 아이템 안에 저장된 탄약이나 charges 회수하기
+
+일부 아이템은 탄약을 추상적인 charges로 저장하지만, 인벤토리에 나타나는 물리 아이템은
+다른 단위를 쓸 수 있습니다. 중요한 특수 사례는 플루토늄 연료입니다. 도구와 차량 부품은
+플루토늄을 `PLUTONIUM_CHARGES` 단위로 저장하지만, 인벤토리 연료전지는 온전한 아이템입니다.
+부분 플루토늄 charges를 `item::spawn`과 수동 `charges` 대입으로 변환하면 0-charge 유령
+아이템을 만들 수 있으므로 금지합니다.
+
+총기, 도구, 탄창, 차량 연료 저장소의 저장된 탄약을 물리 아이템으로 바꿀 때는
+`stored_ammo.h`를 사용하세요.
+
+```cpp
+for( auto &ammo : recover_stored_ammo( source_item, stored_ammo_remainder_handling::discard ) ) {
+    drop_or_handle( std::move( ammo ), who );
+}
+```
+
+나머지 처리 정책을 명시적으로 선택하세요.
+
+- `stored_ammo_remainder_handling::discard`: 제작, 분해, 해체처럼 원본 아이템이 파괴될 때
+  사용합니다. 온전한 탄약 아이템은 회수하고, 아이템으로 존재할 수 없는 나머지는 지웁니다.
+- `stored_ammo_remainder_handling::preserve`: 차량에서 온전한 연료 아이템만 빼고 부분 연료는
+  부품에 남기는 경우처럼 원본이 세계에 남을 때 사용합니다.
+
+물리 표현을 검사하거나 스폰하기만 하는 코드에는 `stored_ammo_item_charges`,
+`stored_ammo_charges_for_items`, `spawn_stored_ammo`를 사용하세요. 이렇게 하면 charge에서
+아이템으로 변환하는 경로가 하나로 문서화되고, 호출자가 플루토늄 반올림 규칙을 다시 구현하지
+않아도 됩니다.
+
+## 차량 연료 저장소
+
+차량 부품에는 별도의 탄약/연료 저장소가 있습니다. 부품 내부를 직접 읽지 말고
+`vehicle::fuel_left()`, `vehicle::fuels_left()`, `vehicle::drain()`, 부품 탄약 API 같은 차량
+API를 사용하세요.
+
+고체 차량 연료를 인벤토리 아이템으로 꺼낼 때도 최종 저장 charge에서 아이템 charge로
+변환하는 단계는 `stored_ammo.h`를 사용하세요. 이렇게 하면 온전한 아이템으로 표현할 수 없는
+부분 연료를 보존할 수 있습니다.
+
+```cpp
+const auto stored_charges = veh.fuel_left( fuel );
+auto fuel_item = spawn_stored_ammo( fuel, stored_charges );
+if( fuel_item ) {
+    veh.drain( fuel, stored_ammo_charges_for_items( fuel, fuel_item->charges ) );
+}
+```
+
+## `NO_UNLOAD`와 회수 정책
+
+아이템의 `NO_UNLOAD`는 플레이어가 일반 unload UI로 그 아이템을 비울 수 없어야 한다는 뜻입니다.
+제작, 분해, 해체로 담고 있는 아이템이 파괴될 때 무슨 일이 일어나야 하는지를 자동으로 정하지는
+않습니다. 그런 경로에서는 정책을 명시하고 테스트를 추가하세요.
+
+- 원본 아이템이 살아남으면 아이템으로 표현할 수 없는 나머지를 보존합니다.
+- 원본 아이템이 소비되면 온전한 탄약 아이템을 회수하고, 인벤토리 아이템으로 존재할 수 없는
+  나머지는 버립니다.
+
+## 테스트 체크리스트
+
+아이템, 탄약, 연료 코드를 바꿀 때는 저장 구조와 경계 조건을 테스트하세요.
+
+- 내부 탄약을 쓰는 도구 또는 총기.
+- 충전식 배터리 셀처럼 내용물 탄약을 가진 탄창.
+- 제작/분해 재료로 소비되는 원본 아이템.
+- unload 뒤에도 세계에 남는 원본 아이템.
+- 탄약 없음과 물리 아이템 1개 미만의 부분 탄약, 특히 플루토늄 연료.
+- 여러 개의 온전한 물리 아이템과 부분 나머지가 함께 있는 경우.
+
+회수된 아이템 스택과 원본에 남은 탄약을 모두 확인하는 테스트를 선호하세요.

--- a/src/character.h
+++ b/src/character.h
@@ -2555,12 +2555,28 @@ class Character : public Creature, public location_visitable<Character>
         select_item_component( const std::vector<item_comp> &components,
                                int batch, inventory &map_inv, bool can_cancel = false,
                                const std::function<bool( const item & )> &filter = return_true<item>, bool player_inv = true );
+        enum class component_ammo_handling {
+            recover,
+            preserve
+        };
+
+        struct consume_items_options {
+            map *source_map = nullptr;
+            const comp_selection<item_comp> *selection = nullptr;
+            int batch = 1;
+            tripoint_bub_ms origin = tripoint_bub_ms::zero();
+            int radius = PICKUP_RANGE;
+            std::function<bool( const item & )> filter = return_true<item>;
+            component_ammo_handling ammo_handling = component_ammo_handling::recover;
+        };
+
         std::vector<detached_ptr<item>> consume_items( const comp_selection<item_comp> &is, int batch,
                                      const std::function<bool( const item & )> &filter = return_true<item> );
         std::vector<detached_ptr<item>> consume_items( map &m, const comp_selection<item_comp> &is,
                                      int batch,
                                      const tripoint_bub_ms &origin, int radius,
                                      const std::function<bool( const item & )> &filter = return_true<item> );
+        auto consume_items( const consume_items_options &opts ) -> std::vector<detached_ptr<item>>;
         std::vector<detached_ptr<item>> consume_items( const std::vector<item_comp> &components,
                                      int batch = 1,
                                      const std::function<bool( const item & )> &filter = return_true<item> );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -64,6 +64,115 @@ std::string enum_to_string<usage_from>( usage_from data )
 
 } // namespace io
 
+namespace
+{
+
+struct selected_tool_context {
+    Character &crafter;
+    const inventory &map_inv;
+    int batch_size = 1;
+};
+
+struct selected_tool_prepayment {
+    bool available = true;
+    bool full = true;
+};
+
+enum class tool_charge_prepayment {
+    full,
+    start_only,
+};
+
+auto selected_tool_has_charges( const comp_selection<tool_comp> &tool_sel,
+                                const selected_tool_context &ctx, int charges ) -> bool
+{
+    switch( tool_sel.use_from ) {
+        case usage_from::player:
+            return ctx.crafter.has_charges( tool_sel.comp.type, charges );
+        case usage_from::map:
+            return ctx.map_inv.has_charges( tool_sel.comp.type, charges );
+        case usage_from::both:
+            return ctx.crafter.charges_of( tool_sel.comp.type ) +
+                   ctx.map_inv.charges_of( tool_sel.comp.type ) >= charges;
+        case usage_from::none:
+        case usage_from::cancel:
+        case usage_from::num_usages_from:
+            break;
+    }
+    return true;
+}
+
+auto selected_tool_exists( const comp_selection<tool_comp> &tool_sel,
+                           const selected_tool_context &ctx ) -> bool
+{
+    switch( tool_sel.use_from ) {
+        case usage_from::player:
+            return ctx.crafter.has_amount( tool_sel.comp.type, 1 );
+        case usage_from::map:
+            return ctx.map_inv.has_tools( tool_sel.comp.type, 1 );
+        case usage_from::both:
+            return ctx.crafter.amount_of( tool_sel.comp.type ) +
+                   ctx.map_inv.amount_of( tool_sel.comp.type ) >= 1;
+        case usage_from::none:
+        case usage_from::cancel:
+        case usage_from::num_usages_from:
+            break;
+    }
+    return true;
+}
+
+auto selected_tool_prepayment_state( const std::vector<comp_selection<tool_comp>> &tool_selections,
+                                     const selected_tool_context &ctx ) -> selected_tool_prepayment
+{
+    auto result = selected_tool_prepayment{};
+    for( const comp_selection<tool_comp> &tool_sel : tool_selections ) {
+        if( tool_sel.comp.count <= 0 ) {
+            if( !selected_tool_exists( tool_sel, ctx ) ) {
+                result.available = false;
+            }
+            continue;
+        }
+
+        const auto full_cost = tool_sel.comp.count * ctx.batch_size;
+        if( selected_tool_has_charges( tool_sel, ctx, full_cost ) ) {
+            continue;
+        }
+
+        result.full = false;
+        if( !selected_tool_has_charges( tool_sel, ctx, crafting::charges_for_starting( full_cost ) ) ) {
+            result.available = false;
+        }
+    }
+    return result;
+}
+
+auto selected_tool_charge_cost( int full_cost, tool_charge_prepayment prepayment ) -> int
+{
+    switch( prepayment ) {
+        case tool_charge_prepayment::full:
+            return full_cost;
+        case tool_charge_prepayment::start_only:
+            return crafting::charges_for_starting( full_cost );
+    }
+    return full_cost;
+}
+
+auto consume_selected_tool_charges( const std::vector<comp_selection<tool_comp>> &tool_selections,
+                                    const selected_tool_context &ctx,
+                                    tool_charge_prepayment prepayment ) -> void
+{
+    for( const comp_selection<tool_comp> &tool : tool_selections ) {
+        if( tool.comp.count <= 0 ) {
+            continue;
+        }
+        auto to_consume = tool;
+        to_consume.comp.count = selected_tool_charge_cost( tool.comp.count * ctx.batch_size, prepayment );
+        ctx.crafter.consume_tools( to_consume, 1 );
+    }
+}
+
+} // namespace
+
 template<typename CompType>
 void comp_selection<CompType>::serialize( JsonOut &jsout ) const
 {
@@ -172,7 +281,9 @@ void craft_command::execute( const tripoint_bub_ms &new_loc )
         }
     }
 
-    crafter->start_craft( *this, loc );
+    if( crafter->start_craft( *this, loc ) == nullptr ) {
+        return;
+    }
     crafter->last_batch = batch_size;
     crafter->lastrecipe = rec->ident();
 
@@ -245,6 +356,22 @@ detached_ptr<item> craft_command::create_in_progress_craft()
     }
 
     const auto filter = rec->get_component_filter( flags );
+    const auto tool_context = selected_tool_context{
+        .crafter = *crafter,
+        .map_inv = map_inv,
+        .batch_size = batch_size,
+    };
+    const auto tool_prepayment = selected_tool_prepayment_state( tool_selections, tool_context );
+    if( !tool_prepayment.available ) {
+        return detached_ptr<item>();
+    }
+
+    // Prepay tool charges before consuming components. A component can be a magazine installed
+    // in the selected tool; detaching it first would make the tool look empty and abort crafting
+    // after materials had already been consumed.
+    consume_selected_tool_charges( tool_selections, tool_context,
+                                   tool_prepayment.full ? tool_charge_prepayment::full :
+                                   tool_charge_prepayment::start_only );
 
     for( const auto &it : item_selections ) {
         std::vector<detached_ptr<item>> tmp = crafter->consume_items( it, batch_size, filter );
@@ -274,105 +401,8 @@ detached_ptr<item> craft_command::create_in_progress_craft()
 
     new_craft->set_cached_tool_selections( tool_selections );
     new_craft->set_tools_to_continue( true );
-
-    bool can_fully_prepay = true;
-    for( const comp_selection<tool_comp> &tool_sel : tool_selections ) {
-        const auto type = tool_sel.comp.type;
-        if( tool_sel.comp.count > 0 ) {
-            const auto full_cost = tool_sel.comp.count * batch_size;
-            switch( tool_sel.use_from ) {
-                case usage_from::player:
-                    if( !crafter->has_charges( type, full_cost ) ) {
-                        can_fully_prepay = false;
-                    }
-                    break;
-                case usage_from::map:
-                    if( !map_inv.has_charges( type, full_cost ) ) {
-                        can_fully_prepay = false;
-                    }
-                    break;
-                case usage_from::both:
-                    if( crafter->charges_of( type ) + map_inv.charges_of( type ) < full_cost ) {
-                        can_fully_prepay = false;
-                    }
-                    break;
-                case usage_from::none:
-                case usage_from::cancel:
-                case usage_from::num_usages_from:
-                    break;
-            }
-        } else {
-            switch( tool_sel.use_from ) {
-                case usage_from::player:
-                    if( !crafter->has_amount( type, 1 ) ) {
-                        return detached_ptr<item>();
-                    }
-                    break;
-                case usage_from::map:
-                    if( !map_inv.has_tools( type, 1 ) ) {
-                        return detached_ptr<item>();
-                    }
-                    break;
-                case usage_from::both:
-                    if( crafter->amount_of( type ) + map_inv.amount_of( type ) < 1 ) {
-                        return detached_ptr<item>();
-                    }
-                    break;
-                case usage_from::none:
-                case usage_from::cancel:
-                case usage_from::num_usages_from:
-                    break;
-            }
-        }
-    }
-
-    if( can_fully_prepay ) {
-        for( const comp_selection<tool_comp> &tool : tool_selections ) {
-            if( tool.comp.count <= 0 ) {
-                continue;
-            }
-            auto to_consume = tool;
-            to_consume.comp.count *= batch_size;
-            crafter->consume_tools( to_consume, 1 );
-        }
+    if( tool_prepayment.full ) {
         new_craft->set_var( "craft_tools_fully_prepaid", 1 );
-    } else {
-        // Consume only the starting fraction; the rest will be paid per 5% step during crafting.
-        for( const comp_selection<tool_comp> &tool_sel : tool_selections ) {
-            if( tool_sel.comp.count <= 0 ) {
-                continue;
-            }
-            const auto full_cost = tool_sel.comp.count * batch_size;
-            const auto start_cost = crafting::charges_for_starting( full_cost );
-            bool has_start = false;
-            switch( tool_sel.use_from ) {
-                case usage_from::player:
-                    has_start = crafter->has_charges( tool_sel.comp.type, start_cost );
-                    break;
-                case usage_from::map:
-                    has_start = map_inv.has_charges( tool_sel.comp.type, start_cost );
-                    break;
-                case usage_from::both:
-                    has_start = crafter->charges_of( tool_sel.comp.type ) +
-                                map_inv.charges_of( tool_sel.comp.type ) >= start_cost;
-                    break;
-                default:
-                    has_start = true;
-                    break;
-            }
-            if( !has_start ) {
-                return detached_ptr<item>();
-            }
-        }
-        for( const comp_selection<tool_comp> &tool_sel : tool_selections ) {
-            if( tool_sel.comp.count <= 0 ) {
-                continue;
-            }
-            auto to_consume = tool_sel;
-            to_consume.comp.count = crafting::charges_for_starting( tool_sel.comp.count * batch_size );
-            crafter->consume_tools( to_consume, 1 );
-        }
-        // craft_tools_fully_prepaid is intentionally NOT set; do_turn will consume per step.
     }
     new_craft->set_next_failure_point( *crafter );
 

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -374,7 +374,13 @@ detached_ptr<item> craft_command::create_in_progress_craft()
                                    tool_charge_prepayment::start_only );
 
     for( const auto &it : item_selections ) {
-        std::vector<detached_ptr<item>> tmp = crafter->consume_items( it, batch_size, filter );
+        auto tmp = crafter->consume_items( {
+            .selection = &it,
+            .batch = batch_size,
+            .origin = crafter->bub_pos(),
+            .filter = filter,
+            .ammo_handling = Character::component_ammo_handling::preserve,
+        } );
         used.insert( used.end(), std::make_move_iterator( tmp.begin() ),
                      std::make_move_iterator( tmp.end() ) );
     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2398,6 +2398,49 @@ void remove_ammo( std::vector<item *> &dis_items, Character &who )
     }
 }
 
+namespace
+{
+
+auto stored_ammo_remaining( const item &dis_item ) -> int
+{
+    return dis_item.is_magazine() ? dis_item.ammo_remaining() : dis_item.charges;
+}
+
+auto recoverable_ammo_charges( const item &dis_item ) -> int
+{
+    const auto raw_charges = stored_ammo_remaining( dis_item );
+    if( raw_charges <= 0 || dis_item.ammo_current().is_null() ) {
+        return 0;
+    }
+    return dis_item.ammo_current() == itype_plut_cell ? raw_charges / PLUTONIUM_CHARGES : raw_charges;
+}
+
+auto clear_stored_ammo( item &dis_item ) -> void
+{
+    if( dis_item.is_magazine() ) {
+        dis_item.ammo_unset();
+    } else {
+        dis_item.charges = 0;
+    }
+}
+
+auto drop_stored_ammo( item &dis_item, Character &who ) -> void
+{
+    if( stored_ammo_remaining( dis_item ) <= 0 || dis_item.ammo_current().is_null() ) {
+        return;
+    }
+
+    const auto ammo_charges = recoverable_ammo_charges( dis_item );
+    if( ammo_charges > 0 ) {
+        auto ammodrop = item::spawn( dis_item.ammo_current(), calendar::turn );
+        ammodrop->charges = ammo_charges;
+        drop_or_handle( std::move( ammodrop ), who );
+    }
+    clear_stored_ammo( dis_item );
+}
+
+} // namespace
+
 void remove_ammo( item &dis_item, Character &who )
 {
     std::vector<detached_ptr<item>> removed;
@@ -2412,23 +2455,8 @@ void remove_ammo( item &dis_item, Character &who )
         drop_or_handle( std::move( it ), who );
     }
 
-    if( dis_item.has_flag( flag_NO_UNLOAD ) ) {
-        return;
-    }
-    if( dis_item.is_gun() && !dis_item.ammo_current().is_null() ) {
-        detached_ptr<item> ammodrop = item::spawn( dis_item.ammo_current(), calendar::turn );
-        ammodrop->charges = dis_item.charges;
-        drop_or_handle( std::move( ammodrop ), who );
-        dis_item.charges = 0;
-    }
-    if( dis_item.is_tool() && dis_item.charges > 0 && !dis_item.ammo_current().is_null() ) {
-        detached_ptr<item> ammodrop = item::spawn( dis_item.ammo_current(), calendar::turn );
-        ammodrop->charges = dis_item.charges;
-        if( dis_item.ammo_current() == itype_plut_cell ) {
-            ammodrop->charges /= PLUTONIUM_CHARGES;
-        }
-        drop_or_handle( std::move( ammodrop ), who );
-        dis_item.charges = 0;
+    if( dis_item.is_gun() || dis_item.is_tool() || dis_item.is_magazine() ) {
+        drop_stored_ammo( dis_item, who );
     }
 }
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1087,6 +1087,91 @@ void item::inherit_flags( const std::vector<item *> &parents, const recipe &maki
     }
 }
 
+namespace
+{
+
+auto drop_or_handle( detached_ptr<item> &&newit, Character &who ) -> void
+{
+    if( newit->made_of( LIQUID ) && who.is_avatar() ) {
+        // TODO: what about NPCs?
+        liquid_handler::handle_all_liquid( std::move( newit ), PICKUP_RANGE );
+    } else {
+        who.as_player()->i_add_or_drop( std::move( newit ) );
+    }
+}
+
+auto load_stored_ammo_into_result( item &result, const itype_id &ammo, int charges ) -> int
+{
+    if( charges <= 0 || ammo.is_null() ) {
+        return 0;
+    }
+
+    if( result.typeId() == ammo && result.count_by_charges() ) {
+        result.charges += charges;
+        return charges;
+    }
+
+    if( !( result.is_tool() || result.is_gun() || result.is_magazine() ) || !ammo->ammo ) {
+        return 0;
+    }
+    if( !result.ammo_types().contains( ammo->ammo->type ) ) {
+        return 0;
+    }
+    if( !result.ammo_current().is_null() && result.ammo_current() != ammo ) {
+        return 0;
+    }
+
+    const auto available_capacity = result.ammo_capacity() - result.ammo_remaining();
+    const auto charges_to_load = std::min( charges, available_capacity );
+    if( charges_to_load <= 0 ) {
+        return 0;
+    }
+
+    result.ammo_set( ammo, result.ammo_remaining() + charges_to_load );
+    return charges_to_load;
+}
+
+auto load_stored_ammo_into_results( std::vector<detached_ptr<item>> &results,
+                                    const itype_id &ammo, int charges ) -> int
+{
+    auto remaining_charges = charges;
+    for( detached_ptr<item> &result : results ) {
+        remaining_charges -= load_stored_ammo_into_result( *result, ammo, remaining_charges );
+        if( remaining_charges <= 0 ) {
+            break;
+        }
+    }
+    return charges - remaining_charges;
+}
+
+auto transfer_or_recover_component_ammo( std::vector<detached_ptr<item>> &components,
+        std::vector<detached_ptr<item>> &results, Character &who ) -> void
+{
+    for( detached_ptr<item> &component : components ) {
+        if( !( component->is_gun() || component->is_tool() || component->is_magazine() ) ) {
+            continue;
+        }
+
+        const auto ammo = component->ammo_current();
+        const auto stored_charges = component->ammo_remaining();
+        if( ammo.is_null() || stored_charges <= 0 ) {
+            continue;
+        }
+
+        const auto loaded_charges = load_stored_ammo_into_results( results, ammo, stored_charges );
+        if( loaded_charges > 0 ) {
+            component->ammo_consume( loaded_charges, who.bub_pos() );
+        }
+
+        for( auto &recovered : recover_stored_ammo( *component,
+                stored_ammo_remainder_handling::discard ) ) {
+            drop_or_handle( std::move( recovered ), who );
+        }
+    }
+}
+
+} // namespace
+
 void complete_craft( Character &who, item &craft )
 {
     if( !craft.is_craft() ) {
@@ -1097,16 +1182,18 @@ void complete_craft( Character &who, item &craft )
     const recipe &making = craft.get_making();
     const int batch_size = craft.charges;
     std::vector<detached_ptr<item>> used = craft.remove_components();
-    std::vector<item *> used_items;
-    used_items.reserve( used.size() );
-    for( detached_ptr<item> &it : used ) {
-        used_items.push_back( &*it );
-    }
     const double relative_rot = craft.get_relative_rot();
     const bool ignore_component = making.has_flag( "NUTRIENT_OVERRIDE" );
 
     // Set up the new item, and assign an inventory letter if available
     std::vector<detached_ptr<item>> newits = making.create_results( batch_size );
+    transfer_or_recover_component_ammo( used, newits, who );
+
+    std::vector<item *> used_items;
+    used_items.reserve( used.size() );
+    for( detached_ptr<item> &it : used ) {
+        used_items.push_back( &*it );
+    }
 
     const bool should_heat = making.hot_result();
     const bool is_dehydrated = making.dehydrate_result();
@@ -1328,7 +1415,13 @@ bool Character::can_continue_craft( item &craft )
             item_selections.push_back( is );
         }
         for( const auto &it : item_selections ) {
-            std::vector<detached_ptr<item>> items = consume_items( it, batch_size, filter );
+            auto items = consume_items( {
+                .selection = &it,
+                .batch = batch_size,
+                .origin = bub_pos(),
+                .filter = filter,
+                .ammo_handling = component_ammo_handling::preserve,
+            } );
             for( detached_ptr<item> &it : items ) {
                 craft.add_component( std::move( it ) );
             }
@@ -1596,16 +1689,6 @@ comp_selection<item_comp> Character::select_item_component( const std::vector<it
     return selected;
 }
 
-static void drop_or_handle( detached_ptr<item> &&newit, Character &who )
-{
-    if( newit->made_of( LIQUID ) && who.is_avatar() ) {
-        // TODO: what about NPCs?
-        liquid_handler::handle_all_liquid( std::move( newit ), PICKUP_RANGE );
-    } else {
-        who.as_player()->i_add_or_drop( std::move( newit ) );
-    }
-}
-
 // Prompts player to empty all newly-unsealed containers in inventory
 // Called after something that might have opened containers (making them buckets) but not emptied them
 static void empty_buckets( Character &p )
@@ -1631,7 +1714,12 @@ std::vector<detached_ptr<item>> Character::consume_items( const comp_selection<i
                              int batch,
                              const std::function<bool( const item & )> &filter )
 {
-    return consume_items( get_map(), is, batch, bub_pos(), PICKUP_RANGE, filter );
+    return consume_items( {
+        .selection = &is,
+        .batch = batch,
+        .origin = bub_pos(),
+        .filter = filter,
+    } );
 }
 
 std::vector<detached_ptr<item>> Character::consume_items( map &m,
@@ -1640,64 +1728,82 @@ std::vector<detached_ptr<item>> Character::consume_items( map &m,
                              const tripoint_bub_ms &origin, int radius,
                              const std::function<bool( const item & )> &filter )
 {
-    std::vector<detached_ptr<item>> ret;
+    return consume_items( {
+        .source_map = &m,
+        .selection = &is,
+        .batch = batch,
+        .origin = origin,
+        .radius = radius,
+        .filter = filter,
+    } );
+}
+
+auto Character::consume_items( const consume_items_options &opts ) ->
+std::vector<detached_ptr<item>>
+{
+    auto ret = std::vector<detached_ptr<item>> {};
 
     if( has_trait( trait_DEBUG_HS ) ) {
         return ret;
     }
 
-    item_comp selected_comp = is.comp;
+    auto &source_map = opts.source_map != nullptr ? *opts.source_map : get_map();
+    const auto &selection = *opts.selection;
+    auto selected_comp = selection.comp;
 
-    const tripoint_bub_ms &loc = origin;
-    const bool by_charges = item::count_by_charges( selected_comp.type ) && selected_comp.count > 0;
+    const auto by_charges = item::count_by_charges( selected_comp.type ) && selected_comp.count > 0;
     // Count given to use_amount/use_charges, changed by those functions!
-    int real_count = ( selected_comp.count > 0 ) ? selected_comp.count * batch : std::abs(
-                         selected_comp.count );
+    auto real_count = ( selected_comp.count > 0 ) ? selected_comp.count * opts.batch : std::abs(
+                          selected_comp.count );
     // First try to get everything from the map, than (remaining amount) from player
-    if( is.use_from & usage_from::map ) {
+    if( selection.use_from & usage_from::map ) {
         if( by_charges ) {
-            std::vector<detached_ptr<item>> tmp = m.use_charges( loc, radius, selected_comp.type, real_count,
-                                                  filter );
+            auto tmp = source_map.use_charges( opts.origin, opts.radius, selected_comp.type, real_count,
+                                               opts.filter );
             ret.insert( ret.end(), std::make_move_iterator( tmp.begin() ),
                         std::make_move_iterator( tmp.end() ) );
         } else {
-            std::vector<detached_ptr<item>> tmp = g->m.use_amount( loc, radius, selected_comp.type, real_count,
-                                                  filter );
-            std::vector<item *> as_p;
+            auto tmp = source_map.use_amount( opts.origin, opts.radius, selected_comp.type, real_count,
+                                              opts.filter );
+            auto as_p = std::vector<item *> {};
             as_p.reserve( tmp.size() );
             for( detached_ptr<item> &i : tmp ) {
                 as_p.push_back( &*i );
             }
-            remove_ammo( as_p, *this );
+            if( opts.ammo_handling == component_ammo_handling::recover ) {
+                remove_ammo( as_p, *this );
+            }
             ret.insert( ret.end(), std::make_move_iterator( tmp.begin() ),
                         std::make_move_iterator( tmp.end() ) );
         }
     }
-    if( is.use_from & usage_from::player ) {
+    if( selection.use_from & usage_from::player ) {
         if( by_charges ) {
-            std::vector<detached_ptr<item>> tmp = use_charges( selected_comp.type, real_count, filter );
+            auto tmp = use_charges( selected_comp.type, real_count, opts.filter );
             ret.insert( ret.end(), std::make_move_iterator( tmp.begin() ),
                         std::make_move_iterator( tmp.end() ) );
         } else {
-            std::vector<detached_ptr<item>> tmp = use_amount( selected_comp.type, real_count, filter );
-            std::vector<item *> as_p;
+            auto tmp = use_amount( selected_comp.type, real_count, opts.filter );
+            auto as_p = std::vector<item *> {};
             as_p.reserve( tmp.size() );
             for( detached_ptr<item> &i : tmp ) {
                 as_p.push_back( &*i );
             }
-            remove_ammo( as_p, *this );
+            if( opts.ammo_handling == component_ammo_handling::recover ) {
+                remove_ammo( as_p, *this );
+            }
             ret.insert( ret.end(), std::make_move_iterator( tmp.begin() ),
                         std::make_move_iterator( tmp.end() ) );
         }
     }
     // condense those items into one
     if( by_charges && ret.size() > 1 ) {
-        std::vector<detached_ptr<item>>::iterator b = ret.begin();
-        b++;
-        while( ret.size() > 1 ) {
-            ret.front()->charges += ( *b )->charges;
-            b = ret.erase( b );
+        auto total_charges = 0;
+        for( const detached_ptr<item> &it : ret ) {
+            total_charges += it->charges;
         }
+        ret.front()->charges = total_charges;
+        ret.erase( ret.begin() + 1, ret.end() );
     }
     lastconsumed = selected_comp.type;
     empty_buckets( *this );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -36,7 +36,6 @@
 #include "flag.h"
 #include "flat_set.h"
 #include "game.h"
-#include "game_constants.h"
 #include "game_inventory.h"
 #include "handle_liquid.h"
 #include "inventory.h"
@@ -67,6 +66,7 @@
 #include "string_formatter.h"
 #include "string_id.h"
 #include "string_input_popup.h"
+#include "stored_ammo.h"
 #include "string_utils.h"
 #include "translations.h"
 #include "type_id.h"
@@ -82,8 +82,6 @@
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
 
 static const efftype_id effect_contacts( "contacts" );
-
-static const itype_id itype_plut_cell( "plut_cell" );
 
 static const skill_id skill_cooking( "cooking" );
 static const skill_id skill_electronics( "electronics" );
@@ -2398,49 +2396,6 @@ void remove_ammo( std::vector<item *> &dis_items, Character &who )
     }
 }
 
-namespace
-{
-
-auto stored_ammo_remaining( const item &dis_item ) -> int
-{
-    return dis_item.is_magazine() ? dis_item.ammo_remaining() : dis_item.charges;
-}
-
-auto recoverable_ammo_charges( const item &dis_item ) -> int
-{
-    const auto raw_charges = stored_ammo_remaining( dis_item );
-    if( raw_charges <= 0 || dis_item.ammo_current().is_null() ) {
-        return 0;
-    }
-    return dis_item.ammo_current() == itype_plut_cell ? raw_charges / PLUTONIUM_CHARGES : raw_charges;
-}
-
-auto clear_stored_ammo( item &dis_item ) -> void
-{
-    if( dis_item.is_magazine() ) {
-        dis_item.ammo_unset();
-    } else {
-        dis_item.charges = 0;
-    }
-}
-
-auto drop_stored_ammo( item &dis_item, Character &who ) -> void
-{
-    if( stored_ammo_remaining( dis_item ) <= 0 || dis_item.ammo_current().is_null() ) {
-        return;
-    }
-
-    const auto ammo_charges = recoverable_ammo_charges( dis_item );
-    if( ammo_charges > 0 ) {
-        auto ammodrop = item::spawn( dis_item.ammo_current(), calendar::turn );
-        ammodrop->charges = ammo_charges;
-        drop_or_handle( std::move( ammodrop ), who );
-    }
-    clear_stored_ammo( dis_item );
-}
-
-} // namespace
-
 void remove_ammo( item &dis_item, Character &who )
 {
     std::vector<detached_ptr<item>> removed;
@@ -2456,7 +2411,9 @@ void remove_ammo( item &dis_item, Character &who )
     }
 
     if( dis_item.is_gun() || dis_item.is_tool() || dis_item.is_magazine() ) {
-        drop_stored_ammo( dis_item, who );
+        for( auto &ammo : recover_stored_ammo( dis_item, stored_ammo_remainder_handling::discard ) ) {
+            drop_or_handle( std::move( ammo ), who );
+        }
     }
 }
 

--- a/src/stored_ammo.cpp
+++ b/src/stored_ammo.cpp
@@ -1,0 +1,90 @@
+#include "stored_ammo.h"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "calendar.h"
+#include "game_constants.h"
+#include "item.h"
+#include "itype.h"
+
+namespace
+{
+
+const auto itype_plut_cell = itype_id( "plut_cell" );
+
+auto stored_ammo_remaining( const item &source ) -> int
+{
+    return source.is_magazine() ? source.ammo_remaining() : source.charges;
+}
+
+auto set_stored_ammo_remaining( item &source, const itype_id &ammo, int charges ) -> void
+{
+    const auto remaining_charges = std::max( charges, 0 );
+    if( source.is_magazine() ) {
+        if( remaining_charges > 0 ) {
+            source.ammo_set( ammo, remaining_charges );
+        } else {
+            source.ammo_unset();
+        }
+        return;
+    }
+
+    source.charges = remaining_charges;
+    if( remaining_charges == 0 ) {
+        source.ammo_unset();
+    }
+}
+
+} // namespace
+
+auto stored_ammo_item_charges( const itype_id &ammo, int stored_charges ) -> int
+{
+    if( stored_charges <= 0 || ammo.is_null() ) {
+        return 0;
+    }
+    return ammo == itype_plut_cell ? stored_charges / PLUTONIUM_CHARGES : stored_charges;
+}
+
+auto stored_ammo_charges_for_items( const itype_id &ammo, int item_charges ) -> int
+{
+    if( item_charges <= 0 || ammo.is_null() ) {
+        return 0;
+    }
+    return ammo == itype_plut_cell ? item_charges * PLUTONIUM_CHARGES : item_charges;
+}
+
+auto spawn_stored_ammo( const itype_id &ammo, int stored_charges ) -> detached_ptr<item>
+{
+    const auto item_charges = stored_ammo_item_charges( ammo, stored_charges );
+    if( item_charges <= 0 ) {
+        return detached_ptr<item>();
+    }
+
+    auto ammodrop = item::spawn( ammo, calendar::turn );
+    ammodrop->charges = item_charges;
+    return ammodrop;
+}
+
+auto recover_stored_ammo( item &source,
+                          stored_ammo_remainder_handling remainder_handling ) -> recovered_stored_ammo
+{
+    auto recovered = recovered_stored_ammo();
+    const auto ammo = source.ammo_current();
+    const auto starting_charges = stored_ammo_remaining( source );
+    if( starting_charges <= 0 || ammo.is_null() ) {
+        return recovered;
+    }
+
+    const auto recovered_item_charges = stored_ammo_item_charges( ammo, starting_charges );
+    const auto consumed_charges = stored_ammo_charges_for_items( ammo, recovered_item_charges );
+    if( auto ammodrop = spawn_stored_ammo( ammo, starting_charges ) ) {
+        recovered.push_back( std::move( ammodrop ) );
+    }
+
+    const auto remaining_charges = remainder_handling == stored_ammo_remainder_handling::preserve ?
+                                   starting_charges - consumed_charges : 0;
+    set_stored_ammo_remaining( source, ammo, remaining_charges );
+    return recovered;
+}

--- a/src/stored_ammo.h
+++ b/src/stored_ammo.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <vector>
+
+#include "detached_ptr.h"
+#include "type_id.h"
+
+class item;
+
+using recovered_stored_ammo = std::vector<detached_ptr<item>>;
+
+/// Controls what happens to stored charges that cannot be represented as a physical ammo item.
+///
+/// Most ammo maps 1 stored charge to 1 item charge.  Plutonium fuel cells are different:
+/// vehicle parts and tools store plutonium energy in `PLUTONIUM_CHARGES` units, while the
+/// inventory item stores whole fuel cells.  A partial cell must never be spawned as a
+/// zero-charge item.  Callers that consume the container should discard the remainder; callers
+/// that are only unloading complete units should preserve it.
+enum class stored_ammo_remainder_handling {
+    preserve,
+    discard
+};
+
+/// Returns how many physical item charges can be made from stored ammo charges.
+///
+/// This is the only conversion point from abstract stored ammo charges to item charges.  It
+/// intentionally rounds plutonium fuel down to complete cells so partial plutonium cannot become
+/// a ghost inventory item.
+auto stored_ammo_item_charges( const itype_id &ammo, int stored_charges ) -> int;
+
+/// Returns how many stored charges should be removed for recovered physical item charges.
+auto stored_ammo_charges_for_items( const itype_id &ammo, int item_charges ) -> int;
+
+/// Spawns the physical ammo item represented by stored charges, or returns null if none exists.
+auto spawn_stored_ammo( const itype_id &ammo, int stored_charges ) -> detached_ptr<item>;
+
+/// Removes recoverable stored ammo from an item and returns physical ammo items.
+///
+/// This handles guns, tools, and magazines through the same conversion path.  Use `discard` when
+/// the source item is being destroyed (crafting/disassembly/salvage).  Use `preserve` when the
+/// source remains in the world and only complete recoverable units should be removed.
+auto recover_stored_ammo( item &source,
+                          stored_ammo_remainder_handling remainder_handling ) -> recovered_stored_ammo;

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3143,9 +3143,10 @@ void act_vehicle_unload_fuel( vehicle *veh )
 {
     auto &you = get_avatar();
     std::vector<itype_id> fuels;
-    for( auto &e : veh->fuels_left() ) {
-        if( e.first == fuel_type_battery || e.first->phase != SOLID ) {
-            // This skips battery and plutonium cells
+    for( const auto &e : veh->fuels_left() ) {
+        if( e.first == fuel_type_battery || e.first->phase != SOLID ||
+            ( e.first == itype_plut_cell && e.second < PLUTONIUM_CHARGES ) ) {
+            // This skips batteries and partial plutonium cells
             continue;
         }
         fuels.push_back( e.first );
@@ -3158,13 +3159,9 @@ void act_vehicle_unload_fuel( vehicle *veh )
     if( fuels.size() > 1 ) {
         uilist smenu;
         smenu.text = _( "Remove what?" );
-        for( size_t i = 0; i < fuels.size(); i++ ) {
-            const itype_id &fuel = fuels[i];
-            if( fuel == itype_plut_cell && veh->fuel_left( fuel ) < PLUTONIUM_CHARGES ) {
-                continue;
-            }
+        for( const auto &fuel : fuels ) {
             smenu.entries.emplace_back( uilist_entry( item::nname( fuel ) )
-                                        .with_retval( static_cast<int>( i ) ) );
+                                        .with_retval( static_cast<int>( smenu.entries.size() ) ) );
         }
         smenu.query();
         if( smenu.ret < 0 || static_cast<size_t>( smenu.ret ) >= fuels.size() ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -27,7 +27,6 @@
 #include "faction.h"
 #include "fault.h"
 #include "game.h"
-#include "game_constants.h"
 #include "handle_liquid.h"
 #include "item.h"
 #include "item_contents.h"
@@ -48,6 +47,7 @@
 #include "string_formatter.h"
 #include "string_id.h"
 #include "string_input_popup.h"
+#include "stored_ammo.h"
 #include "string_utils.h"
 #include "tileray.h"
 #include "translations.h"
@@ -72,7 +72,6 @@
 static const itype_id fuel_type_battery( "battery" );
 
 static const itype_id itype_battery( "battery" );
-static const itype_id itype_plut_cell( "plut_cell" );
 
 static const skill_id skill_mechanics( "mechanics" );
 
@@ -3145,8 +3144,8 @@ void act_vehicle_unload_fuel( vehicle *veh )
     std::vector<itype_id> fuels;
     for( const auto &e : veh->fuels_left() ) {
         if( e.first == fuel_type_battery || e.first->phase != SOLID ||
-            ( e.first == itype_plut_cell && e.second < PLUTONIUM_CHARGES ) ) {
-            // This skips batteries and partial plutonium cells
+            stored_ammo_item_charges( e.first, e.second ) <= 0 ) {
+            // This skips batteries and fuels without complete removable items.
             continue;
         }
         fuels.push_back( e.first );
@@ -3173,22 +3172,17 @@ void act_vehicle_unload_fuel( vehicle *veh )
         fuel = fuels.front();
     }
 
-    int qty = veh->fuel_left( fuel );
-    if( fuel == itype_plut_cell ) {
-        if( qty / PLUTONIUM_CHARGES == 0 ) {
-            add_msg( m_info, _( "The vehicle has no fully charged plutonium cells." ) );
-            return;
-        }
-        detached_ptr<item> plutonium = item::spawn( fuel, calendar::turn, qty / PLUTONIUM_CHARGES );
-        add_msg( m_info, _( "You unload %s from the vehicle." ), plutonium->display_name() );
-        veh->drain( fuel, qty - ( qty % PLUTONIUM_CHARGES ) );
-        you.i_add_or_drop( std::move( plutonium ) );
-    } else {
-        detached_ptr<item> solid_fuel = item::spawn( fuel, calendar::turn, qty );
-        add_msg( m_info, _( "You unload %s from the vehicle." ), solid_fuel->display_name() );
-        veh->drain( fuel, qty );
-        you.i_add_or_drop( std::move( solid_fuel ) );
+    const auto qty = veh->fuel_left( fuel );
+    const auto item_charges = stored_ammo_item_charges( fuel, qty );
+    auto solid_fuel = spawn_stored_ammo( fuel, qty );
+    if( !solid_fuel ) {
+        add_msg( m_info, _( "The vehicle has no complete solid fuel items left to remove." ) );
+        return;
     }
+
+    add_msg( m_info, _( "You unload %s from the vehicle." ), solid_fuel->display_name() );
+    veh->drain( fuel, stored_ammo_charges_for_items( fuel, item_charges ) );
+    you.i_add_or_drop( std::move( solid_fuel ) );
 }
 
 /**

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -21,6 +21,7 @@
 #include "crafting.h"
 #include "distribution_grid.h"
 #include "game.h"
+#include "game_constants.h"
 #include "item.h"
 #include "itype.h"
 #include "map.h"
@@ -40,6 +41,8 @@
 
 class inventory;
 
+static const auto itype_battery = itype_id( "battery" );
+static const auto itype_plut_cell = itype_id( "plut_cell" );
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 static const trait_id trait_DEBUG_STORAGE( "DEBUG_STORAGE" );
 
@@ -452,6 +455,39 @@ TEST_CASE( "tools use charge to craft", "[crafting][charge]" )
             }
         }
     }
+}
+
+TEST_CASE( "crafting with charged magazines recovers ammo", "[crafting][charge]" )
+{
+    clear_all_state();
+    clear_avatar();
+    auto &you = get_avatar();
+    you.wear_item( item::spawn( "backpack" ), false );
+
+    auto battery = item::spawn( "light_plus_battery_cell" );
+    battery->ammo_set( itype_battery, 42 );
+    REQUIRE( battery->ammo_remaining() == 42 );
+
+    remove_ammo( *battery, you );
+
+    CHECK( battery->ammo_remaining() == 0 );
+    CHECK( you.charges_of( itype_battery ) == 42 );
+}
+
+TEST_CASE( "partial plutonium charges do not leave empty fuel cells", "[crafting][charge]" )
+{
+    clear_all_state();
+    clear_avatar();
+    auto &you = get_avatar();
+    you.wear_item( item::spawn( "backpack" ), false );
+
+    auto tool = item::spawn( "adv_UPS_off", calendar::turn, PLUTONIUM_CHARGES - 1 );
+    REQUIRE( tool->ammo_current() == itype_plut_cell );
+
+    remove_ammo( *tool, you );
+
+    CHECK( tool->ammo_remaining() == 0 );
+    CHECK( you.items_with( []( const auto & it ) { return it.typeId() == itype_plut_cell; } ).empty() );
 }
 
 TEST_CASE( "tool_use", "[crafting][tool]" )

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -490,6 +490,25 @@ TEST_CASE( "partial plutonium charges do not leave empty fuel cells", "[crafting
     CHECK( you.items_with( []( const auto & it ) { return it.typeId() == itype_plut_cell; } ).empty() );
 }
 
+TEST_CASE( "crafting with mixed plutonium charges recovers only complete cells",
+           "[crafting][charge]" )
+{
+    clear_all_state();
+    clear_avatar();
+    auto &you = get_avatar();
+    you.wear_item( item::spawn( "backpack" ), false );
+
+    auto tool = item::spawn( "adv_UPS_off", calendar::turn, PLUTONIUM_CHARGES * 2 + 10 );
+    REQUIRE( tool->ammo_current() == itype_plut_cell );
+
+    remove_ammo( *tool, you );
+
+    const auto recovered = you.items_with( []( const auto & it ) { return it.typeId() == itype_plut_cell; } );
+    REQUIRE( recovered.size() == 1 );
+    CHECK( recovered.front()->charges == 2 );
+    CHECK( tool->ammo_remaining() == 0 );
+}
+
 TEST_CASE( "tool_use", "[crafting][tool]" )
 {
     clear_all_state();

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -485,14 +485,27 @@ TEST_CASE( "crafting consumes tool charges before loaded battery components", "[
     auto &you = get_avatar();
     const recipe &rec = recipe_to_make.obj();
     you.learn_recipe( &rec );
+    you.set_skill_level( rec.skill_used, 10 );
+    for( const auto &required_skill : rec.required_skills ) {
+        you.set_skill_level( required_skill.first, 10 );
+    }
     REQUIRE( !you.activity );
 
     you.make_craft( recipe_to_make, 1 );
 
     REQUIRE( you.activity );
-    CHECK( you.activity->id() == activity_id( "ACT_CRAFT" ) );
-    CHECK( you.items_with( []( const auto & it ) { return it.typeId() == itype_medium_plus_battery_cell; } ).empty() );
-    CHECK( you.charges_of( itype_battery ) == 140 );
+    while( you.activity && you.activity->id() == activity_id( "ACT_CRAFT" ) ) {
+        you.moves = 100;
+        you.activity->do_turn( you );
+    }
+
+    const auto results = you.items_with( []( const auto & it ) {
+        return it.typeId() == itype_medium_plus_battery_cell;
+    } );
+    REQUIRE( results.size() == 1 );
+    CHECK( results.front()->ammo_current() == itype_battery );
+    CHECK( results.front()->ammo_remaining() == 140 );
+    CHECK( you.charges_of( itype_battery ) == 0 );
     CHECK( get_remaining_charges( "soldering_iron" ) == 0 );
 }
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -42,6 +42,8 @@
 class inventory;
 
 static const auto itype_battery = itype_id( "battery" );
+static const auto itype_light_plus_battery_cell = itype_id( "light_plus_battery_cell" );
+static const auto itype_medium_plus_battery_cell = itype_id( "medium_plus_battery_cell" );
 static const auto itype_plut_cell = itype_id( "plut_cell" );
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 static const trait_id trait_DEBUG_STORAGE( "DEBUG_STORAGE" );
@@ -455,6 +457,43 @@ TEST_CASE( "tools use charge to craft", "[crafting][charge]" )
             }
         }
     }
+}
+
+TEST_CASE( "crafting consumes tool charges before loaded battery components", "[crafting][charge]" )
+{
+    clear_all_state();
+    std::vector<detached_ptr<item>> tools;
+
+    add_tool( tools, "screwdriver" );
+    add_tool( tools, "solder_wire", 10 );
+    add_tool( tools, "scrap", 4 );
+    add_tool( tools, "cable", 5 );
+    add_tool( tools, "light_plus_battery_cell", 4 );
+
+    auto soldering_iron = item::spawn( "soldering_iron" );
+    auto loaded_cell = item::spawn( "light_plus_battery_cell" );
+    loaded_cell->ammo_set( itype_battery, 150 );
+    soldering_iron->put_in( std::move( loaded_cell ) );
+    REQUIRE( soldering_iron->magazine_current() != nullptr );
+    REQUIRE( soldering_iron->magazine_current()->typeId() == itype_light_plus_battery_cell );
+    REQUIRE( soldering_iron->ammo_remaining() == 150 );
+    tools.push_back( std::move( soldering_iron ) );
+
+    const auto recipe_to_make = recipe_id( "medium_plus_battery_cell" );
+    prep_craft( recipe_to_make, tools, true );
+    set_time( midday );
+    auto &you = get_avatar();
+    const recipe &rec = recipe_to_make.obj();
+    you.learn_recipe( &rec );
+    REQUIRE( !you.activity );
+
+    you.make_craft( recipe_to_make, 1 );
+
+    REQUIRE( you.activity );
+    CHECK( you.activity->id() == activity_id( "ACT_CRAFT" ) );
+    CHECK( you.items_with( []( const auto & it ) { return it.typeId() == itype_medium_plus_battery_cell; } ).empty() );
+    CHECK( you.charges_of( itype_battery ) == 140 );
+    CHECK( get_remaining_charges( "soldering_iron" ) == 0 );
 }
 
 TEST_CASE( "crafting with charged magazines recovers ammo", "[crafting][charge]" )

--- a/tests/stored_ammo_test.cpp
+++ b/tests/stored_ammo_test.cpp
@@ -12,33 +12,115 @@ namespace
 const auto itype_battery = itype_id( "battery" );
 const auto itype_plut_cell = itype_id( "plut_cell" );
 
+constexpr auto partial_plutonium_remainder = 10;
+
 } // namespace
 
-TEST_CASE( "stored ammo conversion itemizes only complete fuel cells", "[stored_ammo]" )
+TEST_CASE( "stored ammo conversion rejects non-itemizable charges", "[stored_ammo]" )
+{
+    CHECK( stored_ammo_item_charges( itype_id::NULL_ID(), 42 ) == 0 );
+    CHECK( stored_ammo_item_charges( itype_battery, 0 ) == 0 );
+    CHECK( stored_ammo_item_charges( itype_battery, -1 ) == 0 );
+    CHECK( stored_ammo_charges_for_items( itype_id::NULL_ID(), 42 ) == 0 );
+    CHECK( stored_ammo_charges_for_items( itype_battery, 0 ) == 0 );
+    CHECK( stored_ammo_charges_for_items( itype_battery, -1 ) == 0 );
+
+    CHECK_FALSE( spawn_stored_ammo( itype_id::NULL_ID(), 42 ) );
+    CHECK_FALSE( spawn_stored_ammo( itype_battery, 0 ) );
+    CHECK_FALSE( spawn_stored_ammo( itype_plut_cell, PLUTONIUM_CHARGES - 1 ) );
+}
+
+TEST_CASE( "stored ammo conversion keeps one-to-one ammo charges", "[stored_ammo]" )
 {
     CHECK( stored_ammo_item_charges( itype_battery, 42 ) == 42 );
     CHECK( stored_ammo_charges_for_items( itype_battery, 42 ) == 42 );
 
-    CHECK( stored_ammo_item_charges( itype_plut_cell, PLUTONIUM_CHARGES - 1 ) == 0 );
-    CHECK( stored_ammo_item_charges( itype_plut_cell, PLUTONIUM_CHARGES ) == 1 );
-    CHECK( stored_ammo_item_charges( itype_plut_cell, PLUTONIUM_CHARGES * 2 + 10 ) == 2 );
-    CHECK( stored_ammo_charges_for_items( itype_plut_cell, 2 ) == PLUTONIUM_CHARGES * 2 );
+    auto battery = spawn_stored_ammo( itype_battery, 42 );
+
+    REQUIRE( battery );
+    CHECK( battery->typeId() == itype_battery );
+    CHECK( battery->charges == 42 );
 }
 
-TEST_CASE( "stored ammo recovery has explicit partial-remainder policy", "[stored_ammo]" )
+TEST_CASE( "stored ammo conversion itemizes only complete fuel cells", "[stored_ammo]" )
 {
-    auto tool = item::spawn( "adv_UPS_off", calendar::turn, PLUTONIUM_CHARGES + 10 );
+    CHECK( stored_ammo_item_charges( itype_plut_cell, PLUTONIUM_CHARGES - 1 ) == 0 );
+    CHECK( stored_ammo_item_charges( itype_plut_cell, PLUTONIUM_CHARGES ) == 1 );
+    CHECK( stored_ammo_item_charges( itype_plut_cell,
+                                     PLUTONIUM_CHARGES * 2 + partial_plutonium_remainder ) == 2 );
+    CHECK( stored_ammo_charges_for_items( itype_plut_cell, 2 ) == PLUTONIUM_CHARGES * 2 );
+
+    auto fuel_cells = spawn_stored_ammo( itype_plut_cell,
+                                         PLUTONIUM_CHARGES * 2 + partial_plutonium_remainder );
+
+    REQUIRE( fuel_cells );
+    CHECK( fuel_cells->typeId() == itype_plut_cell );
+    CHECK( fuel_cells->charges == 2 );
+}
+
+TEST_CASE( "stored ammo recovery empties normal charged magazines", "[stored_ammo]" )
+{
+    auto battery_cell = item::spawn( "light_plus_battery_cell" );
+    battery_cell->ammo_set( itype_battery, 42 );
+    REQUIRE( battery_cell->ammo_remaining() == 42 );
+
+    const auto recovered = recover_stored_ammo( *battery_cell,
+                           stored_ammo_remainder_handling::preserve );
+
+    REQUIRE( recovered.size() == 1 );
+    CHECK( recovered.front()->typeId() == itype_battery );
+    CHECK( recovered.front()->charges == 42 );
+    CHECK( battery_cell->ammo_remaining() == 0 );
+    CHECK( battery_cell->ammo_current().is_null() );
+}
+
+TEST_CASE( "stored ammo recovery handles exact complete fuel cells", "[stored_ammo]" )
+{
+    auto tool = item::spawn( "adv_UPS_off", calendar::turn, PLUTONIUM_CHARGES );
     REQUIRE( tool->ammo_current() == itype_plut_cell );
 
-    auto recovered = recover_stored_ammo( *tool, stored_ammo_remainder_handling::preserve );
+    const auto recovered = recover_stored_ammo( *tool, stored_ammo_remainder_handling::preserve );
 
     REQUIRE( recovered.size() == 1 );
     CHECK( recovered.front()->typeId() == itype_plut_cell );
     CHECK( recovered.front()->charges == 1 );
-    CHECK( tool->ammo_remaining() == 10 );
+    CHECK( tool->ammo_remaining() == 0 );
+}
 
-    recovered = recover_stored_ammo( *tool, stored_ammo_remainder_handling::discard );
+TEST_CASE( "stored ammo recovery preserves partial fuel remainders", "[stored_ammo]" )
+{
+    auto partial_tool = item::spawn( "adv_UPS_off", calendar::turn, PLUTONIUM_CHARGES - 1 );
+    REQUIRE( partial_tool->ammo_current() == itype_plut_cell );
 
-    CHECK( recovered.empty() );
+    const auto partial_recovered = recover_stored_ammo( *partial_tool,
+                                   stored_ammo_remainder_handling::preserve );
+
+    CHECK( partial_recovered.empty() );
+    CHECK( partial_tool->ammo_remaining() == PLUTONIUM_CHARGES - 1 );
+
+    auto mixed_tool = item::spawn( "adv_UPS_off", calendar::turn,
+                                   PLUTONIUM_CHARGES * 2 + partial_plutonium_remainder );
+    REQUIRE( mixed_tool->ammo_current() == itype_plut_cell );
+
+    const auto mixed_recovered = recover_stored_ammo( *mixed_tool,
+                                 stored_ammo_remainder_handling::preserve );
+
+    REQUIRE( mixed_recovered.size() == 1 );
+    CHECK( mixed_recovered.front()->typeId() == itype_plut_cell );
+    CHECK( mixed_recovered.front()->charges == 2 );
+    CHECK( mixed_tool->ammo_remaining() == partial_plutonium_remainder );
+}
+
+TEST_CASE( "stored ammo recovery discards unitemizable consumed remainders", "[stored_ammo]" )
+{
+    auto tool = item::spawn( "adv_UPS_off", calendar::turn,
+                             PLUTONIUM_CHARGES * 2 + partial_plutonium_remainder );
+    REQUIRE( tool->ammo_current() == itype_plut_cell );
+
+    const auto recovered = recover_stored_ammo( *tool, stored_ammo_remainder_handling::discard );
+
+    REQUIRE( recovered.size() == 1 );
+    CHECK( recovered.front()->typeId() == itype_plut_cell );
+    CHECK( recovered.front()->charges == 2 );
     CHECK( tool->ammo_remaining() == 0 );
 }

--- a/tests/stored_ammo_test.cpp
+++ b/tests/stored_ammo_test.cpp
@@ -1,0 +1,44 @@
+#include "catch/catch.hpp"
+
+#include "calendar.h"
+#include "game_constants.h"
+#include "item.h"
+#include "stored_ammo.h"
+#include "type_id.h"
+
+namespace
+{
+
+const auto itype_battery = itype_id( "battery" );
+const auto itype_plut_cell = itype_id( "plut_cell" );
+
+} // namespace
+
+TEST_CASE( "stored ammo conversion itemizes only complete fuel cells", "[stored_ammo]" )
+{
+    CHECK( stored_ammo_item_charges( itype_battery, 42 ) == 42 );
+    CHECK( stored_ammo_charges_for_items( itype_battery, 42 ) == 42 );
+
+    CHECK( stored_ammo_item_charges( itype_plut_cell, PLUTONIUM_CHARGES - 1 ) == 0 );
+    CHECK( stored_ammo_item_charges( itype_plut_cell, PLUTONIUM_CHARGES ) == 1 );
+    CHECK( stored_ammo_item_charges( itype_plut_cell, PLUTONIUM_CHARGES * 2 + 10 ) == 2 );
+    CHECK( stored_ammo_charges_for_items( itype_plut_cell, 2 ) == PLUTONIUM_CHARGES * 2 );
+}
+
+TEST_CASE( "stored ammo recovery has explicit partial-remainder policy", "[stored_ammo]" )
+{
+    auto tool = item::spawn( "adv_UPS_off", calendar::turn, PLUTONIUM_CHARGES + 10 );
+    REQUIRE( tool->ammo_current() == itype_plut_cell );
+
+    auto recovered = recover_stored_ammo( *tool, stored_ammo_remainder_handling::preserve );
+
+    REQUIRE( recovered.size() == 1 );
+    CHECK( recovered.front()->typeId() == itype_plut_cell );
+    CHECK( recovered.front()->charges == 1 );
+    CHECK( tool->ammo_remaining() == 10 );
+
+    recovered = recover_stored_ammo( *tool, stored_ammo_remainder_handling::discard );
+
+    CHECK( recovered.empty() );
+    CHECK( tool->ammo_remaining() == 0 );
+}

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -9,6 +9,7 @@
 #include "calendar.h"
 #include "coordinates.h"
 #include "game.h"
+#include "game_constants.h"
 #include "inventory.h"
 #include "item.h"
 #include "map.h"
@@ -26,7 +27,10 @@
 #include "vpart_range.h"
 
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
+static const auto itype_plut_cell = itype_id( "plut_cell" );
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
+
+auto act_vehicle_unload_fuel( vehicle *veh ) -> void;
 
 static void test_repair( std::vector<detached_ptr<item>> &tools, bool expect_craftable )
 {
@@ -111,6 +115,30 @@ TEST_CASE( "repair_vehicle_part" )
         tools.push_back( item::spawn( "material_aluminium_ingot", bday, 10 ) );
         test_repair( tools, false );
     }
+}
+
+TEST_CASE( "partial vehicle plutonium cannot be unloaded", "[vehicle][veh_interact]" )
+{
+    clear_all_state();
+    build_test_map( ter_id( "t_pavement" ) );
+    auto &here = get_map();
+    auto &you = get_avatar();
+    clear_avatar();
+    you.wear_item( item::spawn( "backpack" ), false );
+
+    const auto vehicle_origin = tripoint( 60, 60, 0 );
+    you.setpos( vehicle_origin + point_south );
+    auto *veh_ptr = here.add_vehicle( vproto_id( "reactor_test" ), vehicle_origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    REQUIRE_FALSE( veh_ptr->reactors.empty() );
+
+    auto &reactor = veh_ptr->part( veh_ptr->reactors.front() );
+    reactor.ammo_set( itype_plut_cell, PLUTONIUM_CHARGES - 1 );
+
+    act_vehicle_unload_fuel( veh_ptr );
+
+    CHECK( reactor.ammo_remaining() == PLUTONIUM_CHARGES - 1 );
+    CHECK( you.items_with( []( const auto & it ) { return it.typeId() == itype_plut_cell; } ).empty() );
 }
 
 TEST_CASE( "debug_hammerspace_installs_full_vehicle_battery", "[vehicle][veh_interact]" )

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -141,6 +141,32 @@ TEST_CASE( "partial vehicle plutonium cannot be unloaded", "[vehicle][veh_intera
     CHECK( you.items_with( []( const auto & it ) { return it.typeId() == itype_plut_cell; } ).empty() );
 }
 
+TEST_CASE( "vehicle plutonium unload preserves partial remainder", "[vehicle][veh_interact]" )
+{
+    clear_all_state();
+    build_test_map( ter_id( "t_pavement" ) );
+    auto &here = get_map();
+    auto &you = get_avatar();
+    clear_avatar();
+    you.wear_item( item::spawn( "backpack" ), false );
+
+    const auto vehicle_origin = tripoint( 60, 60, 0 );
+    you.setpos( vehicle_origin + point_south );
+    auto *veh_ptr = here.add_vehicle( vproto_id( "reactor_test" ), vehicle_origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    REQUIRE_FALSE( veh_ptr->reactors.empty() );
+
+    auto &reactor = veh_ptr->part( veh_ptr->reactors.front() );
+    reactor.ammo_set( itype_plut_cell, PLUTONIUM_CHARGES * 2 + 10 );
+
+    act_vehicle_unload_fuel( veh_ptr );
+
+    const auto recovered = you.items_with( []( const auto & it ) { return it.typeId() == itype_plut_cell; } );
+    REQUIRE( recovered.size() == 1 );
+    CHECK( recovered.front()->charges == 2 );
+    CHECK( reactor.ammo_remaining() == 10 );
+}
+
 TEST_CASE( "debug_hammerspace_installs_full_vehicle_battery", "[vehicle][veh_interact]" )
 {
     clear_all_state();


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="1045" height="321" alt="image" src="https://github.com/user-attachments/assets/2aef13b0-ce7f-4ee9-b5ba-07190907bee8" />

https://discord.com/channels/830879262763909202/1093580823351001098/1501152001369575615

Fixes #8739.

Prevent stored ammo from disappearing when charged magazines/tools are consumed as crafting components, prevent ghost plutonium fuel cells from partial vehicle fuel unloading, and prevent crafting from consuming materials before failing when a selected component is installed in the selected powered tool.

## Describe the solution (The How)

- Recover stored ammo from consumed guns, tools, and magazines through one documented `stored_ammo` helper path.
- Centralize stored-charge to item-charge conversion, including plutonium fuel-cell rounding.
- Make partial-remainder handling explicit: crafting/disassembly discards unitemizable remainders from consumed sources, while vehicle unloading preserves them.
- Prepay selected crafting tool charges before detaching item components, so an installed battery component cannot make the selected tool appear empty after materials are already consumed.
- Guard failed in-progress craft creation before assigning the crafting activity.
- Add item/ammo guide docs in English, Korean, and Japanese, plus an agent rule to keep localized docs in sync.
- Add regression tests for charged magazine ammo recovery, crafting ammo removal, vehicle fuel unloading, installed battery/tool overlap, and the shared conversion/remainder policy.

## Testing

- `cmake --build out/build/linux-full --target astyle`
- `deno fmt AGENTS.md docs/en/dev/guides/items.md docs/ko/dev/guides/items.md docs/ja/dev/guides/items.md`
- `cmake --build --preset linux-full --target cata_test-tiles -j$(nproc)`
- `./out/build/linux-full/tests/cata_test-tiles "[stored_ammo],[crafting][charge],[vehicle][veh_interact]"`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles -j$(nproc)`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I searched for relevant issues/PRs; fixes #8739.

<sup>PR opened by OpenAI on pi</sup>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6cc26a6](https://github.com/cataclysmbn/Cataclysm-BN/commit/6cc26a616936f78d9ff5a5f7d956077da6010127) (fix: preserve crafted battery charge) on 2026-05-28 19:19:41

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26590051073)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26590051073)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26590051073/artifacts/7274603374)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26590051073/artifacts/7273237850)
<!-- END artifact comment -->