### PR TITLE
ci: merge autofix workflow jobs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,34 @@
 src:
-  - src/**/*
+  - changed-files:
+      - any-glob-to-any-file: src/**/*
 
 tests:
-  - tests/**/*
+  - changed-files:
+      - any-glob-to-any-file: tests/**/*
 
 JSON:
-  - data/**/*
+  - changed-files:
+      - any-glob-to-any-file: data/**/*
 
 mods:
-  - data/mods/**/*
+  - changed-files:
+      - any-glob-to-any-file: data/mods/**/*
 
 translation:
-  - lang/**/*
+  - changed-files:
+      - any-glob-to-any-file: lang/**/*
 
 docs:
-  - docs/**/*
+  - changed-files:
+      - any-glob-to-any-file: docs/**/*
 
 scripts:
-  - scripts/**/*
+  - changed-files:
+      - any-glob-to-any-file: scripts/**/*
 
 lua:
-  - "**/*.lua"
-  - src/catalua*.cpp
-  - src/catalua*.h
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.lua"
+          - src/catalua*.cpp
+          - src/catalua*.h

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,14 +25,17 @@ env:
 jobs:
   autofix:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
 
     steps:
       - uses: actions/checkout@v4
 
-      - run: sudo apt-get install astyle ninja-build gettext ccache
+      - env: { DEBIAN_FRONTEND: noninteractive }
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends astyle cmake ninja-build gettext ccache
 
       - uses: denoland/setup-deno@v2
         with: { cache: true }
@@ -95,29 +98,26 @@ jobs:
           deno test --allow-read --allow-env=npm_package_config_libvips,TILESET_PYTHON --allow-ffi
           deno run --allow-read --allow-write scripts/semantic.ts
 
-  validate-pr-title:
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      ( github.event.action == 'opened' || github.event.action == 'edited' || github.event.action == 'reopened' )
+  lint:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      pull-requests: write
       issues: write
+      pull-requests: write
 
     steps:
-      - uses: scarf005/conventional-prs@v0.5.1
+      - if: >-
+          github.event.action == 'opened' ||
+          github.event.action == 'edited' ||
+          github.event.action == 'reopened'
+        uses: scarf005/conventional-prs@v0.5.1
 
-  reject-main-branch-pr:
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      ( github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' )
-    runs-on: ubuntu-slim
-    permissions: { issues: write, pull-requests: write }
-
-    steps:
       - name: Comment and close pull request
-        if: github.event.pull_request.head.ref == github.event.repository.default_branch
+        if: >-
+          always() &&
+          ( github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' ) &&
+          github.event.pull_request.head.ref == github.event.repository.default_branch
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
           body="$(cat <<\BODY
@@ -146,16 +146,9 @@ jobs:
             --comment "$body"
           exit 1
 
-  label-pr:
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      ( github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' )
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
       - uses: actions/labeler@v6
+        if: >-
+          always() &&
+          ( github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #8819.
apparently running 4 jobs in 1 workflow isn't any faster

## Describe the solution (The How)

- Split `autofix.yml` into `autofix` and `lint` jobs with separate permissions.
- Run autofix on `ubuntu-slim` and install missing formatter dependencies with apt.
- Update `.github/labeler.yml` to the `actions/labeler@v6` config format.

## Testing

- `actionlint -ignore SC2086 .github/workflows/autofix.yml`
- `git diff --check`

## Notes

The failing `pull_request_target` labeler run uses the base-branch labeler config during the v6 config transition.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the relevant workflow validation.
- [x] I linked the related PR.

<sup>PR opened by gpt-5.1 high on pi</sup>

