### PR TITLE
fix: color flat trunks but not regular cargo parts

### DIFF
--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -4,7 +4,7 @@
     "id": "car_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "White aluminium", "weight": 8 },
           { "color": "Silver Maple Green", "weight": 8 },
@@ -29,7 +29,7 @@
     "id": "cargo_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "inflate", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "inflate", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "White aluminium", "weight": 8 },
           { "color": "Silver Maple Green", "weight": 8 },
@@ -45,7 +45,7 @@
     "id": "visibility_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "inflate", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "inflate", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "Iris Blue", "weight": 12 },
           { "color": "Cataclysm Red", "weight": 20 },
@@ -65,7 +65,7 @@
     "id": "military_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "Cataclysm Green", "weight": 20 },
           { "color": "North Grey", "weight": 10 },
@@ -81,7 +81,7 @@
     "id": "police_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "Ink Black", "weight": 10 },
           { "color": "Silver Grey", "weight": 10 },
@@ -96,7 +96,7 @@
     "id": "swat_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [ { "color": "Ink Black", "weight": 10 }, { "color": "Steel Blue", "weight": 5 } ]
       }
     ]
@@ -106,7 +106,7 @@
     "id": "construction_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [ { "color": "Traffic Yellow", "weight": 10 }, { "color": "Carrot Orange", "weight": 5 } ]
       }
     ]
@@ -116,7 +116,7 @@
     "id": "bus_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [ { "color": "Traffic Yellow", "weight": 1 } ]
       }
     ]
@@ -126,7 +126,7 @@
     "id": "wienermobile_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [ { "color": "Carrot Orange", "weight": 1 } ]
       }
     ]
@@ -136,7 +136,7 @@
     "id": "limo_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "Ink Black", "weight": 10 },
           { "color": "White aluminium", "weight": 10 },
@@ -150,7 +150,7 @@
     "id": "sneaky_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "North Grey", "weight": 10 },
           { "color": "Ink Black", "weight": 10 },
@@ -164,7 +164,7 @@
     "id": "fighter_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk", "hatch" ],
+        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "North Grey", "weight": 10 },
           { "color": "Ink Black", "weight": 10 },

--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -316,8 +316,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
     },
-    "damage_reduction": { "all": 28 },
-    "default_color": "#622625"
+    "damage_reduction": { "all": 28 }
   },
   {
     "copy-from": "trunk_abstract",
@@ -369,7 +368,8 @@
     "name": { "str": "flat trunk" },
     "looks_like": "hatch",
     "size": "100 L",
-    "flags": [ "OBSTACLE", "HALF_BOARD", "NO_ROOF_NEEDED", "CARGO", "LOCKABLE_CARGO" ]
+    "flags": [ "OBSTACLE", "HALF_BOARD", "NO_ROOF_NEEDED", "CARGO", "LOCKABLE_CARGO" ],
+    "default_color": "#622625"
   },
   {
     "copy-from": "trunk_flat",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Floor trunks getting colored is weird, they aren't made of body panels.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Edited use of trunk in vehicle palettes to specify ID `trunk_flat` instead.
2. Moved default color from trunk abstract to flat trunks, as those are the only ones to be a body panel item thing.

## Describe alternatives you've considered

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Ported file changes to playthrough build, load-tested, spawned affected vehicles.
<img width="547" height="480" alt="image" src="https://github.com/user-attachments/assets/61f70bac-a37e-4494-a1a7-c6027a76d151" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
