### PR TITLE
test: stabilize adjacent vehicle cargo pickup

### DIFF
--- a/tests/pickup_test.cpp
+++ b/tests/pickup_test.cpp
@@ -59,6 +59,7 @@ TEST_CASE( "nearby pickup finds adjacent vehicle cargo", "[pickup][vehicle]" )
     const std::optional<vpart_reference> cargo = here.veh_at( cart_pos ).part_with_feature( "CARGO",
             true );
     REQUIRE( cargo );
+    cargo->vehicle().get_items( cargo->part_index() ).clear();
     REQUIRE_FALSE( cargo->vehicle().add_item( cargo->part(), item::spawn( "jeans" ) ) );
 
     const auto pickup_items = pickup::nearby_items_for_pickup( center );


### PR DESCRIPTION
## Purpose of change (The Why)

Related to #8819.

The adjacent vehicle cargo pickup test used a shopping cart that can spawn random `trash_cart` cargo, making the expected item count nondeterministic.

## Describe the solution (The How)

Clear generated vehicle cargo before inserting the fixture item.

## Testing

- `cmake --preset linux-full`
- `cmake --build --preset linux-full --target astyle`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "nearby pickup finds adjacent vehicle cargo"`
- `for seed in $(seq 1 20); do ./out/build/linux-full/tests/cata_test-tiles "nearby pickup finds adjacent vehicle cargo" --rng-seed "$seed" >/tmp/pickup-seed-$seed.log || { cat /tmp/pickup-seed-$seed.log; exit 1; }; done`
- `./out/build/linux-full/tests/cata_test-tiles "[pickup]"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked the relevant PR.

<sup>PR opened by gpt-5.1 high on pi</sup>
