### PR TITLE
feat(lua,mods): add Skills Through Kills Lua mod

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -26,6 +26,10 @@ scopes:
   - port
   - lua
   - mods/Arcana
+  - mods/Arcana_Crit_Patch
+  - mods/Arcana_Dinomod_Patch
+  - mods/Arcana_MagiclalNights_Patch
+  - mods/Arcana_aftershock_Patch
   - mods/CheesyInnaWoodFixes
   - mods/DinoMod
   - mods/MMA
@@ -46,10 +50,12 @@ scopes:
   - mods/UDP_BN_FAKE_SNOW
   - mods/aftershock
   - mods/alt_map_key
+  - mods/callback_lua_test
   - mods/cbm_slots
   - mods/change_hairstyle
   - mods/civilians
   - mods/classic_zombies
+  - mods/color_expansion
   - mods/crazy_cataclysm
   - mods/crt_expansion
   - mods/dangerous_fungi
@@ -58,6 +64,8 @@ scopes:
   - mods/exotic_ammo
   - mods/flowerpots_plus
   - mods/fuji_mpp
+  - mods/gunchair
+  - mods/i_noencum_backpacks
   - mods/innawoods
   - mods/jump_pad
   - mods/lethal_zeds
@@ -69,19 +77,24 @@ scopes:
   - mods/no_reviving_zombies
   - mods/no_zombify
   - mods/novitamins
+  - mods/npc_lua_hook_test
   - mods/nuclear_tear
   - mods/pathfinding_stockfish
   - mods/pride_flags
   - mods/resurrection_tech
   - mods/rpg_system
+  - mods/sample-uv-mod
   - mods/saveload_lua_test
+  - mods/skills_through_kills
   - mods/smart_house_remote_mod
+  - mods/spawn_hook_test
   - mods/speedydex
   - mods/stats_through_kills
   - mods/tablet_ebook
   - mods/teleportation_tech
   - mods/test_data
   - mods/test_lua_hooks
+  - mods/test_lua_require
   - mods/udp_redux
   - mods/underground_dynamic_temperature
   - mods/weather_variants

--- a/data/lua/lib/ui.lua
+++ b/data/lua/lib/ui.lua
@@ -1,26 +1,25 @@
 local ui = {}
 
----@type fun(str: string): void
-ui.query_any_key = function(str)
+---@param str string
+---@param color Color?
+ui.query_any_key = function(str, color)
   local popup = QueryPopup.new()
   popup:message(str)
+  if color then popup:message_color(color) end
   popup:allow_any_key(true)
   popup:query()
 end
 
----@type fun(str: string): boolean
+---@param str string
+---@return boolean
 ui.query_yn = function(str)
   local popup = QueryPopup.new()
   popup:message(str)
   return popup:query_yn() == "YES"
 end
 
----@type fun(str: string): void
-ui.popup = function(str)
-  local popup = QueryPopup.new()
-  popup:message(str)
-  popup:allow_any_key(true)
-  popup:query()
-end
+---@param str string
+---@param color Color?
+ui.popup = function(str, color) ui.query_any_key(str, color) end
 
 return ui

--- a/data/mods/NPC_lua_hook_test/main.lua
+++ b/data/mods/NPC_lua_hook_test/main.lua
@@ -1,6 +1,7 @@
 gdebug.log_info("NPC Lua hook test activated.")
 
 local mod = game.mod_runtime[game.current_mod]
+local ui = require("lib.ui")
 
 ---@param params OnDialogueStartParams
 mod.on_dialogue_start = function(params)
@@ -33,11 +34,7 @@ mod.on_dialogue_end = function(params)
 end
 
 ---@param params OnTryNPCInterationParams
-mod.on_try_npc_interaction = function(params)
-  local check = QueryPopup.new()
-  check:message("Allow Interaction?")
-  return check:query_yn() == "YES"
-end
+mod.on_try_npc_interaction = function(params) return ui.query_yn("Allow Interaction?") end
 
 ---@param params OnTryNPCInterationParams
 mod.force_talk = function(params)

