### PR TITLE
test: stabilize active item cache test

### DIFF
--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -1,7 +1,6 @@
 #include "catch/catch.hpp"
 
-#include <memory>
-#include <set>
+#include <utility>
 
 #include "calendar.h"
 #include "game.h"
@@ -14,32 +13,32 @@
 TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
 {
     clear_all_state();
-    for( int z = -OVERMAP_DEPTH; z < OVERMAP_HEIGHT; ++z ) {
-        for( int x = 0; x < g_mapsize_x; ++x ) {
-            for( int y = 0; y < g_mapsize_y; ++y ) {
+    for( auto z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; ++z ) {
+        for( auto x = 0; x < g_mapsize_x; ++x ) {
+            for( auto y = 0; y < g_mapsize_y; ++y ) {
                 g->m.i_clear( { x, y, z } );
             }
         }
     }
     REQUIRE( g->m.get_submaps_with_active_items().empty() );
     // An arbitrary active item.
-    item &active = *item::spawn_temporary( "firecracker_act", calendar::start_of_cataclysm,
+    auto &active = *item::spawn_temporary( "firecracker_act", calendar::start_of_cataclysm,
                                            item::default_charges_tag() );
     active.activate();
 
     // For each space in a wide area place the item and check if the cache has been updated.
-    int z = 0;
-    for( int x = 0; x < g_mapsize_x; ++x ) {
-        for( int y = 0; y < g_mapsize_y; ++y ) {
+    const auto z = 0;
+    for( auto x = 0; x < g_mapsize_x; ++x ) {
+        for( auto y = 0; y < g_mapsize_y; ++y ) {
             REQUIRE( g->m.i_at( { x, y, z } ).empty() );
             CAPTURE( x, y, z );
-            auto abs_loc = g->m.get_abs_sub() + tripoint( x / SEEX, y / SEEY, z );
+            const auto abs_loc = g->m.get_abs_sub() + tripoint( x / SEEX, y / SEEY, z );
             CAPTURE( abs_loc.x(), abs_loc.y(), abs_loc.z() );
             REQUIRE( g->m.get_submaps_with_active_items().empty() );
             REQUIRE( g->m.get_submaps_with_active_items().find( abs_loc.raw() ) ==
                      g->m.get_submaps_with_active_items().end() );
-            detached_ptr<item> n = item::spawn( active );
-            item &item_ref = *n;
+            auto n = item::spawn( active );
+            auto &item_ref = *n;
             g->m.add_item( { x, y, z }, std::move( n ) );
             REQUIRE( item_ref.is_active() );
             REQUIRE_FALSE( g->m.get_submaps_with_active_items().empty() );


### PR DESCRIPTION
## Purpose of change (The Why)

Related: #8772

Fixes a flaky `place_active_item_at_various_coordinates` assertion caused by the test cleanup skipping the top z-level.

## Describe the solution (The How)

Clears the full inclusive z-level range before asserting the global active item cache is empty.

## Testing

- `cmake --build --preset linux-curses --target astyle`
- `cmake --build --preset linux-curses --target cata_test -j$(nproc)`
- `./out/build/linux-curses/tests/cata_test "place_active_item_at_various_coordinates" --rng-seed 1778240110 --user-dir=/tmp/cata-active-cache-test-3`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked the relevant PR.

<sup>PR opened by gpt-5.4 high on pi</sup>
