### PR TITLE
feat(UI): add pickup all nearby action

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -1778,10 +1778,17 @@
   },
   {
     "type": "keybinding",
-    "name": "Pick up Nearby Item(s)",
+    "name": "Pick up items from one nearby tile",
     "category": "DEFAULTMODE",
     "id": "pickup",
     "bindings": [ { "input_method": "keyboard", "key": "g" } ]
+  },
+  {
+    "type": "keybinding",
+    "name": "Pick up items from all nearby tiles",
+    "category": "DEFAULTMODE",
+    "id": "pickup_all",
+    "bindings": [ { "input_method": "keyboard", "key": "," } ]
   },
   {
     "type": "keybinding",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -142,6 +142,8 @@ std::string action_ident( action_id act )
             return "advinv";
         case ACTION_PICKUP:
             return "pickup";
+        case ACTION_PICKUP_ALL:
+            return "pickup_all";
         case ACTION_PICKUP_FEET:
             return "pickup_feet";
         case ACTION_GRAB:
@@ -689,6 +691,7 @@ bool can_interact_at( action_id action, const tripoint &p )
         case ACTION_EXAMINE:
             return can_examine_at( p );
         case ACTION_PICKUP:
+        case ACTION_PICKUP_ALL:
         case ACTION_PICKUP_FEET:
             return can_pickup_at( p );
         default:
@@ -963,7 +966,7 @@ action_id handle_action_menu()
             register_actions( {
                 ACTION_EXAMINE, ACTION_SMASH, ACTION_MOVE_DOWN, ACTION_MOVE_UP,
                 ACTION_OPEN, ACTION_CLOSE, ACTION_CHAT, ACTION_PICKUP,
-                ACTION_PICKUP_FEET, ACTION_GRAB, ACTION_HAUL, ACTION_BUTCHER, ACTION_LOOT,
+                ACTION_PICKUP_ALL, ACTION_PICKUP_FEET, ACTION_GRAB, ACTION_HAUL, ACTION_BUTCHER, ACTION_LOOT,
             } );
             register_lua_action_entries( category_id );
         } else if( category_id == "combat" ) {

--- a/src/action.h
+++ b/src/action.h
@@ -97,8 +97,10 @@ enum action_id : int {
     ACTION_SMASH,
     /** Examine or pick up items from adjacent square */
     ACTION_EXAMINE,
-    /** Pick up items from current/adjacent squares */
+    /** Pick up items from one current/adjacent square */
     ACTION_PICKUP,
+    /** Pick up items from all current/adjacent squares */
+    ACTION_PICKUP_ALL,
     /** Pick up items from current square. Auto pickup if only one item */
     ACTION_PICKUP_FEET,
     /** Grab or let go of an object */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2674,6 +2674,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "examine" );
     ctxt.register_action( "advinv" );
     ctxt.register_action( "pickup" );
+    ctxt.register_action( "pickup_all" );
     ctxt.register_action( "pickup_feet" );
     ctxt.register_action( "grab" );
     ctxt.register_action( "haul" );
@@ -7348,6 +7349,11 @@ void game::pickup()
         return;
     }
     pickup( *examp_ );
+}
+
+void game::pickup_all()
+{
+    pickup::pick_up_all_nearby();
 }
 
 void game::pickup( const tripoint &p )

--- a/src/game.h
+++ b/src/game.h
@@ -924,9 +924,10 @@ class game : public submap_load_listener
         void examine( const tripoint &p ); // Examine nearby terrain  'e'
         void examine();
 
-        void pickup(); // Pickup nearby items 'g', min 0
+        void pickup(); // Pick up items from one nearby tile 'g', min 0
+        void pickup_all(); // Pick up items from all nearby tiles ',', min 0
         void pickup( const tripoint &p );
-        void pickup_feet(); // Pick items at player position ',', min 1
+        void pickup_feet(); // Pick items at player position, min 1
 
         void drop(); // Drop an item  'd'
         void drop_in_direction(); // Drop w/ direction  'D'

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2160,6 +2160,16 @@ bool game::handle_action()
                 }
                 break;
 
