### PR TITLE
feat: make experimental vehicles always locked

### DIFF
--- a/data/json/vehicles/military.json
+++ b/data/json/vehicles/military.json
@@ -2103,6 +2103,7 @@
       [ "=----|  " ],
       [ "oooooo  " ]
     ],
+    "flags": [ "VEHICLE_LOCKED" ],
     "parts": [
       { "x": -3, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
       { "x": -2, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
@@ -2237,6 +2238,7 @@
     "id": "tank_xm_hover",
     "type": "vehicle",
     "name": "XMH Hover Tank",
+    "flags": [ "VEHICLE_LOCKED" ],
     "parts": [
       { "x": -3, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_sw" ] },
       { "x": -2, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ] },
@@ -2377,6 +2379,7 @@
     "id": "xapc_hover",
     "type": "vehicle",
     "name": "Experimental Hover APC",
+    "flags": [ "VEHICLE_LOCKED" ],
     "parts": [
       { "x": 5, "y": 2, "parts": [ "frame_carbon_cover", "hdhalfboard_ne", "plating_military" ] },
       {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Adds a small barrier in case an early game player manages to stumble upon a powerful experimental vehicle. Also prevents the player from just running into a hover vehicle in the blacksite.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds the locked flag to the experimental electric tank and hover tank and hover apc
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
someone left the keys to this secret hover vehicle on the dashboard
## Testing
debug teleported to blacksites, everything looks good
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
I have not broken my rule of not buffing the feral black ops any more because this isn't a buff to them :)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.