### PR TITLE
build: migrate release builds to cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
           - name: macOS Curses x64
             artifact: osx-curses-x64
             os: macos-15-intel
+            preset: osx-curses-x64-dist
             tiles: false
             sound: false
             ext: dmg
@@ -75,6 +76,7 @@ jobs:
           - name: macOS Tiles x64
             artifact: osx-tiles-x64
             os: macos-15-intel
+            preset: osx-tiles-x64-dist
             tiles: true
             sound: true
             ext: dmg
@@ -84,6 +86,7 @@ jobs:
           - name: macOS Curses ARM
             artifact: osx-curses-arm
             os: macos-15
+            preset: osx-curses-arm-dist
             tiles: false
             sound: false
             ext: dmg
@@ -92,6 +95,7 @@ jobs:
           - name: macOS Tiles ARM
             artifact: osx-tiles-arm
             os: macos-15
+            preset: osx-tiles-arm-dist
             tiles: true
             sound: true
             ext: dmg
@@ -262,10 +266,13 @@ jobs:
       - name: Install build dependencies (mac)
         if: runner.os == 'macOS'
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install gettext parallel llvm@20 astyle sqlite3 zlib cmake ninja
+          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install gettext parallel llvm@20 astyle sqlite3 zlib cmake ninja ncurses flac pkg-config
           python3 -m venv ./venv
           source ./venv/bin/activate
           pip3 install mac_alias==2.2.0 dmgbuild==1.6.1 biplist polib luaparser
+          echo "CMAKE_PREFIX_PATH=$(brew --prefix ncurses):$(brew --prefix flac)" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$(brew --prefix flac)/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "$PWD/venv/bin" >> "$GITHUB_PATH"
 
       - name: Setup ccache (mac)
         if: runner.os == 'macOS'
@@ -372,13 +379,16 @@ jobs:
             -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc/src/cataclysm-bn-tiles.pdb" `
             -DestinationPath "cbn-${{ matrix.artifact }}-${{ inputs.version-label }}-pdb.zip"
 
-      # Build with Make (macOS) - TODO: migrate to CMake once dmgdist target is implemented
-      - name: Build CBN (osx)
+      - name: Configure and Build with CMake (macOS)
         if: runner.os == 'macOS'
