### PR TITLE
feat: add color palettes to trucks, vans and busses

### DIFF
--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -125,6 +125,18 @@
   },
   {
     "type": "vehicle_color_palette",
+    "id": "wienermobile_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "colors": [
+          { "color": "Carrot Orange", "weight": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
     "id": "limo_standard",
     "palette": [
       {

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -117,9 +117,7 @@
     "palette": [
       {
         "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
-        "colors": [
-          { "color": "Traffic Yellow", "weight": 1 }
-        ]
+        "colors": [ { "color": "Traffic Yellow", "weight": 1 } ]
       }
     ]
   },
@@ -129,9 +127,7 @@
     "palette": [
       {
         "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
-        "colors": [
-          { "color": "Carrot Orange", "weight": 1 }
-        ]
+        "colors": [ { "color": "Carrot Orange", "weight": 1 } ]
       }
     ]
   },

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -139,7 +139,7 @@
         "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
         "colors": [
           { "color": "Ink Black", "weight": 10 },
-          { "color": "Silver Grey", "weight": 10 },
+          { "color": "White aluminium", "weight": 10 },
           { "color": "Signal Pink", "weight": 1 }
         ]
       }

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -113,6 +113,32 @@
   },
   {
     "type": "vehicle_color_palette",
+    "id": "bus_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "colors": [
+          { "color": "Traffic Yellow", "weight": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "limo_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "colors": [
+          { "color": "Ink Black", "weight": 10 },
+          { "color": "Silver Grey", "weight": 10 },
+          { "color": "Signal Pink", "weight": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
     "id": "sneaky_standard",
     "palette": [
       {

--- a/data/json/vehicles/trucks.json
+++ b/data/json/vehicles/trucks.json
@@ -10,6 +10,7 @@
       [ "======='#'|" ],
       [ "-O------+-O" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical", "cargo_space" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
@@ -102,6 +103,7 @@
       [ "======='#'|" ],
       [ "-O------+-O" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical", "cargo_space" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
@@ -604,6 +606,7 @@
       [ "==='#'|" ],
       [ "o---+-o" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "windshield", "roof" ] },
@@ -678,6 +681,7 @@
       [ "==='#'|" ],
       [ "o---+-o" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "windshield", "roof" ] },
@@ -752,6 +756,7 @@
       [ "OO ---+=O-" ],
       [ "       o  " ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "hdframe_horizontal", "board_horizontal" ] },
       { "x": -1, "y": 1, "parts": [ "hdframe_horizontal", "board_horizontal" ] },

--- a/data/json/vehicles/vans_busses.json
+++ b/data/json/vehicles/vans_busses.json
@@ -127,6 +127,7 @@
       [ "O----+-O" ],
       [ "     o " ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_horizontal", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal_front" ] },
@@ -216,6 +217,7 @@
       [ "+===|#'|" ],
       [ "O----+-O" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_horizontal", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
@@ -297,6 +299,7 @@
       [ "+===|#'|" ],
       [ "O----+-O" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_horizontal", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
@@ -379,6 +382,7 @@
       [ "+===#'|" ],
       [ "o-+++-o" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical", "trunk", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
@@ -458,6 +462,7 @@
       [ "+===#'|" ],
       [ "o-+++-o" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "xlframe_vertical", "trunk", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "xlframe_vertical_2", "aisle_vertical", "roof" ] },
@@ -537,6 +542,7 @@
       [ "O-#-+-O" ],
       [ "     o " ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
@@ -633,6 +639,7 @@
       [ "O-#-+-O" ],
       [ "     o " ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
@@ -754,6 +761,7 @@
       [ "O-#-+-O" ],
       [ "     o " ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
@@ -866,6 +874,7 @@
     "id": "lux_rv",
     "type": "vehicle",
     "name": "Luxury RV",
+    "color_palette": "car_standard",
     "blueprint": [  ],
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_horizontal", "floodlight", "roof" ] },
@@ -1004,6 +1013,7 @@
     "type": "vehicle",
     "name": "Survivor RV",
     "blueprint": [  ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "trunk_floor", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "frame_horizontal", "lit_aisle_horizontal", "aisle_curtain", "roof" ] },
@@ -1158,6 +1168,7 @@
       [ "+OO-+-+-O" ],
       [ "       o " ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal", "headlight" ] },
@@ -1293,6 +1304,7 @@
       [ "+OO-+-+-O" ],
       [ "       o " ]
     ],
+    "color_palette": "car_standard",  
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal_front", "headlight" ] },
@@ -1407,6 +1419,7 @@
       [ "|C=###+#'|" ],
       [ "o-+----+-o" ]
     ],
+    "color_palette": "limo_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "seat_leather", "seatbelt", "roof" ] },
       {
@@ -1512,6 +1525,7 @@
       [ "'#######.'H" ],
       [ "''O'''''+'O" ]
     ],
+    "color_palette": "bus_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal_2", "halfboard_horizontal_2", "headlight" ] },
@@ -1605,6 +1619,7 @@
       [ "'#######.'H" ],
       [ "''O'''''+'O" ]
     ],
+    "color_palette": "police_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal_2", "halfboard_horizontal_2", "headlight", "plating_steel" ] },
@@ -1724,6 +1739,7 @@
       [ "''O'+''''''+'O" ],
       [ "            o" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal_2", "halfboard_horizontal_2", "headlight" ] },
@@ -1841,6 +1857,7 @@
       [ "''O-----'''+'O" ],
       [ "            o" ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal_2", "halfboard_horizontal_2", "headlight" ] },
@@ -2094,6 +2111,7 @@
       [ "+-O-+-O+" ],
       [ "      o " ]
     ],
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "chimes", "roof" ] },

--- a/data/json/vehicles/vans_busses.json
+++ b/data/json/vehicles/vans_busses.json
@@ -2111,7 +2111,7 @@
       [ "+-O-+-O+" ],
       [ "      o " ]
     ],
-    "color_palette": "car_standard",
+    "color_palette": "wienermobile_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "aisle_vertical", "chimes", "roof" ] },

--- a/data/json/vehicles/vans_busses.json
+++ b/data/json/vehicles/vans_busses.json
@@ -1304,7 +1304,7 @@
       [ "+OO-+-+-O" ],
       [ "       o " ]
     ],
-    "color_palette": "car_standard",  
+    "color_palette": "car_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical_2", "lit_aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_horizontal", "halfboard_horizontal_front", "headlight" ] },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Regular civilian vehicles such as rvs, pickup trucks and vans are all standard catalysm red, which looks a bit out of place next to all the colorful standard cars

Additionally, the limo, schoolbus and prison bus could all do with more specific color palettes in the name of being immersive


## Describe the solution (The How)

Limos are now primarily black or white, with a very small chance of being pink

<img width="581" height="431" alt="2026-05-09-23:10:06" src="https://github.com/user-attachments/assets/1856fb7c-baed-464f-8da2-d8261bfd466c" />


Schoolbusses are now yellow, as they should be

<img width="181" height="389" alt="2026-05-09-23:10:34" src="https://github.com/user-attachments/assets/cb7003c5-2aa4-446a-9e3e-fb4c58526227" />

Prison busses use the police color palette (black/silver/navy/lightblue)

The Wienermobile is now orange I guess, I dunno

The flatbed truck, Pickup truck, Semi truck, Cube van, Moving van, Blinkie Van, Hippie Van, Ice cream truck, Regular/Survivor/Luxury RV, and Regular/Tour bus all use the car_standard palette

## Describe alternatives you've considered

- Not doing this

## Testing

Booted up game and it all looked good

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

