### PR TITLE
feat: add `debug weightlessness` mutation

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6843,6 +6843,15 @@
   },
   {
     "type": "mutation",
+    "id": "DEBUG_WEIGHTLESSNESS",
+    "name": { "str": "Debug Weightlessness" },
+    "points": 99,
+    "valid": false,
+    "description": "Newton discovered gravity in 1687. People before 1687:",
+    "debug": true
+  },
+  {
+    "type": "mutation",
     "id": "DEBUG_BIONICS",
     "name": { "str": "Debug Bionic Installation" },
     "points": 99,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -290,6 +290,7 @@ static const trait_id trait_DEBUG_LS( "DEBUG_LS" );
 static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
 static const trait_id trait_DEBUG_NOTEMP( "DEBUG_NOTEMP" );
 static const trait_id trait_DEBUG_STORAGE( "DEBUG_STORAGE" );
+static const trait_id trait_DEBUG_WEIGHTLESSNESS( "DEBUG_WEIGHTLESSNESS" );
 static const trait_id trait_DOWN( "DOWN" );
 static const trait_id trait_ELECTRORECEPTORS( "ELECTRORECEPTORS" );
 static const trait_id trait_FASTLEARNER( "FASTLEARNER" );
@@ -4448,17 +4449,16 @@ char_encumbrance_data Character::calc_encumbrance( const item &new_item ) const
 
 units::mass Character::get_weight() const
 {
-    units::mass ret = 0_gram;
-    units::mass wornWeight = std::accumulate( worn.begin(), worn.end(), 0_gram,
-    []( units::mass sum, const item * const & itm ) {
-        return sum + itm->weight();
-    } );
+    if( has_trait( trait_DEBUG_WEIGHTLESSNESS ) ) { return 0_gram; }
 
-    ret += bodyweight();       // The base weight of the player's body
-    ret += inv.weight();           // Weight of the stored inventory
-    ret += wornWeight;             // Weight of worn items
-    ret += primary_weapon().weight();        // Weight of wielded item
-    ret += bionics_weight();       // Weight of installed bionics
+    const auto worn_weight = std::ranges::fold_left( worn, 0_gram,
+    []( const auto sum, const auto * const itm ) { return sum + itm->weight(); } );
+
+    auto ret = bodyweight();                       // The base weight of the player's body
+    ret += inv.weight();                           // Weight of the stored inventory
+    ret += worn_weight;                            // Weight of worn items
+    ret += primary_weapon().weight();              // Weight of wielded item
+    ret += bionics_weight();                       // Weight of installed bionics
     return ret;
 }
 

--- a/tests/speed_test.cpp
+++ b/tests/speed_test.cpp
@@ -7,6 +7,8 @@
 #include "map_helpers.h"
 #include "state_helpers.h"
 
+static const trait_id trait_DEBUG_WEIGHTLESSNESS( "DEBUG_WEIGHTLESSNESS" );
+
 static void advance_turn( Character &guy )
 {
     guy.process_turn();
@@ -99,6 +101,21 @@ static void carry_weight_test( Character &guy, int load_kg, int speed_exp )
     }
 }
 
+static auto equip_carried_weight( Character &guy ) -> units::mass
+{
+    auto backpack = item::spawn( "test_backpack" );
+    auto inventory_item = item::spawn( "test_1kg_cube" );
+    auto wielded_item = item::spawn( "test_1kg_cube" );
+
+    const auto carried_weight = backpack->weight() + inventory_item->weight() + wielded_item->weight();
+
+    guy.wear_item( std::move( backpack ), false );
+    guy.i_add( std::move( inventory_item ) );
+    guy.wield( std::move( wielded_item ) );
+
+    return carried_weight;
+}
+
 TEST_CASE( "Character is slowed down while overburdened", "[speed]" )
 {
     clear_all_state();
@@ -124,5 +141,36 @@ TEST_CASE( "Character is slowed down while overburdened", "[speed]" )
     SECTION( "Carry weight significantly over carry capacity" ) {
         // 228% gives -32 speed (25 * 1.28)
         carry_weight_test( guy, 102, 68 );
+    }
+}
+
+TEST_CASE( "Debug weightlessness ignores carried item weight", "[speed][debug]" )
+{
+    clear_all_state();
+    player &guy = *get_player_character().as_player();
+
+    SECTION( "Normal carrying adds to character weight" ) {
+        clear_character( guy, false );
+        const auto base_weight = guy.get_weight();
+        const auto carried_weight = equip_carried_weight( guy );
+
+        CHECK( guy.get_weight() - base_weight == carried_weight );
+    }
+
+    SECTION( "Debug carrying capacity still adds to character weight" ) {
+        clear_character( guy, true );
+        const auto base_weight = guy.get_weight();
+        const auto carried_weight = equip_carried_weight( guy );
+
+        CHECK( guy.get_weight() - base_weight == carried_weight );
+    }
+
+    SECTION( "Debug weightlessness zeroes character weight" ) {
+        clear_character( guy, true );
+        guy.set_mutation( trait_DEBUG_WEIGHTLESSNESS );
+        const auto carried_weight = equip_carried_weight( guy );
+        CAPTURE( carried_weight );
+
+        CHECK( guy.get_weight() == 0_gram );
     }
 }


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/ecb62ca6-9492-40fb-ae0a-bbeb3ae50476" />

closes #8774

Debug Carrying Capacity still added carried item mass to total character weight, so overloaded debug characters could still sink boats or prevent aircraft from launching.

## Describe the solution (The How)

You are zero grams™ when `Debug Weightlessness` is enabled

## Testing

1. spawn ton of lead
2. enable debug carrying capacity and debug weightlessness
3. spawn helicopter
4. can ride helicopter
5. remove debug weightlessness
6. helicopter crashes to ground

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.github.com/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sup>PR opened by o3 high on pi</sup>