-        run: |
-          source ./venv/bin/activate
-          make -j3 CCACHE=1 TILES=${{ matrix.tiles && '1' || '0' }} SOUND=${{ matrix.sound && '1' || '0' }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 OSX_MIN=11 FRAMEWORK=1 COMPILER=$(brew --prefix llvm@20)/bin/clang++ dmgdist
-          mv CataclysmBN-*.dmg cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.dmg
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: ${{ matrix.preset }}
+          buildPreset: ${{ matrix.preset }}
+
+      - name: Rename distribution package (macOS)
+        if: runner.os == 'macOS'
+        run: mv CataclysmBN-*.dmg cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.dmg
 
       # Android builds
       - name: Set up JDK 11 (android)

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -33,24 +33,28 @@ jobs:
         include:
           - name: osx-curses-x64
             os: macos-15-intel
+            preset: osx-curses-x64-dist
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
             os: macos-15-intel
+            preset: osx-tiles-x64-dist
             tiles: 1
             artifact: osx-tiles-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-curses-arm
             os: macos-15
+            preset: osx-curses-arm-dist
             tiles: 0
             artifact: osx-curses-arm
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-arm
             os: macos-15
+            preset: osx-tiles-arm-dist
             tiles: 1
             artifact: osx-tiles-arm
             ext: dmg
@@ -77,10 +81,13 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext parallel llvm@20 astyle sqlite3 zlib
+          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext parallel llvm@20 astyle sqlite3 zlib cmake ninja ncurses flac pkg-config
           python3 -m venv ./venv
           source ./venv/bin/activate
           pip3 install mac_alias==2.2.0 dmgbuild==1.6.1 biplist polib luaparser
+          echo "CMAKE_PREFIX_PATH=$(brew --prefix ncurses):$(brew --prefix flac)" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$(brew --prefix flac)/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "$PWD/venv/bin" >> "$GITHUB_PATH"
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -97,9 +104,10 @@ jobs:
       - name: Check Clang OK
         run: |
           echo "Clang++ version:"
-          $(brew --prefix llvm@20)/bin/clang++ --version  # Ensure clang++ is installed and working
+          clang++ --version
 
-      - name: Build
-        run: |
-          source ./venv/bin/activate
-          make -j3 CCACHE=1 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=11 PCH=0 COMPILER=$(brew --prefix llvm@20)/bin/clang++ dmgdist
+      - name: Configure and Build with CMake
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: ${{ matrix.preset }}
+          buildPreset: ${{ matrix.preset }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,6 +574,88 @@ if (RELEASE)
     endif()
 endif()
 
+if (APPLE AND RELEASE AND (TILES OR CURSES))
+    if (TILES)
+        set(CATA_OSX_GAME_TARGET cataclysm-bn-tiles)
+    else()
+        set(CATA_OSX_GAME_TARGET cataclysm-bn)
+    endif()
+
+    set(CATA_OSX_APP_DIR "${CMAKE_SOURCE_DIR}/Cataclysm.app")
+    set(CATA_OSX_CONTENTS_DIR "${CATA_OSX_APP_DIR}/Contents")
+    set(CATA_OSX_RESOURCES_DIR "${CATA_OSX_CONTENTS_DIR}/Resources")
+    set(CATA_OSX_DATA_DIR "${CATA_OSX_RESOURCES_DIR}/data")
+    set(CATA_OSX_FRAMEWORKS_DIR "" CACHE PATH "Directory containing macOS SDL2 frameworks for app packaging.")
+    if (NOT CATA_OSX_FRAMEWORKS_DIR)
+        if (EXISTS "$ENV{HOME}/Library/Frameworks/SDL2.framework")
+            set(CATA_OSX_FRAMEWORKS_DIR "$ENV{HOME}/Library/Frameworks")
+        elseif (EXISTS "/Library/Frameworks/SDL2.framework")
+            set(CATA_OSX_FRAMEWORKS_DIR "/Library/Frameworks")
+        endif()
+    endif()
+
+    set(CATA_OSX_COPY_RESOURCE_COMMANDS)
+    if (TILES)
+        list(APPEND CATA_OSX_COPY_RESOURCE_COMMANDS
+            COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/gfx" "${CATA_OSX_RESOURCES_DIR}/gfx")
+    endif()
+    if (SOUND)
+        list(APPEND CATA_OSX_COPY_RESOURCE_COMMANDS
+            COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/sound" "${CATA_OSX_DATA_DIR}/sound")
+    endif()
+
+    set(CATA_OSX_COPY_FRAMEWORK_COMMANDS)
+    if (TILES AND CATA_OSX_FRAMEWORKS_DIR)
+        set(CATA_OSX_FRAMEWORK_NAMES SDL2 SDL2_image SDL2_ttf)
+        if (SOUND)
+            list(APPEND CATA_OSX_FRAMEWORK_NAMES SDL2_mixer)
+        endif()
+        foreach (CATA_OSX_FRAMEWORK_NAME ${CATA_OSX_FRAMEWORK_NAMES})
+            list(APPEND CATA_OSX_COPY_FRAMEWORK_COMMANDS
+                COMMAND ${CMAKE_COMMAND} -E copy_directory
+                    "${CATA_OSX_FRAMEWORKS_DIR}/${CATA_OSX_FRAMEWORK_NAME}.framework"
+                    "${CATA_OSX_RESOURCES_DIR}/${CATA_OSX_FRAMEWORK_NAME}.framework")
+        endforeach()
+    endif()
+
+    add_custom_target(osx-app
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${CATA_OSX_APP_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CATA_OSX_CONTENTS_DIR}/MacOS"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CATA_OSX_RESOURCES_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CATA_OSX_DATA_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/build-data/osx/Info.plist" "${CATA_OSX_CONTENTS_DIR}/Info.plist"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/build-data/osx/Cataclysm.sh" "${CATA_OSX_CONTENTS_DIR}/MacOS/Cataclysm.sh"
+        COMMAND chmod +x "${CATA_OSX_CONTENTS_DIR}/MacOS/Cataclysm.sh"
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${CATA_OSX_GAME_TARGET}>" "${CATA_OSX_RESOURCES_DIR}/$<TARGET_FILE_NAME:${CATA_OSX_GAME_TARGET}>"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/build-data/osx/AppIcon.icns" "${CATA_OSX_RESOURCES_DIR}/AppIcon.icns"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/font" "${CATA_OSX_DATA_DIR}/font"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/json" "${CATA_OSX_DATA_DIR}/json"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/mods" "${CATA_OSX_DATA_DIR}/mods"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/names" "${CATA_OSX_DATA_DIR}/names"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/raw" "${CATA_OSX_DATA_DIR}/raw"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/motd" "${CATA_OSX_DATA_DIR}/motd"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/credits" "${CATA_OSX_DATA_DIR}/credits"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/title" "${CATA_OSX_DATA_DIR}/title"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/help" "${CATA_OSX_DATA_DIR}/help"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/data/lua" "${CATA_OSX_DATA_DIR}/lua"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/lang/mo" "${CATA_OSX_RESOURCES_DIR}/lang/mo"
+        ${CATA_OSX_COPY_RESOURCE_COMMANDS}
+        ${CATA_OSX_COPY_FRAMEWORK_COMMANDS}
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        DEPENDS ${CATA_OSX_GAME_TARGET} translations)
+
+    if (GIT_VERSION)
+        set(CATA_OSX_DMG_VERSION "${GIT_VERSION}")
+    else()
+        set(CATA_OSX_DMG_VERSION unknown)
+    endif()
+    add_custom_target(dmgdist
+        COMMAND plutil -convert binary1 "${CATA_OSX_APP_DIR}/Contents/Info.plist"
+        COMMAND dmgbuild -s build-data/osx/dmgsettings.py "Cataclysm BN" "CataclysmBN-${CATA_OSX_DMG_VERSION}.dmg"
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        DEPENDS osx-app)
+endif()
+
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -201,17 +201,79 @@
       }
     },
     {
-      "name": "osx-arm-dist",
-      "inherits": ["osx-arm-slim"],
+      "name": "osx-dist-base",
+      "hidden": true,
       "binaryDir": "${sourceDir}/build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CATA_CCACHE": "ON",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_FIND_FRAMEWORK": "FIRST",
+        "USE_HOME_DIR": "ON",
+        "USE_PREFIX_DATA_DIR": "OFF",
+        "LANGUAGES": "all",
+        "BACKTRACE": "ON",
+        "JSON_FORMAT": "ON",
+        "TESTS": "OFF",
+        "LUA_DOCS_ON_BUILD": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "osx-curses-x64-dist",
+      "inherits": ["osx-dist-base"],
+      "displayName": "macOS x64 Distribution (Curses, Languages)",
+      "description": "For creating portable macOS x64 distribution packages with curses.",
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "x86_64",
+        "CURSES": "ON",
+        "TILES": "OFF",
+        "SOUND": "OFF"
+      }
+    },
+    {
+      "name": "osx-tiles-x64-dist",
+      "inherits": ["osx-dist-base"],
+      "displayName": "macOS x64 Distribution (Tiles, Sounds, Languages)",
+      "description": "For creating portable macOS x64 distribution packages with tiles and sound.",
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "x86_64",
+        "CURSES": "OFF",
+        "TILES": "ON",
+        "SOUND": "ON"
+      }
+    },
+    {
+      "name": "osx-curses-arm-dist",
+      "inherits": ["osx-dist-base"],
+      "displayName": "macOS ARM Distribution (Curses, Languages)",
+      "description": "For creating portable macOS ARM distribution packages with curses.",
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "arm64",
+        "CURSES": "ON",
+        "TILES": "OFF",
+        "SOUND": "OFF"
+      }
+    },
+    {
+      "name": "osx-tiles-arm-dist",
+      "inherits": ["osx-dist-base"],
       "displayName": "macOS ARM Distribution (Tiles, Sounds, Languages)",
       "description": "For creating portable macOS ARM distribution packages with tiles and sound.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "LANGUAGES": "all",
-        "BACKTRACE": "ON",
-        "JSON_FORMAT": "ON"
+        "CMAKE_OSX_ARCHITECTURES": "arm64",
+        "CURSES": "OFF",
+        "TILES": "ON",
+        "SOUND": "ON"
       }
