### PR TITLE
build: reverts "build: improve MSVC build speed"

### DIFF
--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -93,7 +93,7 @@ jobs:
         uses: lukka/run-vcpkg@main
         id: runvcpkg
         with:
-          vcpkgDirectory: "${{ github.workspace }}/../b/vcpkg"
+          vcpkgDirectory: "${{ runner.workspace }}/b/vcpkg"
 
       - name: Integrate vcpkg
         run: |
@@ -114,7 +114,7 @@ jobs:
             msvc-cmake-windows-tiles-sounds-x64-msvc-${{ github.ref_name }}
             msvc-cmake-windows-tiles-sounds-x64-msvc-main
             msvc-cmake-windows-tiles-sounds-x64-msvc-
-          max-size: 1G
+          max-size: 500M
           verbose: 2
           save: ${{ github.event_name != 'pull_request' }}
 
@@ -123,7 +123,6 @@ jobs:
           echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $env:GITHUB_ENV
           echo "CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros,pch_defines" >> $env:GITHUB_ENV
           echo "CCACHE_NOHASHDIR=1" >> $env:GITHUB_ENV
-          echo "CCACHE_COMPILERCHECK=content" >> $env:GITHUB_ENV
 
       # build-scripts/windows-tiles-sounds-x64-msvc.cmake (CMAKE_PROJECT_INCLUDE_BEFORE)
       # bootstraps the MSVC toolchain via VsDevCmd.bat if not already in a VS environment,

--- a/build-scripts/MSVC.cmake
+++ b/build-scripts/MSVC.cmake
@@ -35,13 +35,11 @@ C++ flags used by all builds:
 
 Additional C++ flags used by RelWithDebInfo builds:
 
-/Z7  Generate embedded CodeView debug information
 /Ob1 Inline Function Expansion (1 = only when marked as such)
 /Oi  Generate Intrinsic Functions
 
 Linker flags used by all builds:
 
-/DEBUG is only used for Debug and RelWithDebInfo builds.
 /OPT:REF  remove unreferenced COMDATs
 /OPT:ICF  folds identical COMDATs
 /DYNAMICBASE  does this app really need ASLR ?
@@ -51,8 +49,6 @@ No need to force /TLBID:1 because is default
 #]=======================================================================]
 
 # Path has changed, so this configure run will find cl.exe
-set(CMAKE_POLICY_DEFAULT_CMP0141 NEW)
-set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 set(CMAKE_C_COMPILER   cl.exe)
 set(CMAKE_CXX_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_CXX_FLAGS_INIT "\
@@ -60,7 +56,8 @@ set(CMAKE_CXX_FLAGS_INIT "\
 /wd4068 /wd4146 /wd4819 /wd6237 /wd6319 /wd26444 /wd26451 /wd26495 /WX- /W1 \
 /TP /Zc:forScope /Zc:inline /Zc:wchar_t"
 )
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "/Oi")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "/Zi /Oi")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "/Zi")
 add_compile_definitions(
     _SCL_SECURE_NO_WARNINGS
     _CRT_SECURE_NO_WARNINGS
@@ -69,7 +66,7 @@ add_compile_definitions(
     USE_VCPKG
 )
 add_link_options(
-    "$<$<CONFIG:Debug,RelWithDebInfo>:/DEBUG>"
+    /DEBUG
     /OPT:REF
     /OPT:ICF
     /LTCG:OFF

--- a/build-scripts/windows-tiles-sounds-x64-msvc.cmake
+++ b/build-scripts/windows-tiles-sounds-x64-msvc.cmake
@@ -50,6 +50,7 @@ find_program(CCACHE_EXE ccache)
 if(CCACHE_EXE)
     set(CMAKE_C_COMPILER_LAUNCHER   ccache)
     set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 endif()
 
 # Automatic gettext setup for Windows


### PR DESCRIPTION
Reverts cataclysmbn/Cataclysm-BN#8823
/DEBUG was required to output the .pdb file, and it's removal caused nightlies to fail and windows crash logs to be useless.