### PR TITLE
feat(balance): add recipe for explosive slugs and .50 raufoss, add improvised 40mm explosive ammo

### DIFF
--- a/data/json/items/ammo/40x46mm.json
+++ b/data/json/items/ammo/40x46mm.json
@@ -140,5 +140,23 @@
     "proportional": { "recoil": 1.2 },
     "casing": "40x46mm_m199_casing",
     "extend": { "effects": [ "SHOT" ] }
+  },
+  {
+    "id": "40x46mm_makeshift_he",
+    "copy-from": "40x46mm_m433",
+    "type": "AMMO",
+    "name": { "str": "improvised 40x46mm HE" },
+    "description": "A high velocity 40x46mm HEDP grenade, loaded with a homemade explosive round.  Packs quite a punch, though less effective against armor than proper HEDP.",
+    "proportional": { "price_postapoc": 0.8, "damage": { "damage_type": "bullet", "amount": 0.6, "armor_penetration": 0.4 } },
+    "extend": { "effects": [ "EXPLOSIVE" ] },
+    "delete": { "effects": [ "FRAG" ] }
+  },
+  {
+    "id": "40x46mm_makeshift_he_m199",
+    "copy-from": "40x46mm_makeshift_he",
+    "type": "AMMO",
+    "name": { "str": "improvised 40x46mm HE" },
+    "description": "A low velocity 40x46mm grenade, with a homemade high explosive round, loaded into the M199 casing used by M576 buckshot shells.  No less effective than any other improvised explosive 40x46mm round.",
+    "casing": "40x46mm_m199_casing"
   }
 ]

--- a/data/json/items/ammo/40x53mm.json
+++ b/data/json/items/ammo/40x53mm.json
@@ -72,5 +72,15 @@
     "damage": { "damage_type": "bullet", "amount": 104, "armor_penetration": 46 },
     "proportional": { "recoil": 1.4 },
     "casing": "40x53mm_m169_casing"
+  },
+  {
+    "id": "40x53mm_makeshift_he",
+    "copy-from": "40x53mm_m430a1",
+    "type": "AMMO",
+    "name": { "str": "improvised 40x53mm HE" },
+    "description": "A high velocity 40x53mm HEDP grenade, loaded with a homemade explosive round.  Packs quite a punch, though less effective against armor than proper HEDP.",
+    "proportional": { "price_postapoc": 0.8, "damage": { "damage_type": "bullet", "amount": 0.6, "armor_penetration": 0.4 } },
+    "extend": { "effects": [ "EXPLOSIVE" ] },
+    "delete": { "effects": [ "FRAG" ] }
   }
 ]

--- a/data/json/items/ammo/50.json
+++ b/data/json/items/ammo/50.json
@@ -61,12 +61,26 @@
     "name": { "str": ".50 BMG Raufoss Mk 211" },
     "price": "600 USD",
     "price_postapoc": "75 USD",
-    "description": "This variant of the .50 BMG round makes the most of the caliber's potential payload delivery: the tip is loaded with an incendiary mix, which ignites on impact, detonating the RDX or PETN charge.  This also ignites a secondary zirconium powder incendiary charge that surrounds a tungsten carbide penetrator, both encased by a mild steel cup.  Fragments from the cup and burning metallic powder follow the penetrator through armored targets, increasing lethality.  These rare, complicated, and expensive rounds are not likely to be manufactured again; use them wisely.",
+    "description": "This variant of the .50 BMG round makes the most of the caliber's potential payload delivery: the tip is loaded with an incendiary mix, which ignites on impact, detonating the RDX or PETN charge.  This also ignites a secondary zirconium powder incendiary charge that surrounds a tungsten carbide penetrator, both encased by a mild steel cup.  Fragments from the cup and burning metallic powder follow the penetrator through armored targets, increasing lethality.",
     "//": "NO_PENETRATE_OBSTACLES so it detonates on impact",
     "effects": [ "INCENDIARY", "EXPLOSIVE_BIG", "NO_PENETRATE_OBSTACLES" ],
     "//2": "mk 211 is estimated to be as effective as 20mm, which would have 65kJ energy, or 255 damage. ~181 damage is fair.",
     "relative": { "damage": { "damage_type": "bullet", "amount": 50, "armor_penetration": 25 } },
     "dispersion": 100
