### PR TITLE
fix: balance encumbrance on wearing sided worn items

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4729,15 +4729,19 @@ void item::on_wear( Character &who )
             int lhs = 0;
             int rhs = 0;
             set_side( side::LEFT );
-            const char_encumbrance_data left_enc = who.get_encumbrance( *this );
+            const char_encumbrance_data left_enc = who.get_encumbrance();
             for( const bodypart_id &bp : all_bps ) {
-                lhs += left_enc.elems.at( bp.id() ).encumbrance;
+                if( get_covered_body_parts().test( bp.id() ) ) {
+                    lhs += left_enc.elems.at( bp.id() ).encumbrance;
+                }
             }
 
             set_side( side::RIGHT );
-            const char_encumbrance_data right_enc = who.get_encumbrance( *this );
+            const char_encumbrance_data right_enc = who.get_encumbrance();
             for( const bodypart_id &bp : all_bps ) {
-                rhs += right_enc.elems.at( bp.id() ).encumbrance;
+                if( get_covered_body_parts().test( bp.id() ) ) {
+                    rhs += right_enc.elems.at( bp.id() ).encumbrance;
+                }
             }
 
             set_side( lhs <= rhs ? side::LEFT : side::RIGHT );


### PR DESCRIPTION
## Purpose of change (The Why)
resolves #8833 

## Describe the solution (The How)
Dont iterate over every bodypart, only the one the armor is on
Compare left to right then

## Describe alternatives you've considered
None

## Testing
Couldn't replicate issue
Note: seems to be scrungly at times

## Additional context
I scrungle

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.