### PR TITLE
fix(UI): scale loading images to full screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ auto print_button( const catacurses::window &w, const button_options &opts ) -> 
 - **SHOULD NOT** modify existing headers with >10 usages. Create new header with pure functions.
 - **MUST** use modern C++23 features.
 - **MUST** use options struct for functions with more than 3 parameters. Use designated initializers at call sites.
+- **MUST NOT** manually write an options/struct type at a call site when the function parameter type makes it inferable; use `{ .field = value }` instead of `options_type{ .field = value }`.
 - **SHOULD** search for existing solution because it's a large, legacy codebase.
 
 ## Workflow
@@ -135,3 +136,5 @@ rg -C2 -i 'speedway' lang/po/ko.po | rg -v '^(#:|--)' | head -n 20
 
 - **Docs**: [Building](./docs/en/dev/guides/building/cmake.md), [Formatting](./docs/en/dev/guides/formatting.md), [Dev Index](./docs/en/dev/).
 - **Review**: [LLM Guide](./.github/llm_review_guide.md).
+
+- When fixing a bug, preserve requested behavior and visible content unless the user explicitly asks to remove it; fix the underlying issue instead of suppressing the affected feature.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -108,7 +108,7 @@
 #include "item.h"
 #include "item_category.h"
 #include "item_contents.h"
-#include "item_functions.h";
+#include "item_functions.h"
 #include "item_stack.h"
 #include "itype.h"
 #include "iuse.h"

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -38,6 +38,24 @@ struct loading_image_cache {
 };
 #endif
 
