### PR TITLE
fix(UI): keep removed local keybindings reset to global

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -252,6 +252,17 @@ void input_manager::load( const std::string &file_name, bool is_user_preferences
             events.push_back( new_event );
         }
 
+        if( is_user_preferences && context != default_context_id &&
+            action.get_bool( "is_deleted", false ) ) {
+            if( actions.contains( action_id ) ) {
+                auto &attributes = actions[action_id];
+                attributes.input_events.clear();
+                attributes.is_user_created = false;
+                attributes.is_deleted = true;
+            }
+            continue;
+        }
+
         // An invariant of this class is that user-created, local keybindings
         // with an empty set of input_events do not exist in the
         // action_contexts map. In prior versions of this class, this was not
@@ -268,8 +279,9 @@ void input_manager::load( const std::string &file_name, bool is_user_preferences
             actions.contains( action_id ) ) {
             // In case this is the second file containing user preferences,
             // this replaces the default bindings with the user's preferences.
-            action_attributes &attributes = actions[action_id];
+            auto &attributes = actions[action_id];
             attributes.input_events = events;
+            attributes.is_deleted = false;
             if( action.has_member( "is_user_created" ) ) {
                 attributes.is_user_created = action.get_bool( "is_user_created" );
             }
@@ -292,9 +304,12 @@ void input_manager::save()
 
                 jsout.member( "id", action.first );
                 jsout.member( "category", a->first );
-                bool is_user_created = action.second.is_user_created;
+                const auto is_user_created = action.second.is_user_created;
                 if( is_user_created ) {
                     jsout.member( "is_user_created", is_user_created );
+                }
+                if( action.second.is_deleted ) {
+                    jsout.member( "is_deleted", true );
                 }
 
                 jsout.member( "bindings" );
@@ -509,7 +524,7 @@ const action_attributes &input_manager::get_action_attributes(
         const t_action_contexts::const_iterator action_context = action_contexts.find( context );
         if( action_context != action_contexts.end() ) {
             const t_actions::const_iterator action = action_context->second.find( action_id );
-            if( action != action_context->second.end() ) {
+            if( action != action_context->second.end() && !action->second.is_deleted ) {
                 if( overwrites_default ) {
                     *overwrites_default = true;
                 }
@@ -562,9 +577,11 @@ input_manager::t_input_event_list &input_manager::get_or_create_event_list(
     // A new action is created in the event that the user creates a local
     // keymapping that masks a global one.
     if( !actions.contains( action_descriptor ) ) {
-        action_attributes &attributes = actions[action_descriptor];
+        auto &attributes = actions[action_descriptor];
         attributes.name = get_default_action_name( action_descriptor );
         attributes.is_user_created = true;
+    } else if( actions[action_descriptor].is_deleted ) {
+        actions[action_descriptor].is_deleted = false;
     }
 
     return actions[action_descriptor].input_events;
@@ -587,7 +604,7 @@ void input_manager::remove_input_for_action(
                 // there's an attempt to remove bindings anyway, presumably the user wants
                 // to fully remove the binding from that context.
                 if( action->second.input_events.empty() ) {
-                    actions.erase( action );
+                    action->second.is_deleted = true;
                 } else {
                     action->second.input_events.clear();
                 }

--- a/src/input.h
+++ b/src/input.h
@@ -184,8 +184,9 @@ struct input_event {
  * A set of attributes for an action
  */
 struct action_attributes {
-    action_attributes() : is_user_created( false ) {}
+    action_attributes() : is_user_created( false ), is_deleted( false ) {}
     bool is_user_created;
+    bool is_deleted;
     translation name;
     std::vector<input_event> input_events;
 };

--- a/tests/input_test.cpp
+++ b/tests/input_test.cpp
@@ -1,0 +1,82 @@
+#include "catch/catch.hpp"
+
+#include <algorithm>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "filesystem.h"
+#include "input.h"
+#include "path_info.h"
+
+namespace
+{
+
+class user_keybindings_file_guard
+{
+    public:
+        ~user_keybindings_file_guard() {
+            remove_file( PATH_INFO::user_keybindings() );
+            inp_mngr.init();
+        }
+};
+
+auto write_user_keybindings( const std::string &entry ) -> void
+{
+    auto file = std::ofstream( PATH_INFO::user_keybindings(), std::ios::binary );
+    REQUIRE( file.good() );
+    file << "[\n" << entry << "\n]\n";
+}
+
+auto read_user_keybindings() -> std::string
+{
+    auto file = std::ifstream( PATH_INFO::user_keybindings(), std::ios::binary );
+    REQUIRE( file.good() );
+    return { std::istreambuf_iterator<char>( file ), std::istreambuf_iterator<char>() };
+}
+
+auto npc_trade_right_keys() -> std::vector<char>
+{
+    auto ctxt = input_context( "NPC_TRADE" );
+    return ctxt.keys_bound_to( "RIGHT" );
+}
+
+auto contains_key( const std::vector<char> &keys, const char key ) -> bool
+{
+    return std::ranges::find( keys, key ) != keys.end();
+}
+
+} // namespace
+
+TEST_CASE( "deleted local keybindings fall back to global bindings", "[input][keybindings]" )
+{
+    auto restore_keybindings = user_keybindings_file_guard();
+
+    write_user_keybindings( R"({
+  "type": "keybinding",
+  "id": "RIGHT",
+  "category": "NPC_TRADE",
+  "bindings": []
+})" );
+    inp_mngr.init();
+
+    auto keys = npc_trade_right_keys();
+    CHECK( keys.empty() );
+
+    write_user_keybindings( R"({
+  "type": "keybinding",
+  "id": "RIGHT",
+  "category": "NPC_TRADE",
+  "is_deleted": true,
+  "bindings": []
+})" );
+    inp_mngr.init();
+
+    keys = npc_trade_right_keys();
+    CHECK( contains_key( keys, 'l' ) );
+    CHECK( contains_key( keys, '6' ) );
+
+    inp_mngr.save();
+    CHECK( read_user_keybindings().find( "\"is_deleted\": true" ) != std::string::npos );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

Fix removed local keybindings returning after restart and masking global bindings again.

Related to #6126, but does not fully resolve it. #6126 also covers adding global keybindings while local keybindings still exist.

## Describe the solution (The How)

Persist a deleted-local marker for non-default keybindings and skip those local actions during lookup/load, so resetting a local binding falls back to the global binding across restarts.

## Testing

- `cmake --preset linux-full`
- `cmake --build out/build/linux-full --target astyle`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[input][keybindings]"`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`

## Additional context

The keybindings menu first clears a default local binding to `bindings: []`, which displays `Unbound locally!` and still masks global bindings. A second remove erased that local entry only in memory; saving had no way to represent the deletion, so default local bindings from `data/raw/keybindings` loaded again on the next start. Manual file edits to empty `bindings` preserve the local mask, matching the reported `Unbound locally!` behavior.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I mentioned the related keybinding issue context.

<sup>PR opened by ChatGPT high on pi</sup>