--- a/data/mods/callback_lua_test/main.lua
+++ b/data/mods/callback_lua_test/main.lua
@@ -2,6 +2,7 @@ gdebug.log_info("Callback Lua Test: Main")
 
 local mod = game.mod_runtime[game.current_mod]
 local storage = game.mod_storage[game.current_mod]
+local ui = require("lib.ui")
 mod.storage = storage
 
 local player = function() return gapi.get_avatar() end
@@ -10,11 +11,7 @@ local player_name = function() return player().name end
 
 local iname = function(item) return item:tname(1, true, 0) end
 
-local query = function(prompt)
-  local q = QueryPopup.new()
-  q:message(prompt)
-  return q:query_yn() == "YES"
-end
+local query = function(prompt) return ui.query_yn(prompt) end
 
 mod.can_equip = function(wear, params)
   local user = params.user

--- a/data/mods/skills_through_kills/main.lua
+++ b/data/mods/skills_through_kills/main.lua
@@ -1,0 +1,325 @@
+gdebug.log_info("Skills Through Kills: Main")
+
+---@class ModSkillsThroughKills
+local mod = game.mod_runtime[game.current_mod]
+local gettext = locale.gettext
+local ui = require("lib.ui")
+
+local XP_VALUE_KEY = "skills_through_kills_xp"
+local MAX_SKILL_LEVEL = 10
+
+local SKILL_DEFS = {
+  { id = "dodge", name = gettext("Dodging") },
+  { id = "melee", name = gettext("Melee") },
+  { id = "unarmed", name = gettext("Unarmed Combat") },
+  { id = "bashing", name = gettext("Bashing Weapons") },
+  { id = "cutting", name = gettext("Cutting Weapons") },
+  { id = "stabbing", name = gettext("Piercing Weapons") },
+  { id = "throw", name = gettext("Throwing") },
+  { id = "gun", name = gettext("Marksmanship") },
+  { id = "pistol", name = gettext("Handguns") },
+  { id = "shotgun", name = gettext("Shotguns") },
+  { id = "smg", name = gettext("Submachine Guns") },
+  { id = "rifle", name = gettext("Rifles") },
+  { id = "archery", name = gettext("Archery") },
+  { id = "launcher", name = gettext("Launchers") },
+  { id = "mechanics", name = gettext("Mechanics") },
+  { id = "electronics", name = gettext("Electronics") },
+  { id = "cooking", name = gettext("Cooking") },
+  { id = "tailor", name = gettext("Tailoring") },
+  { id = "firstaid", name = gettext("First Aid") },
+  { id = "speech", name = gettext("Speaking") },
+  { id = "barter", name = gettext("Bartering") },
+  { id = "computer", name = gettext("Computers") },
+  { id = "survival", name = gettext("Survival") },
+  { id = "traps", name = gettext("Trapping") },
+  { id = "swimming", name = gettext("Athletics") },
+  { id = "driving", name = gettext("Driving") },
+  { id = "fabrication", name = gettext("Fabrication") },
+  { id = "spellcraft", name = gettext("Spellcraft") },
+}
+
+---@class SkillsThroughKillsSkill
+---@field id string
+---@field skill_id SkillId
+---@field name string
+
+---@type SkillsThroughKillsSkill[]|nil
+local cached_skills = nil
+
+---@param text string
+---@param color string
+---@return string
+local function color_text(text, color) return string.format("<color_%s>%s</color>", color, text) end
+
+---@param number integer
+---@return string
+local function number_shorthand(number)
+  if math.abs(number) < 1000 then return tostring(number) end
+  if math.abs(number) < 1000000 then return string.format("%dk", math.floor(number / 1000)) end
+  return string.format("%dm", math.floor(number / 1000000))
+end
+
+---@param character Character
+---@return integer
+local function get_xp(character)
+  local value = character:get_value(XP_VALUE_KEY)
+  if value == "" then return 0 end
+  return tonumber(value) or 0
+end
+
+---@param character Character
+---@param value integer
+local function set_xp(character, value) character:set_value(XP_VALUE_KEY, tostring(math.floor(value))) end
+
+---@param character Character
+---@param amount integer
+local function add_xp(character, amount)
+  if amount <= 0 then return end
+  set_xp(character, get_xp(character) + amount)
+end
+
+---@return SkillsThroughKillsSkill[]
+local function get_skills()
+  if cached_skills then return cached_skills end
+
+  cached_skills = {}
+  for _, skill_def in ipairs(SKILL_DEFS) do
+    local skill_id = SkillId.new(skill_def.id)
+    if skill_id:is_valid() then
+      table.insert(cached_skills, {
+        id = skill_def.id,
+        skill_id = skill_id,
+        name = skill_def.name,
+      })
+    end
+  end
+  return cached_skills
+end
+
+---@param skill_id SkillId
+---@return SkillsThroughKillsSkill|nil
+local function find_skill(skill_id)
+  local skill_id_string = skill_id:str()
+  for _, skill in ipairs(get_skills()) do
+    if skill.skill_id:str() == skill_id_string then return skill end
+  end
+  return nil
+end
+
+---@param levels table<string, integer>
+---@return integer
+local function spent_for_levels(levels)
+  local total_levels = 0
+  local total_pow4_levels = 0
+  for _, level in pairs(levels) do
+    total_levels = total_levels + level
+    total_pow4_levels = total_pow4_levels + (level * level * level * level)
+  end
+  return 10 * total_levels + total_levels * total_levels + total_pow4_levels
+end
+
+---@param character Character
+---@return table<string, integer>
+local function skill_levels(character)
+  local levels = {}
+  for _, skill in ipairs(get_skills()) do
+    levels[skill.id] = character:get_skill_level(skill.skill_id)
+  end
+  return levels
+end
+
+---@param character Character
+---@return integer
+local function spent_xp(character) return spent_for_levels(skill_levels(character)) end
+
+---@param character Character
+---@return integer
+local function available_xp(character) return get_xp(character) - spent_xp(character) end
+
+---@param character Character
+---@param skill SkillsThroughKillsSkill
+---@return integer
+local function cost_to_raise(character, skill)
+  local levels = skill_levels(character)
+  local current_level = levels[skill.id] or 0
+  levels[skill.id] = current_level + 1
+  return spent_for_levels(levels) - spent_xp(character)
+end
+
+---@param monster Monster
+---@return integer
+local function monster_xp(monster)
+  local monster_type = monster:get_type():obj()
+  return math.max(0, monster_type.difficulty + monster_type.difficulty_base)
+end
+
+---@param character Character
+---@param skill SkillsThroughKillsSkill
+---@return boolean
+local function try_raise_skill(character, skill)
+  local level = character:get_skill_level(skill.skill_id)
+  if level >= MAX_SKILL_LEVEL then
+    ui.popup(gettext("This skill is already at the maximum level."))
+    return false
+  end
+
+  local available = available_xp(character)
+  local cost = cost_to_raise(character, skill)
+  if available < cost then
+    ui.popup(
+      string.format(
+        gettext("Not enough XP to raise %s (%d -> %d).\nNeeded XP: %d\nAvailable XP: %d"),
+        skill.name,
+        level,
+        level + 1,
+        cost,
+        available
+      )
+    )
+    return false
+  end
+
+  if
+    not ui.query_yn(
+      string.format(
+        gettext("Raise %s from level %d to level %d?\nThis uses %d XP out of %d available XP."),
+        skill.name,
+        level,
+        level + 1,
+        cost,
+        available
+      )
+    )
+  then
+    return false
+  end
+
+  character:set_skill_level(skill.skill_id, level + 1)
+  gapi.add_msg(MsgType.good, string.format(gettext("You raise %s to level %d."), skill.name, level + 1))
+  return true
+end
+
+---@param character Character
+---@param skill SkillsThroughKillsSkill
+---@return string
+local function skill_info_text(character, skill)
+  local level = character:get_skill_level(skill.skill_id)
+  local available = available_xp(character)
+  local total = get_xp(character)
+  local spent = spent_xp(character)
+
+  if level >= MAX_SKILL_LEVEL then
+    return string.format(
+      "%s\n%s",
+      color_text(gettext("Skills Through Kills"), "light_green"),
+      string.format(
+        gettext("Total XP: %d | Spent XP: %d | Available XP: %d\nThis skill is at maximum level."),
+        total,
+        spent,
+        available
+      )
+    )
+  end
+
+  local cost = cost_to_raise(character, skill)
+  local percentage = math.floor(100 * available / cost)
+  local readiness = available >= cost and color_text(gettext("ready"), "light_green")
+    or string.format(gettext("%d%% funded"), percentage)
+
+  return string.format(
+    "%s\n%s",
+    color_text(gettext("Skills Through Kills"), "light_green"),
+    string.format(
+      gettext(
+        "Total XP: %d | Spent XP: %d | Available XP: %d\nCost to raise to level %d: %d XP (%s).\nPress Enter to spend XP on this skill."
+      ),
+      total,
+      spent,
+      available,
+      level + 1,
+      cost,
+      readiness
+    )
+  )
+end
+
+---@param params table
+mod.on_mon_death = function(params)
+  ---@type Creature|nil
+  local killer = params.killer
+  ---@type Monster|nil
+  local monster = params.mon
+  if not killer or not monster then return end
+  if not killer:is_avatar() then return end
+  if monster:is_hallucination() then return end
+
+  add_xp(killer:as_character(), monster_xp(monster))
+end
+
+---@param params table
+mod.on_character_death = function(params)
+  ---@type Creature|nil
+  local killer = params.killer
+  ---@type Character|nil
+  local character = params.char
+  if not killer or not character then return end
+  if not killer:is_avatar() then return end
+  if character:is_avatar() then return end
+
+  add_xp(killer:as_character(), 10)
+end
+
+---@param params table
+mod.on_character_display_skill_action = function(params)
+  ---@type Character|nil
+  local character = params.character
+  ---@type SkillId|nil
+  local skill_id = params.skill
+  if not character or not skill_id then return end
+  if not character:is_avatar() then return end
+
+  local skill = find_skill(skill_id)
+  if not skill then return end
+
+  params.results.handled = true
+  try_raise_skill(character, skill)
+end
+
+---@param params table
+mod.on_character_display_skill_info = function(params)
+  ---@type Character|nil
+  local character = params.character
+  ---@type SkillId|nil
+  local skill_id = params.skill
+  if not character or not skill_id then return end
+  if not character:is_avatar() then return end
+
+  local skill = find_skill(skill_id)
+  if not skill then return end
+
+  params.results.text = skill_info_text(character, skill)
+end
+
+---@return table
+local function draw_xp_widget()
+  local avatar = gapi.get_avatar()
+  if not avatar then return {} end
+
+  local available = available_xp(avatar)
+  local total = get_xp(avatar)
+  local available_color = available >= 0 and "light_green" or "light_red"
+  return {
+    { text = string.format("XP: %s", number_shorthand(available)), color = available_color },
+    { text = string.format("Total: %s", number_shorthand(total)), color = "light_gray" },
+  }
+end
+
+sidebar.register_widget({
+  id = "skills_through_kills_xp",
+  name = gettext("Skills Through Kills XP"),
+  height = 2,
+  order = 25,
+  default_toggle = true,
+  draw = draw_xp_widget,
+})

