### PR TITLE
feat: add vehicle color palettes to aircraft

### DIFF
--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -88,7 +88,8 @@
           { "color": "Noble Grey", "weight": 20, "//": "Federal Standard 36176" },
           { "color": "Baby Blue", "weight": 10 },
           { "color": "Onyx Black", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
-          { "color": "Technical Blue", "weight": 5 },
+          { "color": "Technical Blue", "weight": 10 },
+          { "color": "Linen Blue", "weight": 5 },
           { "color": "Ruby Violet", "weight": 1, "//": "Sneaky military craft :)" }
         ]
       }

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -263,13 +263,13 @@
         "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "Prince Grey", "weight": 10 },
-        { "color": "Ink Black", "weight": 5 },
+          { "color": "Ink Black", "weight": 5 },
           { "color": "Copper Red", "weight": 5 },
           { "color": "Persian Orange", "weight": 5 },
           { "color": "Traffic Yellow", "weight": 5 },
           { "color": "Ranger Green", "weight": 5 },
           { "color": "Caribbean Blue", "weight": 5 },
-          { "color": "Coronation Blue", "weight": 1}
+          { "color": "Coronation Blue", "weight": 1 }
         ]
       }
     ]
@@ -283,10 +283,10 @@
         "colors": [
           { "color": "White aluminium", "weight": 15 },
           { "color": "British Mauve", "weight": 10 },
-          { "color": "Pompeii Red", "weight": 10},
-          { "color": "Poster Yellow", "weight": 5},
-          { "color": "Golf Green", "weight": 5},
-          { "color": "Coronation Blue", "weight": 1}
+          { "color": "Pompeii Red", "weight": 10 },
+          { "color": "Poster Yellow", "weight": 5 },
+          { "color": "Golf Green", "weight": 5 },
+          { "color": "Coronation Blue", "weight": 1 }
         ]
       }
     ]

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -85,10 +85,10 @@
       {
         "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "trunk_carbon_flat", "hatch" ],
         "colors": [
-          { "color": "Noble Grey", "weight": 20, "//": "FS 36176" },
+          { "color": "Noble Grey", "weight": 20, "//": "Federal Standard 36176" },
           { "color": "Baby Blue", "weight": 10 },
           { "color": "Onyx Black", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
-          { "color": "Linen Blue", "weight": 5 },
+          { "color": "Technical Blue", "weight": 5 },
           { "color": "Ruby Violet", "weight": 1, "//": "Sneaky military craft :)" }
         ]
       }
@@ -250,6 +250,42 @@
           { "color": "North Grey", "weight": 10 },
           { "color": "Ink Black", "weight": 10 },
           { "color": "Ruby Violet", "weight": 5, "//": "Sneaky military craft :)" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "aircraft_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "Prince Grey", "weight": 10 },
+        { "color": "Ink Black", "weight": 5 },
+          { "color": "Copper Red", "weight": 5 },
+          { "color": "Persian Orange", "weight": 5 },
+          { "color": "Traffic Yellow", "weight": 5 },
+          { "color": "Ranger Green", "weight": 5 },
+          { "color": "Caribbean Blue", "weight": 5 },
+          { "color": "Coronation Blue", "weight": 1}
+        ]
+      }
+    ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "aircraft_commercial",
+    "palette": [
+      {
+        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "colors": [
+          { "color": "White aluminium", "weight": 15 },
+          { "color": "British Mauve", "weight": 10 },
+          { "color": "Pompeii Red", "weight": 10},
+          { "color": "Poster Yellow", "weight": 5},
+          { "color": "Golf Green", "weight": 5},
+          { "color": "Coronation Blue", "weight": 1}
         ]
       }
     ]

--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -12,6 +12,7 @@
       [ "       |   " ],
       [ "       |   " ]
     ],