+auto get_scaled_loading_image_size( const loading_image_scaling_options &opts ) ->
+std::optional<point>
+{
+    if( opts.image_size.x <= 0 || opts.image_size.y <= 0 || opts.screen_size.x <= 0 ||
+        opts.screen_size.y <= 0 ) {
+        return std::nullopt;
+    }
+
+    const auto width_scale = static_cast<double>( opts.screen_size.x ) /
+                             static_cast<double>( opts.image_size.x );
+    const auto height_scale = static_cast<double>( opts.screen_size.y ) /
+                              static_cast<double>( opts.image_size.y );
+    const auto scale = std::min( width_scale, height_scale );
+
+    return point( std::max( 1, static_cast<int>( std::lround( opts.image_size.x * scale ) ) ),
+                  std::max( 1, static_cast<int>( std::lround( opts.image_size.y * scale ) ) ) );
+}
+
 namespace
 {
 
@@ -238,27 +256,48 @@ auto get_loading_image_cache( loading_image_cache &cache,
 
 auto get_loading_image_rect( const point &image_size ) -> std::optional<SDL_Rect>
 {
-    if( image_size.x <= 0 || image_size.y <= 0 ) { return std::nullopt; }
+    const auto window_size = get_sdl_window_size();
+    const auto buffer_size = get_sdl_display_buffer_size();
+    if( window_size.x <= 0 || window_size.y <= 0 || buffer_size.x <= 0 || buffer_size.y <= 0 ) {
+        return std::nullopt;
+    }
 
-    const auto screen_dimensions = get_window_dimensions( catacurses::stdscr ).window_size_pixel;
-    if( screen_dimensions.x <= 0 || screen_dimensions.y <= 0 ) { return std::nullopt; }
+    return get_scaled_loading_image_size( loading_image_scaling_options{ .image_size = image_size,
+                                          .screen_size = window_size } )
+    .transform( [&window_size, &buffer_size]( const point & scaled_size ) {
+        const auto output_rect = SDL_Rect{
+            ( window_size.x - scaled_size.x ) / 2,
+            ( window_size.y - scaled_size.y ) / 2,
+            scaled_size.x,
+            scaled_size.y
+        };
+        return SDL_Rect{
+            static_cast<int>( std::lround( static_cast<double>( output_rect.x ) * buffer_size.x /
+                                           window_size.x ) ),
+            static_cast<int>( std::lround( static_cast<double>( output_rect.y ) * buffer_size.y /
+                                           window_size.y ) ),
+            static_cast<int>( std::lround( static_cast<double>( output_rect.w ) * buffer_size.x /
+                                           window_size.x ) ),
+            static_cast<int>( std::lround( static_cast<double>( output_rect.h ) * buffer_size.y /
+                                           window_size.y ) )
+        };
+    } );
+}
 
-    const auto max_width = static_cast<double>( screen_dimensions.x ) * 0.9;
-    const auto max_height = static_cast<double>( screen_dimensions.y ) * 0.9;
-    const auto width_scale = max_width / static_cast<double>( image_size.x );
-    const auto height_scale = max_height / static_cast<double>( image_size.y );
-    const auto scale = std::min( width_scale, height_scale );
-    const auto scaled_width = std::max( 1, static_cast<int>( std::lround( image_size.x * scale ) ) );
-    const auto scaled_height = std::max( 1, static_cast<int>( std::lround( image_size.y * scale ) ) );
+auto get_loading_image_author_pos( const std::string &text ) -> std::optional<point>
+{
+    const auto screen_dimensions = get_sdl_display_buffer_size();
+    const auto font_size = get_sdl_font_size();
+    if( screen_dimensions.x <= 0 || screen_dimensions.y <= 0 || font_size.x <= 0 ||
+        font_size.y <= 0 ) {
+        return std::nullopt;
+    }
 
-    const auto rect = SDL_Rect{
-        ( screen_dimensions.x - scaled_width ) / 2,
-        ( screen_dimensions.y - scaled_height ) / 2,
-        scaled_width,
-        scaled_height
-    };
+    const auto text_width = utf8_width( text, true );
+    if( text_width <= 0 ) { return std::nullopt; }
 
-    return rect;
+    return point( std::max( 0, screen_dimensions.x - ( text_width + 1 ) * font_size.x ),
+                  std::max( 0, screen_dimensions.y - font_size.y ) );
 }
 
 auto draw_loading_image_author( const std::string &author ) -> bool
@@ -266,26 +305,16 @@ auto draw_loading_image_author( const std::string &author ) -> bool
     if( author.empty() ) { return false; }
 
     const auto text = string_format( _( "by %s" ), author );
-    const auto window_width = getmaxx( catacurses::stdscr );
-    const auto window_height = getmaxy( catacurses::stdscr );
-    if( window_width <= 0 || window_height <= 0 ) { return false; }
+    const auto text_pos = get_loading_image_author_pos( text );
+    if( !text_pos ) { return false; }
 
-    const auto text_width = utf8_width( text, true );
-    const auto text_pos = point( std::max( 0, window_width - text_width - 1 ), window_height - 1 );
-    static const auto outline_offsets = std::array<point, 8> {
-        point( -1, -1 ), point( 0, -1 ), point( 1, -1 ), point( -1, 0 ),
-        point( 1, 0 ), point( -1, 1 ), point( 0, 1 ), point( 1, 1 )
-    };
-
-    for( const auto &offset : outline_offsets ) {
-        const auto outline_pos = text_pos + offset;
-        if( outline_pos.x >= 0 && outline_pos.y >= 0 && outline_pos.x < window_width &&
-            outline_pos.y < window_height ) {
-            trim_and_print( catacurses::stdscr, outline_pos, window_width - outline_pos.x, c_black, text );
-        }
-    }
-    trim_and_print( catacurses::stdscr, text_pos, window_width - text_pos.x, c_white, text );
-    wnoutrefresh( catacurses::stdscr );
+    draw_sdl_text_outlined( {
+        .text = text,
+        .pos_pixel = *text_pos,
+        .text_color = catacurses::white,
+        .outline_color = catacurses::black,
+        .outline_thickness = 2
+    } );
     return true;
 }
 
@@ -294,6 +323,40 @@ auto draw_loading_image_author_if_present( const std::optional<std::string> &aut
     return author.transform( draw_loading_image_author ).value_or( false );
 }
 
+struct sdl_render_state_guard {
+    const SDL_Renderer_Ptr &renderer;
+    point logical_size = point_zero;
+    float scale_x = 1.0f;
+    float scale_y = 1.0f;
+    SDL_Rect viewport = {};
+    std::optional<SDL_Rect> clip_rect;
+
+    explicit sdl_render_state_guard( const SDL_Renderer_Ptr &renderer ) : renderer( renderer ) {
+        SDL_RenderGetLogicalSize( renderer.get(), &logical_size.x, &logical_size.y );
+        SDL_RenderGetScale( renderer.get(), &scale_x, &scale_y );
+        SDL_RenderGetViewport( renderer.get(), &viewport );
+        if( SDL_RenderIsClipEnabled( renderer.get() ) ) {
+            clip_rect.emplace();
+            SDL_RenderGetClipRect( renderer.get(), &*clip_rect );
+        }
+        SDL_RenderSetClipRect( renderer.get(), nullptr );
+        SDL_RenderSetLogicalSize( renderer.get(), 0, 0 );
+        SDL_RenderSetScale( renderer.get(), 1.0f, 1.0f );
+        SDL_RenderSetViewport( renderer.get(), nullptr );
+    }
+
+    ~sdl_render_state_guard() {
+        if( logical_size.x > 0 && logical_size.y > 0 ) {
+            SDL_RenderSetLogicalSize( renderer.get(), logical_size.x, logical_size.y );
+        } else {
+            SDL_RenderSetLogicalSize( renderer.get(), 0, 0 );
+            SDL_RenderSetScale( renderer.get(), scale_x, scale_y );
+            SDL_RenderSetViewport( renderer.get(), &viewport );
+        }
+        SDL_RenderSetClipRect( renderer.get(), clip_rect ? &*clip_rect : nullptr );
+    }
+};
+
 #endif // defined( TILES )
 
 } // namespace
