### PR TITLE
feat: add vehicle color palettes to farm, fire and ems vics

### DIFF
--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -113,6 +113,50 @@
   },
   {
     "type": "vehicle_color_palette",
+    "id": "farm_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Flame Red", "weight": 10 },
+          { "color": "Universal Green", "weight": 10 },
+          { "color": "LED Blue", "weight": 2 },
+          { "color": "Persian Orange", "weight": 2 },
+          { "color": "Poster Yellow", "weight": 2 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "firetruck_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Flame Red", "weight": 20 },
+          { "color": "White aluminium", "weight": 5 },
+          { "color": "Neon Green", "weight": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "ems_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "White aluminium", "weight": 20 },
+          { "color": "Flame Red", "weight": 10 },
+          { "color": "Traffic Yellow", "weight": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
     "id": "bus_standard",
     "palette": [
       {

--- a/data/json/vehicles/emergency.json
+++ b/data/json/vehicles/emergency.json
@@ -12,6 +12,7 @@
       [ "O--+-+-O" ],
       [ "      o " ]
     ],
+    "color_palette": "ems_standard",
     "parts": [
       { "x": 0, "y": 1, "parts": [ "frame_vertical", "box", "roof" ] },
       {
@@ -183,6 +184,7 @@
       [ "|T|#|#'" ],
       [ "OO---+'" ]
     ],
+    "color_palette": "firetruck_standard",
     "parts": [
       {
         "x": -5,
@@ -339,6 +341,7 @@
       [ "|+++-+-+-" ],
       [ "        o" ]
     ],
+    "color_palette": "firetruck_standard",
     "parts": [
       { "x": 2, "y": -1, "parts": [ "hdframe_nw", "halfboard_nw" ] },
       { "x": 2, "y": 0, "parts": [ "hdframe_horizontal", "halfboard_horizontal", "horn_big" ] },

--- a/data/json/vehicles/farm.json
+++ b/data/json/vehicles/farm.json
@@ -8,6 +8,7 @@
       [ "&&#==&" ],
       [ " O  O " ]
     ],
+    "color_palette": "farm_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_vertical", "seat", "controls", "dashboard" ] },
       {
@@ -39,6 +40,7 @@
       [ "8|=x|" ],
       [ "O-+-O" ]
     ],
+    "color_palette": "farm_standard",
     "parts": [
       { "x": 0, "y": 1, "part": "frame_vertical" },
       { "x": 0, "y": 1, "part": "door_opaque" },
@@ -102,6 +104,7 @@
       [ "+O  O" ],
       [ "&    " ]
     ],
+    "color_palette": "farm_standard",
     "parts": [
       { "x": 2, "y": 0, "part": "frame_horizontal" },
       { "x": 2, "y": 0, "part": "halfboard_vertical" },
@@ -147,6 +150,7 @@
       [ "+O  O" ],
       [ "&    " ]
     ],
+    "color_palette": "farm_standard",
     "parts": [
       { "x": 2, "y": 0, "part": "frame_horizontal" },
       { "x": 2, "y": 0, "part": "halfboard_vertical" },
@@ -189,6 +193,7 @@
       [ "+O  O" ],
       [ "&    " ]
     ],
+    "color_palette": "farm_standard",
     "parts": [
       { "x": 2, "y": 0, "part": "frame_horizontal" },
       { "x": 2, "y": 0, "part": "halfboard_vertical" },
@@ -301,6 +306,7 @@
       [ "H|-+'||" ],
       [ "&ooooo " ]
     ],
+    "color_palette": "farm_standard",
     "parts": [
       { "x": -2, "y": -2, "parts": [ "frame_horizontal", "tread1" ] },
       { "x": -1, "y": -2, "parts": [ "frame_horizontal", "tread1" ] },
@@ -353,6 +359,7 @@
       [ "H|-+'||" ],
       [ "&ooooo " ]
     ],
+    "color_palette": "farm_standard",
     "parts": [
       { "x": -2, "y": -2, "parts": [ "frame_horizontal", "tread1" ] },
       { "x": -1, "y": -2, "parts": [ "frame_horizontal", "tread1" ] },
@@ -405,6 +412,7 @@
       [ "H|-+'||" ],
       [ "&ooooo " ]
     ],
+    "color_palette": "farm_standard",
     "parts": [
       { "x": -2, "y": -2, "parts": [ "frame_horizontal", "tread1" ] },
       { "x": -1, "y": -2, "parts": [ "frame_horizontal", "tread1" ] },

--- a/data/json/vehicles/helicopters.json
+++ b/data/json/vehicles/helicopters.json
@@ -275,6 +275,7 @@
     "type": "vehicle",
     "name": "Medevac helicopter",
     "blueprint": [  ],
+    "color_palette": "ems_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_cross", "aisle_vertical", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "frame_cross", "door_internal", "small_civilian_rotors", "roof" ] },
@@ -400,6 +401,7 @@
     "type": "vehicle",
     "name": "Medevac helicopter",
     "blueprint": [  ],
+    "color_palette": "ems_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_cross", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "frame_cross", "door_internal", "roof" ] },
@@ -515,6 +517,7 @@
     "type": "vehicle",
     "name": "Medevac helicopter",
     "blueprint": [  ],
+    "color_palette": "ems_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_cross", "aisle_vertical", "roof" ] },
       { "x": -1, "y": 1, "parts": [ "frame_cross", "door_internal", "small_civilian_rotors", "roof" ] },
@@ -575,6 +578,7 @@
     "type": "vehicle",
     "name": "Medevac helicopter",
     "blueprint": [  ],
+    "color_palette": "ems_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_cross", "aisle_vertical", "roof" ] },
       { "x": 2, "y": 2, "parts": [ "frame_ne", "halfboard_ne" ] },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Ambulances, Medivacs helis, firetrucks and all farm vehicles were all the standard cataclysm red all the time


## Describe the solution (The How)

Farm Vehicles now can appear in red/green and rarely orange yellow or blue
<img width="510" height="527" alt="2026-05-10-12:11:49" src="https://github.com/user-attachments/assets/a488abc5-e1e4-4813-be3f-3cf644784eaa" />

Firetrucks can now appear in red, rarely white and very rarely lime-yellow (actual firetruck color I swear)
<img width="774" height="426" alt="2026-05-10-12:11:45" src="https://github.com/user-attachments/assets/fce0f74d-6a10-467a-a3ae-30acc20649bf" />

Ambulances and medivac helis can now appear in white, sometimes red and very rarely yellow
<img width="933" height="405" alt="2026-05-10-12:11:41" src="https://github.com/user-attachments/assets/0c961280-0bf0-4f20-bbad-fde5e05d575e" />


## Describe alternatives you've considered

- Not doing this

- Not adding the lime-yellow firetruck

It is an actual color used for firetrucks, kinda rare outside of airport firetrucks however

- Finding a better yellow for the rare yellow ems vehicles?

The one I chose just about matches the yellow some of the medevac helis have irl, dunno

## Testing

Booted up the game and everything works

## Additional context


## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