+    "color_palette": "aircraft_standard",
     "parts": [
       {
         "x": 0,
@@ -97,6 +98,7 @@
       [ "    ###|## " ],
       [ "       |   " ]
     ],
+    "color_palette": "aircraft_standard",
     "parts": [
       {
         "x": 0,
@@ -259,6 +261,7 @@
       " OOO->OOOOOOOOO ",
       "  OOOOOOOOOOOO "
     ],
+    "color_palette": "aircraft_commercial",
     "blueprint_origin": { "x": 10, "y": 3 },
     "palette": { "O": [ "airship_balloon_external" ] },
     "parts": [
@@ -487,6 +490,7 @@
     "id": "passenger_plane",
     "type": "vehicle",
     "name": "Passenger Plane",
+    "color_palette": "aircraft_commercial",
     "parts": [
       { "x": 4, "y": 0, "parts": [ "frame_vertical_2", "roof", "trunk_floor" ] },
       { "x": 9, "y": 1, "parts": [ "frame_horizontal_2", "headlight", "halfboard_ne" ] },
@@ -703,6 +707,7 @@
     "id": "cargo_plane",
     "type": "vehicle",
     "name": "Cargo Plane",
+    "color_palette": "aircraft_commercial",
     "parts": [
       { "x": 4, "y": 0, "parts": [ "frame_vertical_2", "roof", "cargo_space", "aisle_lights" ] },
       { "x": 9, "y": 1, "parts": [ "frame_horizontal_2", "headlight", "halfboard_ne" ] },

--- a/data/json/vehicles/helicopters.json
+++ b/data/json/vehicles/helicopters.json
@@ -4,6 +4,7 @@
     "type": "vehicle",
     "name": "2-seater helicopter",
     "blueprint": [  ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
       {
@@ -46,6 +47,7 @@
     "type": "vehicle",
     "name": "2-seater helicopter",
     "blueprint": [  ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
       {
@@ -100,6 +102,7 @@
     "type": "vehicle",
     "name": "Small helicopter",
     "blueprint": [  ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -1, "y": 1, "parts": [ "frame_se", "windshield" ] },
       { "x": -1, "y": -1, "parts": [ "frame_sw", "windshield" ] },
@@ -140,6 +143,7 @@
     "type": "vehicle",
     "name": "2-seater helicopter",
     "blueprint": [  ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical" ] },
       {
@@ -190,6 +194,7 @@
     "type": "vehicle",
     "name": "Small helicopter",
     "blueprint": [  ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -1, "y": 1, "parts": [ "frame_se" ] },
       { "x": 2, "y": -1, "parts": [ "frame_nw", "xlhalfboard_nw" ] },
@@ -228,6 +233,7 @@
     "type": "vehicle",
     "name": "Small helicopter",
     "blueprint": [  ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -1, "y": 1, "parts": [ "frame_se", "aluminum_board_se" ] },
       { "x": 2, "y": -1, "parts": [ "frame_nw", "xlhalfboard_nw" ] },
@@ -332,6 +338,7 @@
     "type": "vehicle",
     "name": "Small helicopter",
     "blueprint": [  ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -1, "y": 1, "parts": [ "frame_se", "windshield" ] },
       { "x": -1, "y": -1, "parts": [ "frame_sw" ] },
@@ -365,6 +372,7 @@
     "type": "vehicle",
     "name": "SmallFlier2 Wreck",
     "blueprint": [  ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -1, "y": 1, "parts": [ "frame_se", "board_se" ] },
       { "x": -1, "y": -1, "parts": [ "frame_sw", "board_sw" ] },
@@ -471,6 +479,7 @@
     "type": "vehicle",
     "name": "Small helicopter",
     "blueprint": [  ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -1, "y": 1, "parts": [ "frame_se", "board_se" ] },
       { "x": 2, "y": -1, "parts": [ "frame_nw", "xlhalfboard_nw" ] },
@@ -816,6 +825,7 @@
     "type": "vehicle",
     "name": "AH-64 Apache",
     "blueprint": [  ],
+    "color_palette": "military_heli",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_horizontal", { "part": "tank_55gal_drum", "fuel": "jp8" } ] },
       {
@@ -951,6 +961,7 @@
     "type": "vehicle",
     "name": "AH-64 Apache",
     "blueprint": [  ],
+    "color_palette": "military_heli",
     "parts": [
       {
         "x": -3,
@@ -1047,6 +1058,7 @@
       [ "       ||     " ],
       [ "        t     " ]
     ],
+    "color_palette": "military_heli",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical", "board_vertical", "plating_military" ] },
       { "x": -1, "y": 1, "parts": [ "frame_ne", "board_ne", "plating_military" ] },
@@ -1173,6 +1185,7 @@
       [ "       ||     " ],
       [ "        t     " ]
     ],
+    "color_palette": "military_heli",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_vertical", "board_vertical", "plating_military" ] },
       { "x": -1, "y": 1, "parts": [ "frame_ne", "board_ne", "plating_military" ] },
@@ -1593,6 +1606,7 @@
     "type": "vehicle",
     "name": "V-22 Osprey",
     "blueprint": [  ],
+    "color_palette": "military_heli",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_cross", "aisle_vertical", "roof", "NBC_seal" ] },
       { "x": -12, "y": 2, "parts": [ "frame_vertical", "board_vertical", "plating_steel", "roof", "NBC_seal" ] },
@@ -1847,6 +1861,7 @@
     "id": "helicopter_osprey_2c",
     "type": "vehicle",
     "name": "V-22 Osprey",
+    "color_palette": "military_heli",
     "blueprint": [  ],
     "parts": [
       { "x": -12, "y": 2, "parts": [ "frame_vertical", "board_vertical", "plating_steel", "roof", "NBC_seal" ] },
@@ -2182,6 +2197,7 @@
     "type": "vehicle",
     "name": "UH-60 Blackhawk",
     "blueprint": [  ],
+    "color_palette": "military_heli",
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_cross", "aisle_vertical", "roof", "NBC_seal" ] },
       { "x": -1, "y": 1, "parts": [ "frame_cross", "door_internal", "roof", "NBC_seal" ] },
@@ -2349,6 +2365,7 @@
     "id": "helicopter_blackhawk_3c",
     "type": "vehicle",
     "name": "UH-60 Blackhawk",
+    "color_palette": "military_heli",
     "blueprint": [  ],
     "parts": [
       { "x": -3, "y": 1, "parts": [ "frame_cross", "aisle_vertical", "roof", "NBC_seal" ] },
@@ -2455,6 +2472,7 @@
     "type": "vehicle",
     "name": "Gyrocopter",
     "blueprint": [ [ "-X#" ] ],
+    "color_palette": "aircraft_standard",
     "parts": [
       { "x": -2, "y": 0, "parts": [ "xlframe_vertical" ] },
       {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Civilian aircraft are all cataclysm red, and theyd probably look better with some other colors

## Describe the solution (The How)

The cessna, floatplane, 2 seated heli, regular heli and gyrocopter can spawn in white, black, red, orange, yellow, green, blue or purple

<img width="1059" height="674" alt="2026-05-10-22:12:45" src="https://github.com/user-attachments/assets/b4f0c693-82a9-4a5d-92fa-156d42ece0f2" />


The cargo plane, passenger plane and blimp (just the cab, not the balloons) can now spawn in white, commonly red or blue, uncommonly yellow or green and rarely the above purple (not pictured cus I ran out of space)

<img width="1666" height="750" alt="2026-05-10-22:10:01" src="https://github.com/user-attachments/assets/042caafa-4fba-487f-b316-916b04bcdb0a" />

Also adds Technical Blue to the military_figher palette

<img width="382" height="435" alt="2026-05-10-22:38:29" src="https://github.com/user-attachments/assets/19033eed-1fe7-43f4-a779-498edac49018" />

Also also adds military_heli to some helis I missed

## Describe alternatives you've considered

- Not doing this

- Have the cesna/floatplane and commercial planes just spawn as plane white

Would probably be really boring, so I decided to color them based on actual cessna color options and a handful of commercial passenger liverys instead

## Testing

Booted up the game and everything looks fine

## Additional context

Hopefully the last one of these prs? Provided I havent missed anything

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.