### PR TITLE
fix(i18n): add context for ambiguous Korean terms

### DIFF
--- a/.agents/skills/i18n-context/SKILL.md
+++ b/.agents/skills/i18n-context/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: i18n-context
+description: Add gettext context for ambiguous user-facing strings and repair affected PO translations.
+compatibility: Requires git, rg, gettext tools, and Python.
+---
+
+# I18n Context
+
+Use this when one English msgid has multiple meanings and a locale needs different translations.
+
+## Hard requirements
+
+- Do not reduce requested word/context coverage for review risk, churn, or convenience.
+- If a requested meaning needs loader support for contextual translation, add loader support.
+- Do not open or update a PR while `msgfmt` or printf checks fail for the touched locale.
+- Do not dismiss `msgfmt`/printf failures as pre-existing when this task touches that locale.
+
+## Workflow
+
+- Find every shared msgid before editing:
+  - `rg -n 'msgid "<word>"|msgctxt .*\nmsgid "<word>"' lang/po/<lang>.po`
+  - `rg -n '"<word>"|translate_marker\( "<word>" \)|_\( "<word>" \)' data src`
+- Split meanings at the source, following #8729 and #8741:
+  - C++ runtime strings: `pgettext( "short specific context", "text" )`.
+  - C++ marker-only strings: `translate_marker_context( "short specific context", "text" )`.
+  - JSON translated strings: `{ "ctxt": "short specific context", "str": "text" }` or matching plural fields.
+  - Snippet arrays: `{ "text": { "ctxt": "short specific context", "str": "text" } }`.
+  - If a JSON field is currently `std::string`, convert it to `translation` so contextual JSON can load.
+- Keep context names terse and UI-specific, e.g. `time format`, `map extra`, `music genre`, `damage type`.
+- Update `lang/po/<lang>.po` for each new `msgctxt`; do not rely on the old shared `msgstr`.
+- Preserve old uncontexted entries only when some source still uses the shared msgid.
+- For Korean, check existing glossary first:
+  - `rg -C2 -i '<term>' lang/po/ko.po | rg -v '^(#:|--)' | head -n 20`
+- Validate after editing:
+  - `python3 lang/extract_json_strings.py -i data/json -o /tmp/catabn-i18n-context.pot --tracked-only`
+  - `msgfmt -f -c -o /tmp/ko.mo lang/po/ko.po`
+  - `./tools/check_po_printf_format.py`
+  - If JSON changed, run `./build-scripts/lint-json.sh`.
+
+## PR references
+
+- #8729 split ambiguous yes/no labels in C++ with `pgettext` and `translate_marker_context`.
+- #8741 split ambiguous animal/action/species/fish names in JSON with `ctxt` and updated PO entries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,15 @@ deno task docs:gen
 
 - **Commit**: Commit **ATOMICALLY**. **MUST** Follow [Conventional Commits](./docs/en/contribute/changelog_guidelines.md). **MUST NOT** add body/footer unless critical.
 
+## WHEN working on i18n / PO context
+
+- **MUST NOT** reduce requested string/context coverage for review risk or churn. If the user names a word and its meanings, handle every named meaning.
+- If adding JSON context requires loader support, add loader support instead of leaving a source uncontexted.
+- **MUST** run `msgfmt -f -c -o /tmp/ko.mo lang/po/ko.po` after touching Korean PO files and fix reported errors before PR.
+- **MUST** run `./tools/check_po_printf_format.py` after touching PO files and fix reported errors before PR.
+- Do not call PO/printf errors pre-existing to skip them when the task touches that locale or validation path.
+- If a mistake is found during the task, update AGENTS/skill immediately and fix the current branch before summarizing.
+
 ## WHEN translating docs
 
 When translating, MUST search for correct glossary, e.g

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -42,7 +42,7 @@
     "chip_resist": 12,
     "repaired_with": "resin_chunk",
     "salvaged_into": "resin_chunk",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
     "burn_products": [ [ "resin_chunk", 1 ] ]