@@ -301,10 +364,13 @@ auto draw_loading_image_author_if_present( const std::optional<std::string> &aut
 #if defined( TILES )
 auto loading_image_splash::advance_loading_image() -> bool
 {
-    if( next_loading_image_path >= loading_image_paths.size() ) {
+    if( loading_image_paths.empty() ) {
         loading_image_path.clear();
         loading_image_author.reset();
         return false;
+    }
+    if( next_loading_image_path >= loading_image_paths.size() ) {
+        next_loading_image_path = 0;
     }
 
     loading_image_path = loading_image_paths[next_loading_image_path++];
@@ -317,11 +383,17 @@ auto loading_image_splash::draw_current_loading_image() -> bool
     while( !loading_image_path.empty() ) {
         const auto *const cache = get_loading_image_cache( *loading_image_cache_state, loading_image_path );
         if( cache != nullptr ) {
-            return get_loading_image_rect( cache->image_size )
-            .transform( [cache]( const SDL_Rect & rect ) {
-                RenderCopy( get_sdl_renderer(), cache->texture, nullptr, &rect );
-                return true;
-            } ).value_or( false );
+            const auto rect = get_loading_image_rect( cache->image_size );
+            if( !rect ) {
+                log_loading_image( string_format( "failed to calculate rect for '%s'", loading_image_path ) );
+                return false;
+            }
+            const auto &renderer = get_sdl_renderer();
+            const auto render_state_guard = sdl_render_state_guard( renderer );
+            clear_sdl_display_buffer();
+            RenderCopy( renderer, cache->texture, nullptr, &*rect );
+            draw_loading_image_author_if_present( loading_image_author );
+            return true;
         }
         if( !advance_loading_image() ) {
             break;
@@ -349,9 +421,7 @@ loading_image_splash::loading_image_splash()
             this->loading_image_lookup_attempted = true;
             advance_loading_image();
         }
-        if( draw_current_loading_image() ) {
-            draw_loading_image_author_if_present( loading_image_author );
-        }
+        draw_current_loading_image();
 #endif
     } );
 }
@@ -366,7 +436,12 @@ loading_ui::loading_ui( bool display )
     }
 }
 
-loading_ui::~loading_ui() = default;
+loading_ui::~loading_ui()
+{
+#if defined( TILES )
+    clear_sdl_display_buffer_before_redraw();
+#endif
+}
 
 void loading_ui::add_entry( const std::string &description )
 {

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -46,14 +46,11 @@ std::optional<point>
         return std::nullopt;
     }
 
-    const auto width_scale = static_cast<double>( opts.screen_size.x ) /
-                             static_cast<double>( opts.image_size.x );
     const auto height_scale = static_cast<double>( opts.screen_size.y ) /
                               static_cast<double>( opts.image_size.y );
