### PR TITLE
fix(UI): add default skin tone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Before writing **ANY** code, verify:
 | `void fn(a, b, c, d, e)`               | `void fn(options_struct)`                                                        |
 | `[](){\n return 1; \n }`               | `[](){ return 1; }`                                                              |
 
-**Prefer `std::ranges`/`std::views`/`std::ranges::to`/cata_algo.h for collection work. Avoid manual iterator increment loops unless required by mutation semantics.**
+**Prefer `std::ranges`/`std::views`/`std::ranges::to`/cata_algo.h for collection work. Avoid manual iterator increment loops unless required by mutation semantics. When a file uses multiple range/view calls, reduce repeated qualifications with local aliases such as `namespace views = std::views;` or `using std::ranges::to`; avoid broad `using namespace` directives in headers.**
 
 ## Coding Convention
 

--- a/data/json/external_tileset/External_Tileset_DP_Skin.json
+++ b/data/json/external_tileset/External_Tileset_DP_Skin.json
@@ -4,6 +4,7 @@
     "compatibility": [ "UNDEAD_PEOPLE_BASE", "UNDEAD_PEOPLE" ],
     "tints": [
       { "id": "SKIN_DARK", "fg": "#55381c", "blend_mode": "multiply" },
+      { "id": "SKIN_LIGHTER", "fg": "#ffe3d7", "blend_mode": "multiply" },
       { "id": "SKIN_LIGHT", "fg": "#ffccb5", "blend_mode": "multiply" },
       { "id": "SKIN_MEDIUM", "fg": "#bf876a", "blend_mode": "multiply" },
       { "id": "SKIN_PINK", "fg": "#ffb5bc", "blend_mode": "multiply" },
@@ -22,6 +23,8 @@
         "tiles": [
           { "id": "overlay_female_mutation_SKIN_DARK", "fg": 0, "rotates": false },
           { "id": "overlay_male_mutation_SKIN_DARK", "fg": 1, "rotates": false },
+          { "id": "overlay_female_mutation_SKIN_LIGHTER", "fg": 0, "rotates": false },
+          { "id": "overlay_male_mutation_SKIN_LIGHTER", "fg": 1, "rotates": false },
           { "id": "overlay_female_mutation_SKIN_LIGHT", "fg": 0, "rotates": false },
           { "id": "overlay_male_mutation_SKIN_LIGHT", "fg": 1, "rotates": false },
           { "id": "overlay_female_mutation_SKIN_MEDIUM", "fg": 0, "rotates": false },

--- a/data/json/mutations/mutation_appearance.json
+++ b/data/json/mutations/mutation_appearance.json
@@ -372,6 +372,18 @@
     "types": [ "skin_tone" ]
   },
   {
+    "id": "SKIN_LIGHTER",
+    "type": "mutation",
+    "name": { "str": "Skin tone: lighter" },
+    "description": "You have a lighter peach skin tone.",
+    "points": 0,
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": false,
+    "types": [ "skin_tone" ]
+  },
+  {
     "id": "SKIN_LIGHT",
     "type": "mutation",
     "name": { "str": "Skin tone: light" },

--- a/data/json/mutations/mutation_ordering.json
+++ b/data/json/mutations/mutation_ordering.json
@@ -54,6 +54,7 @@
           "PLANTSKIN",
           "PALE",
           "SKIN_DARK",
+          "SKIN_LIGHTER",
           "SKIN_LIGHT",
           "SKIN_MEDIUM",
           "SKIN_PINK",

--- a/data/json/mutations/mutation_type.json
+++ b/data/json/mutations/mutation_type.json
@@ -70,7 +70,8 @@
   {
     "type": "mutation_type",
     "id": "skin_tone",
-    "mandatory_one": true
+    "mandatory_one": true,
+    "default_trait": "SKIN_LIGHTER"
   },
   {
     "type": "mutation_type",

--- a/data/json/npcs/appearance_trait_groups.json
+++ b/data/json/npcs/appearance_trait_groups.json
@@ -228,6 +228,7 @@
       { "trait": "SKIN_MEDIUM", "prob": 25 },
       { "trait": "SKIN_TAN", "prob": 25 },
       { "trait": "SKIN_PINK", "prob": 5 },
+      { "trait": "SKIN_LIGHTER", "prob": 5 },
       { "trait": "SKIN_LIGHT", "prob": 10 }
     ]
   },
@@ -235,7 +236,12 @@
     "type": "trait_group",
     "id": "Skin_Fair",
     "subtype": "distribution",
-    "traits": [ { "trait": "SKIN_PINK", "prob": 5 }, { "trait": "SKIN_LIGHT", "prob": 8 }, { "trait": "SKIN_OLIVE", "prob": 3 } ]
+    "traits": [
+      { "trait": "SKIN_LIGHTER", "prob": 4 },
+      { "trait": "SKIN_PINK", "prob": 5 },
+      { "trait": "SKIN_LIGHT", "prob": 8 },
+      { "trait": "SKIN_OLIVE", "prob": 3 }
+    ]
   },
   {
     "type": "trait_group",
@@ -244,6 +250,7 @@
     "traits": [
       { "trait": "SKIN_MEDIUM", "prob": 10 },
       { "trait": "SKIN_PINK", "prob": 20 },
+      { "trait": "SKIN_LIGHTER", "prob": 15 },
       { "trait": "SKIN_LIGHT", "prob": 50 },
       { "trait": "SKIN_OLIVE", "prob": 20 }
     ]

--- a/docs/en/mod/json/reference/creatures/mutations.md
+++ b/docs/en/mod/json/reference/creatures/mutations.md
@@ -160,6 +160,7 @@ Mutation types group related mutations together. They are defined as separate JS
   "type": "mutation_type",
   "id": "hair_color", // Unique string ID for this type
   "mandatory_one": true, // If true, characters must always have at least one mutation of this type. Implies swap_on_conflict. (default: false)
+  "default_trait": "SKIN_LIGHTER", // Optional mutation added to loaded characters that lack this mandatory type. (default: none)
   "swap_on_conflict": true, // If true, selecting a new mutation of this type in character creation automatically removes the previously held mutation of the same type instead of showing a conflict error. (default: false)
   "random_chance": 50 // Percent chance (0–100) that a mutation of this type is randomly assigned during cosmetic randomization. Only used if mandatory_one is false. (default: 0)
 }