@@ -88,7 +88,7 @@
     "chip_resist": 10,
     "repaired_with": "acidchitin_piece",
     "salvaged_into": "acidchitin_piece",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
     "burn_data": [
@@ -118,7 +118,7 @@
     "wind_resist": 90,
     "repaired_with": "bone",
     "salvaged_into": "skewer_bone",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
     "vitamins": [ [ "calcium", 2 ] ],
@@ -211,7 +211,7 @@
     "salvaged_into": "cardboard",
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_data": [ { "fuel": 10, "smoke": 1, "burn": 10 }, { "fuel": 8, "smoke": 1, "burn": 20 }, { "fuel": 5, "smoke": 1, "burn": 50 } ],
     "burn_products": [ [ "ash", 0.013 ] ]
   },
@@ -233,7 +233,7 @@
     "chip_resist": 20,
     "dmg_adj": [ "chipped", "cracked", "split", "broken" ],
     "bash_dmg_verb": "cracked",
-    "cut_dmg_verb": "cut"
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" }
   },
   {
     "type": "material",
@@ -254,7 +254,7 @@
     "wind_resist": 90,
     "repaired_with": "chitin_piece",
     "salvaged_into": "chitin_piece",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
     "burn_data": [
@@ -281,7 +281,7 @@
     "chip_resist": 6,
     "dmg_adj": [ "chipped", "scratched", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_products": [ [ "ceramic_shard", 1 ] ]
   },
   {
@@ -329,7 +329,7 @@
     "salvaged_into": "rag",
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
       { "fuel": 1, "smoke": 1, "burn": 1 },
@@ -443,7 +443,7 @@
     "elec_resist": 1,
     "chip_resist": 2,
     "repaired_with": "leather",
-    "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
     "burn_data": [
@@ -470,7 +470,7 @@
     "chip_resist": 4,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_products": [ [ "ceramic_shard", 1 ] ]
   },
   {
@@ -492,7 +492,7 @@
     "chip_resist": 1,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "bruised",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "vitC", 2 ] ],
     "burn_data": [
       { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "1250 ml" },
@@ -574,7 +574,7 @@
     "chip_resist": 0,
     "repaired_with": "glass_shard",
     "salvaged_into": "glass_shard",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "scratched",
     "burn_data": [
@@ -736,7 +736,7 @@
   {
     "type": "material",
     "id": "iron",
-    "name": "Iron",
+    "name": { "ctxt": "material", "str": "Iron" },
     "density": 52,
     "specific_heat_liquid": 0.82,
     "specific_heat_solid": 0.45,
@@ -776,7 +776,7 @@
     "chip_resist": 2,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_data": [ { "fuel": 1, "smoke": 1, "burn": 1 }, { "fuel": 1, "smoke": 1, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ]
   },
   {
@@ -806,7 +806,7 @@
     "salvaged_into": "kevlar_plate",
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
-    "cut_dmg_verb": "cut"
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" }
   },
   {
     "type": "material",
@@ -828,7 +828,7 @@
     "salvaged_into": "kevlar_plate",
     "dmg_adj": [ "marked", "dented", "scarred", "broken" ],
     "bash_dmg_verb": "ripped",
-    "cut_dmg_verb": "cut"
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" }
   },
   {
     "type": "material",
@@ -874,7 +874,7 @@
     "wind_resist": 90,
     "repaired_with": "leather",
     "salvaged_into": "leather",
-    "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
     "burn_data": [
@@ -930,7 +930,7 @@
     "warmth_when_wet": 1,
     "repaired_with": "neoprene",
     "salvaged_into": "neoprene",
-    "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
     "burn_data": [
@@ -961,7 +961,7 @@
     "salvaged_into": "nomex",
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_products": [ [ "nomex", 1 ] ],
     "burn_data": [ { "immune": true }, { "immune": true }, { "immune": true } ]
   },
@@ -1029,7 +1029,7 @@
     "salvaged_into": "paper",
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_data": [ { "fuel": 10, "smoke": 1, "burn": 10 }, { "fuel": 8, "smoke": 1, "burn": 20 }, { "fuel": 5, "smoke": 1, "burn": 50 } ],
     "burn_products": [ [ "ash", 0.013 ] ]
   },
@@ -1053,7 +1053,7 @@
     "salvaged_into": "withered",
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_data": [ { "fuel": 10, "smoke": 1, "burn": 10 }, { "fuel": 8, "smoke": 1, "burn": 20 }, { "fuel": 5, "smoke": 1, "burn": 50 } ],
     "burn_products": [ [ "ash", 0.013 ] ]
   },
@@ -1076,7 +1076,7 @@
     "wind_resist": 90,
     "repaired_with": "plastic_chunk",
     "salvaged_into": "plastic_chunk",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
     "burn_data": [
@@ -1266,7 +1266,7 @@
     "fire_resist": 3,
     "elec_resist": 2,
     "chip_resist": 20,
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
     "burn_products": [ [ "pebble", 1 ] ]
@@ -1337,7 +1337,7 @@
     "salvaged_into": "nylon",
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "650 ml" },
       { "fuel": 1, "smoke": 1, "burn": 1 },
@@ -1392,7 +1392,7 @@
     "chip_resist": 2,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "calcium", 0.1 ], [ "vitA", 1 ], [ "vitC", 0.5 ] ],
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
@@ -1419,7 +1419,7 @@
     "chip_resist": 2,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "calcium", 0.1 ], [ "vitA", 2 ], [ "vitC", 4 ], [ "iron", 0.1 ] ],
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
@@ -1446,7 +1446,7 @@
     "chip_resist": 2,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "calcium", 0.3 ], [ "vitC", 0.6 ], [ "iron", 0.8 ] ],
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
@@ -1473,7 +1473,7 @@
     "chip_resist": 2,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "calcium", 1.8 ], [ "vitC", 5.2 ], [ "iron", 0.9 ] ],
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
@@ -1500,7 +1500,7 @@
     "chip_resist": 2,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "calcium", 0.3 ], [ "iron", 1 ] ],
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
@@ -1527,7 +1527,7 @@
     "chip_resist": 2,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "calcium", 0.4 ], [ "iron", 4 ] ],
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
@@ -1579,7 +1579,7 @@
     "chip_resist": 1,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "vitB", 1 ], [ "iron", 0.1 ] ],
     "burn_data": [ { "fuel": 1, "smoke": 2, "burn": 1 }, { "fuel": 1, "smoke": 2, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ]
   },
