### PR TITLE
feat: Add animal training with persistent bonuses

### DIFF
--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -31,6 +31,7 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
+    "pet_training": { "hp_mult": 1.05, "melee_mult": 1.05, "dodge_mult": 1.1, "max_level": 1 },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ]
   },
   {
@@ -78,7 +79,8 @@
       "food": [ "BIRDFOOD" ],
       "feed": "The %s seems to like you!",
       "pet": "The %s flies around you and briefly perches on your arm."
-    }
+    },
+    "pet_training": { "hp_mult": 1.05, "melee_mult": 1.1, "dodge_mult": 1.15, "max_level": 2 }
   },
   {
     "id": "mon_duck",
@@ -112,7 +114,8 @@
       "food": [ "BIRDFOOD" ],
       "feed": "The %s seems to like you!",
       "pet": "The %s quacks happily at you as you pat its head."
-    }
+    },
+    "pet_training": { "hp_mult": 1.05, "melee_mult": 1.05, "dodge_mult": 1.1, "max_level": 1 }
   },
   {
     "id": "mon_goose_canadian",
@@ -165,7 +168,8 @@
       "food": [ "BIRDFOOD" ],
       "feed": "The %s seems to like you!",
       "pet": "The %s clucks happily at you as you pat its head."
-    }
+    },
+    "pet_training": { "hp_mult": 1.1, "melee_mult": 1.1, "dodge_mult": 1.1, "max_level": 2 }
   },
   {
     "id": "mon_pheasant",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -946,6 +946,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.15, "dodge_mult": 1.15, "max_level": 3 },
     "special_attacks": [ [ "EAT_FOOD", 100 ], [ "PARROT_AT_DANGER", 0 ] ],
     "flags": [
       "ANIMAL",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -298,7 +298,8 @@
       "KEENNOSE",
       "BLEED"
     ],
-    "petfood": { "food": [ "DOGFOOD" ], "feed": "The %s seems to like you!", "pet": "The %s squeals happily at you." }
+    "petfood": { "food": [ "DOGFOOD" ], "feed": "The %s seems to like you!", "pet": "The %s squeals happily at you." },
+    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.25, "dodge_mult": 1.1, "max_level": 3 }
   },
   {
     "id": "mon_bobcat",
@@ -401,6 +402,7 @@
       "feed": "The %s seems to like you!  Or maybe it just tolerates your presence better.  It's hard to tell with felines.",
       "pet": "The %s sofly purrs as you pet it.  It demands more."
     },
