### PR TITLE
build: bundle CDDA tilesets in releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CDDA_TILESETS_REPO: I-am-Erk/CDDA-Tilesets
           CDDA_TILESETS_RELEASE: "2026-05-03"
-          CDDA_TILESETS: UltimateCataclysm ChibiUltica Ultica_iso
+          CDDA_TILESETS: UltimateCataclysm ChibiUltica
         shell: bash
         run: |
           set -euo pipefail
@@ -159,7 +159,7 @@ jobs:
 
           Source repository: https://github.com/I-am-Erk/CDDA-Tilesets
           Source release: https://github.com/I-am-Erk/CDDA-Tilesets/releases/tag/2026-05-03
-          Bundled assets: UltimateCataclysm.zip, ChibiUltica.zip, Ultica_iso.zip
+          Bundled assets: UltimateCataclysm.zip, ChibiUltica.zip
 
           The CDDA-Tilesets repository states that Cataclysm: Dark Days Ahead and
           the Ultimate Cataclysm tileset are volunteer contributions under the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
             artifact: android-x64
             os: ubuntu-latest
             android: arm64
+            tiles: true
             ext: apk
             content-type: application/apk
 
@@ -109,6 +110,7 @@ jobs:
             artifact: android-bundle
             os: ubuntu-latest
             android: bundle
+            tiles: true
             ext: aab
             content-type: application/aap
 
@@ -126,6 +128,49 @@ jobs:
           commit sha: ${{ github.sha }}
           commit url: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
           EOL
+
+      - name: Bundle CDDA tilesets
+        if: matrix.tiles == true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CDDA_TILESETS_REPO: I-am-Erk/CDDA-Tilesets
+          CDDA_TILESETS_RELEASE: "2026-05-03"
+          CDDA_TILESETS: UltimateCataclysm ChibiUltica Ultica_iso
+        shell: bash
+        run: |
+          set -euo pipefail
+          download_dir="$RUNNER_TEMP/cdda-tilesets"
+          rm -rf "$download_dir"
+          mkdir -p "$download_dir"
+
+          for tileset in $CDDA_TILESETS; do
+            gh release download "$CDDA_TILESETS_RELEASE" \
+              --repo "$CDDA_TILESETS_REPO" \
+              --pattern "$tileset.zip" \
+              --dir "$download_dir" \
+              --clobber
+            rm -rf "gfx/$tileset"
+            unzip -q "$download_dir/$tileset.zip" -d gfx
+          done
+
+          cat >gfx/CDDA-Tilesets-2026-05-03-CREDITS.txt <<'EOF'
+          Bundled CDDA-Tilesets release assets
+          ====================================
+
+          Source repository: https://github.com/I-am-Erk/CDDA-Tilesets
+          Source release: https://github.com/I-am-Erk/CDDA-Tilesets/releases/tag/2026-05-03
+          Bundled assets: UltimateCataclysm.zip, ChibiUltica.zip, Ultica_iso.zip
+
+          The CDDA-Tilesets repository states that Cataclysm: Dark Days Ahead and
+          the Ultimate Cataclysm tileset are volunteer contributions under the
+          Creative Commons Attribution-ShareAlike 3.0 Unported License:
+          http://creativecommons.org/licenses/by-sa/3.0/
+
+          Per the tileset metadata, further sprite credits are maintained in the
+          source repository under gfx/UltimateCataclysm and gfx.  ChibiUltica also
+          includes Dungeon Crawl: Stone Soup sprites under CC0; see its tileset.txt
+          for that notice.
+          EOF
 
       # Windows MSVC setup
       - name: Setup msys2 (windows msvc)
@@ -367,11 +412,18 @@ jobs:
         working-directory: ./android
         env:
           NDK_CCACHE: ccache
+          KEYSTORE: ${{ secrets.KEYSTORE }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
         run: |
-          echo "${{ secrets.KEYSTORE }}" > release.keystore.asc
-          gpg -d --passphrase "${{ secrets.KEYSTORE_PASSWORD }}" --batch release.keystore.asc > app/release.keystore
-          echo "${{ secrets.KEYSTORE_PROPERTIES }}" > keystore.properties.asc
-          gpg -d --passphrase "${{ secrets.KEYSTORE_PASSWORD }}" --batch keystore.properties.asc > keystore.properties
+          if [ -n "$KEYSTORE" ] && [ -n "$KEYSTORE_PASSWORD" ] && [ -n "$KEYSTORE_PROPERTIES" ]; then
+            printf '%s' "$KEYSTORE" > release.keystore.asc
+            gpg -d --passphrase "$KEYSTORE_PASSWORD" --batch release.keystore.asc > app/release.keystore
+            printf '%s' "$KEYSTORE_PROPERTIES" > keystore.properties.asc
+            gpg -d --passphrase "$KEYSTORE_PASSWORD" --batch keystore.properties.asc > keystore.properties
+          else
+            echo "::warning::Android signing secrets are unavailable; building unsigned release artifacts"
+          fi
           chmod +x gradlew
 
           # Determine build variant based on version label


### PR DESCRIPTION
## Purpose of change (The Why)

continuation of #8759, #8760
Bundle the 2026-05-03 CDDA-Tilesets release assets in release `gfx` packages:

- UltimateCataclysm
- ChibiUltica
- ~~Ultica_iso~~ (buggy)

Source: https://github.com/I-am-Erk/CDDA-Tilesets/releases/tag/2026-05-03

## Describe the solution (The How)

Download those release zips in the reusable release build workflow for tiles/Android artifacts before packaging, replace the bundled UltimateCataclysm copy, and add `gfx/CDDA-Tilesets-2026-05-03-CREDITS.txt` to release packages for source/license attribution.

Forked manual releases build unsigned Android artifacts when signing secrets are unavailable.

## Testing

- `actionlint .github/workflows/build.yml`
- Local smoke-run of the new `unzip` bundle step against a temp workspace verified all three tilesets and the credits file are created.
- Manual release workflow from fork passed with the simplified `tiles: true` matrix check: https://github.com/scarf005/Cataclysm-BN/actions/runs/25539710492
- Public fork release with built artifacts: https://github.com/scarf005/Cataclysm-BN/releases/tag/v0.0.8765
- Verified public release artifacts contain `UltimateCataclysm`, `ChibiUltica`, `Ultica_iso`, and `CDDA-Tilesets-2026-05-03-CREDITS.txt`:
  - Linux tiles tarball
  - Windows tiles zip
  - macOS tiles x64/ARM dmg
  - Android APK/AAB

## Additional context

<sup>PR opened by gpt-5.5 high on pi</sup>

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style). (workflow-only; `actionlint` used)
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why). (no related issue found)

### Optional

- [x] This PR modifies build process or code organization.
  - [x] Please document the changes in the appropriate location in the `docs/` folder. (release workflow-only; PR description documents CI behavior)
  - [x] If documentation for this feature or process does not exist, please write it.
  - [x] If the change alters versions of software required to build or work with the game, please document it. (no requirement changes)