+            case ACTION_PICKUP_ALL:
+                if( u.has_active_mutation( trait_SHELL2 ) ) {
+                    add_msg( m_info, _( "You can't pick anything up while you're in your shell." ) );
+                } else if( u.is_mounted() ) {
+                    add_msg( m_info, _( "You can't pick anything up while you're riding." ) );
+                } else {
+                    pickup_all();
+                }
+                break;
+
             case ACTION_PICKUP_FEET:
                 if( u.has_active_mutation( trait_SHELL2 ) ) {
                     add_msg( m_info, _( "You can't pick anything up while you're in your shell." ) );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -1,6 +1,7 @@
 #include "pickup.h"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <functional>
 #include <list>
@@ -8,6 +9,7 @@
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <utility>
 #include <vector>
@@ -612,118 +614,38 @@ std::vector<std::list<item_stack::iterator>> flatten( const std::vector<stacked_
 
 } // namespace pickup
 
-// Pick up items at (pos).
-void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
+namespace
 {
-    int cargo_part = -1;
 
-    const optional_vpart_position vp = g->m.veh_at( p );
-    vehicle *const veh = veh_pointer_or_null( vp );
-    bool from_vehicle = false;
+auto append_item_iterators( item_stack &stack, std::vector<item_stack::iterator> &items ) -> void
+{
+    // The pickup UI needs stable item_stack iterators so selected items can be detached later.
+    std::ranges::for_each( std::views::iota( stack.begin(), stack.end() ), [&]( const auto iter ) {
+        items.emplace_back( iter );
+    } );
+}
 
-    if( min != -1 ) {
-        if( veh != nullptr && get_items_from == prompt ) {
-            const std::optional<vpart_reference> carg = vp.part_with_feature( "CARGO", false );
-            const bool veh_has_items = carg && !veh->get_items( carg->part_index() ).empty();
-            const bool map_has_items = g->m.has_items( p );
-            if( veh_has_items && map_has_items ) {
-                uilist amenu( _( "Get items from where?" ), { _( "Get items from vehicle cargo" ), _( "Get items on the ground" ) } );
-                if( amenu.ret == UILIST_CANCEL ) {
-                    return;
-                }
-                get_items_from = static_cast<from_where>( amenu.ret );
-            } else if( veh_has_items ) {
-                get_items_from = from_cargo;
-            }
-        }
-        if( get_items_from == from_cargo ) {
-            const std::optional<vpart_reference> carg = vp.part_with_feature( "CARGO", false );
-            cargo_part = carg ? carg->part_index() : -1;
-            from_vehicle = cargo_part >= 0;
-        } else {
-            // Nothing to change, default is to pick from ground anyway.
-            if( g->m.has_flag( "SEALED", p ) ) {
-                return;
-            }
-        }
-    }
-
-    if( !from_vehicle ) {
-        bool isEmpty = ( g->m.i_at( p ).empty() );
-
-        // Hide the pickup window if this is a toilet and there's nothing here
-        // but non-frozen water.
-        if( ( !isEmpty ) && g->m.furn( p ) == f_toilet ) {
-            isEmpty = true;
-            for( const item * const &maybe_water : g->m.i_at( p ) ) {
-                if( maybe_water->typeId() != itype_id( "water" ) ) {
-                    isEmpty = false;
-                    break;
-                }
-            }
-        }
-
-        if( isEmpty && ( min != -1 || !get_option<bool>( "AUTO_PICKUP_ADJACENT" ) ) ) {
-            return;
-        }
-    }
-
-    // which items are we grabbing?
-    std::vector<item_stack::iterator> here;
-    if( from_vehicle ) {
-        vehicle_stack vehitems = veh->get_items( cargo_part );
-        for( item_stack::iterator it = vehitems.begin(); it != vehitems.end(); ++it ) {
-            here.push_back( it );
-        }
-    } else {
-        map_stack mapitems = g->m.i_at( p );
-        for( item_stack::iterator it = mapitems.begin(); it != mapitems.end(); ++it ) {
-            here.push_back( it );
-        }
-    }
-
-    if( min == -1 ) {
-        // Recursively pick up adjacent items if that option is on.
-        if( get_option<bool>( "AUTO_PICKUP_ADJACENT" ) && g->u.pos() == p ) {
-            //Autopickup adjacent
-            direction adjacentDir[8] = {direction::NORTH, direction::NORTHEAST, direction::EAST, direction::SOUTHEAST, direction::SOUTH, direction::SOUTHWEST, direction::WEST, direction::NORTHWEST};
-            for( auto &elem : adjacentDir ) {
-
-                tripoint apos = tripoint( displace_XY( elem ), 0 );
-                apos += p;
-
-                pick_up( apos, min );
-            }
-        }
-
-        // Bail out if this square cannot be auto-picked-up
-        if( g->check_zone( zone_type_id( "NO_AUTO_PICKUP" ), p ) ) {
-            return;
-        } else if( g->m.has_flag( "SEALED", p ) ) {
-            return;
-        }
+auto pick_up_from_items( const std::vector<item_stack::iterator> &here, const int min,
+                         const std::optional<tripoint> &starting_pos ) -> void
+{
+    if( here.empty() ) {
+        return;
     }
 
     // Not many items, just grab them
     if( static_cast<int>( here.size() ) <= min && min != -1 ) {
-        if( from_vehicle ) {
-            g->u.assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
-            std::vector<pickup::pick_drop_selection> { { *here.front(), std::nullopt, {} } },
-            std::nullopt ) ) );
-        } else {
-            g->u.assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
-            std::vector<pickup::pick_drop_selection> { { *here.front(), std::nullopt, {} } },
-            g->u.pos() ) ) );
-        }
+        g->u.assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
+        std::vector<pickup::pick_drop_selection> { { *here.front(), std::nullopt, {} } },
+        starting_pos ) ) );
         return;
     }
 