--- a/data/mods/skills_through_kills/modinfo.json
+++ b/data/mods/skills_through_kills/modinfo.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "skills_through_kills",
+    "name": "Skills Through Kills",
+    "authors": [ "Coolthulhu" ],
+    "description": "Changes the skill experience system from \"learn by doing\" to \"spend experience from kills on skills\".",
+    "category": "rebalance",
+    "lua_api_version": 2,
+    "dependencies": [ "bn" ],
+    "conflicts": [ "stats_through_kills" ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SKILLS_THROUGH_KILLS",
+    "info": "Replace \"learn by doing\" by spending experience from kills on skills.",
+    "stype": "bool",
+    "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SKILL_TRAINING_SPEED",
+    "info": "Disables regular skill training while Skills Through Kills is active.",
+    "stype": "float",
+    "value": 0.0
+  }
+]

--- a/data/mods/skills_through_kills/preload.lua
+++ b/data/mods/skills_through_kills/preload.lua
@@ -1,0 +1,9 @@
+gdebug.log_info("Skills Through Kills: Preload")
+
+---@class ModSkillsThroughKills
+local mod = game.mod_runtime[game.current_mod]
+
+game.add_hook("on_mon_death", function(...) return mod.on_mon_death(...) end)
+game.add_hook("on_character_death", function(...) return mod.on_character_death(...) end)
+game.add_hook("on_character_display_skill_action", function(...) return mod.on_character_display_skill_action(...) end)
+game.add_hook("on_character_display_skill_info", function(...) return mod.on_character_display_skill_info(...) end)