+    "pet_training": { "hp_mult": 1.1, "melee_mult": 1.15, "dodge_mult": 1.25, "max_level": 2 },
     "flags": [
       "SEES",
       "HEARS",
@@ -760,6 +762,7 @@
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "special_attacks": [ [ "EAT_CROP", 4800 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you! It lets you pat its head and seems friendly." },
+    "pet_training": { "hp_mult": 1.25, "melee_mult": 1.15, "dodge_mult": 1.05, "max_level": 3 },
     "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE" ]
   },
   {
@@ -797,6 +800,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.15, "melee_mult": 1.15, "dodge_mult": 1.2, "max_level": 3 },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CANPLAY", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "KEENNOSE", "BLEED" ]
   },
   {
@@ -905,7 +909,8 @@
       "food": [ "CATTLEFOOD" ],
       "feed": "The %s seems to like you!",
       "pet": "The %s kicks its leg happily as you scratch it."
-    }
+    },
+    "pet_training": { "hp_mult": 1.15, "melee_mult": 1.1, "dodge_mult": 1.2, "max_level": 2 }
   },
   {
     "id": "mon_dog",
@@ -1006,6 +1011,7 @@
     "harvest": "mammal_small_leather",
     "reproduction": { "baby_monster": "mon_dog_bull_pup", "baby_count": 7, "baby_timer": 300 },
     "//": "7 puppies and 300-320 days per-litter for size medium canines",
+    "pet_training": { "hp_mult": 1.25, "melee_mult": 1.2, "dodge_mult": 1.1, "max_level": 3 },
     "flags": [
       "ANIMAL",
       "CANPLAY",
@@ -1080,6 +1086,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.25, "dodge_mult": 1.15, "max_level": 4 },
     "flags": [
       "ANIMAL",
       "CANPLAY",
@@ -1155,6 +1162,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.1, "melee_mult": 1.1, "dodge_mult": 1.15, "max_level": 2 },
     "flags": [
       "ANIMAL",
       "CANPLAY",
@@ -1232,6 +1240,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.1, "melee_mult": 1.1, "dodge_mult": 1.25, "max_level": 3 },
     "flags": [
       "ANIMAL",
       "CLIMBS",
@@ -1303,7 +1312,8 @@
     "fear_triggers": [ "HURT" ],
     "special_attacks": [ [ "LUNGE", 5 ] ],
     "reproduction": { "baby_monster": "mon_dog_boxer_pup", "baby_count": 4, "baby_timer": 270 },
-    "//": "1-4 puppies & 270 days per-litter for size small canines"
+    "//": "1-4 puppies & 270 days per-litter for size small canines",
+    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.25, "dodge_mult": 1.15, "max_level": 4 }
   },
   {
     "id": "mon_dog_boxer_pup",
@@ -1383,6 +1393,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.05, "melee_mult": 1.1, "dodge_mult": 1.15, "max_level": 2 },
     "flags": [
       "ANIMAL",
       "CANPLAY",
@@ -1456,6 +1467,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.1, "melee_mult": 1.1, "dodge_mult": 1.15, "max_level": 2 },
     "flags": [
       "ANIMAL",
       "CANPLAY",
@@ -1532,6 +1544,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.2, "dodge_mult": 1.2, "max_level": 5 },
     "flags": [
       "ANIMAL",
       "CANPLAY",
@@ -1610,6 +1623,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.25, "melee_mult": 1.15, "dodge_mult": 1.1, "max_level": 3 },
     "flags": [
       "ANIMAL",
       "CANPLAY",
@@ -1689,6 +1703,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.25, "melee_mult": 1.2, "dodge_mult": 1.15, "max_level": 4 },
     "flags": [
       "ANIMAL",
       "CANPLAY",
@@ -1765,6 +1780,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.15, "melee_mult": 1.15, "dodge_mult": 1.2, "max_level": 3 },
     "flags": [
       "ANIMAL",
       "CLIMBS",
@@ -2001,7 +2017,14 @@
     "reproduction": { "baby_monster": "mon_horse_foal", "baby_count": 1, "baby_timer": 360 },
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "special_attacks": [ [ "EAT_CROP", 7200 ] ],
-    "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you! It lets you pat its head and seems friendly." },
+    "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you! It lets you pat its head and seems friendly.", "pet": "The %s nuzzles you affectionately." },
+    "pet_training": {
+      "hp_mult": 1.2,
+      "melee_mult": 1.15,
+      "dodge_mult": 1.15,
+      "max_level": 3,
+      "level_flags": [ { "level": 1, "flags": [ "COMBAT_MOUNT" ] } ]
+    },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER_1", "WARM" ]
   },
   {
@@ -2290,6 +2313,7 @@
     "death_function": [ "NORMAL" ],
     "special_attacks": [ [ "EAT_FOOD", 2400 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you! It lets you pat its head and seems friendly." },
+    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.15, "dodge_mult": 1.1, "max_level": 2 },
     "flags": [
       "SEES",
       "HEARS",
@@ -2329,6 +2353,7 @@
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "death_function": [ "NORMAL" ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you! It lets you pat its head and seems friendly." },
+    "pet_training": { "hp_mult": 1.05, "melee_mult": 1.05, "dodge_mult": 1.2, "max_level": 1 },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "CANPLAY", "PET_WONT_FOLLOW", "WARM" ]
   },
   {
@@ -2359,7 +2384,8 @@
     "anger_triggers": [ "FRIEND_ATTACKED", "HURT" ],
     "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "BLEED" ],
-    "petfood": { "food": [ "CATFOOD", "DOGFOOD" ], "feed": "The %s seems to like you!", "pet": "The %s looks at you lovingly." }
+    "petfood": { "food": [ "CATFOOD", "DOGFOOD" ], "feed": "The %s seems to like you!", "pet": "The %s looks at you lovingly." },
+    "pet_training": { "hp_mult": 1.1, "melee_mult": 1.1, "dodge_mult": 1.15, "max_level": 2 }
   },
   {
     "id": "mon_rat_king",
@@ -2482,6 +2508,7 @@
     "death_function": [ "NORMAL" ],
     "special_attacks": [ [ "EAT_CROP", 14400 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you! It lets you pat its head and seems friendly." },
+    "pet_training": { "hp_mult": 1.15, "melee_mult": 1.05, "dodge_mult": 1.05, "max_level": 2 },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "SHEARABLE", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE" ]
   },
   {
@@ -2595,6 +2622,13 @@
     "anger_triggers": [ "STALK", "FRIEND_ATTACKED", "FRIEND_DIED", "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "placate_triggers": [ "MEAT" ],
     "death_function": [ "NORMAL" ],
+    "petfood": {
+      "food": [ "DOGFOOD" ],
+      "feed": "The %s eyes you warily, then cautiously accepts the food.",
+      "pet": "The %s allows you to touch it, watching you intently.",
+      "tamer_traits": [ [ "THRESH_LUPINE" ] ]
+    },
+    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.2, "dodge_mult": 1.2, "max_level": 4 },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "BLEED" ]
   }
 ]

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2017,7 +2017,11 @@
     "reproduction": { "baby_monster": "mon_horse_foal", "baby_count": 1, "baby_timer": 360 },
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "special_attacks": [ [ "EAT_CROP", 7200 ] ],
-    "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you! It lets you pat its head and seems friendly.", "pet": "The %s nuzzles you affectionately." },
+    "petfood": {
+      "food": [ "CATTLEFOOD" ],
+      "feed": "The %s seems to like you! It lets you pat its head and seems friendly.",
+      "pet": "The %s nuzzles you affectionately."
+    },
     "pet_training": {
       "hp_mult": 1.2,
       "melee_mult": 1.15,

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2628,7 +2628,7 @@
       "pet": "The %s allows you to touch it, watching you intently.",
       "tamer_traits": [ [ "THRESH_LUPINE" ] ]
     },
-    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.2, "dodge_mult": 1.2, "max_level": 4 },
+    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.2, "dodge_mult": 1.2, "max_level": 5, "min_skill": 5 },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "BLEED" ]
   }
 ]

