### PR TITLE
fix: split vehicles segfaulting

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2624,7 +2624,7 @@ bool vehicle::find_and_split_vehicles( int exclude )
         bool success = split_vehicles( all_vehicles );
         if( success ) {
             // update the active cache
-            shift_parts( point_zero );
+            g->m.reset_vehicle_cache();
             return true;
         }
     }
@@ -2681,11 +2681,10 @@ bool vehicle::split_vehicles( const std::vector<std::vector <int>> &new_vehs,
         if( new_vehicle == nullptr ) {
             // make sure the split_part0 is a legal 0,0 part
             if( split_parts.size() > 1 ) {
-                for( size_t sp = 0; sp < split_parts.size(); sp++ ) {
-                    int p = split_parts[ sp ];
+                for( const auto p : split_parts ) {
                     if( part_info( p ).location == part_location_structure &&
                         !part_info( p ).has_flag( "PROTRUSION" ) ) {
-                        split_part0 = sp;
+                        split_part0 = p;
                         break;
                     }
                 }

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <set>
 #include <vector>
@@ -11,6 +12,7 @@
 #include "type_id.h"
 #include "point.h"
 #include "state_helpers.h"
+#include "veh_type.h"
 
 TEST_CASE( "vehicle_split_section" )
 {
@@ -83,4 +85,34 @@ TEST_CASE( "vehicle_split_section" )
         }
         break;
     }
+}
+
+TEST_CASE( "split vehicle keeps selected structure part at origin" )
+{
+    clear_all_state();
+    auto &here = get_map();
+    const auto vehicle_origin = tripoint( 10, 10, 0 );
+    auto *veh_ptr = here.add_vehicle( vproto_id( "none" ), vehicle_origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    const auto anchor_frame = veh_ptr->install_part( point_zero, vpart_id( "frame_vertical" ), true );
+    REQUIRE( anchor_frame >= 0 );
+    const auto split_mount = point( 5, 0 );
+    const auto split_frame = veh_ptr->install_part( split_mount, vpart_id( "frame_vertical" ), true );
+    REQUIRE( split_frame >= 0 );
+    const auto split_seat = veh_ptr->install_part( split_mount, vpart_id( "seat" ), true );
+    REQUIRE( split_seat >= 0 );
+    const auto original_split_pos = veh_ptr->global_part_pos3( split_frame );
+
+    REQUIRE( veh_ptr->split_vehicles( { { split_frame, split_seat } } ) );
+    const auto vehs = here.get_vehicles();
+    REQUIRE( vehs.size() == 2 );
+    const auto split_vehicle = std::ranges::find_if( vehs, [veh_ptr]( const auto & veh ) { return veh.v != veh_ptr; } );
+    REQUIRE( split_vehicle != vehs.end() );
+    const auto *new_vehicle = split_vehicle->v;
+
+    const auto origin_parts = new_vehicle->parts_at_relative( point_zero, true );
+    REQUIRE( !origin_parts.empty() );
+    CHECK( std::ranges::any_of( origin_parts, [new_vehicle]( const auto part_index ) { return new_vehicle->part_info( part_index ).location == "structure"; } ) );
+    CHECK( new_vehicle->global_part_pos3( origin_parts.front() ) == original_split_pos );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #8762.

## Describe the solution (The How)

- Fix a vehicle split bug where the new vehicle origin used the split part list offset instead of the actual part index.
- This could leave split vehicle data inconsistent after a monster bashed a vehicle apart, leading to an access violation in the subsequent cache refresh path.
- Refresh the active vehicle cache directly after splitting instead of using a zero-distance part shift.

## Describe alternatives you've considered

Keeping the zero-distance shift would preserve the old cache side effect, but it also touches labels and loot zones unnecessarily. Direct cache refresh is narrower.

## Testing

- built and opened attached save in #8762
- kept walking left as per issue
- did not segfault

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sup>PR opened by GPT-5.4 high on pi</sup>