+  },
+  {
+    "id": "bp_50_mk211",
+    "copy-from": "50_mk211",
+    "type": "AMMO",
+    "name": { "str": ".50 BMG Raufoss Mk 211, black powder" },
+    "proportional": {
+      "price": 0.5,
+      "price_postapoc": 0.5,
+      "damage": { "damage_type": "bullet", "amount": 0.8, "armor_penetration": 0.5 },
+      "recoil": 0.76,
+      "dispersion": 1.2
+    },
+    "extend": { "effects": [ "RECYCLED", "BLACKPOWDER", "MUZZLE_SMOKE" ] }
   },
   {
     "id": "bp_50_incendiary",

--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -159,10 +159,23 @@
     "description": "A shotgun shell shooting a small explosive.  Damaging, but rather inaccurate and short ranged.  Banned in several states.",
     "price": "30 USD",
     "price_postapoc": "16 USD",
-    "//2": "currently can't be crafted",
     "count": 5,
     "damage": { "damage_type": "bullet", "amount": 30, "armor_penetration": 10 },
     "extend": { "effects": [ "EXPLOSIVE", "NO_PENETRATE_OBSTACLES" ] }
+  },
+  {
+    "id": "bp_shot_he",
+    "copy-from": "shot_he",
+    "type": "AMMO",
+    "name": { "str": "explosive slug, black powder" },
+    "proportional": {
+      "price": 0.5,
+      "price_postapoc": 0.5,
+      "damage": { "damage_type": "bullet", "amount": 0.8 },
+      "recoil": 0.76,
+      "dispersion": 1.2
+    },
+    "extend": { "effects": [ "RECYCLED", "MUZZLE_SMOKE" ] }
   },
   {
     "id": "shot_scrap",

--- a/data/json/recipes/ammo/launcher.json
+++ b/data/json/recipes/ammo/launcher.json
@@ -65,6 +65,30 @@
     ]
   },
   {
+    "result": "40x53mm_makeshift_he",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_LAUNCHER",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "skills_required": [ "launcher", 2 ],
+    "time": "10 m",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "recipe_bullets", 4 ], [ "manual_shotgun", 4 ], [ "textbook_launcher", 4 ] ],
+    "charges": 1,
+    "reversible": true,
+    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 16 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CASING_PRESSING", "level": 2 } ],
+    "components": [
+      [ [ "paper", 1 ], [ "wax", 1 ] ],
+      [ [ "military_explosive", 4, "LIST" ], [ "stable_explosive", 4, "LIST" ] ],
+      [ [ "gunpowder", 35 ] ],
+      [ [ "impact_fuze", 1 ] ],
+      [ [ "40x53mm_m169_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ]
+    ]
+  },
+  {
     "result": "40x46mm_buckshot_m118",
     "type": "recipe",
     "category": "CC_AMMO",
@@ -193,6 +217,54 @@
       [ [ "gunpowder", 30 ] ],
       [ [ "40x46mm_m199_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ]
+    ]
+  },
+  {
+    "result": "40x46mm_makeshift_he",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_LAUNCHER",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "skills_required": [ "launcher", 2 ],
+    "time": "10 m",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "recipe_bullets", 4 ], [ "manual_shotgun", 4 ], [ "textbook_launcher", 4 ] ],
+    "charges": 1,
+    "reversible": true,
+    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 12 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CASING_PRESSING", "level": 2 } ],
+    "components": [
+      [ [ "paper", 1 ], [ "wax", 1 ] ],
+      [ [ "military_explosive", 3, "LIST" ], [ "stable_explosive", 3, "LIST" ] ],
+      [ [ "gunpowder", 30 ] ],
+      [ [ "impact_fuze", 1 ] ],
+      [ [ "40x46mm_m118_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ]
+    ]
+  },
+  {
+    "result": "40x46mm_makeshift_he_m199",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_LAUNCHER",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "skills_required": [ "launcher", 2 ],
+    "time": "10 m",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "recipe_bullets", 4 ], [ "manual_shotgun", 4 ], [ "textbook_launcher", 4 ] ],
+    "charges": 1,
+    "reversible": true,
+    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 12 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CASING_PRESSING", "level": 2 } ],
+    "components": [
+      [ [ "paper", 1 ], [ "wax", 1 ] ],
+      [ [ "military_explosive", 3, "LIST" ], [ "stable_explosive", 3, "LIST" ] ],
+      [ [ "gunpowder", 30 ] ],
+      [ [ "impact_fuze", 1 ] ],
+      [ [ "40x46mm_m199_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ]
     ]
   },
   {

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -565,6 +565,54 @@
     ]
   },
   {
+    "result": "50_mk211",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_RIFLE",
+    "skill_used": "fabrication",
+    "difficulty": 8,
+    "skills_required": [ "gun", 7 ],
+    "time": "2 m",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "recipe_bullets", 6 ] ],
+    "charges": 1,
+    "reversible": true,
+    "using": [ [ "rifle_bullet_forming", 9 ], [ "ammo_bullet", 6 ] ],
+    "components": [
+      [ [ "50_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 30 ] ],
+      [ [ "copper", 6 ] ],
+      [ [ "military_explosive", 4, "LIST" ], [ "stable_explosive", 4, "LIST" ] ],
+      [ [ "incendiary", 20 ] ],
+      [ [ "impact_fuze", 1 ] ]
+    ]
+  },
+  {
+    "result": "bp_50_mk211",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_RIFLE",
+    "skill_used": "fabrication",
+    "difficulty": 8,
+    "skills_required": [ "gun", 7 ],
+    "time": "2 m",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "recipe_bullets", 6 ] ],
+    "charges": 1,
+    "reversible": true,
+    "using": [ [ "rifle_bullet_forming", 9 ], [ "ammo_bullet", 6 ] ],
+    "components": [
+      [ [ "50_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 30 ] ],
+      [ [ "copper", 6 ] ],
+      [ [ "military_explosive", 4, "LIST" ], [ "stable_explosive", 4, "LIST" ] ],
+      [ [ "incendiary", 20 ] ],
+      [ [ "impact_fuze", 1 ] ]
+    ]
+  },
+  {
     "result": "bp_50bmg",
     "type": "recipe",
     "category": "CC_AMMO",

--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -556,5 +556,43 @@
     "reversible": true,
     "book_learn": [ [ "recipe_bullets", 2 ], [ "manual_shotgun", 2 ] ],
     "components": [ [ [ "pebble", 10 ] ], [ [ "paper", 1 ] ] ]
+  },
+  {
+    "result": "shot_he",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_SHOT",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "skills_required": [ "gun", 1 ],
+    "time": "2 m",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "textbook_anarch", 4 ], [ "recipe_bullets", 3 ], [ "manual_shotgun", 3 ] ],
+    "charges": 1,
+    "using": [ [ "shot_forming", 1 ], [ "ammo_shot", 1 ] ],
+    "components": [
+      [ [ "gunpowder", 3 ] ],
+      [ [ "military_explosive", 3, "LIST" ], [ "stable_explosive", 3, "LIST" ] ],
+      [ [ "impact_fuze", 1 ] ]
+    ]
+  },
+  {
+    "result": "bp_shot_he",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_SHOT",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "skills_required": [ "gun", 1 ],
+    "time": "2 m",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "textbook_anarch", 4 ], [ "recipe_bullets", 3 ], [ "manual_shotgun", 3 ] ],
+    "charges": 1,
+    "using": [ [ "shot_forming", 1 ], [ "ammo_shot", 1 ] ],
+    "components": [
+      [ [ "chem_black_powder", 3 ] ],
+      [ [ "military_explosive", 3, "LIST" ], [ "stable_explosive", 3, "LIST" ] ],
+      [ [ "impact_fuze", 1 ] ]
+    ]
   }
 ]