--- a/data/json/monsters/mutant_animal.json
+++ b/data/json/monsters/mutant_animal.json
@@ -15,6 +15,7 @@
       "feed": "The %s seems to like you!  Or maybe it just tolerates your presence better.  It's hard to tell with felines.",
       "pet": "The %s sofly purrs as you pet it.  It demands more."
     },
+    "pet_training": { "hp_mult": 1.1, "melee_mult": 1.15, "dodge_mult": 1.25, "max_level": 2 },
     "flags": [
       "SEES",
       "HEARS",
@@ -433,6 +434,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
       "pet": "The %s happily wags its tail while you pat their head."
     },
+    "pet_training": { "hp_mult": 1.2, "melee_mult": 1.15, "dodge_mult": 1.15, "max_level": 3 },
     "flags": [
       "ANIMAL",
       "CANPLAY",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4222,14 +4222,15 @@ void activity_handlers::train_pet_finish( player_activity *act, player *p )
 {
     if( 4 * p->get_skill_level( skill_survival ) >= rng( 0, 100 ) ) {
         auto mon = act->monsters[0].lock();
-        if( mon ) {
-            mon->monster_flags.insert( MF_COMBAT_MOUNT );
+        if( mon && mon->type->pet_training ) {
+            mon->training_level = std::min( mon->training_level + 1, mon->type->pet_training->max_level );
             p->add_msg_if_player( m_good,
-                                  _( "Training your %s has finally succeeded, they should be less skittish in combat now." ),
-                                  act->str_values[0] );
+                                  _( "Training your %s has paid off!  They are now at training level %d/%d." ),
+                                  act->str_values[0], mon->training_level,
+                                  mon->type->pet_training->max_level );
         }
     } else {
-        p->add_msg_if_player( m_good,
+        p->add_msg_if_player( m_neutral,
                               _( "Training your %s takes time, it seems they are making a bit of progress at least." ),
                               act->str_values[0] );
     }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4220,8 +4220,16 @@ void activity_handlers::play_with_pet_finish( player_activity *act, player *p )
 
 void activity_handlers::train_pet_finish( player_activity *act, player *p )
 {
+    auto mon = act->monsters[0].lock();
+    if( mon && mon->type->pet_training &&
+        p->get_skill_level( skill_survival ) < mon->type->pet_training->min_skill ) {
+        p->add_msg_if_player( m_bad,
+                              _( "You lack the skill to train %s effectively." ),
+                              act->str_values[0] );
+        act->set_to_null();
+        return;
+    }
     if( 4 * p->get_skill_level( skill_survival ) >= rng( 0, 100 ) ) {
-        auto mon = act->monsters[0].lock();
         if( mon && mon->type->pet_training ) {
             mon->training_level = std::min( mon->training_level + 1, mon->type->pet_training->max_level );
             for( const auto &lf : mon->type->pet_training->level_flags ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -195,6 +195,7 @@ static const efftype_id effect_sheared( "sheared" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_tied( "tied" );
 static const efftype_id effect_under_op( "under_operation" );
+static const efftype_id effect_well_fed( "well_fed" );
 
 static const fault_id fault_bionic_nonsterile( "fault_bionic_nonsterile" );
 
@@ -4229,6 +4230,7 @@ void activity_handlers::train_pet_finish( player_activity *act, player *p )
         act->set_to_null();
         return;
     }
+    mon->remove_effect( effect_well_fed );
     if( 4 * p->get_skill_level( skill_survival ) >= rng( 0, 100 ) ) {
         if( mon && mon->type->pet_training ) {
             mon->training_level = std::min( mon->training_level + 1, mon->type->pet_training->max_level );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4224,6 +4224,9 @@ void activity_handlers::train_pet_finish( player_activity *act, player *p )
         auto mon = act->monsters[0].lock();
         if( mon && mon->type->pet_training ) {
             mon->training_level = std::min( mon->training_level + 1, mon->type->pet_training->max_level );
+            if( mon->training_level == 1 && mon->has_flag( MF_PET_MOUNTABLE ) ) {
+                mon->monster_flags.insert( MF_COMBAT_MOUNT );
+            }
             p->add_msg_if_player( m_good,
                                   _( "Training your %s has paid off!  They are now at training level %d/%d." ),
                                   act->str_values[0], mon->training_level,

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4224,8 +4224,12 @@ void activity_handlers::train_pet_finish( player_activity *act, player *p )
         auto mon = act->monsters[0].lock();
         if( mon && mon->type->pet_training ) {
             mon->training_level = std::min( mon->training_level + 1, mon->type->pet_training->max_level );
-            if( mon->training_level == 1 && mon->has_flag( MF_PET_MOUNTABLE ) ) {
-                mon->monster_flags.insert( MF_COMBAT_MOUNT );
+            for( const auto &lf : mon->type->pet_training->level_flags ) {
+                if( lf.level == mon->training_level ) {
+                    for( const m_flag f : lf.flags ) {
+                        mon->monster_flags.insert( f );
+                    }
+                }
             }
             p->add_msg_if_player( m_good,
                                   _( "Training your %s has paid off!  They are now at training level %d/%d." ),

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -74,15 +74,6 @@ static const flag_id json_flag_MECH_BAT( "MECH_BAT" );
 namespace
 {
 
-auto can_train_pet( monster &z ) -> bool
-{
-    return get_player_character().get_skill_level( skill_survival ) > 3 &&
-           z.has_flag( MF_PET_MOUNTABLE ) &&
-           !z.has_flag( MF_COMBAT_MOUNT ) &&
-           !z.has_flag( MF_CANT_TRAIN ) &&
-           z.type->has_fear_trigger( mon_trigger::HOSTILE_CLOSE );
-}
-
 } // namespace
 
 bool monexamine::pet_menu( monster &z )
@@ -164,8 +155,18 @@ bool monexamine::pet_menu( monster &z )
     if( z.has_flag( MF_CANPLAY ) ) {
         amenu.addentry( play_with_pet, true, 'y', _( "Play with %s" ), pet_name );
     }
-    if( can_train_pet( z ) ) {
-        amenu.addentry( train_combat_pet, true, '[', _( "Train %s" ), pet_name );
+    if( !z.type->pet_training ) {
+        amenu.addentry( train_combat_pet, false, '[', _( "Train %s (cannot be trained)" ), pet_name );
+    } else if( z.has_flag( MF_CANT_TRAIN ) ) {
+        amenu.addentry( train_combat_pet, false, '[', _( "Train %s (cannot be trained)" ), pet_name );
+    } else if( z.training_level >= z.type->pet_training->max_level ) {
+        amenu.addentry( train_combat_pet, false, '[', _( "Train %s (level %d/%d - fully trained)" ),
+                        pet_name, z.training_level, z.type->pet_training->max_level );
+    } else if( get_player_character().get_skill_level( skill_survival ) <= 3 ) {
+        amenu.addentry( train_combat_pet, false, '[', _( "Train %s (requires survival 4)" ), pet_name );
+    } else {
+        amenu.addentry( train_combat_pet, true, '[', _( "Train %s (level %d/%d)" ), pet_name,
+                        z.training_level, z.type->pet_training->max_level );
     }
     if( z.has_effect( effect_tied ) ) {
         amenu.addentry( untie, true, 'u', _( "Untie" ) );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -163,7 +163,8 @@ bool monexamine::pet_menu( monster &z )
     } else if( z.training_level >= z.type->pet_training->max_level ) {
         amenu.addentry( train_combat_pet, false, '[', _( "Train %s (level %d/%d - fully trained)" ),
                         pet_name, z.training_level, z.type->pet_training->max_level );
-    } else if( get_player_character().get_skill_level( skill_survival ) < z.type->pet_training->min_skill ) {
+    } else if( get_player_character().get_skill_level( skill_survival ) <
+               z.type->pet_training->min_skill ) {
         amenu.addentry( train_combat_pet, false, '[', _( "Train %s (requires survival %d)" ), pet_name,
                         z.type->pet_training->min_skill );
     } else if( !z.has_effect( effect_well_fed ) ) {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -163,8 +163,9 @@ bool monexamine::pet_menu( monster &z )
     } else if( z.training_level >= z.type->pet_training->max_level ) {
         amenu.addentry( train_combat_pet, false, '[', _( "Train %s (level %d/%d - fully trained)" ),
                         pet_name, z.training_level, z.type->pet_training->max_level );
-    } else if( get_player_character().get_skill_level( skill_survival ) <= 3 ) {
-        amenu.addentry( train_combat_pet, false, '[', _( "Train %s (requires survival 4)" ), pet_name );
+    } else if( get_player_character().get_skill_level( skill_survival ) < z.type->pet_training->min_skill ) {
+        amenu.addentry( train_combat_pet, false, '[', _( "Train %s (requires survival %d)" ), pet_name,
+                        z.type->pet_training->min_skill );
     } else if( !z.has_effect( effect_well_fed ) ) {
         amenu.addentry( train_combat_pet, false, '[', _( "Train %s (requires well-fed)" ), pet_name );
     } else {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -59,6 +59,7 @@ static const efftype_id effect_saddled( "monster_saddled" );
 static const efftype_id effect_leashed( "leashed" );
 static const efftype_id effect_led_by_leash( "led_by_leash" );
 static const efftype_id effect_tied( "tied" );
+static const efftype_id effect_well_fed( "well_fed" );
 
 static const itype_id itype_cash_card( "cash_card" );
 static const itype_id itype_id_industrial( "id_industrial" );
@@ -164,6 +165,8 @@ bool monexamine::pet_menu( monster &z )
                         pet_name, z.training_level, z.type->pet_training->max_level );
     } else if( get_player_character().get_skill_level( skill_survival ) <= 3 ) {
         amenu.addentry( train_combat_pet, false, '[', _( "Train %s (requires survival 4)" ), pet_name );
+    } else if( !z.has_effect( effect_well_fed ) ) {
+        amenu.addentry( train_combat_pet, false, '[', _( "Train %s (requires well-fed)" ), pet_name );
     } else {
         amenu.addentry( train_combat_pet, true, '[', _( "Train %s (level %d/%d)" ), pet_name,
                         z.training_level, z.type->pet_training->max_level );
@@ -883,8 +886,8 @@ void monexamine::play_with( monster &z )
 
 void monexamine::train_pet( monster &z )
 {
-    std::string pet_name = z.get_name();
     avatar &you = get_avatar();
+    std::string pet_name = z.get_name();
     you.assign_activity( ACT_TRAIN_PET, to_moves<int>( 60_minutes ) );
     you.activity->monsters.push_back( g->shared_from( z ) );
     you.activity->str_values.push_back( pet_name );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1025,7 +1025,7 @@ std::string monster::extended_description() const
     }
 
     if( training_level > 0 && type->pet_training ) {
-        const auto training_adj = []( float ratio ) -> const char * {
+        const auto training_adj = []( float ratio ) -> const char* { // *NOPAD*
             if( ratio > 1.5f )
             {
                 return _( "much" );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1025,7 +1025,7 @@ std::string monster::extended_description() const
     }
 
     if( training_level > 0 && type->pet_training ) {
-        const auto training_adj = []( float ratio ) -> const char* {
+        const auto training_adj = []( float ratio ) -> const char * {
             if( ratio > 1.5f )
             {
                 return _( "much" );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1024,6 +1024,29 @@ std::string monster::extended_description() const
         ss += std::string( _( "It has a head." ) ) + "\n";
     }
 
+    if( training_level > 0 && type->pet_training ) {
+        const auto training_adj = []( float ratio ) -> const char * {
+            if( ratio > 1.5f ) {
+                return _( "much" );
+            } else if( ratio > 1.25f ) {
+                return _( "noticeably" );
+            }
+            return _( "slightly" );
+        };
+        const float hp_ratio    = std::pow( type->pet_training->hp,    training_level );
+        const float melee_ratio = std::pow( type->pet_training->melee, training_level );
+        const float dodge_ratio = std::pow( type->pet_training->dodge, training_level );
+        if( hp_ratio > 1.0f ) {
+            ss += string_format( _( "It is %s tougher than normal." ),    training_adj( hp_ratio ) )    + "\n";
+        }
+        if( melee_ratio > 1.0f ) {
+            ss += string_format( _( "It is %s stronger than normal." ),   training_adj( melee_ratio ) ) + "\n";
+        }
+        if( dodge_ratio > 1.0f ) {
+            ss += string_format( _( "It is %s more agile than normal." ), training_adj( dodge_ratio ) ) + "\n";
+        }
+    }
+
     ss += "--\n";
     ss += std::string( _( "In melee, you can expect to:" ) ) + "\n";
     ss += string_format( _( "Deal average damage per second: <stat>%.1f</stat>" ),
@@ -2502,12 +2525,20 @@ int monster::get_armor_type( damage_type dt, bodypart_id bp ) const
 
 float monster::get_hit_base() const
 {
-    return type->melee_skill;
+    float base = type->melee_skill;
+    if( training_level > 0 && type->pet_training ) {
+        base *= std::pow( type->pet_training->melee, training_level );
+    }
+    return base;
 }
 
 float monster::get_dodge_base() const
 {
-    return type->sk_dodge;
+    float base = type->sk_dodge;
+    if( training_level > 0 && type->pet_training ) {
+        base *= std::pow( type->pet_training->dodge, training_level );
+    }
+    return base;
 }
 
 float monster::hit_roll() const
@@ -2573,7 +2604,11 @@ float monster::get_dodge() const
 
 float monster::get_melee() const
 {
-    return type->melee_skill;
+    float base = type->melee_skill;
+    if( training_level > 0 && type->pet_training ) {
+        base *= std::pow( type->pet_training->melee, training_level );
+    }
+    return base;
 }
 
 float monster::dodge_roll()
@@ -3749,12 +3784,16 @@ void monster::on_damage_of_type( int amt, damage_type dt, const bodypart_id &bp 
 
 int monster::get_hp_max( const bodypart_id & ) const
 {
-    return type->hp;
+    return get_hp_max();
 }
 
 int monster::get_hp_max() const
 {
-    return type->hp;
+    int base = type->hp;
+    if( training_level > 0 && type->pet_training ) {
+        return static_cast<int>( base * std::pow( type->pet_training->hp, training_level ) );
+    }
+    return base;
 }
 
 int monster::get_hp( const bodypart_id & ) const

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1025,7 +1025,7 @@ std::string monster::extended_description() const
     }
 
     if( training_level > 0 && type->pet_training ) {
-        const auto training_adj = []( float ratio ) -> const char* { // *NOPAD*
+        const auto training_adj = []( float ratio ) -> const std::string {
             if( ratio > 1.5f )
             {
                 return _( "much" );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1025,10 +1025,12 @@ std::string monster::extended_description() const
     }
 
     if( training_level > 0 && type->pet_training ) {
-        const auto training_adj = []( float ratio ) -> const char * {
-            if( ratio > 1.5f ) {
+        const auto training_adj = []( float ratio ) -> const char* {
+            if( ratio > 1.5f )
+            {
                 return _( "much" );
-            } else if( ratio > 1.25f ) {
+            } else if( ratio > 1.25f )
+            {
                 return _( "noticeably" );
             }
             return _( "slightly" );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1025,7 +1025,7 @@ std::string monster::extended_description() const
     }
 
     if( training_level > 0 && type->pet_training ) {
-        const auto training_adj = []( float ratio ) -> const char * {
+        const auto training_adj = []( float ratio ) -> const char* {
             if( ratio > 1.5f )
             {
                 return _( "much" );

--- a/src/monster.h
+++ b/src/monster.h
@@ -610,6 +610,7 @@ class monster : public Creature, public location_visitable<monster>
 
         // DEFINING VALUES
         int friendly;
+        int training_level = 0;
         int anger = 0;
         int morale = 0;
         // Per-npcmove-pass cache of attitude_to() result for a generic NPC (no special traits).

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -850,6 +850,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         pt.read( "melee_mult", ptm.melee );
         pt.read( "dodge_mult", ptm.dodge );
         pt.read( "max_level", ptm.max_level );
+        pt.read( "min_skill", ptm.min_skill );
         if( pt.has_array( "level_flags" ) ) {
             for( JsonObject lf_obj : pt.get_array( "level_flags" ) ) {
                 pet_training_level_flags lf;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -850,6 +850,16 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         pt.read( "melee_mult", ptm.melee );
         pt.read( "dodge_mult", ptm.dodge );
         pt.read( "max_level", ptm.max_level );
+        if( pt.has_array( "level_flags" ) ) {
+            for( JsonObject lf_obj : pt.get_array( "level_flags" ) ) {
+                pet_training_level_flags lf;
+                lf_obj.read( "level", lf.level );
+                for( const std::string &flag_str : lf_obj.get_array( "flags" ) ) {
+                    lf.flags.push_back( io::string_to_enum<m_flag>( flag_str ) );
+                }
+                ptm.level_flags.push_back( std::move( lf ) );
+            }
+        }
         pet_training = ptm;
     }
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -843,6 +843,16 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     // Load pet food data
     optional( jo, was_loaded, "petfood", petfood );
 
+    if( jo.has_object( "pet_training" ) ) {
+        JsonObject pt = jo.get_object( "pet_training" );
+        pet_training_multipliers ptm;
+        pt.read( "hp_mult", ptm.hp );
+        pt.read( "melee_mult", ptm.melee );
+        pt.read( "dodge_mult", ptm.dodge );
+        pt.read( "max_level", ptm.max_level );
+        pet_training = ptm;
+    }
+
     if( jo.has_array( "scents_tracked" ) ) {
         for( const std::string line : jo.get_array( "scents_tracked" ) ) {
             scents_tracked.emplace( line );

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -354,6 +354,7 @@ struct mtype {
             float melee = 1.15f;
             float dodge = 1.15f;
             int max_level = 3;
+            int min_skill = 3;
             std::vector<pet_training_level_flags> level_flags;
         };
         // Per-level stat multipliers when this monster is trained as a pet.

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -342,6 +342,18 @@ struct mtype {
         // Pet food category this monster is in
         pet_food_data petfood;
 
+        struct pet_training_multipliers {
+            // Per-level multipliers: 1.2 means each training level gives +20% of base stat.
+            // Values below 1.0 would decrease stats; values above 1.0 increase them.
+            float hp = 1.2f;
+            float melee = 1.15f;
+            float dodge = 1.15f;
+            int max_level = 3;
+        };
+        // Per-level stat multipliers when this monster is trained as a pet.
+        // Absent means this monster cannot be trained.
+        std::optional<pet_training_multipliers> pet_training;
+
         std::set<scenttype_id> scents_tracked; /**Types of scent tracked by this mtype*/
         std::set<scenttype_id> scents_ignored; /**Types of scent ignored by this mtype*/
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -342,6 +342,11 @@ struct mtype {
         // Pet food category this monster is in
         pet_food_data petfood;
 
+        struct pet_training_level_flags {
+            int level = 0;
+            std::vector<m_flag> flags;
+        };
+
         struct pet_training_multipliers {
             // Per-level multipliers: 1.2 means each training level gives +20% of base stat.
             // Values below 1.0 would decrease stats; values above 1.0 increase them.
@@ -349,6 +354,7 @@ struct mtype {
             float melee = 1.15f;
             float dodge = 1.15f;
             int max_level = 3;
+            std::vector<pet_training_level_flags> level_flags;
         };
         // Per-level stat multipliers when this monster is trained as a pet.
         // Absent means this monster cannot be trained.

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2040,6 +2040,7 @@ void monster::load( const JsonObject &data )
     }
 
     data.read( "friendly", friendly );
+    data.read( "training_level", training_level );
     data.read( "mission_id", mission_id );
     data.read( "no_extra_death_drops", no_extra_death_drops );
     data.read( "dead", dead );
@@ -2143,6 +2144,7 @@ void monster::store( JsonOut &json ) const
     json.member( "hp", hp );
     json.member( "special_attacks", special_attacks );
     json.member( "friendly", friendly );
+    json.member( "training_level", training_level );
     json.member( "fish_population", fish_population );
     json.member( "faction", faction.id().str() );
     json.member( "mission_id", mission_id );


### PR DESCRIPTION
## Purpose of change (The Why)

Gives a bit more value to having combat pets with you instead of leaving them at home forever.

## Describe the solution (The How)

Adds a training_level integer field to monsters and modifiers for HP, melee and dodge.
Max level by default is 3 but can be set via json.
Training benefits are shown when examining the pet.
Flags can be given with a training level, settable in json.

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<img width="952" height="509" alt="image" src="https://github.com/user-attachments/assets/31a1846b-9c63-4cef-9714-e6be21517804" />

<img width="492" height="350" alt="image" src="https://github.com/user-attachments/assets/ea02eba8-8379-41f5-87df-527e38073892" />



## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
