### PR TITLE
fix: fix problematic autosave during an in-progress craft

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2293,6 +2293,53 @@ void craft_activity_actor::do_complete_craft( player_activity &/*act*/, Characte
     }
 }
 
+act_progress_message craft_activity_actor::get_progress_message(
+    const player_activity &act, const Character &who ) const
+{
+    if( !rec || !is_valid ) {
+        return act_progress_message::make_empty();
+    }
+
+    const int assistants = who.available_assistant_count( *rec );
+    const double base_total_moves = std::max( 1, rec->batch_time( batch_size, 1.0f, 0 ) );
+    const double remaining_pct = 1.0 - craft_counter / 10'000'000.0;
+    const float total_mult = act.speed.total();
+    const int remaining_turns = static_cast<int>( remaining_pct * base_total_moves / 100 /
+                                std::max( 0.01f, total_mult ) );
+
+    const std::string time_desc = string_format( _( "Time left: %s" ),
+                                  to_string( time_duration::from_turns( remaining_turns ) ) );
+
+    const auto fmt_spd = [&]( float level, const std::string & name ) -> std::string {
+        const int pct = static_cast<int>( level * 100 );
+        if( pct == 100 ) {
+            return "";
+        }
+        nc_color col = pct > 100 ? c_green : c_red;
+        return string_format( " - %s: %s\n", name,
+                              colorize( std::to_string( pct ) + '%', col ) );
+    };
+
+    std::string mults_desc = _( "Crafting speed multipliers:\n" );
+    const int total_pct = static_cast<int>( total_mult * 100 );
+    nc_color total_col = total_pct > 100 ? c_green : c_red;
+    mults_desc += string_format( " - %s: %s\n", _( "Total" ),
+                                 colorize( std::to_string( total_pct ) + '%', total_col ) );
+    mults_desc += fmt_spd( act.speed.player_speed, _( "Speed" ) );
+    mults_desc += fmt_spd( act.speed.light, _( "Light" ) );
+    mults_desc += fmt_spd( act.speed.bench_factor, _( "Workbench" ) );
+    mults_desc += fmt_spd( act.speed.morale, _( "Morale" ) );
+    mults_desc += fmt_spd( act.speed.tools, _( "Tools" ) );
+    if( assistants > 0 ) {
+        mults_desc += fmt_spd( act.speed.assist, _( "Assistants" ) );
+    }
+
+    return act_progress_message::make_full(
+               string_format( _( "%s: %s\n\n%s\n\n%s" ),
+                              act.get_verb().translated(), rec->result_name(),
+                              time_desc, mults_desc ) );
+}
+
 void craft_activity_actor::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2312,7 +2312,8 @@ act_progress_message craft_activity_actor::get_progress_message(
 
     const auto fmt_spd = [&]( float level, const std::string & name ) -> std::string {
         const int pct = static_cast<int>( level * 100 );
-        if( pct == 100 ) {
+        if( pct == 100 )
+        {
             return "";
         }
         nc_color col = pct > 100 ? c_green : c_red;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -17,6 +17,7 @@
 #include "character_functions.h"
 #include "construction.h"
 #include "construction_partial.h"
+#include "craft_command.h"
 #include "crafting.h"
 #include "debug.h"
 #include "enums.h"
@@ -2060,12 +2061,14 @@ craft_activity_actor::craft_activity_actor(
     const tripoint &location,
     std::vector<comp_selection<item_comp>> item_selections,
     std::vector<comp_selection<tool_comp>> tool_selections,
-    bool tools_prepaid
+    bool tools_prepaid,
+    bool is_long
 ) : rec( rec ), batch_size( batch_size ), craft_counter( craft_counter ),
     location( location ),
     item_selections( std::move( item_selections ) ),
     tool_selections( std::move( tool_selections ) ),
     tools_prepaid( tools_prepaid ),
+    is_long( is_long ),
     is_valid( rec != nullptr )
 {}
 
@@ -2283,6 +2286,11 @@ void craft_activity_actor::do_complete_craft( player_activity &/*act*/, Characte
     }
     ::complete_craft( who, *craft_item );
     craft_item->detach();
+    if( is_long && rec ) {
+        if( who.making_would_work( rec->ident(), batch_size ) ) {
+            who.last_craft->execute( location );
+        }
+    }
 }
 
 void craft_activity_actor::serialize( JsonOut &jsout ) const
@@ -2296,6 +2304,7 @@ void craft_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "item_selections", item_selections );
     jsout.member( "tool_selections", tool_selections );
     jsout.member( "tools_prepaid", tools_prepaid );
+    jsout.member( "is_long", is_long );
     jsout.member( "last_turn_nr", last_turn_nr );
     jsout.end_object();
 }