-    const auto scale = std::min( width_scale, height_scale );
 
-    return point( std::max( 1, static_cast<int>( std::lround( opts.image_size.x * scale ) ) ),
-                  std::max( 1, static_cast<int>( std::lround( opts.image_size.y * scale ) ) ) );
+    return point( std::max( 1, static_cast<int>( std::lround( opts.image_size.x * height_scale ) ) ),
+                  opts.screen_size.y );
 }
 
 namespace
@@ -262,8 +259,7 @@ auto get_loading_image_rect( const point &image_size ) -> std::optional<SDL_Rect
         return std::nullopt;
     }
 
-    return get_scaled_loading_image_size( loading_image_scaling_options{ .image_size = image_size,
-                                          .screen_size = window_size } )
+    return get_scaled_loading_image_size( { .image_size = image_size, .screen_size = window_size } )
     .transform( [&window_size, &buffer_size]( const point & scaled_size ) {
         const auto output_rect = SDL_Rect{
             ( window_size.x - scaled_size.x ) / 2,
@@ -362,40 +358,42 @@ struct sdl_render_state_guard {
 } // namespace
 
 #if defined( TILES )
-auto loading_image_splash::advance_loading_image() -> bool
+auto advance_loading_image( loading_image_selection_state &state ) -> bool
 {
-    if( loading_image_paths.empty() ) {
-        loading_image_path.clear();
-        loading_image_author.reset();
+    if( state.paths.empty() ) {
+        state.current_path.clear();
+        state.current_author.reset();
         return false;
     }
-    if( next_loading_image_path >= loading_image_paths.size() ) {
-        next_loading_image_path = 0;
+    if( state.next_path >= state.paths.size() ) {
+        state.next_path = 0;
     }
 
-    loading_image_path = loading_image_paths[next_loading_image_path++];
-    loading_image_author = get_loading_image_author( loading_image_path );
+    state.current_path = state.paths[state.next_path++];
+    state.current_author = get_loading_image_author( state.current_path );
     return true;
 }
 
 auto loading_image_splash::draw_current_loading_image() -> bool
 {
-    while( !loading_image_path.empty() ) {
-        const auto *const cache = get_loading_image_cache( *loading_image_cache_state, loading_image_path );
+    while( !this->selection_state->current_path.empty() ) {
+        const auto *const cache = get_loading_image_cache( *loading_image_cache_state,
+                                  this->selection_state->current_path );
         if( cache != nullptr ) {
             const auto rect = get_loading_image_rect( cache->image_size );
             if( !rect ) {
-                log_loading_image( string_format( "failed to calculate rect for '%s'", loading_image_path ) );
+                log_loading_image( string_format( "failed to calculate rect for '%s'",
+                                                  this->selection_state->current_path ) );
                 return false;
             }
             const auto &renderer = get_sdl_renderer();
             const auto render_state_guard = sdl_render_state_guard( renderer );
             clear_sdl_display_buffer();
             RenderCopy( renderer, cache->texture, nullptr, &*rect );
-            draw_loading_image_author_if_present( loading_image_author );
+            draw_loading_image_author_if_present( this->selection_state->current_author );
             return true;
         }
-        if( !advance_loading_image() ) {
+        if( !advance_loading_image( *this->selection_state ) ) {
             break;
         }
     }
@@ -404,27 +402,55 @@ auto loading_image_splash::draw_current_loading_image() -> bool
 }
 #endif
 
-loading_image_splash::loading_image_splash()
-{
 #if defined( TILES )
+loading_image_splash::loading_image_splash() : selection_state( &owned_selection_state )
+{
     loading_image_cache_state = std::make_unique<loading_image_cache>();
-#endif
 
     ui_background = std::make_unique<background_pane>( [this]() {
-#if defined( TILES )
         if( !get_option<bool>( "LOADING_SCREEN_IMAGES" ) ) {
             return;
         }
-        if( !this->loading_image_lookup_attempted && can_choose_loading_image_path() ) {
-            loading_image_paths = choose_loading_image_paths();
-            next_loading_image_path = 0;
-            this->loading_image_lookup_attempted = true;
-            advance_loading_image();
+        if( !this->selection_state->lookup_attempted && can_choose_loading_image_path() ) {
+            this->selection_state->paths = choose_loading_image_paths();
+            this->selection_state->next_path = 0;
+            this->selection_state->lookup_attempted = true;
+        }
+        if( !selected_image_for_this_ui && this->selection_state->lookup_attempted ) {
+            selected_image_for_this_ui = true;
+            advance_loading_image( *this->selection_state );
         }
         draw_current_loading_image();
-#endif
     } );
 }
+
+loading_image_splash::loading_image_splash( loading_image_selection_state &selection_state ) :
+    selection_state( &selection_state )
+{
+    loading_image_cache_state = std::make_unique<loading_image_cache>();
+
+    ui_background = std::make_unique<background_pane>( [this]() {
+        if( !get_option<bool>( "LOADING_SCREEN_IMAGES" ) ) {
+            return;
+        }
+        if( !this->selection_state->lookup_attempted && can_choose_loading_image_path() ) {
+            this->selection_state->paths = choose_loading_image_paths();
+            this->selection_state->next_path = 0;
+            this->selection_state->lookup_attempted = true;
+        }
+        if( !selected_image_for_this_ui && this->selection_state->lookup_attempted ) {
+            selected_image_for_this_ui = true;
+            advance_loading_image( *this->selection_state );
+        }
+        draw_current_loading_image();
+    } );
+}
+#else
+loading_image_splash::loading_image_splash()
+{
+    ui_background = std::make_unique<background_pane>();
+}
+#endif
 
 loading_image_splash::~loading_image_splash() = default;
 
@@ -463,7 +489,11 @@ void loading_ui::new_context( const std::string &desc )
 void loading_ui::init()
 {
     if( menu != nullptr && ui == nullptr ) {
+#if defined( TILES )
+        ui_splash = std::make_unique<loading_image_splash>( loading_image_selection );
+#else
         ui_splash = std::make_unique<loading_image_splash>();
+#endif
 
         ui = std::make_unique<ui_adaptor>();
         ui->on_screen_resize( [this]( ui_adaptor & ui ) { menu->reposition( ui ); } );

--- a/src/loading_ui.h
+++ b/src/loading_ui.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "point.h"
+
 #if defined( TILES )
 struct loading_image_cache;
 #endif
@@ -14,6 +16,14 @@ class background_pane;
 class loading_image_splash;
 class ui_adaptor;
 class uilist;
+
+struct loading_image_scaling_options {
+    point image_size = point_zero;
+    point screen_size = point_zero;
+};
+
+auto get_scaled_loading_image_size( const loading_image_scaling_options &opts ) ->
+std::optional<point>;
 
 class loading_image_splash
 {

--- a/src/loading_ui.h
+++ b/src/loading_ui.h
@@ -10,6 +10,13 @@
 
 #if defined( TILES )
 struct loading_image_cache;
+struct loading_image_selection_state {
+    std::vector<std::string> paths;
+    std::size_t next_path = 0;
+    std::string current_path;
+    std::optional<std::string> current_author;
+    bool lookup_attempted = false;
+};
 #endif
 
 class background_pane;
@@ -29,20 +36,20 @@ class loading_image_splash
 {
     private:
         std::unique_ptr<background_pane> ui_background;
-        std::string loading_image_path;
-        std::optional<std::string> loading_image_author;
-        bool loading_image_lookup_attempted = false;
 #if defined( TILES )
-        std::vector<std::string> loading_image_paths;
-        std::size_t next_loading_image_path = 0;
+        loading_image_selection_state owned_selection_state;
+        loading_image_selection_state *selection_state = nullptr;
+        bool selected_image_for_this_ui = false;
         std::unique_ptr<loading_image_cache> loading_image_cache_state;
 
-        auto advance_loading_image() -> bool;
         auto draw_current_loading_image() -> bool;
 #endif
 
     public:
         loading_image_splash();
+#if defined( TILES )
+        explicit loading_image_splash( loading_image_selection_state &selection_state );
+#endif
         ~loading_image_splash();
 };
 
@@ -52,6 +59,9 @@ class loading_ui
         std::unique_ptr<uilist> menu;
         std::unique_ptr<ui_adaptor> ui;
         std::unique_ptr<loading_image_splash> ui_splash;
+#if defined( TILES )
+        loading_image_selection_state loading_image_selection;
+#endif
 
         void init();
     public:

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -116,6 +116,7 @@ static uint32_t lastupdate = 0;
 static uint32_t interval = 25;
 static bool needupdate = false;
 static bool need_invalidate_framebuffers = false;
+static bool clear_display_buffer_before_redraw = false;
 static const std::string empty_string;
 
 palette_array windowsPalette;
@@ -848,6 +849,23 @@ static point draw_string( Font &font,
         p.x += mk_wcwidth( ch32 ) * font.width;
     }
     return p;
+}
+
+void draw_sdl_text_outlined( const sdl_text_outline_options &opts )
+{
+    if( !font || !renderer || opts.text.empty() ) { return; }
+
+    const auto outline_thickness = std::max( 0, opts.outline_thickness );
+    for( auto y = -outline_thickness; y <= outline_thickness; ++y ) {
+        for( auto x = -outline_thickness; x <= outline_thickness; ++x ) {
+            if( x != 0 || y != 0 ) {
+                draw_string( *font, renderer, geometry, opts.text, opts.pos_pixel + point( x, y ),
+                             static_cast<unsigned char>( opts.outline_color ) );
+            }
+        }
+    }
+    draw_string( *font, renderer, geometry, opts.text, opts.pos_pixel,
+                 static_cast<unsigned char>( opts.text_color ) );
 }
 
 void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bool blink )
@@ -1630,6 +1648,12 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w )
 
 void cata_cursesport::curses_drawwindow( const catacurses::window &w )
 {
+    if( clear_display_buffer_before_redraw ) {
+        clear_display_buffer_before_redraw = false;
+        SetRenderTarget( renderer, display_buffer );
+        ClearScreen();
+    }
+
     if( scaling_factor > 1 ) {
         SDL_RenderSetLogicalSize( renderer.get(), WindowWidth / scaling_factor,
                                   WindowHeight / scaling_factor );
@@ -4088,6 +4112,43 @@ window_dimensions get_window_dimensions( const catacurses::window &win )
 window_dimensions get_window_dimensions( point pos, point size )
 {
     return get_window_dimensions( {}, pos, size );
+}
+
+auto get_sdl_display_buffer_size() -> point
+{
+    if( !display_buffer ) { return point_zero; }
+
+    auto width = 0;
+    auto height = 0;
+    if( SDL_QueryTexture( display_buffer.get(), nullptr, nullptr, &width, &height ) != 0 ) {
+        return point_zero;
+    }
+    return point( width, height );
+}
+
+auto get_sdl_window_size() -> point
+{
+    return point( std::max( 1, WindowWidth / scaling_factor ),
+                  std::max( 1, WindowHeight / scaling_factor ) );
+}
+
+auto get_sdl_font_size() -> point
+{
+    return point( fontwidth, fontheight );
+}
+
+void clear_sdl_display_buffer()
+{
+    if( !renderer || !display_buffer ) { return; }
+
+    SetRenderTarget( renderer, display_buffer );
+    ClearScreen();
+}
+
+void clear_sdl_display_buffer_before_redraw()
+{
+    clear_display_buffer_before_redraw = true;
+    reinitialize_framebuffer( true );
 }
 
 std::optional<tripoint> input_context::get_coordinates( const catacurses::window &capture_win_ )

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -14,6 +14,7 @@ class cata_tiles;
 
 namespace catacurses
 {
+enum base_color : short;
 class window;
 } // namespace catacurses
 
@@ -40,6 +41,19 @@ window_dimensions get_window_dimensions( const catacurses::window &win );
 // Get dimensional info of an imaginary normal catacurses::window with the given
 // position and size. Unlike real catacurses::window, size can be zero.
 window_dimensions get_window_dimensions( point pos, point size );
+auto get_sdl_display_buffer_size() -> point;
+auto get_sdl_window_size() -> point;
+auto get_sdl_font_size() -> point;
+void clear_sdl_display_buffer();
+void clear_sdl_display_buffer_before_redraw();
+struct sdl_text_outline_options {
+    std::string text;
+    point pos_pixel = point_zero;
+    catacurses::base_color text_color = {};
+    catacurses::base_color outline_color = {};
+    int outline_thickness = 1;
+};
+void draw_sdl_text_outlined( const sdl_text_outline_options &opts );
 
 const SDL_Renderer_Ptr &get_sdl_renderer();
 

--- a/tests/loading_ui_test.cpp
+++ b/tests/loading_ui_test.cpp
@@ -1,9 +1,45 @@
 #include "catch/catch.hpp"
 
+#include "loading_ui.h"
 #include "options.h"
 
 TEST_CASE( "loading_screen_images_option_exists", "[loading_ui]" )
 {
     REQUIRE( get_options().has_option( "LOADING_SCREEN_IMAGES" ) );
     CHECK( get_options().get_option( "LOADING_SCREEN_IMAGES" ).getValue() == "true" );
+}
+
+TEST_CASE( "loading_screen_image_scales_to_full_screen_size", "[loading_ui]" )
+{
+    const auto scaled_size = get_scaled_loading_image_size( loading_image_scaling_options{
+        .image_size = point( 2560, 1440 ),
+        .screen_size = point( 1600, 900 )
+    } );
+
+    REQUIRE( scaled_size.has_value() );
+    CHECK( *scaled_size == point( 1600, 900 ) );
+}
+
+TEST_CASE( "loading_screen_image_preserves_aspect_ratio_for_different_screen_ratio",
+           "[loading_ui]" )
+{
+    const auto scaled_size = get_scaled_loading_image_size( loading_image_scaling_options{
+        .image_size = point( 2560, 1440 ),
+        .screen_size = point( 1600, 700 )
+    } );
+
+    REQUIRE( scaled_size.has_value() );
+    CHECK( *scaled_size == point( 1244, 700 ) );
+}
+
+TEST_CASE( "loading_screen_image_scaling_rejects_invalid_sizes", "[loading_ui]" )
+{
+    CHECK( !get_scaled_loading_image_size( loading_image_scaling_options{
+        .image_size = point_zero,
+        .screen_size = point( 1280, 720 )
+    } ).has_value() );
+    CHECK( !get_scaled_loading_image_size( loading_image_scaling_options{
+        .image_size = point( 1920, 1080 ),
+        .screen_size = point_zero
+    } ).has_value() );
 }

--- a/tests/loading_ui_test.cpp
+++ b/tests/loading_ui_test.cpp
@@ -20,8 +20,7 @@ TEST_CASE( "loading_screen_image_scales_to_full_screen_size", "[loading_ui]" )
     CHECK( *scaled_size == point( 1600, 900 ) );
 }
 
-TEST_CASE( "loading_screen_image_preserves_aspect_ratio_for_different_screen_ratio",
-           "[loading_ui]" )
+TEST_CASE( "loading_screen_image_fits_full_height_and_scales_width", "[loading_ui]" )
 {
     const auto scaled_size = get_scaled_loading_image_size( loading_image_scaling_options{
         .image_size = point( 2560, 1440 ),
@@ -30,6 +29,17 @@ TEST_CASE( "loading_screen_image_preserves_aspect_ratio_for_different_screen_rat
 
     REQUIRE( scaled_size.has_value() );
     CHECK( *scaled_size == point( 1244, 700 ) );
+}
+
+TEST_CASE( "loading_screen_image_fits_full_height_for_tall_image", "[loading_ui]" )
+{
+    const auto scaled_size = get_scaled_loading_image_size( loading_image_scaling_options{
+        .image_size = point( 1000, 2000 ),
+        .screen_size = point( 1600, 900 )
+    } );
+
+    REQUIRE( scaled_size.has_value() );
+    CHECK( *scaled_size == point( 450, 900 ) );
 }
 
 TEST_CASE( "loading_screen_image_scaling_rejects_invalid_sizes", "[loading_ui]" )


### PR DESCRIPTION
## Purpose of change (The Why)

Continuation of #8617.

Loading splash images were capped at 90% of the window dimensions.

## Describe the solution (The How)

Scale loading images against the full window while preserving aspect ratio.

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/c3ecffee-0460-480e-9521-26a7916b01e4" />

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sup>PR opened by gpt-5.1 high on pi</sup>