--- a/data/mods/smart_house_remotes/main.lua
+++ b/data/mods/smart_house_remotes/main.lua
@@ -9,6 +9,7 @@ gdebug.log_info("SHR: main.")
 --
 
 local mod = game.mod_runtime[game.current_mod]
+local ui = require("lib.ui")
 
 --[[
     When we export Lua function, Lua is smart enough not to garbage collect
@@ -242,36 +243,24 @@ end
 
 -- Show 'not enough power' error
 mod.show_low_power_error = function()
-  local pp = QueryPopup.new()
   --~ Message on the remote, stylized as calculator led display.
   --~ Shown when there's not enough grid charge.
-  pp:message(locale.gettext("Low Current At Endpoint"))
   -- This color is awful, but it's a cheap LCD display, what did you expect?
-  pp:message_color(Color.i_green)
-  pp:allow_any_key(true)
-  pp:query()
+  ui.popup(locale.gettext("Low Current At Endpoint"), Color.i_green)
 end
 
 -- Show 'no signal' error
 mod.show_no_signal_error = function()
-  local pp = QueryPopup.new()
   --~ Message on the remote, stylized as calculator led display.
   --~ Shown when player is too far away from the area.
-  pp:message(locale.gettext("No Signal"))
-  pp:message_color(Color.i_green)
-  pp:allow_any_key(true)
-  pp:query()
+  ui.popup(locale.gettext("No Signal"), Color.i_green)
 end
 
 -- Show 'no valid blocks' error
 mod.show_no_endpoints_error = function()
-  local pp = QueryPopup.new()
   --~ Message on the remote, stylized as calculator led display.
   --~ Shown when there's nothing to activate.
-  pp:message(locale.gettext("No Endpoints Available"))
-  pp:message_color(Color.i_green)
-  pp:allow_any_key(true)
-  pp:query()
+  ui.popup(locale.gettext("No Endpoints Available"), Color.i_green)
 end
 
 -- Add message indicating the remote works

--- a/data/mods/teleportation_mod/main.lua
+++ b/data/mods/teleportation_mod/main.lua
@@ -10,6 +10,7 @@ power_charge_kj_multiplier = 1000
 
 local mod = game.mod_runtime[game.current_mod]
 local storage = game.mod_storage[game.current_mod]
+local ui = require("lib.ui")
 
 --Item id (static)
 
@@ -441,17 +442,12 @@ end
 mod.network_info = function(pos)
   -- spam out all stations and anchors
 
-  local ui_network_info = QueryPopup.new()
   local message_text = mod.create_network_message(pos)
-  ui_network_info:message(message_text)
-  ui_network_info:message_color(Color.c_white)
-  ui_network_info:allow_any_key(true)
-  ui_network_info:query()
+  ui.popup(message_text, Color.c_white)
   return 1
 end
 
 mod.show_readme_info = function()
-  local ui_mod_info = QueryPopup.new()
   local modinfo = [[
 Teleporters - the future, today!
 
@@ -471,10 +467,7 @@ stations are present, you can pick which one to fill.
 
 The current rate is ]] .. power_charge_kj_multiplier .. [[kJ per 1 unit
 of charge. Both rates can be changed in the config. ]]
-  ui_mod_info:message(modinfo)
-  ui_mod_info:message_color(Color.c_white)
-  ui_mod_info:allow_any_key(true)
-  ui_mod_info:query()
+  ui.popup(modinfo, Color.c_white)
   return 0
 end
 

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -711,6 +711,22 @@ void cata::detail::reg_hooks_examples( sol::state &lua )
     DOC_PARAMS( "params" );
     luna::set_fx( lib, "on_character_reset_stats", []( const sol::table & ) {} );
 
+    DOC( "Called when a skill is confirmed on the character display (`@`) skill tab.  " );
+    DOC( "The hook receives a table with keys:  " );
+    DOC( "* `character` (Character)  " );
+    DOC( "* `skill` (SkillId)  " );
+    DOC( "Set `params.results.handled = true` to prevent the default training toggle.  " );
+    DOC_PARAMS( "params" );
+    luna::set_fx( lib, "on_character_display_skill_action", []( const sol::table & ) {} );
+
+    DOC( "Called when drawing skill info on the character display (`@`) skill tab.  " );
+    DOC( "The hook receives a table with keys:  " );
+    DOC( "* `character` (Character)  " );
+    DOC( "* `skill` (SkillId)  " );
+    DOC( "Set `params.results.text` to append text below the regular skill description.  " );
+    DOC_PARAMS( "params" );
+    luna::set_fx( lib, "on_character_display_skill_info", []( const sol::table & ) {} );
+
     DOC( "Called when character gets the effect which has `EFFECT_LUA_ON_ADDED` flag.  " );
     DOC( "The hook receives a table with keys:  " );
     DOC( "* `char` (Character)  " );

--- a/src/catalua_bindings_ids.cpp
+++ b/src/catalua_bindings_ids.cpp
@@ -169,6 +169,18 @@ void cata::detail::reg_types( sol::state &lua )
     }
 #undef UT_CLASS
 
+#define UT_CLASS mtype
+    {
+        sol::usertype<mtype> ut =
+            luna::new_usertype<mtype>( lua, luna::no_bases, luna::no_constructor );
+
+        SET_MEMB_RO( id );
+        SET_MEMB_RO( difficulty );
+        SET_MEMB_RO( difficulty_base );
+        SET_FX_T( nname, std::string( unsigned int ) const );
+    }
+#undef UT_CLASS
+
 #define UT_CLASS ter_t
     {
         sol::usertype<ter_t> ut =

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -18,6 +18,8 @@ constexpr auto hook_names = std::array
     "on_dialogue_option",
     "on_dialogue_end",
     "on_character_reset_stats",
+    "on_character_display_skill_action",
+    "on_character_display_skill_info",
     "on_character_effect_added",
     "on_character_effect",
     "on_character_effect_removed",

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -9,6 +9,8 @@
 #include "addiction.h"
 #include "avatar.h"
 #include "bionics.h"
+#include "catalua_hooks.h"
+#include "catalua_sol.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character_effects.h"
@@ -896,7 +898,8 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
     wnoutrefresh( w_skills );
 }
 
-static void draw_skills_info( const catacurses::window &w_info, unsigned int line,
+static void draw_skills_info( const catacurses::window &w_info, const Character &you,
+                              unsigned int line,
                               const std::vector<HeaderSkill> &skillslist )
 {
     werase( w_info );
@@ -911,9 +914,19 @@ static void draw_skills_info( const catacurses::window &w_info, unsigned int lin
     werase( w_info );
 
     if( selectedSkill ) {
+        auto description = selectedSkill->description();
+        const auto hook_results = cata::run_hooks( "on_character_display_skill_info",
+        [&]( sol::table & params ) {
+            params["character"] = &you;
+            params["skill"] = selectedSkill->ident();
+        } );
+        const auto extra_text = hook_results.get_or( "text", std::string() );
+        if( !extra_text.empty() ) {
+            description += "\n\n" + extra_text;
+        }
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray,
-                        selectedSkill->description() );
+                        description );
     }
     wnoutrefresh( w_info );
 }
@@ -1039,7 +1052,7 @@ static void draw_info_window( const catacurses::window &w_info, const Character 
             draw_encumbrance_info( w_info, you, line );
             break;
         case player_display_tab::skills:
-            draw_skills_info( w_info, line, skillslist );
+            draw_skills_info( w_info, you, line, skillslist );
             break;
         case player_display_tab::traits:
             draw_traits_info( w_info, line, traitslist );
@@ -1207,7 +1220,14 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
                     selectedSkill = skillslist[line].skill;
                 }
                 if( selectedSkill ) {
-                    you.get_skill_level_object( selectedSkill->ident() ).toggleTraining();
+                    const auto hook_results = cata::run_hooks( "on_character_display_skill_action",
+                    [&]( sol::table & params ) {
+                        params["character"] = &you;
+                        params["skill"] = selectedSkill->ident();
+                    } );
+                    if( !hook_results.get_or( "handled", false ) ) {
+                        you.get_skill_level_object( selectedSkill->ident() ).toggleTraining();
+                    }
                 }
                 invalidate_tab( curtab );
                 break;


### PR DESCRIPTION
## Purpose of change (The Why)

Reimplements #6082 as a Lua mod.

## Describe the solution (The How)

Adds a `skills_through_kills` mod that:

- disables regular skill training by setting `SKILL_TRAINING_SPEED` to 0 while active
- tracks monster and NPC kill XP from Lua hooks
- integrates skill spending into the `@` character screen skill tab via new Lua hooks
- appends XP/cost information to the selected skill description in `@`
- spends XP using the original PR formula: `10 * total skill levels + total skill levels ^ 2 + sum(skill level ^ 4)`
- adds small Lua API bindings for monster type difficulty fields so the mod can use `difficulty + difficulty_base`
- conflicts with Stats Through Kills

## Describe alternatives you've considered

A separate ledger item was initially used to avoid touching character display code, but `@` is better UX because it keeps skill management in the existing skill UI.

## Testing

- [x] `./build-scripts/lint-json.sh data/mods/skills_through_kills`
- [x] `cmake --preset linux-full`
- [x] `cmake --build --preset linux-full --target astyle`
- [x] `cmake --build --preset linux-full --target style-json-parallel`
- [x] `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- [x] `cmake --build --preset linux-full --target cata_test-tiles`
- [x] `./out/build/linux-full/src/cataclysm-bn-tiles --userdir /tmp/cbn-user-stk-lua --check-mods skills_through_kills`
- [x] `./out/build/linux-full/tests/cata_test-tiles "[lua]"`
- [x] `deno task semantic`

## Additional context

Lua syntax check with `luac` was skipped because `luac` is not installed in the local environment.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR adds/removes a mod.
  - [x] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [x] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [x] I have committed the output of `deno task semantic`.
- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [x] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
