### PR TITLE
feat: add vehicle color pallettes for law enforcment and construction vehicles

### DIFF
--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -659,6 +659,7 @@
     "description": "You dont really know what this is, it appears to be filled with paint. But the paint seems to be shimmering and switching colors as you look at it. Use this tool to make graffiti on the floor or to paint objects.",
     "weight": "340 g",
     "volume": "250 ml",
+    "looks_like": "spray_can",
     "price": "10000 USD",
     "price_postapoc": "10 USD",
     "material": "aluminum",

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -97,10 +97,7 @@
     "palette": [
       {
         "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
-        "colors": [
-          { "color": "Ink Black", "weight": 10 },
-          { "color": "Steel Blue", "weight": 5 }
-        ]
+        "colors": [ { "color": "Ink Black", "weight": 10 }, { "color": "Steel Blue", "weight": 5 } ]
       }
     ]
   },
@@ -110,10 +107,7 @@
     "palette": [
       {
         "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
-        "colors": [
-          { "color": "Traffic Yellow", "weight": 10 },
-          { "color": "Carrot Orange", "weight": 5 }
-        ]
+        "colors": [ { "color": "Traffic Yellow", "weight": 10 }, { "color": "Carrot Orange", "weight": 5 } ]
       }
     ]
   },

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -78,6 +78,47 @@
   },
   {
     "type": "vehicle_color_palette",
+    "id": "police_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "colors": [
+          { "color": "Ink Black", "weight": 10 },
+          { "color": "Silver Grey", "weight": 10 },
+          { "color": "Silver Fir Blue", "weight": 2 },
+          { "color": "Steel Blue", "weight": 5 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "swat_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "colors": [
+          { "color": "Ink Black", "weight": 10 },
+          { "color": "Steel Blue", "weight": 5 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "construction_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "colors": [
+          { "color": "Traffic Yellow", "weight": 10 },
+          { "color": "Carrot Orange", "weight": 5 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
     "id": "sneaky_standard",
     "palette": [
       {

--- a/data/json/vehicles/emergency.json
+++ b/data/json/vehicles/emergency.json
@@ -113,6 +113,7 @@
       [ "+=##'|" ],
       [ "o-++-o" ]
     ],
+    "color_palette": "swat_standard",
     "parts": [
       {
         "x": 0,
@@ -481,6 +482,7 @@
       [ "+=##'|" ],
       [ "o-++-o" ]
     ],
+    "color_palette": "police_standard",
     "parts": [
       {
         "x": 0,
@@ -553,6 +555,7 @@
       [ "+=##'|" ],
       [ "o-++-o" ]
     ],
+    "color_palette": "police_standard",
     "parts": [
       {
         "x": 0,
@@ -626,6 +629,7 @@
       [ "+==##'|" ],
       [ "-o-++-o" ]
     ],
+    "color_palette": "police_standard",
     "parts": [
       {
         "x": 0,
@@ -708,6 +712,7 @@
       [ "+==##'|" ],
       [ "-o-++-o" ]
     ],
+    "color_palette": "police_standard",
     "parts": [
       {
         "x": 0,
@@ -792,6 +797,7 @@
       [ "+==##'|" ],
       [ "-o-++-o" ]
     ],
+    "color_palette": "police_standard",
     "parts": [
       {
         "x": 0,
@@ -877,6 +883,7 @@
       [ "O--+-+-O" ],
       [ "     o " ]
     ],
+    "color_palette": "swat_standard",
     "parts": [
       { "x": 0, "y": 1, "parts": [ "hdframe_vertical", "aisle_horizontal", "hdroof" ] },
       {

--- a/data/json/vehicles/utility.json
+++ b/data/json/vehicles/utility.json
@@ -102,6 +102,7 @@
     "type": "vehicle",
     "name": "Portable Generator",
     "blueprint": [ [ "o-" ] ],
+    "color_palette": "construction_standard",
     "parts": [
       {
         "x": 1,

--- a/data/json/vehicles/utility.json
+++ b/data/json/vehicles/utility.json
@@ -59,6 +59,7 @@
       [ "|X={" ],
       [ "o-=o" ]
     ],
+    "color_palette": "construction_standard",
     "parts": [
       {
         "x": 0,
@@ -137,6 +138,7 @@
       [ "B='H'B" ],
       [ "B--+'B" ]
     ],
+    "color_palette": "construction_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_horizontal", "roller_drum" ] },
       { "x": -1, "y": 1, "parts": [ "frame_horizontal", "windshield", "roof" ] },
@@ -195,6 +197,7 @@
       [ "o#o-" ],
       [ "o|o-" ]
     ],
+    "color_palette": "construction_standard",
     "parts": [
       { "x": -1, "y": 1, "parts": [ "frame_se", "halfboard_se", "wheel_mount_light_steerable", "wheel_small" ] },
       { "x": 1, "y": 0, "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_light_steerable", "wheel_small" ] },
@@ -224,6 +227,7 @@
       [ "|X==&" ],
       [ "o-=o " ]
     ],
+    "color_palette": "construction_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "hdframe_cross", "seat", "floodlight", "horn_big", "seatbelt", "dashboard", "controls" ] },
       { "x": 0, "y": -1, "parts": [ "hdframe_nw", "wheel_mount_medium", "wheel_wide_or" ] },
@@ -257,6 +261,7 @@
     "id": "roadheader_mining",
     "type": "vehicle",
     "name": "Mining Roadheader",
+    "color_palette": "construction_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "hdframe_cross", "seat", "controls", "seatbelt", "dashboard", "vehicle_alarm", "hdroof" ] },
       { "x": -1, "y": 0, "parts": [ "hdframe_cross", "aisle_vertical", "hdroof" ] },

--- a/data/json/vehicles/vans_busses.json
+++ b/data/json/vehicles/vans_busses.json
@@ -1970,6 +1970,7 @@
       [ "O--+-+-O" ],
       [ "     o " ]
     ],
+    "color_palette": "swat_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "aisle_horizontal", "hdroof" ] },
       { "x": 2, "y": 2, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal_2", "plating_steel" ] },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Law enforcement vehicles and construction vehicles typically come in a very select range of colors, black/silver/blue for police fleet vehicles, black or blue for swat vehicles and yellow or occasionally orange for construction vehicles

Having these vehicles actually spawn as those colors is probably a bit more immersive and also just looks better in cases where heavy duty car parts are mixed with regular steel car parts (i.e the swat van)

## Describe the solution (The How)

Construction vehicles now spawn in a bright yellow or orange
<img width="615" height="596" alt="2026-05-09-17:07:21" src="https://github.com/user-attachments/assets/390ea7d7-363f-4b16-aaa0-a0ee0f8aa457" />

Poilice fleet vehicles now spawn in black, silver, navy or very rarely a light blue silver 
<img width="937" height="278" alt="2026-05-09-17:20:09" src="https://github.com/user-attachments/assets/8fe78f15-bbfb-4aac-a773-fc3445c93418" />

FBI/Swat vehicles now spawn in black or navy
<img width="515" height="293" alt="2026-05-09-17:07:26" src="https://github.com/user-attachments/assets/fd5f8bfa-bbdc-4926-9545-713c86c23cc0" />


Also adds a looks_like entry to the super spraycan


## Describe alternatives you've considered
- Not doing this?

- Finding a better navy color


## Testing

Spawned the vehicles in and they look alright


## Additional context


## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
