### PR TITLE
fix: make the player spawn near quest hubs like hub01 and refugee center

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1897,7 +1897,7 @@
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 50, 100 ],
-    "flags": [ "UNIQUE", "GLOBALLY_UNIQUE", "ELECTRIC_GRID" ]
+    "flags": [ "UNIQUE", "GLOBALLY_UNIQUE", "ELECTRIC_GRID", "ENDGAME" ]
   },
   {
     "type": "overmap_special",
@@ -3056,7 +3056,7 @@
     "city_sizes": [ 1, 16 ],
     "occurrences": [ 35, 100 ],
     "rotate": false,
-    "flags": [ "ELECTRIC_GRID", "UNIQUE", "GLOBALLY_UNIQUE" ]
+    "flags": [ "ELECTRIC_GRID", "UNIQUE", "GLOBALLY_UNIQUE", "ENDGAME" ]
   },
   {
     "type": "overmap_special",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1896,7 +1896,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 50, 100 ],
+    "occurrences": [ 1, 1 ],
     "flags": [ "UNIQUE", "GLOBALLY_UNIQUE", "ELECTRIC_GRID", "ENDGAME" ]
   },
   {
@@ -3054,7 +3054,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 1, 16 ],
-    "occurrences": [ 35, 100 ],
+    "occurrences": [ 1, 1 ],
     "rotate": false,
     "flags": [ "ELECTRIC_GRID", "UNIQUE", "GLOBALLY_UNIQUE", "ENDGAME" ]
   },

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6343,9 +6343,9 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
             if( special.has_flag( "ENDGAME" ) && globally_unique ) {
                 amount_to_place = is_true_center ? 1 : 0;
             } else {
-            //FINGERS CROSSED EMOGI
-            amount_to_place = x_in_y( min, max ) && ( !globally_unique ||
-                              !get_overmapbuffer( dimension_id_ ).contains_unique_special( id ) ) ? 1 : 0;
+                //FINGERS CROSSED EMOGI
+                amount_to_place = x_in_y( min, max ) && ( !globally_unique ||
+                                  !get_overmapbuffer( dimension_id_ ).contains_unique_special( id ) ) ? 1 : 0;
             }
         } else {
             // Number of instances normalized to terrain ratio

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6268,6 +6268,10 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
         if( is_true_center && s->has_flag( "ENDGAME" ) ) {
             weight *= 1000;
         }
+        // Make certain global unique specials flagged as specific to endgame don't spawn elsewhere.
+        if( !is_true_center && s->has_flag( "ENDGAME" ) && s->has_flag( "GLOBALLY_UNIQUE" ) ) {
+            weight = 0;
+        }
         return weight;
     };
     std::sort( enabled_specials.begin(), enabled_specials.end(),
@@ -6336,10 +6340,13 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
         int amount_to_place;
         if( unique || globally_unique ) {
             const overmap_special_id &id = iter.special_details->id;
-
+            if( special.has_flag( "ENDGAME" ) && globally_unique ) {
+                amount_to_place = is_true_center ? 1 : 0;
+            } else {
             //FINGERS CROSSED EMOGI
             amount_to_place = x_in_y( min, max ) && ( !globally_unique ||
                               !get_overmapbuffer( dimension_id_ ).contains_unique_special( id ) ) ? 1 : 0;
+            }
         } else {
             // Number of instances normalized to terrain ratio
             float real_max = std::max( static_cast<float>( min ), max * rate );

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -212,6 +212,8 @@ tripoint_abs_omt start_location::find_player_initial_location() const
     // creating overmaps as necessary.
     const int radius = 3;
     std::vector<point_abs_om> overmaps = closest_points_first( point_abs_om(), radius );
+    // Shuffle 8 first ones after (0,0) so that (0,0) retains priority, but if not so that we don't always start at (1,0)
+    std::shuffle( overmaps.begin() + 1, overmaps.begin() + 8, rng_get_engine() );
     for( const point_abs_om &omp : overmaps ) {
         overmap &omap = get_primary_overmapbuffer().get( omp );
         const tripoint_om_omt omtstart = omap.find_random_omt( random_target() );

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -212,10 +212,6 @@ tripoint_abs_omt start_location::find_player_initial_location() const
     // creating overmaps as necessary.
     const int radius = 3;
     std::vector<point_abs_om> overmaps = closest_points_first( point_abs_om(), radius );
-    // Skip overmap (0,0), that's endgame
-    overmaps.erase( overmaps.begin() );
-    // Shuffle 8 first ones so that we don't always start at (1,0)
-    std::shuffle( overmaps.begin(), overmaps.begin() + 7, rng_get_engine() );
     for( const point_abs_om &omp : overmaps ) {
         overmap &omap = get_primary_overmapbuffer().get( omp );
         const tripoint_om_omt omtstart = omap.find_random_omt( random_target() );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
many people never experience any of the quests in the game cause the quest hubs end up spawning like 800 tiles away from the starting location.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Removes the restriction which prevents the player from spawning on overmap 0,0, and makes it have high priority for initial spawn by removing the shuffle of spawn overmap priorities. Adds the endgame flag to the refugee center and hub01, which forces them to spawn on overmap 0,0, thus forcing the player to spawn near the quest hubs.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
power armor before refugee center

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.