### PR TITLE
feat: add vehicle color palettes to military vehicles

### DIFF
--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -71,8 +71,8 @@
           { "color": "Almond Green", "weight": 20, "//": "CARC Green 383 (Federal Standard 34094)" },
           { "color": "Tree bark brown", "weight": 10, "//": "CARC Brown 383ish (Federal Standard 30051)" },
           { "color": "Onyx Black", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
-          { "color": "Manzanilla Olive", "weight": 5, "//": "CARC Sand (Federal Standard 33303)"  },
-          { "color": "Light Ash Brown", "weight": 5, "//": "CARC Tan 686 (Federal Standard 33446)"  },
+          { "color": "Manzanilla Olive", "weight": 5, "//": "CARC Sand (Federal Standard 33303)" },
+          { "color": "Light Ash Brown", "weight": 5, "//": "CARC Tan 686 (Federal Standard 33446)" },
           { "color": "Ruby Violet", "weight": 1, "//": "Sneaky military craft :)" }
         ]
       }

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -63,6 +63,56 @@
   {
     "type": "vehicle_color_palette",
     "id": "military_standard",
+    "//": "Actual US Military vehicle colors, See: Federal Standard FED-STD-595B",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Almond Green", "weight": 20, "//": "CARC Green 383 (Federal Standard 34094)" },
+          { "color": "Tree bark brown", "weight": 10, "//": "CARC Brown 383ish (Federal Standard 30051)" },
+          { "color": "Onyx Black", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
+          { "color": "Manzanilla Olive", "weight": 5, "//": "CARC Sand (Federal Standard 33303)"  },
+          { "color": "Light Ash Brown", "weight": 5, "//": "CARC Tan 686 (Federal Standard 33446)"  },
+          { "color": "Ruby Violet", "weight": 1, "//": "Sneaky military craft :)" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_fighter",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "trunk_carbon_flat", "hatch" ],
+        "colors": [
+          { "color": "Noble Grey", "weight": 20, "//": "FS 36176" },
+          { "color": "Baby Blue", "weight": 10 },
+          { "color": "Onyx Black", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
+          { "color": "Linen Blue", "weight": 5 },
+          { "color": "Ruby Violet", "weight": 1, "//": "Sneaky military craft :)" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_heli",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Cataclysm Green", "weight": 20 },
+          { "color": "Onyx Black", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
+          { "color": "Baby Blue", "weight": 5 },
+          { "color": "White aluminium", "weight": 5 },
+          { "color": "Ruby Violet", "weight": 1, "//": "Sneaky military craft :)" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_boat",
     "palette": [
       {
         "fuzzy_ids": [ "board", "windshield", "door", "roof", "trunk_flat", "hatch" ],
@@ -85,8 +135,8 @@
         "colors": [
           { "color": "Ink Black", "weight": 10 },
           { "color": "Silver Grey", "weight": 10 },
-          { "color": "Silver Fir Blue", "weight": 2 },
-          { "color": "Steel Blue", "weight": 5 }
+          { "color": "Steel Blue", "weight": 5 },
+          { "color": "Silver Fir Blue", "weight": 2, "//": "old pre-90s style police lightblue" }
         ]
       }
     ]
@@ -136,7 +186,8 @@
         "colors": [
           { "color": "Flame Red", "weight": 20 },
           { "color": "White aluminium", "weight": 5 },
-          { "color": "Neon Green", "weight": 1 }
+          { "color": "LED Green", "weight": 5, "//": "this is actually a yellow" },
+          { "color": "Neon Green", "weight": 1, "//": "airport firetruck color" }
         ]
       }
     ]
@@ -199,20 +250,6 @@
           { "color": "North Grey", "weight": 10 },
           { "color": "Ink Black", "weight": 10 },
           { "color": "Ruby Violet", "weight": 5, "//": "Sneaky military craft :)" }
-        ]
-      }
-    ]
-  },
-  {
-    "type": "vehicle_color_palette",
-    "id": "fighter_standard",
-    "palette": [
-      {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
-        "colors": [
-          { "color": "North Grey", "weight": 10 },
-          { "color": "Ink Black", "weight": 10 },
-          { "color": "Ruby Violet", "weight": 1, "//": "Sneaky military craft :)" }
         ]
       }
     ]

--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -932,6 +932,7 @@
       "# {|#      ",
       "  |(       "
     ],
+    "color_palette": "military_fighter",
     "blueprint_origin": { "x": 8, "y": 3 },
     "palette": {
       "-": [ "xlframe_vertical", "carbon_halfboard_vertical" ],
@@ -1014,7 +1015,7 @@
       "  |b#      ",
       "  |(       "
     ],
-    "color_palette": "fighter_standard",
+    "color_palette": "military_fighter",
     "blueprint_origin": { "x": 8, "y": 3 },
     "palette": {
       "-": [ "xlframe_vertical", "carbon_halfboard_vertical" ],
@@ -1088,6 +1089,7 @@
     "id": "plane_f15e_eagle",
     "type": "vehicle",
     "name": "F-15E Strike Eagle",
+    "color_palette": "military_fighter",
     "parts": [
       { "x": -6, "y": -1, "parts": [ "xlframe_vertical", "wing_carbon_horizontal", "carbon_halfboard_vertical" ] },
       {

--- a/data/json/vehicles/boats.json
+++ b/data/json/vehicles/boats.json
@@ -631,7 +631,7 @@
       [ "|=t'#_#'_||" ],
       [ "|O||'+'||| " ]
     ],
-    "color_palette": "military_standard",
+    "color_palette": "military_boat",
     "parts": [
       {
         "x": -6,
@@ -818,7 +818,7 @@
       [ "|=_______________||  " ],
       [ "||OO||||||||||||||   " ]
     ],
-    "color_palette": "military_standard",
+    "color_palette": "military_boat",
     "parts": [
       { "x": -11, "y": 0, "parts": [ "frame_cross", "plating_steel", "metal_boat_hull" ] },
       { "x": -10, "y": 0, "parts": [ "frame_cross", "aisle_vertical", "metal_boat_hull" ] },
@@ -1206,7 +1206,7 @@
       [ "|=_______________||  " ],
       [ "||OO||||||||||||||   " ]
     ],
-    "color_palette": "military_standard",
+    "color_palette": "military_boat",
     "parts": [
       { "x": -11, "y": 0, "parts": [ "frame_cross", "plating_steel", "metal_boat_hull" ] },
       { "x": -10, "y": 0, "parts": [ "frame_cross", "aisle_vertical", "metal_boat_hull" ] },
@@ -1583,7 +1583,7 @@
       [ "=#'||" ],
       [ "|||| " ]
     ],
-    "color_palette": "military_standard",
+    "color_palette": "military_boat",
     "parts": [
       {
         "x": -1,

--- a/data/json/vehicles/helicopters.json
+++ b/data/json/vehicles/helicopters.json
@@ -640,6 +640,7 @@
     "type": "vehicle",
     "name": "AH-64 Apache",
     "blueprint": [  ],
+    "color_palette": "military_heli",
     "parts": [
       {
         "x": -3,
@@ -1254,6 +1255,7 @@
     "type": "vehicle",
     "name": "V-22 Osprey",
     "blueprint": [  ],
+    "color_palette": "military_heli",
     "parts": [
       {
         "x": -12,
@@ -2013,6 +2015,7 @@
     "type": "vehicle",
     "name": "UH-60 Blackhawk",
     "blueprint": [  ],
+    "color_palette": "military_heli",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_cross", "aisle_vertical", "roof", "NBC_seal" ] },
       { "x": -1, "y": 1, "parts": [ "frame_cross", "door_internal", "roof", "NBC_seal" ] },

--- a/data/json/vehicles/military.json
+++ b/data/json/vehicles/military.json
@@ -4,6 +4,7 @@
     "type": "vehicle",
     "name": "Mechanized Infantry Carrier",
     "//": "Wheeled, composite-armor variant based on Stryker; grenade launcher version",
+    "color_palette": "military_standard",
     "parts": [
       { "y": 2, "x": 5, "parts": [ "hdframe_ne", "hdhalfboard_ne", "plating_military" ] },
       { "y": 1, "x": 5, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military" ] },
@@ -96,6 +97,7 @@
     "id": "aapc-mg",
     "type": "vehicle",
     "name": "Mechanized Infantry Carrier",
+    "color_palette": "military_standard",
     "parts": [
       { "y": 2, "x": 5, "parts": [ "hdframe_ne", "hdhalfboard_ne", "plating_military" ] },
       { "y": 1, "x": 5, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_military" ] },
@@ -185,6 +187,7 @@
     "type": "vehicle",
     "name": "Armored Personnel Carrier",
     "//": "Tracked variant with lighter armor, based off M113",
+    "color_palette": "military_standard",
     "parts": [
       { "y": 2, "x": 5, "parts": [ "hdframe_ne", "hdhalfboard_ne", "plating_steel" ] },
       { "y": 1, "x": 5, "parts": [ "hdframe_horizontal", "hdhalfboard_horizontal", "plating_steel" ] },
@@ -254,6 +257,7 @@
     "type": "vehicle",
     "name": "Armored Personnel Carrier",
     "//": "grenade launcher version",
+    "color_palette": "military_standard",
     "items": [ { "y": -1, "x": 3, "chance": 2, "items": [ "id_military" ] } ],
     "parts": [
       { "y": 2, "x": 5, "parts": [ "hdframe_ne", "hdhalfboard_ne", "plating_steel" ] },
@@ -335,6 +339,7 @@
       [ "------||||" ],
       [ "oooooooooo" ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       { "x": -7, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
       { "x": -6, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
@@ -526,6 +531,7 @@
       [ "|H##'|H" ],
       [ "O-++-OH" ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       { "y": 3, "x": 3, "parts": [ "hdframe_horizontal", "plating_military" ] },
       { "y": 2, "x": 3, "parts": [ "hdframe_horizontal_2", "plating_military" ] },
@@ -605,6 +611,7 @@
       [ "|H##'|H" ],
       [ "O-++-OH" ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       { "y": 3, "x": 3, "parts": [ "hdframe_horizontal", "plating_military" ] },
       { "y": 2, "x": 3, "parts": [ "hdframe_horizontal_2", "plating_military" ] },
@@ -684,6 +691,7 @@
       [ "|H##'|H" ],
       [ "O-++-OH" ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       { "y": 3, "x": 3, "parts": [ "hdframe_horizontal", "plating_military" ] },
       { "y": 2, "x": 3, "parts": [ "hdframe_horizontal_2", "plating_military" ] },
@@ -767,6 +775,7 @@
     "id": "jltv",
     "type": "vehicle",
     "name": "Joint Light Tactical Vehicle",
+    "color_palette": "military_standard",
     "parts": [
       {
         "x": 2,
@@ -886,6 +895,7 @@
     "id": "jltv_gl",
     "type": "vehicle",
     "name": "Joint Light Tactical Vehicle",
+    "color_palette": "military_standard",
     "parts": [
       {
         "x": 2,
@@ -1005,6 +1015,7 @@
     "id": "jltv_tow",
     "type": "vehicle",
     "name": "Joint Light Tactical Vehicle",
+    "color_palette": "military_standard",
     "parts": [
       {
         "x": 2,
@@ -1135,6 +1146,7 @@
       [ "#OO#'#'|>" ],
       [ "-OO--+-O-" ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       { "y": 3, "x": 3, "parts": [ "hdframe_ne", "plating_spiked" ] },
       { "y": 2, "x": 3, "parts": [ "hdframe_horizontal_2", "plating_spiked" ] },
@@ -1257,6 +1269,7 @@
       [ "o|t#'|H" ],
       [ " o|_'oH" ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       { "x": 3, "y": -1, "parts": [ "hdframe_horizontal" ] },
       {
@@ -1562,6 +1575,7 @@
       [ "|||-+-|||| " ],
       [ "oooooooooo " ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       { "x": -5, "y": -3, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
       { "x": -4, "y": -3, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
@@ -1719,6 +1733,7 @@
       [ "|||--+-||||" ],
       [ "ooooooooooo" ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       { "x": -8, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
       { "x": -7, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
@@ -1935,6 +1950,7 @@
       [ "=--+-||||  " ],
       [ "ooooooooo  " ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       { "x": -6, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
       { "x": -5, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
@@ -2103,6 +2119,7 @@
       [ "=----|  " ],
       [ "oooooo  " ]
     ],
+    "color_palette": "military_standard",
     "flags": [ "VEHICLE_LOCKED" ],
     "parts": [
       { "x": -3, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
@@ -2239,6 +2256,7 @@
     "type": "vehicle",
     "name": "XMH Hover Tank",
     "flags": [ "VEHICLE_LOCKED" ],
+    "color_palette": "military_standard",
     "parts": [
       { "x": -3, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_sw" ] },
       { "x": -2, "y": -2, "parts": [ "frame_carbon_cover", "plating_military", "hdhalfboard_vertical" ] },
@@ -2380,6 +2398,7 @@
     "type": "vehicle",
     "name": "Experimental Hover APC",
     "flags": [ "VEHICLE_LOCKED" ],
+    "color_palette": "military_standard",
     "parts": [
       { "x": 5, "y": 2, "parts": [ "frame_carbon_cover", "hdhalfboard_ne", "plating_military" ] },
       {

--- a/data/json/vehicles/vans_busses.json
+++ b/data/json/vehicles/vans_busses.json
@@ -10,6 +10,7 @@
       [ "|H#t'|>" ],
       [ "O-++-O>" ]
     ],
+    "color_palette": "military_standard",
     "parts": [
       {
         "x": -3,

--- a/data/mods/MoreVehicleColors/vehicle_palette.json
+++ b/data/mods/MoreVehicleColors/vehicle_palette.json
@@ -61,7 +61,7 @@
   },
   {
     "type": "vehicle_color_palette",
-    "id": "military_standard",
+    "id": "military_boat",
     "palette": [
       {
         "fuzzy_ids": [ "board", "windshield", "door", "roof" ],
@@ -93,7 +93,7 @@
   },
   {
     "type": "vehicle_color_palette",
-    "id": "fighter_standard",
+    "id": "military_fighter",
     "palette": [
       {
         "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof" ],


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

pretty much all the military vehicles lack color palettes and are all just the standard catalcysm green

## Describe the solution (The How)

military_standard was moved to military_boats (cus thats all it was used for), and was replaced with a new color palette
fighter_standard was renamed to military_fighter and given a bunch of new colors

The APC, MPC, IFV, Humvee, Armored Car, JLTV and tanks now spawns in standard us military colors (Green 383, Brown 383, Black, Sand, Tan 686)

<img width="834" height="310" alt="2026-05-10-15:59:00" src="https://github.com/user-attachments/assets/b47c501e-6fee-4844-9e9d-6744999cdc91" />

The F-15, F-35 and AV-8 now spawns in cold grey, black, baby blue, navy blue and very rarely purple

<img width="1116" height="841" alt="2026-05-10-16:11:49" src="https://github.com/user-attachments/assets/db4473a4-a248-4319-89bf-365de78c26d9" />

The Apache, Osprey and Blackhawk now spawns in Green, Black, Baby Blue, White and very rarely purple

<img width="985" height="442" alt="2026-05-10-16:12:53" src="https://github.com/user-attachments/assets/0073bc2b-2642-41d5-9e48-e73cccff044e" />

Firetrucks now also have an additional yellow color it can spawn in cus someone mentioned it on the discord

<img width="428" height="699" alt="2026-05-10-16:14:32" src="https://github.com/user-attachments/assets/a354ad4d-7e5b-4f3f-ae8c-eecff2a25988" />


## Describe alternatives you've considered

- Not doing this

## Testing

Booted up the game and it looked aight

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

