### PR TITLE
build: improve MSVC build speed

### DIFF
--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -93,7 +93,7 @@ jobs:
         uses: lukka/run-vcpkg@main
         id: runvcpkg
         with:
-          vcpkgDirectory: "${{ runner.workspace }}/b/vcpkg"
+          vcpkgDirectory: "${{ github.workspace }}/../b/vcpkg"
 
       - name: Integrate vcpkg
         run: |
@@ -114,7 +114,7 @@ jobs:
             msvc-cmake-windows-tiles-sounds-x64-msvc-${{ github.ref_name }}
             msvc-cmake-windows-tiles-sounds-x64-msvc-main
             msvc-cmake-windows-tiles-sounds-x64-msvc-
-          max-size: 500M
+          max-size: 1G
           verbose: 2
           save: ${{ github.event_name != 'pull_request' }}
 
@@ -123,6 +123,7 @@ jobs:
           echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $env:GITHUB_ENV
           echo "CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros,pch_defines" >> $env:GITHUB_ENV
           echo "CCACHE_NOHASHDIR=1" >> $env:GITHUB_ENV
+          echo "CCACHE_COMPILERCHECK=content" >> $env:GITHUB_ENV
 
       # build-scripts/windows-tiles-sounds-x64-msvc.cmake (CMAKE_PROJECT_INCLUDE_BEFORE)
       # bootstraps the MSVC toolchain via VsDevCmd.bat if not already in a VS environment,

--- a/build-scripts/MSVC.cmake
+++ b/build-scripts/MSVC.cmake
@@ -35,11 +35,13 @@ C++ flags used by all builds:
 
 Additional C++ flags used by RelWithDebInfo builds:
 
+/Z7  Generate embedded CodeView debug information
 /Ob1 Inline Function Expansion (1 = only when marked as such)
 /Oi  Generate Intrinsic Functions
 
 Linker flags used by all builds:
 
+/DEBUG is only used for Debug and RelWithDebInfo builds.
 /OPT:REF  remove unreferenced COMDATs
 /OPT:ICF  folds identical COMDATs
 /DYNAMICBASE  does this app really need ASLR ?
@@ -49,6 +51,8 @@ No need to force /TLBID:1 because is default
 #]=======================================================================]
 
 # Path has changed, so this configure run will find cl.exe
+set(CMAKE_POLICY_DEFAULT_CMP0141 NEW)
+set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 set(CMAKE_C_COMPILER   cl.exe)
 set(CMAKE_CXX_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_CXX_FLAGS_INIT "\
@@ -56,8 +60,7 @@ set(CMAKE_CXX_FLAGS_INIT "\
 /wd4068 /wd4146 /wd4819 /wd6237 /wd6319 /wd26444 /wd26451 /wd26495 /WX- /W1 \
 /TP /Zc:forScope /Zc:inline /Zc:wchar_t"
 )
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "/Zi /Oi")
-set(CMAKE_CXX_FLAGS_RELEASE_INIT "/Zi")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "/Oi")
 add_compile_definitions(
     _SCL_SECURE_NO_WARNINGS
     _CRT_SECURE_NO_WARNINGS
@@ -66,7 +69,7 @@ add_compile_definitions(
     USE_VCPKG
 )
 add_link_options(
-    /DEBUG
+    "$<$<CONFIG:Debug,RelWithDebInfo>:/DEBUG>"
     /OPT:REF
     /OPT:ICF
     /LTCG:OFF

--- a/build-scripts/windows-tiles-sounds-x64-msvc.cmake
+++ b/build-scripts/windows-tiles-sounds-x64-msvc.cmake
@@ -50,7 +50,6 @@ find_program(CCACHE_EXE ccache)
 if(CCACHE_EXE)
     set(CMAKE_C_COMPILER_LAUNCHER   ccache)
     set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
-    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 endif()
 
 # Automatic gettext setup for Windows


### PR DESCRIPTION
## Purpose of change (The Why)

Related: #8819

The Windows MSVC PR job spends most of its time compiling, but ccache previously reported `0 / 599` cacheable compiler calls. ccache 4.9 rejects MSVC `/Zi` and `/ZI`, while `/Z7` is supported.[^ccache-zi]

## Describe the solution (The How)

Keep the job as `RelWithDebInfo` so reviewer artifacts remain useful, while making the compiler invocations cacheable:

- use CMake's MSVC debug information abstraction with `Embedded`, which maps to `/Z7`[^cmake-debug-format]
- stop forcing `/Zi` through `CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT` and `CMAKE_CXX_FLAGS_RELEASE_INIT`
- only pass linker `/DEBUG` for Debug/RelWithDebInfo, since `/DEBUG` emits the executable PDB[^msvc-debug]
- increase the MSVC ccache size and use `CCACHE_COMPILERCHECK=content`, which asks ccache to hash compiler contents instead of relying on timestamp/size checks[^ccache-compiler-check]

I verified `/MP` while reviewing this: it is not the ccache blocker here. Microsoft documents `/MP` as a compiler-side parallelism option for source files on the command line,[^msvc-mp] and ccache 4.9 handles `/MP` as an MSVC compiler-only argument.[^ccache-mp] This PR leaves `/MP` unchanged and fixes the documented `/Zi` cacheability problem instead.

## Testing

- `actionlint .github/workflows/msvc-full-features-cmake.yml`
- `git diff --check`
- `distrobox enter fedora -- fish -lc 'cmake --version; cmake --help-policy CMP0141 >/dev/null'`
- Previous Windows MSVC CI attempt passed after the cacheability changes: ccache reported `597 / 599` cacheable calls and `0` unsupported compiler options

[^ccache-zi]: https://github.com/ccache/ccache/blob/v4.9/src/argprocessing.cpp#L1241-L1247
[^cmake-debug-format]: https://cmake.org/cmake/help/latest/prop_tgt/MSVC_DEBUG_INFORMATION_FORMAT.html
[^msvc-debug]: https://learn.microsoft.com/en-us/cpp/build/reference/debug-generate-debug-info?view=msvc-170
[^ccache-compiler-check]: https://ccache.dev/manual/4.9.html#config_compiler_check
[^msvc-mp]: https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=msvc-170
[^ccache-mp]: https://github.com/ccache/ccache/blob/v4.9/src/argprocessing.cpp#L669-L672

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the relevant formatting/validation commands.
- [x] No closing issue.

<sup>PR opened by gpt-5.4 high on pi</sup>