-    const std::vector<stacked_items> &stacked_here_new = stack_for_pickup_ui( here );
+    const auto stacked_here_new = pickup::stack_for_pickup_ui( here );
     // To avoid having to rewrite things.
     // TODO: Remove flattening
-    const std::vector<std::list<item_stack::iterator>> &stacked_here = flatten( stacked_here_new );
-    std::vector<pickup_count> getitem( stacked_here.size() );
-    std::vector<std::optional<size_t>> parents = calculate_parents( stacked_here );
+    const auto stacked_here = pickup::flatten( stacked_here_new );
+    auto getitem = std::vector<pickup_count>( stacked_here.size() );
+    const auto parents = pickup::calculate_parents( stacked_here );
     for( size_t i = 0; i < getitem.size(); i++ ) {
         getitem[i].parent = parents[i];
         if( parents[i] ) {
@@ -1299,13 +1221,154 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
     std::vector<pickup::pick_drop_selection> targets = pickup::optimize_pickup( locations, quantities );
     g->u.assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>
                           ( targets,
-                            g->u.pos() ) ) );
+                            starting_pos ) ) );
     if( min == -1 ) {
         // Auto pickup will need to auto resume since there can be several of them on the stack.
         g->u.activity->auto_resume = true;
     }
 
     g->reenter_fullscreen();