--- a/data/json/uncraft/ammo/50bmg.json
+++ b/data/json/uncraft/ammo/50bmg.json
@@ -15,23 +15,5 @@
       [ [ "copper", 6 ] ]
     ],
     "charges": 1
-  },
-  {
-    "result": "50_mk211",
-    "type": "uncraft",
-    "skill_used": "fabrication",
-    "difficulty": 8,
-    "skills_required": [ "gun", 7 ],
-    "time": "2 m",
-    "qualities": [ { "id": "PULL", "level": 2 } ],
-    "components": [
-      [ [ "lead", 15 ] ],
-      [ [ "chem_rdx", 20 ] ],
-      [ [ "50_casing", 1 ] ],
-      [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 30 ] ],
-      [ [ "copper", 6 ] ]
-    ],
-    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/shot.json
+++ b/data/json/uncraft/ammo/shot.json
@@ -58,12 +58,35 @@
     "type": "uncraft",
     "result": "shot_he",
     "skill_used": "fabrication",
-    "difficulty": 2,
+    "difficulty": 3,
     "skills_required": [ "gun", 1 ],
     "time": "10 s",
     "//": "A little more carefully...",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "chem_rdx", 15 ] ] ],
+    "components": [
+      [ [ "shot_hull", 1 ] ],
+      [ [ "shotgun_primer", 1 ] ],
+      [ [ "gunpowder", 3 ] ],
+      [ [ "chem_compositionb", 24 ] ],
+      [ [ "impact_fuze", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "type": "uncraft",
+    "result": "bp_shot_he",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "skills_required": [ "gun", 1 ],
+    "time": "10 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [
+      [ [ "shot_hull", 1 ] ],
+      [ [ "shotgun_primer", 1 ] ],
+      [ [ "chem_black_powder", 3 ] ],
+      [ [ "chem_compositionb", 24 ] ],
+      [ [ "impact_fuze", 1 ] ]
+    ],
     "charges": 1
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

We have craftable explosive arrows, and we have explosive tank/IFV rounds. Might as well add some in-between options.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Adds makeshift high explosive ammo for 40x46mm and 40x53mm, along with associated recipes.
2. Added a recipe for explosive slugs, along with a blackpowder variant.
3. Adjusted uncraft recipe for explosive shells accordingly, bumping it up a bit in difficulty and including an impact fuze.
4. Added recipe for .50 raufoss rounds, and added a blackpowder variant.
5. Misc: Removed uncraft for raufoss since rifle recipes are all currently reversible.

## Describe alternatives you've considered

1. Phasing out the multiple different 40x46mm cases in favor of making them generic.
2. Converting more ammo to use uncrafts instead of reversible recipes since we evidently want to use that more now, at least until we finally get it so ammo can remember what it was made out of.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
