### PR TITLE
feat: add butcher menu unload actor and fix unload loop

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -23,6 +23,7 @@
 #include "iexamine.h"
 #include "input.h"
 #include "item.h"
+#include "item_functions.h"
 #include "lua_action_menu.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -593,13 +594,15 @@ bool can_butcher_at( const tripoint &p )
     for( item *&items_it : items ) {
         if( items_it->is_corpse() ) {
             if( factor != INT_MIN  || factorD != INT_MIN ) {
-                has_corpse = true;
+                return true;
             }
         } else if( crafting::can_disassemble( you, *items_it, crafting_inv ).success() ) {
-            has_item = true;
+            return true;
+        } else if( item_funcs::can_be_unloaded( *items_it ) ) {
+            return true;
         }
     }
-    return has_corpse || has_item;
+    return false;
 }
 
 bool can_move_vertical_at( const tripoint &p, int movez )

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1391,25 +1391,32 @@ void avatar_action::unload( avatar &you )
     avatar_funcs::unload_item( you, *loc );
 }
 
-void avatar_action::unload_all( avatar &you )
+void avatar_action::unload_all( avatar &you, bool inv )
 {
-    auto unloaded = 0;
-    while( true ) {
+    bool unloaded = false;
+    if( inv ) {
         auto items = you.all_items();
-        const auto target = std::ranges::find_if( items, []( const auto * it ) {
-            return item_funcs::can_be_unloaded( *it );
-        } );
-
-        if( target == items.end() ) {
-            break;
+        for( item *it : items ) {
+            if( item_funcs::can_be_unloaded( *it ) ) {
+                if( !avatar_funcs::unload_item( you, *it ) ) {
+                    break;
+                }
+                unloaded = true;
+            }
         }
-        if( !avatar_funcs::unload_item( you, **target ) ) {
-            break;
+    } else {
+        auto items = get_map().i_at( you.pos() );
+        for( item *it : items ) {
+            if( item_funcs::can_be_unloaded( *it ) ) {
+                if( !avatar_funcs::unload_item( you, *it ) ) {
+                    break;
+                }
+                unloaded = true;
+            }
         }
-        ++unloaded;
     }
 
-    if( unloaded == 0 ) {
+    if( !unloaded ) {
         add_msg( _( "You have nothing to unload." ) );
     }
 }

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -61,7 +61,7 @@ void reload_weapon( bool try_everything = true );
  * If it's a gun, some gunmods can also be loaded.
  */
 void unload( avatar &you );
-void unload_all( avatar &you );
+void unload_all( avatar &you, bool inv = true );
 
 /**
  * Checks if the weapon is valid and if the player meets certain conditions for firing it.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -108,6 +108,7 @@
 #include "item.h"
 #include "item_category.h"
 #include "item_contents.h"
+#include "item_functions.h";
 #include "item_stack.h"
 #include "itype.h"
 #include "iuse.h"
@@ -10672,6 +10673,7 @@ void game::butcher()
     std::vector<item *> corpses;
     std::vector<item *> disassembles;
     std::vector<item *> salvageables;
+    std::vector<item *> unloadables;
     map_stack items = m.i_at( u.pos() );
     const inventory &crafting_inv = u.crafting_inventory();
     auto q_cache = u.crafting_inventory().get_quality_cache();
@@ -10681,6 +10683,7 @@ void game::butcher()
     corpses.reserve( items.size() );
     salvageables.reserve( items.size() );
     disassembles.reserve( items.size() );
+    unloadables.reserve( items.size() );
 
     // Split into corpses, disassemble-able, and salvageable items
     // It's not much additional work to just generate a corpse list and
@@ -10696,6 +10699,9 @@ void game::butcher()
                 disassembles.push_back( current_item );
             } else if( !first_item_without_tools ) {
                 first_item_without_tools = current_item;
+            }
+            if( item_funcs::can_be_unloaded( *current_item ) ) {
+                unloadables.push_back( current_item );
             }
         }
     }
@@ -10737,6 +10743,7 @@ void game::butcher()
         MULTIBUTCHER,
         MULTIDISASSEMBLE_ONE,
         MULTIDISASSEMBLE_ALL,
+        MULTIUNLOAD_ALL,
         NUM_BUTCHER_ACTIONS
     };
     // What are we butchering (i.e.. which vector to pick indices from)
@@ -10807,6 +10814,10 @@ void game::butcher()
             kmenu.addentry_col( MULTISALVAGE, true, 'z', _( "Salvage everything" ),
                                 to_string_clipped( time_duration::from_turns( time_to_salvage / 100 ) ) );
         }
+        if( unloadables.size() > 1 ) {
+            kmenu.addentry_col( MULTIUNLOAD_ALL, true, 'u', _( "Unload Everything" ),
+                                std::to_string( unloadables.size() ) + + _( " objects" ) );
+        }
 
         kmenu.query();
 
@@ -10864,6 +10875,9 @@ void game::butcher()
                     break;
                 case MULTIDISASSEMBLE_ALL:
                     crafting::disassemble_all( u, true );
+                    break;
+                case MULTIUNLOAD_ALL:
+                    avatar_action::unload_all( u, false );
                     break;
                 default:
                     debugmsg( "Invalid butchery type: %d", indexer_index );


### PR DESCRIPTION
## Purpose of change (The Why)
Apparently everything is wrong with #8641 
That it ( from the inventory ) does not unload everything on the ground

## Describe the solution (The How)
So adds butcher menu support
And prevents infinite loop with unloading liquids into other liquid containers by not reiterating over the containers

## Describe alternatives you've considered
Adding I have already been unloaded list?

## Testing
Butcher menu works
In bag unload works

## Additional context
I screm

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.