+}
+
+} // namespace
+
+// Pick up items at (pos).
+auto pickup::pick_up( const tripoint &p, int min, from_where get_items_from ) -> void
+{
+    auto cargo_part = -1;
+
+    const auto vp = g->m.veh_at( p );
+    auto *const veh = veh_pointer_or_null( vp );
+    auto from_vehicle = false;
+
+    if( min != -1 ) {
+        if( veh != nullptr && get_items_from == prompt ) {
+            const auto carg = vp.part_with_feature( "CARGO", false );
+            const auto veh_has_items = carg && !veh->get_items( carg->part_index() ).empty();
+            const auto map_has_items = g->m.has_items( p );
+            if( veh_has_items && map_has_items ) {
+                auto amenu = uilist( _( "Get items from where?" ), { _( "Get items from vehicle cargo" ),
+                                     _( "Get items on the ground" )
+                                                                   } );
+                if( amenu.ret == UILIST_CANCEL ) {
+                    return;
+                }
+                get_items_from = static_cast<from_where>( amenu.ret );
+            } else if( veh_has_items ) {
+                get_items_from = from_cargo;
+            }
+        }
+        if( get_items_from == from_cargo ) {
+            const auto carg = vp.part_with_feature( "CARGO", false );
+            cargo_part = carg ? carg->part_index() : -1;
+            from_vehicle = cargo_part >= 0;
+        } else {
+            // Nothing to change, default is to pick from ground anyway.
+            if( g->m.has_flag( "SEALED", p ) ) {
+                return;
+            }
+        }
+    }
+
+    if( !from_vehicle ) {
+        auto isEmpty = ( g->m.i_at( p ).empty() );
+
+        // Hide the pickup window if this is a toilet and there's nothing here
+        // but non-frozen water.
+        if( ( !isEmpty ) && g->m.furn( p ) == f_toilet ) {
+            isEmpty = true;
+            for( const auto *const maybe_water : g->m.i_at( p ) ) {
+                if( maybe_water->typeId() != itype_id( "water" ) ) {
+                    isEmpty = false;
+                    break;
+                }
+            }
+        }
+
+        if( isEmpty && ( min != -1 || !get_option<bool>( "AUTO_PICKUP_ADJACENT" ) ) ) {
+            return;
+        }
+    }
+
+    // which items are we grabbing?
+    auto here = std::vector<item_stack::iterator> {};
+    if( from_vehicle ) {
+        auto vehitems = veh->get_items( cargo_part );
+        append_item_iterators( vehitems, here );
+    } else {
+        auto mapitems = g->m.i_at( p );
+        append_item_iterators( mapitems, here );
+    }
+
+    if( min == -1 ) {
+        // Recursively pick up adjacent items if that option is on.
+        if( get_option<bool>( "AUTO_PICKUP_ADJACENT" ) && g->u.pos() == p ) {
+            //Autopickup adjacent
+            const auto adjacentDir = std::array{ direction::NORTH, direction::NORTHEAST,
+                                                 direction::EAST, direction::SOUTHEAST, direction::SOUTH,
+                                                 direction::SOUTHWEST, direction::WEST, direction::NORTHWEST };
+            for( const auto elem : adjacentDir ) {
+
+                auto apos = tripoint( displace_XY( elem ), 0 );
+                apos += p;
+
+                pick_up( apos, min );
+            }
+        }
+
+        // Bail out if this square cannot be auto-picked-up
+        if( g->check_zone( zone_type_id( "NO_AUTO_PICKUP" ), p ) ) {
+            return;
+        } else if( g->m.has_flag( "SEALED", p ) ) {
+            return;
+        }
+    }
+
+    const auto starting_pos = from_vehicle ? std::nullopt : std::make_optional( g->u.pos() );
+    pick_up_from_items( here, min, starting_pos );
+}
+
+auto pickup::nearby_items_for_pickup( const tripoint &center ) -> nearby_pickup_items
+{
+    auto result = nearby_pickup_items{};
+    auto &here = get_map();
+    for( const tripoint &pos : here.points_in_radius( center, 1 ) ) {
+        if( here.obstructed_by_vehicle_rotation( center, pos ) ) {
+            continue;
+        }
+
+        if( !here.has_flag( "SEALED", pos ) ) {
+            auto mapitems = here.i_at( pos );
+            if( !mapitems.empty() ) {
+                result.has_ground_items = true;
+                append_item_iterators( mapitems, result.items );
+            }
+        }
+
+        const auto vp = here.veh_at( pos );
+        if( !vp ) {
+            continue;
+        }
+        const auto carg = vp.part_with_feature( "CARGO", false );
+        if( !carg ) {
+            continue;
+        }
+        auto vehitems = carg->vehicle().get_items( carg->part_index() );
+        append_item_iterators( vehitems, result.items );
+    }
+    return result;
+}
+
+auto pickup::pick_up_all_nearby() -> void
+{
+    const auto nearby = nearby_items_for_pickup( g->u.pos() );
+    if( nearby.items.empty() ) {
+        add_msg( _( "There is nothing to pick up nearby." ) );
+        return;
+    }
+
+    const auto starting_pos = nearby.has_ground_items ? std::make_optional( g->u.pos() ) : std::nullopt;
+    pick_up_from_items( nearby.items, 0, starting_pos );
 }
 
 //helper function for Pickup::pick_up

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -2,6 +2,8 @@
 
 #include <vector>
 
+#include "item_stack.h"
+
 class item;
 class Character;
 class JsonIn;
@@ -17,12 +19,18 @@ namespace pickup
 
 struct pick_drop_selection;
 
+struct nearby_pickup_items {
+    std::vector<item_stack::iterator> items;
+    bool has_ground_items = false;
+};
+
 /**
  * Returns `false` if the player was presented a prompt and decided to cancel the pickup.
  * `true` in other cases.
  */
-bool do_pickup( std::vector<pick_drop_selection> &targets, bool autopickup );
-bool query_thief();
+auto do_pickup( std::vector<pick_drop_selection> &targets, bool autopickup ) -> bool;
+auto query_thief() -> bool;
+auto nearby_items_for_pickup( const tripoint &center ) -> nearby_pickup_items;
 
 enum from_where : int {
     from_cargo = 0,
@@ -31,9 +39,11 @@ enum from_where : int {
 };
 
 /** Pick up items; 'g' or ',' or via examine() */
-void pick_up( const tripoint &p, int min, from_where get_items_from = prompt );
+auto pick_up( const tripoint &p, int min, from_where get_items_from = prompt ) -> void;
+/** Pick up items from the player's tile and every adjacent tile. */
+auto pick_up_all_nearby() -> void;
 /** Determines the cost of moving an item by a character. */
-int cost_to_move_item( const Character &who, const item &it );
+auto cost_to_move_item( const Character &who, const item &it ) -> int;
 
 /**
  * If character is handling a potentially spillable bucket, gracefully handle what
@@ -45,7 +55,8 @@ int cost_to_move_item( const Character &who, const item &it );
  * @param it item to handle
  * @param m map they are on
  */
-detached_ptr<item> handle_spillable_contents( Character &c, detached_ptr<item> &&it, map &m );
+auto handle_spillable_contents( Character &c, detached_ptr<item> &&it,
+                                map &m ) -> detached_ptr<item>;
 } // namespace pickup
 
 