+    },
+    {
+      "name": "osx-arm-dist",
+      "inherits": ["osx-tiles-arm-dist"],
+      "displayName": "macOS ARM Distribution (Tiles, Sounds, Languages)",
+      "description": "For creating portable macOS ARM distribution packages with tiles and sound."
     },
     {
       "name": "lint",
@@ -346,10 +408,34 @@
       "description": "Build for curses distribution."
     },
     {
+      "name": "osx-curses-x64-dist",
+      "configurePreset": "osx-curses-x64-dist",
+      "targets": ["dmgdist"],
+      "description": "Build a macOS x64 curses DMG."
+    },
+    {
+      "name": "osx-tiles-x64-dist",
+      "configurePreset": "osx-tiles-x64-dist",
+      "targets": ["dmgdist"],
+      "description": "Build a macOS x64 tiles DMG."
+    },
+    {
+      "name": "osx-curses-arm-dist",
+      "configurePreset": "osx-curses-arm-dist",
+      "targets": ["dmgdist"],
+      "description": "Build a macOS ARM curses DMG."
+    },
+    {
+      "name": "osx-tiles-arm-dist",
+      "configurePreset": "osx-tiles-arm-dist",
+      "targets": ["dmgdist"],
+      "description": "Build a macOS ARM tiles DMG."
+    },
+    {
       "name": "osx-arm-dist",
       "configurePreset": "osx-arm-dist",
-      "targets": ["cataclysm-bn-tiles", "json_formatter", "translations"],
-      "description": "Build for macOS ARM tiles distribution."
+      "targets": ["dmgdist"],
+      "description": "Build a macOS ARM tiles DMG."
     },
     {
       "name": "lint",

--- a/build-data/osx/Cataclysm.sh
+++ b/build-data/osx/Cataclysm.sh
@@ -13,8 +13,8 @@ else
     K_FRAMEWORK_PATH=DYLD_FALLBACK_FRAMEWORK_PATH
 fi
 
-if [[ -f cataclysm ]]; then
-    V_SHELL_SCRIPT="export PATH=${PATH} ${K_LIBRARY_PATH}=. ${K_FRAMEWORK_PATH}=.; cd '${PWD}' && ./cataclysm; exit"
+if [[ -f cataclysm-bn ]]; then
+    V_SHELL_SCRIPT="export PATH=${PATH} ${K_LIBRARY_PATH}=. ${K_FRAMEWORK_PATH}=.; cd '${PWD}' && ./cataclysm-bn; exit"
     osascript -e "tell application \"Terminal\" to activate do script \"${V_SHELL_SCRIPT}\""
 else
     export ${K_LIBRARY_PATH}=. ${K_FRAMEWORK_PATH}=.

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -10,13 +10,7 @@ num_jobs=3
 # We might need binaries installed via pip, so ensure that our personal bin dir is on the PATH
 export PATH=$HOME/.local/bin:$PATH
 
-if [ -n "$TEST_STAGE" ]
-then
-    build-scripts/lint-json.sh
-    make style-all-json-parallel RELEASE=1
-
-    tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*/*/*
-elif [ -n "$JUST_JSON" ]
+if [ -n "$JUST_JSON" ]
 then
     echo "Early exit on just-json change"
     exit 0
@@ -27,52 +21,63 @@ ccache --zero-stats
 ccache -M 5G
 ccache --show-stats
 
-echo "CMAKE: $CMAKE, COMPILER: $COMPILER, OS: $OS, TILES: $TILES, SOUND: $SOUND, TEST_STAGE: $TEST_STAGE"
+echo "COMPILER: $COMPILER, OS: $OS, TILES: $TILES, SOUND: $SOUND, TEST_STAGE: $TEST_STAGE"
 echo "LANGUAGES: $LANGUAGES, LIBBACKTRACE: $LIBBACKTRACE, NATIVE: $NATIVE, RELEASE: $RELEASE, CROSS_COMPILATION: $CROSS_COMPILATION"
 
-if [ "$CMAKE" = "1" ]
+if [ "$RELEASE" = "1" ]
 then
-    if [ "$RELEASE" = "1" ]
-    then
-        build_type=MinSizeRel
-    else
-        build_type=Debug
-    fi
-
-    echo "Building with CMake"
-    TILES="${TILES:-0}"
-    CURSES=$((1 - TILES))
-
-    mkdir -p build
-    cmake \
-        -B build \
-        -DBACKTRACE=ON \
-        ${COMPILER:+-DCMAKE_CXX_COMPILER=$COMPILER} \
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        -DCMAKE_BUILD_TYPE="$build_type" \
-        -DTILES="${TILES}" \
-        -DCURSES="${CURSES}" \
-        -DSOUND="${SOUND:-0}"
-
-    make -j$num_jobs -C build
+    build_type=MinSizeRel
 else
-    if [ "$OS" == "macos-14" ]
-    then
-        export NATIVE=osx
-        # if OSX_MIN we specify here is lower than 11 then linker is going
-        # to throw warnings because uncaught_exceptions, SDL and gettext libraries installed from
-        # Homebrew are built with minimum target osx version 11
-        export OSX_MIN=14
-    else
-        export BACKTRACE=1
-    fi
-    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1
+    build_type=Debug
+fi
 
-    # For CI on macOS, patch the test binary so it can find SDL2 libraries.
-    if [[ ! -z "$OS" && "$OS" = "macos-14" ]]
-    then
-        file tests/cata_test
-        install_name_tool -add_rpath "$HOME"/Library/Frameworks tests/cata_test
+TILES="${TILES:-0}"
+CURSES=$((1 - TILES))
+
+cmake_args=(
+    -B build
+    -G Ninja
+    -DBACKTRACE=ON
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    -DCMAKE_BUILD_TYPE="$build_type"
+    -DTILES="$TILES"
+    -DCURSES="$CURSES"
+    -DSOUND="${SOUND:-0}"
+)
+
+if [ -n "$COMPILER" ]; then
+    cmake_args+=( -DCMAKE_CXX_COMPILER="$COMPILER" )
+fi
+
+if [ -n "$TEST_STAGE" ]; then
+    cmake_args+=( -DJSON_FORMAT=ON )
+fi
+
+if [ "$OS" = "macos-14" ]; then
+    cmake_args+=( -DCMAKE_OSX_DEPLOYMENT_TARGET=14 )
+fi
+
+cmake "${cmake_args[@]}"
+
+if [ -n "$TEST_STAGE" ]
+then
+    build-scripts/lint-json.sh
+    cmake --build build --target style-json-parallel --parallel "$num_jobs"
+    tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*/*/*
+fi
+
+cmake --build build --parallel "$num_jobs"
+
+# For CI on macOS, patch the test binary so it can find SDL2 libraries.
+if [[ ! -z "$OS" && "$OS" = "macos-14" ]]
+then
+    test_bin="build/tests/cata_test"
+    if [ "$TILES" = "1" ]; then
+        test_bin="build/tests/cata_test-tiles"
+    fi
+    if [ -f "$test_bin" ]; then
+        file "$test_bin"
+        install_name_tool -add_rpath "$HOME"/Library/Frameworks "$test_bin"
     fi
 fi
 

--- a/build-scripts/requirements.sh
+++ b/build-scripts/requirements.sh
@@ -4,14 +4,7 @@ set -e
 set -x
 
 if [[ "$LIBBACKTRACE" == "1" ]]; then
-    git clone https://github.com/ianlancetaylor/libbacktrace.git
-    (
-        cd libbacktrace
-        git checkout 4d2dd0b172f2c9192f83ba93425f868f2a13c553
-        ./configure
-        make -j$(nproc)
-        sudo make install
-    )
+    echo "LIBBACKTRACE is built by CMake when enabled."
 fi
 
 # needed for newer ubuntu versions

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -121,7 +121,7 @@ Install dependencies via [Homebrew](https://brew.sh/):
 
 ```sh
 brew install cmake ninja ccache sdl2 sdl2_image sdl2_ttf sdl2_mixer \
-  freetype gettext sqlite pkg-config
+  freetype gettext sqlite pkg-config ncurses flac
 ```
 
 > [!NOTE]
@@ -139,11 +139,15 @@ This places executables into `out/build/osx-arm-slim/`.
 
 #### Creating a macOS Distribution
 
+The macOS distribution presets build a DMG with the `dmgdist` target. `dmgbuild` must be available on `PATH`. Tiles builds also package SDL2 frameworks from `~/Library/Frameworks` or `/Library/Frameworks`.
+
 ```sh
-cmake --preset osx-arm-dist
-cmake --build --preset osx-arm-dist
-cmake --install build --prefix cataclysmbn-osx-tiles
+python3 -m pip install dmgbuild biplist
+cmake --preset osx-tiles-arm-dist
+cmake --build --preset osx-tiles-arm-dist
 ```
+
+Use `osx-curses-arm-dist`, `osx-tiles-arm-dist`, `osx-curses-x64-dist`, or `osx-tiles-x64-dist` for the desired architecture and UI.
 
 ### Windows Subsystem for Linux (WSL)
 

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -14,6 +14,15 @@ if(NOT GETTEXT_MSGFMT_EXECUTABLE)
              See CMake compiling guide for details and more info.")
 endif()
 
+execute_process(
+    COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} --help
+    OUTPUT_VARIABLE MSGFMT_HELP
+    ERROR_QUIET
+)
+if (MSGFMT_HELP MATCHES "--no-convert")
+    set(CATA_MSGFMT_NO_CONVERT --no-convert)
+endif ()
+
 if (LANGUAGES STREQUAL all)
     set(LANGUAGES "")
     file(GLOB PO_FILES ${CMAKE_SOURCE_DIR}/lang/po/*.po)
@@ -53,7 +62,7 @@ foreach (LANG ${LANGUAGES})
     add_custom_command(
         OUTPUT ${MO_OUTPUT}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_SOURCE_DIR}/lang/mo/${LANG}/LC_MESSAGES
-        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -f ${CMAKE_SOURCE_DIR}/lang/po/${LANG}.po -o ${MO_OUTPUT}
+        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} ${CATA_MSGFMT_NO_CONVERT} -f ${CMAKE_SOURCE_DIR}/lang/po/${LANG}.po -o ${MO_OUTPUT}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         DEPENDS ${CMAKE_SOURCE_DIR}/lang/po/${LANG}.po
     )

--- a/lang/compile_mo.sh
+++ b/lang/compile_mo.sh
@@ -20,6 +20,13 @@ then
     LOCALE_DIR="lang/mo"
 fi
 
+if msgfmt --help 2>/dev/null | grep -q -- "--no-convert"
+then
+    MSGFMT_NO_CONVERT="--no-convert"
+else
+    MSGFMT_NO_CONVERT=""
+fi
+
 # compile .mo file for each specified language
 if [ $# -gt 0 ] && [ $1 != "all" ]
 then
@@ -27,7 +34,7 @@ then
     do
         f="lang/po/${n}.po"
         mkdir -p $LOCALE_DIR/${n}/LC_MESSAGES
-        msgfmt -f -o $LOCALE_DIR/${n}/LC_MESSAGES/cataclysm-bn.mo ${f}
+        msgfmt $MSGFMT_NO_CONVERT -f -o $LOCALE_DIR/${n}/LC_MESSAGES/cataclysm-bn.mo ${f}
     done
 else
     # if nothing specified, compile .mo file for every .po file in lang/po
@@ -36,6 +43,6 @@ else
     do
         n=`basename $f .po`
         mkdir -p $LOCALE_DIR/${n}/LC_MESSAGES
-        msgfmt -f -o $LOCALE_DIR/${n}/LC_MESSAGES/cataclysm-bn.mo ${f}
+        msgfmt $MSGFMT_NO_CONVERT -f -o $LOCALE_DIR/${n}/LC_MESSAGES/cataclysm-bn.mo ${f}
     done
 fi

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1628,8 +1628,8 @@ class iuse_paint_stuff_config : public iuse_actor
             num_layers
         };
 
-        static constexpr std::string LAYER_VAR = "PAINT_LAYER";
-        static constexpr std::string IUSE_ACTION = "paint_stuff_cfg";
+        static constexpr auto LAYER_VAR = "PAINT_LAYER";
+        static constexpr auto IUSE_ACTION = "paint_stuff_cfg";
 
         iuse_paint_stuff_config( const std::string &type = IUSE_ACTION ) : iuse_actor( type ) {}
         ~iuse_paint_stuff_config() override = default;
@@ -1650,8 +1650,8 @@ class iuse_paint_stuff : public iuse_actor
         float charge_cost = 1.0f;
 
     public:
-        static constexpr std::string PAINT_VAR = "PAINT_COLOR";
-        static constexpr std::string IUSE_ACTION = "paint_stuff";
+        static constexpr auto PAINT_VAR = "PAINT_COLOR";
+        static constexpr auto IUSE_ACTION = "paint_stuff";
 
         iuse_paint_stuff( const std::string &type = IUSE_ACTION ) : iuse_actor( type ) {}
         ~iuse_paint_stuff() override = default;


### PR DESCRIPTION
## Purpose of change (The Why)

Migrate remaining release/manual build paths from Makefile builds to CMake.

## Describe the solution (The How)

- Add CMake macOS app/DMG packaging targets and distribution presets.
- Switch macOS release/manual workflows to CMake presets.
- Update the legacy GHA compile helper to configure/build through CMake.
- Keep translation compilation compatible with gettext variants used by release jobs.
- Document macOS CMake DMG presets.

## Testing

- `deno fmt CMakePresets.json docs/en/dev/guides/building/cmake.md`
- `cmake --list-presets=configure`
- `cmake --list-presets=build`
- `bash -n build-scripts/gha_compile_only.sh build-scripts/requirements.sh lang/compile_mo.sh`
- `python3` YAML parse for `.github/workflows/build.yml` and `.github/workflows/osx.yml`
- `cmake --preset lint`
- `cmake --build build --target json_formatter --parallel 2`
- `cmake -S . -B /tmp/cata-darwin-parse -G Ninja -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DTILES=OFF -DCURSES=ON -DTESTS=OFF -DLANGUAGES=none -DCMAKE_BUILD_TYPE=Release`
- `cmake -S . -B /tmp/cata-cmake-lang -G Ninja -DCURSES=OFF -DTILES=OFF -DTESTS=OFF -DLANGUAGES=nb -DJSON_FORMAT=OFF -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/cata-cmake-lang --target translations --parallel 2`
- `msgfmt --no-convert -f` for every `lang/po/*.po`
- `git diff --check`
- PR CI: all checks passing, including Linux, Windows, Android, and macOS matrix
- Fork manual release `v0.0.8798`: https://github.com/scarf005/Cataclysm-BN/actions/runs/25620438128
  - Uploaded release assets for Linux curses/tiles, macOS curses/tiles x64/ARM, Windows tiles x64 MSVC, Android x64 APK, and Android bundle AAB.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I searched for relevant issues using GitHub issue search; none were found.

### Optional

- [x] This is a PR that modifies build process or code organization.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
  - [x] This change does not alter versions of software required to build or work with the game.

<sup>PR opened by gpt-5.4 high on pi</sup>