@@ -1634,7 +1634,7 @@
     "salvaged_into": "felt_patch",
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "torn",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
       { "fuel": 1, "smoke": 1, "burn": 2 },
@@ -1685,7 +1685,7 @@
     "chip_resist": 1,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "bruised",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "vitC", 2 ] ],
     "burn_data": [
       { "fuel": 1, "smoke": 2, "burn": 1, "volume_per_turn": "1250 ml" },
@@ -1739,7 +1739,7 @@
     "chip_resist": 2,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_data": [ { "fuel": 1, "smoke": 1, "burn": 1 }, { "fuel": 1, "smoke": 1, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ]
   },
   {
@@ -1761,7 +1761,7 @@
     "chip_resist": 0,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "vitamins": [ [ "vitB", 0.5 ], [ "calcium", 1.5 ], [ "iron", 0.1 ] ],
     "burn_data": [
       { "fuel": -100, "smoke": 1, "burn": 1 },
@@ -1788,7 +1788,7 @@
     "chip_resist": 0,
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
-    "cut_dmg_verb": "cut",
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" },
     "burn_data": [
       { "fuel": -100, "smoke": 1, "burn": 1 },
       { "fuel": -50, "smoke": 2, "burn": 1 },
@@ -1881,7 +1881,7 @@
     "chip_resist": 10,
     "repaired_with": "scute_piece",
     "salvaged_into": "scute_piece",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
     "burn_data": [
@@ -1910,7 +1910,7 @@
     "chip_resist": 8,
     "wind_resist": 90,
     "repaired_with": "bone_heavy",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
     "burn_data": [

--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -75,7 +75,7 @@
       "nitwit",
       "piece of an ass",
       "piece of shit",
-      "punk",
+      { "text": { "ctxt": "insult", "str": "punk" } },
       "scumbag",
       "shit-brained <name_b>",
       "shit-eater",

--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -2243,7 +2243,7 @@
     "chip_resist": 20,
     "dmg_adj": [ "chipped", "cracked", "split", "broken" ],
     "bash_dmg_verb": "cracked",
-    "cut_dmg_verb": "cut"
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" }
   },
   {
     "id": "t_tarptent",

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -109,7 +109,7 @@
   {
     "id": "mx_military",
     "type": "map_extra",
-    "name": "Military",
+    "name": { "ctxt": "map extra", "str": "Military" },
     "looks_like": "mon_zombie_soldier",
     "description": "Several corpses of soldiers are here.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_military" },

--- a/data/json/snippets/music.json
+++ b/data/json/snippets/music.json
@@ -180,7 +180,7 @@
       "metal",
       "reggae",
       "ska",
-      "punk",
+      { "text": { "ctxt": "music genre", "str": "punk" } },
       "thrash",
       "goth",
       "industrial",

--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -13,7 +13,7 @@
     "id": "iron",
     "type": "vitamin",
     "vit_type": "vitamin",
-    "name": { "str": "Iron" },
+    "name": { "ctxt": "nutrient", "str": "Iron" },
     "excess": "hypervitaminosis",
     "deficiency": "anemia",
     "min": -12000,

--- a/data/mods/Aftershock/items/materials.json
+++ b/data/mods/Aftershock/items/materials.json
@@ -33,6 +33,6 @@
     "chip_resist": 10,
     "dmg_adj": [ "marked", "dented", "scarred", "broken" ],
     "bash_dmg_verb": "ripped",
-    "cut_dmg_verb": "cut"
+    "cut_dmg_verb": { "ctxt": "material damage verb", "str": "cut" }
   }
 ]

--- a/data/mods/MagicalNights/materials.json
+++ b/data/mods/MagicalNights/materials.json
@@ -16,7 +16,7 @@
     "fire_resist": 20,
     "elec_resist": 2,
     "chip_resist": 15,
-    "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced"
   },
@@ -37,7 +37,7 @@
     "chip_resist": 30,
     "reinforces": true,
     "repaired_with": "dragon_black_scale",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped"
   },
@@ -58,7 +58,7 @@
     "chip_resist": 10,
     "repaired_with": "demon_chitin_piece",
     "salvaged_into": "demon_chitin_piece",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
     "burn_data": [
@@ -101,7 +101,7 @@
     "fire_resist": 20,
     "elec_resist": 20,
     "chip_resist": 15,
-    "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced"
   },
@@ -124,7 +124,7 @@
     "wind_resist": 90,
     "repaired_with": "dragon_bone",
     "salvaged_into": "shard_dragon_bone",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "dmg_adj": [ "scratched", { "ctxt": "material damage adjective", "str": "cut" }, "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped"
   },

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -38,10 +38,12 @@ const material_type &string_id<material_type>::obj() const
 
 material_type::material_type() :
     id( material_id::NULL_ID() ),
-    _bash_dmg_verb( translate_marker( "damages" ) ),
-    _cut_dmg_verb( translate_marker( "damages" ) )
+    _bash_dmg_verb( to_translation( "damages" ) ),
+    _cut_dmg_verb( to_translation( "damages" ) )
 {
-    _dmg_adj = { translate_marker( "lightly damaged" ), translate_marker( "damaged" ), translate_marker( "very damaged" ), translate_marker( "thoroughly damaged" ) };
+    _dmg_adj = { to_translation( "lightly damaged" ), to_translation( "damaged" ),
+                 to_translation( "very damaged" ), to_translation( "thoroughly damaged" )
+               };
 }
 
 static mat_burn_data load_mat_burn_data( const JsonObject &jsobj )
@@ -90,7 +92,7 @@ void material_type::load( const JsonObject &jsobj, const std::string & )
     mandatory( jsobj, was_loaded, "bash_dmg_verb", _bash_dmg_verb );
     mandatory( jsobj, was_loaded, "cut_dmg_verb", _cut_dmg_verb );
 
-    mandatory( jsobj, was_loaded, "dmg_adj", _dmg_adj, string_reader() );
+    mandatory( jsobj, was_loaded, "dmg_adj", _dmg_adj );
 
     if( jsobj.has_array( "burn_data" ) ) {
         for( JsonObject brn : jsobj.get_array( "burn_data" ) ) {
@@ -154,7 +156,7 @@ material_id material_type::ident() const
 
 std::string material_type::name() const
 {
-    return _( _name );
+    return _name.translated();
 }
 
 std::optional<itype_id> material_type::salvaged_into() const
@@ -184,12 +186,12 @@ int material_type::bullet_resist() const
 
 std::string material_type::bash_dmg_verb() const
 {
-    return _( _bash_dmg_verb );
+    return _bash_dmg_verb.translated();
 }
 
 std::string material_type::cut_dmg_verb() const
 {
-    return _( _cut_dmg_verb );
+    return _cut_dmg_verb.translated();
 }
 
 std::string material_type::dmg_adj( int damage ) const
@@ -200,7 +202,8 @@ std::string material_type::dmg_adj( int damage ) const
     }
 
     // apply bounds checking
-    return _( _dmg_adj[std::min( static_cast<size_t>( damage ), _dmg_adj.size() ) - 1] );
+    const auto damage_index = std::min( static_cast<size_t>( damage ), _dmg_adj.size() ) - 1;
+    return _dmg_adj[damage_index].translated();
 }
 
 int material_type::acid_resist() const

--- a/src/material.h
+++ b/src/material.h
@@ -10,6 +10,7 @@
 
 #include "catalua_type_operators.h"
 #include "fire.h"
+#include "translations.h"
 #include "type_id.h"
 
 class material_type;
@@ -29,7 +30,7 @@ class material_type
         bool was_loaded = false;
 
     private:
-        std::string _name;
+        translation _name;
         std::optional<itype_id> _salvaged_into; // this material turns into this item when salvaged
         itype_id _repaired_with = itype_id( "null" ); // this material can be repaired with this item
         int _bash_resist = 0;                         // negative integers means susceptibility
@@ -52,9 +53,9 @@ class material_type
         bool _soft = false;
         bool _reinforces = false;
 
-        std::string _bash_dmg_verb;
-        std::string _cut_dmg_verb;
-        std::vector<std::string> _dmg_adj;
+        translation _bash_dmg_verb;
+        translation _cut_dmg_verb;
+        std::vector<translation> _dmg_adj;
 
         std::map<vitamin_id, double> _vitamins;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1618,7 +1618,7 @@ void options_manager::add_options_interface()
          //~ 12h time, e.g.  11:59pm
     {   { "12h", translate_marker( "12h" ) },
         //~ Military time, e.g.  2359
-        { "military", translate_marker( "Military" ) },
+        { "military", translate_marker_context( "time format", "Military" ) },
         //~ 24h time, e.g.  23:59
         { "24h", translate_marker( "24h" ) }
     },


### PR DESCRIPTION
## Purpose of change (The Why)

Continuation of #8729 and #8741.

## Describe the solution (The How)

- Add an `i18n-context` skill for ambiguous gettext context work.
- Split Korean translations for `punk`, `Iron`, `Military`, and material `cut` strings by context.
- Allow material names and damage verbs/adjectives to load contextual `translation` values.
- Repair Korean PO printf checks touched by validation.

## Testing

- `cmake --preset lint`
- `cmake --build build --target astyle style-json-parallel`
- `cmake --build --preset lint`
- `./build-scripts/lint-json.sh`
- `python3 lang/extract_json_strings.py -i data/json -o /tmp/catabn-i18n-context.pot --tracked-only`
- `python3 lang/extract_json_strings.py -i data/mods -o /tmp/catabn-i18n-context-mods.pot --tracked-only`
- `msgfmt -f -c -o /tmp/ko.mo lang/po/ko.po`
- `./tools/check_po_printf_format.py`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked relevant PRs #8729 and #8741; no closing issue.

<sup>PR opened by gpt-5.4 high on pi</sup>