@@ -2321,6 +2330,7 @@ std::unique_ptr<activity_actor> craft_activity_actor::deserialize( JsonIn &jsin 
     data.read( "item_selections", actor->item_selections );
     data.read( "tool_selections", actor->tool_selections );
     data.read( "tools_prepaid", actor->tools_prepaid );
+    data.read( "is_long", actor->is_long );
     data.read( "last_turn_nr", actor->last_turn_nr );
 
     return actor;

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -168,6 +168,9 @@ class craft_activity_actor final : public activity_actor
         const tripoint &get_location() const { return location; }
         bool are_tools_prepaid() const { return tools_prepaid; }
 
+        act_progress_message get_progress_message( const player_activity &act,
+                const Character &who ) const override;
+
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -124,6 +124,7 @@ class craft_activity_actor final : public activity_actor
         std::vector<comp_selection<tool_comp>> tool_selections;
 
         bool tools_prepaid = false;
+        bool is_long = false;
         bool is_valid = false;
         int last_turn_nr = -1;  // turn# when last do_turn ran; -1 = never set
 
@@ -147,7 +148,8 @@ class craft_activity_actor final : public activity_actor
             const tripoint &location = tripoint_zero,
             std::vector<comp_selection<item_comp>> item_selections = {},
             std::vector<comp_selection<tool_comp>> tool_selections = {},
-            bool tools_prepaid = false
+            bool tools_prepaid = false,
+            bool is_long = false
         );
 
         activity_id get_type() const override {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -805,28 +805,17 @@ item *Character::start_craft( craft_command &command, const tripoint & )
     item *craft_in_world = &*craft;
     set_item_inventory( *this, std::move( craft ) );
 
-    if( is_npc() ) {
-        auto actor = std::make_unique<craft_activity_actor>(
-                         &making,
-                         command.get_batch_size(),
-                         craft_in_world->get_counter(),
-                         bench.position,
-                         command.get_item_selections(),
-                         command.get_tool_selections(),
-                         craft_in_world->get_var( "craft_tools_fully_prepaid", 0 ) == 1
-                     );
-        assign_activity( std::make_unique<player_activity>( std::move( actor ) ) );
-    } else {
-        assign_activity( ACT_CRAFT );
-        activity->targets.emplace_back( craft_in_world );
-        activity->coords.push_back( get_map().getabs( bench.position ) );
-        activity->values.push_back( command.is_long() );
-        // Ugly
-        activity->values.push_back( static_cast<int>( bench.type ) );
-        activity->values.push_back( 100 );
-        activity->values.push_back( 0 );
-        activity->placement = tripoint_zero;
-    }
+    auto actor = std::make_unique<craft_activity_actor>(
+                     &making,
+                     command.get_batch_size(),
+                     craft_in_world->get_counter(),
+                     bench.position,
+                     command.get_item_selections(),
+                     command.get_tool_selections(),
+                     craft_in_world->get_var( "craft_tools_fully_prepaid", 0 ) == 1,
+                     command.is_long()
+                 );
+    assign_activity( std::make_unique<player_activity>( std::move( actor ) ) );
 
     add_msg_player_or_npc(
         pgettext( "in progress craft", "You start working on the %s." ),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8715,7 +8715,7 @@ int iuse::craft( player *p, item *it, bool, const tripoint &pos )
         pgettext( "in progress craft", "You start working on the %s." ),
         pgettext( "in progress craft", "<npcname> starts working on the %s." ), craft_name );
 
-    if( p->is_npc() ) {
+    {
         const recipe &rec = it->get_making();
         auto actor = std::make_unique<craft_activity_actor>(
                          &rec,
@@ -8727,38 +8727,7 @@ int iuse::craft( player *p, item *it, bool, const tripoint &pos )
                          it->get_var( "craft_tools_fully_prepaid", 0 ) == 1
                      );
         p->assign_activity( std::make_unique<player_activity>( std::move( actor ) ) );
-        return 0;
     }
-
-    p->assign_activity( ACT_CRAFT );
-    // Horrible! We have to find the item again...
-    item *where = nullptr;
-    if( p->has_item( *it ) ) {
-        where = it;
-    } else if( const std::optional<vpart_reference> vp = g->m.veh_at( pos ).part_with_feature( "CARGO",
-               false ) ) {
-        const vehicle_cursor vc = vehicle_cursor( vp->vehicle(), vp->part_index() );
-        if( vc.has_item( *it ) ) {
-            where = it;
-        }
-    }
-
-    if( !where ) {
-        map_cursor mc = map_cursor( pos );
-        if( mc.has_item( *it ) ) {
-            where = it;
-        } else {
-            debugmsg( "Incomplete item couldn't be found" );
-            return 0;
-        }
-    }
-    p->activity->targets.emplace_back( where );
-    p->activity->coords.push_back( get_map().getabs( best_bench.position ) );
-    p->activity->values.push_back( 0 ); // Not a long craft
-    // Ugly
-    p->activity->values.push_back( static_cast<int>( best_bench.type ) );
-    p->activity->values.push_back( 100 );
-    p->activity->values.push_back( 0 );
 
     return 0;
 }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -238,7 +238,7 @@ void player_activity::deserialize( JsonIn &jsin )
     // ACT_MIGRATION_CANCEL will clear the backlog and reset npc state
     // this may cause inconvenience but should avoid any lasting damage to npcs
     if( has_actor && type != ACT_MIGRATION_CANCEL ) {
-        if( !data.has_member( "actor" ) ) {
+        if( !data.has_member( "actor" ) || data.has_null( "actor" ) ) {
             type = ACT_MIGRATION_CANCEL;
         } else {
             auto actor = data.get_object( "actor" );


### PR DESCRIPTION
## Purpose of change (The Why)

The refactor (#8776) added craft_activity_actor for NPC crafting but left the player
on the old assign_activity(ACT_CRAFT) path, which wrote "actor": null to saves. 
On load, the deserializer called get_object() on that null and crashed.

## Describe the solution (The How)

The fix converts both player and NPC crafting to use craft_activity_actor
and makes the deserializer treat a null actor as a migration-cancel rather than crashing. 
Also a secondary segfault in the progress tooltip was fixed

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

Lowered autosave to 10 turns and 1 minute, crafted 2 by swords repeatedly until it saved while crafting in the previous version, confirmed crash, switched branch to this one and attempted to load, worked. Repeated the process, no crash, loaded right.

## Additional context

<img width="1812" height="1020" alt="image" src="https://github.com/user-attachments/assets/bf38f831-ebca-4250-aece-50768550d291" />


## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