--- a/tests/pickup_test.cpp
+++ b/tests/pickup_test.cpp
@@ -1,0 +1,69 @@
+#include "catch/catch.hpp"
+
+#include <algorithm>
+
+#include "game.h"
+#include "item.h"
+#include "map.h"
+#include "pickup.h"
+#include "state_helpers.h"
+#include "type_id.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+
+static auto count_pickup_items( const pickup::nearby_pickup_items &pickup_items,
+                                const itype_id &type ) -> int
+{
+    return std::ranges::count_if( pickup_items.items, [&type]( const item_stack::iterator & iter ) {
+        return ( *iter )->typeId() == type;
+    } );
+}
+
+TEST_CASE( "nearby pickup finds items on all adjacent ground tiles", "[pickup]" )
+{
+    clear_all_state();
+
+    map &here = get_map();
+    const auto center = tripoint{ 60, 60, 0 };
+    g->place_player( center );
+
+    for( const tripoint &pos : here.points_in_radius( center, 2 ) ) {
+        here.i_clear( pos );
+    }
+
+    here.add_item_or_charges( center, item::spawn( "rock" ) );
+    here.add_item_or_charges( center + tripoint_east, item::spawn( "stick" ) );
+    here.add_item_or_charges( center + tripoint_east * 2, item::spawn( "jeans" ) );
+
+    const auto pickup_items = pickup::nearby_items_for_pickup( center );
+
+    CHECK( pickup_items.has_ground_items );
+    CHECK( pickup_items.items.size() == 2 );
+    CHECK( count_pickup_items( pickup_items, itype_id( "rock" ) ) == 1 );
+    CHECK( count_pickup_items( pickup_items, itype_id( "stick" ) ) == 1 );
+    CHECK( count_pickup_items( pickup_items, itype_id( "jeans" ) ) == 0 );
+}
+
+TEST_CASE( "nearby pickup finds adjacent vehicle cargo", "[pickup][vehicle]" )
+{
+    clear_all_state();
+
+    map &here = get_map();
+    const auto center = tripoint{ 60, 60, 0 };
+    const auto cart_pos = center + tripoint_east;
+    g->place_player( center );
+
+    auto *const cart = here.add_vehicle( vproto_id( "shopping_cart" ), cart_pos, 0_degrees, 0, 0 );
+    REQUIRE( cart != nullptr );
+
+    const std::optional<vpart_reference> cargo = here.veh_at( cart_pos ).part_with_feature( "CARGO",
+            true );
+    REQUIRE( cargo );
+    REQUIRE_FALSE( cargo->vehicle().add_item( cargo->part(), item::spawn( "jeans" ) ) );
+
+    const auto pickup_items = pickup::nearby_items_for_pickup( center );
+
+    CHECK_FALSE( pickup_items.has_ground_items );
+    CHECK( pickup_items.items.size() == 1 );
+    CHECK( count_pickup_items( pickup_items, itype_id( "jeans" ) ) == 1 );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #8811.

## Describe the solution (The How)

- Adds `pickup_all` for picking up items from the current tile and adjacent tiles in one menu.
- Keeps `pickup` as one nearby tile pickup and binds `pickup_all` to `,`.
- Includes nearby ground items and vehicle cargo.

## Testing
<img width="1410" height="850" alt="Cataclysm: Bright Nights - 0f5b62749ff-dirty (2026-05-11)_01" src="https://github.com/user-attachments/assets/645bbeed-97a2-4cf8-bd3d-b0da56d830f9" />
<img width="1410" height="850" alt="Cataclysm: Bright Nights - 0f5b62749ff-dirty (2026-05-11)_02" src="https://github.com/user-attachments/assets/594cb1fc-6adc-461c-9b5d-b15334213131" />
<img width="1410" height="850" alt="Cataclysm: Bright Nights - 0f5b62749ff-dirty (2026-05-11)_03" src="https://github.com/user-attachments/assets/0018a5b3-8896-48db-b5ea-345d581a6c85" />

- `cmake --build out/build/linux-full --target astyle`
- `cmake --build out/build/linux-full --target cata_test-tiles`
- `cmake --build out/build/linux-full --target cataclysm-bn-tiles`
- `./build-scripts/lint-json.sh`
- `./out/build/linux-full/tests/cata_test-tiles "[pickup]"`

## Additional Context

btw we really need to migrate keybinds to lua having to recompile entire project only to add pickup to game.h does not spark joy

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sup>PR opened by gpt-5.4 high on pi</sup>
