### PR TITLE
fix: remove abundance of mansions, fix outlet malls not spawning

### DIFF
--- a/data/json/overmap/overmap_special/outlet_mall_multitile.json
+++ b/data/json/overmap/overmap_special/outlet_mall_multitile.json
@@ -39,7 +39,7 @@
     "city_distance": [ 2, 10 ],
     "city_sizes": [ 3, -1 ],
     "occurrences": [ 0, 10 ],
-    "flags": [ "CLASSIC", "UNIQUE" ]
+    "flags": [ "CLASSIC" ]
   },
   {
     "type": "mapgen",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2444,7 +2444,7 @@
     "locations": [ "land" ],
     "city_distance": [ 0, 10 ],
     "city_sizes": [ 6, -1 ],
-    "occurrences": [ 85, 100 ],
+    "occurrences": [ 40, 100 ],
     "flags": [ "UNIQUE", "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
@@ -2492,7 +2492,7 @@
     "locations": [ "land" ],
     "city_distance": [ 0, 10 ],
     "city_sizes": [ 6, -1 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 35, 100 ],
     "flags": [ "UNIQUE", "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
@@ -2538,7 +2538,7 @@
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 15, 50 ],
-    "occurrences": [ 60, 100 ],
+    "occurrences": [ 30, 100 ],
     "flags": [ "UNIQUE", "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
@@ -2584,7 +2584,7 @@
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 15, 50 ],
-    "occurrences": [ 35, 100 ],
+    "occurrences": [ 18, 100 ],
     "flags": [ "UNIQUE", "CLASSIC", "ELECTRIC_GRID" ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
outlet malls were not spawning at all, and mansions have always spawned way too much and ruined map variety
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
removes a flag that was stopping the mall from spawning, and halves the chance of each mansion type spawning
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
map being a gta online lobby
## Testing
debug tested and teleported around, spawn rates and map variety seem good
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.