@@ -168,5 +169,6 @@ Mutation types group related mutations together. They are defined as separate JS
 ### Notes
 
 - `mandatory_one` guarantees every new character receives exactly one mutation of that type during creation and rerolls.
+- `default_trait` lets old saves or templates that predate a mandatory appearance type receive a fallback trait when loaded.
 - `swap_on_conflict` alone (without `mandatory_one`) is useful for optional appearance types where only one option makes sense at a time (e.g. facial hair style).
 - `random_chance` and `mandatory_one` are mutually exclusive in intent: a type should use one or the other, not both.

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -499,13 +499,21 @@ struct mutation_category_trait {
         LUA_TYPE_OPS( mutation_category_trait, id );
 };
 
+struct mutation_type_default {
+    std::string type_id;
+    trait_id trait;
+};
+
 void load_mutation_type( const JsonObject &jsobj );
 void reset_mutation_types();
+auto mutation_type_check_consistency() -> void;
 bool mutation_category_is_valid( const mutation_category_id &cat );
 bool mutation_type_exists( const std::string &id );
 bool mutation_type_is_mandatory( const std::string &id );
 bool mutation_type_swaps_on_conflict( const std::string &id );
 int mutation_type_random_chance( const std::string &id );
+auto mutation_type_display_name( const std::string &id ) -> std::string;
+auto get_default_mutations_for_types() -> std::vector<mutation_type_default>;
 std::vector<std::string> get_all_mutation_type_ids();
 std::vector<trait_id> get_mutations_in_types( const std::set<std::string> &ids );
 std::vector<trait_id> get_mutations_in_type( const std::string &id );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -591,6 +591,8 @@ static void check_consistency( const std::vector<trait_id> &mvec, const trait_id
 
 void mutation_branch::check_consistency()
 {
+    mutation_type_check_consistency();
+
     for( const auto &mdata : get_all() ) {
         const auto &mid = mdata.id;
         const std::optional<scenttype_id> &s_id = mdata.scent_typeid;

--- a/src/mutation_type.cpp
+++ b/src/mutation_type.cpp
@@ -1,23 +1,42 @@
 #include "mutation.h" // IWYU pragma: associated
 
+#include <map>
+#include <ranges>
+#include <string>
+#include <vector>
+
+#include "debug.h"
 #include "json.h"
+#include "translations.h"
+
+namespace
+{
+
+namespace views = std::views;
+using std::ranges::to;
 
 struct mutation_type {
     std::string id;
     bool mandatory_one = false;
     bool swap_on_conflict = false;
     int random_chance = 0;
+    trait_id default_trait = trait_id::NULL_ID();
 };
 
-std::map<std::string, mutation_type> mutation_types;
+auto mutation_types = std::map<std::string, mutation_type> {};
+
+} // namespace
 
 void load_mutation_type( const JsonObject &jsobj )
 {
-    mutation_type new_type;
+    auto new_type = mutation_type{};
     new_type.id = jsobj.get_string( "id" );
     new_type.mandatory_one = jsobj.get_bool( "mandatory_one", false );
     new_type.swap_on_conflict = jsobj.get_bool( "swap_on_conflict", false );
     new_type.random_chance = jsobj.get_int( "random_chance", 0 );
+    if( jsobj.has_string( "default_trait" ) ) {
+        new_type.default_trait = trait_id( jsobj.get_string( "default_trait" ) );
+    }
 
     mutation_types[new_type.id] = new_type;
 }
@@ -25,6 +44,20 @@ void load_mutation_type( const JsonObject &jsobj )
 void reset_mutation_types()
 {
     mutation_types.clear();
+}
+
+auto mutation_type_check_consistency() -> void
+{
+    auto types_with_defaults = mutation_types | views::values
+    | views::filter( []( const auto & type ) { return type.default_trait != trait_id::NULL_ID(); } );
+    for( const auto &type : types_with_defaults ) {
+        if( !type.default_trait.is_valid() ) {
+            debugmsg( "mutation type %s uses undefined default trait %s", type.id, type.default_trait.c_str() );
+        } else if( !type.default_trait->types.contains( type.id ) ) {
+            debugmsg( "mutation type %s uses default trait %s that does not belong to that type", type.id,
+                      type.default_trait.c_str() );
+        }
+    }
 }
 
 bool mutation_type_exists( const std::string &id )
@@ -48,6 +81,30 @@ int mutation_type_random_chance( const std::string &id )
 {
     auto it = mutation_types.find( id );
     return it != mutation_types.end() ? it->second.random_chance : 0;
+}
+
+auto mutation_type_display_name( const std::string &id ) -> std::string
+{
+    if( id == "skin_tone" ) {
+        return _( "skin color" );
+    } else if( id == "eye_color" ) {
+        return _( "eye color" );
+    } else if( id == "hair_style" ) {
+        return _( "hair style" );
+    } else if( id == "hair_color" ) {
+        return _( "hair color" );
+    }
+    return id;
+}
+
+auto get_default_mutations_for_types() -> std::vector<mutation_type_default>
+{
+    auto defaults = mutation_types | views::values
+    | views::filter( []( const auto & type ) { return type.default_trait != trait_id::NULL_ID(); } )
+    | views::transform( []( const auto & type ) {
+        return mutation_type_default{ .type_id = type.id, .trait = type.default_trait };
+    } );
+    return defaults | to<std::vector>();
 }
 
 std::vector<std::string> get_all_mutation_type_ids()

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1480,11 +1480,11 @@ tab_direction set_traits( avatar &u, points_left &points )
                     popup( _( "Your profession of %s prevents you from removing this trait." ),
                            u.prof->gender_appropriate_name( u.male ) );
                 } else {
-                    const bool is_mandatory = std::ranges::any_of( cur_trait.obj().types,
+                    const auto mandatory_type = std::ranges::find_if( cur_trait.obj().types,
                     []( const auto & t ) { return mutation_type_is_mandatory( t ); } );
-                    if( is_mandatory ) {
+                    if( mandatory_type != cur_trait.obj().types.end() ) {
                         inc_type = 0;
-                        popup( _( "You must have a trait of this type." ) );
+                        popup( _( "You need to select 1 %s." ), mutation_type_display_name( *mandatory_type ) );
                     }
                 }
             } else if( newcharacter::has_conflicting_trait( u, cur_trait ) ) {
@@ -4035,6 +4035,23 @@ trait_id Character::get_random_trait( const std::function<bool( const mutation_b
     return random_entry( vTraits );
 }
 
+
+auto newcharacter::add_default_mutation_type_traits( Character &ch ) -> void
+{
+    for( const auto &default_mutation : get_default_mutations_for_types() ) {
+        const auto mutations = get_mutations_in_type( default_mutation.type_id );
+        const auto has_mutation_type = std::ranges::any_of( mutations, [&]( const auto & trait ) {
+            return ch.has_trait( trait );
+        } );
+        if( !has_mutation_type && default_mutation.trait.is_valid() ) {
+            if( ch.has_base_trait( default_mutation.trait ) ) {
+                ch.set_mutation( default_mutation.trait );
+            } else {
+                ch.toggle_trait( default_mutation.trait );
+            }
+        }
+    }
+}
 
 void Character::randomize_cosmetic_trait( std::string mutation_type )
 {

--- a/src/newcharacter.h
+++ b/src/newcharacter.h
@@ -43,6 +43,8 @@ trait_id random_bad_trait();
  */
 void add_traits( Character &ch );
 void add_traits( Character &ch, points_left &points );
+/** Adds configured default mutation traits when their mutation type is missing. */
+auto add_default_mutation_type_traits( Character &ch ) -> void;
 
 /** Returns true if character has a conflicting trait to the bionic. */
 bool bionic_has_conflict( const Character &ch, const bionic_id &b );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -85,6 +85,7 @@
 #include "morale_types.h"
 #include "mtype.h"
 #include "mutation.h"
+#include "newcharacter.h"
 #include "npc.h"
 #include "npc_class.h"
 #include "options.h"
@@ -693,6 +694,7 @@ void Character::load( const JsonObject &data )
             }
         }
     }
+    newcharacter::add_default_mutation_type_traits( *this );
     recalculate_size();
 
     data.read( "my_bionics", *my_bionics );

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -18,6 +18,7 @@
 #include "item.h"
 #include "item_contents.h"
 #include "itype.h"
+#include "mutation.h"
 #include "newcharacter.h"
 #include "pldata.h"
 #include "profession.h"
@@ -100,6 +101,31 @@ struct less<failure> {
 // TODO: According to profiling (interrupt, backtrace, wait a few seconds, repeat) with a sample
 // size of 20, 70% of the time is due to the call to Character::set_mutation in try_set_traits.
 // When the mutation stuff isn't commented out, the test takes 110 minutes (not a typo)!
+
+TEST_CASE( "skin_tone_is_mandatory_with_default", "[new_character][traits]" )
+{
+    clear_all_state();
+
+    const auto skin_tone = std::string( "skin_tone" );
+    const auto skin_lighter = trait_id( "SKIN_LIGHTER" );
+
+    CHECK( mutation_type_exists( skin_tone ) );
+    CHECK( mutation_type_is_mandatory( skin_tone ) );
+    CHECK( mutation_type_swaps_on_conflict( skin_tone ) );
+    CHECK( mutation_type_random_chance( skin_tone ) == 0 );
+
+    const auto defaults = get_default_mutations_for_types();
+    CHECK( std::ranges::any_of( defaults, [&]( const auto & default_mutation ) {
+        return default_mutation.type_id == skin_tone && default_mutation.trait == skin_lighter;
+    } ) );
+
+    auto ch = get_sanitized_player();
+    ch.clear_mutations();
+    newcharacter::add_default_mutation_type_traits( ch );
+
+    CHECK( ch.has_base_trait( skin_lighter ) );
+    CHECK( ch.has_trait( skin_lighter ) );
+}
 
 TEST_CASE( "starting_items", "[slow]" )
 {


### PR DESCRIPTION
## Purpose of change (The Why)

Old character presets can lack `skin_tone` and used the default lighter skin color. After skin tone became mandatory, selecting a skin tone made those presets unable to return to their previous visible color.

Related: #8026, #8372

## Describe the solution (The How)

Add `SKIN_LIGHTER` as the default skin tone. Add `default_trait` support to mutation types so loaded characters/templates missing a mandatory appearance type receive the configured fallback. Improve the removal error to name the required appearance type.

## Testing

- `cmake --preset linux-full`
- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target style-json-parallel`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "skin_tone_is_mandatory_with_default"`
- `./build-scripts/lint-json.sh`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked relevant PRs; no issue to close.

<sup>PR opened by gpt-5.1 high on pi</sup>
