### PR TITLE
fix: bloods missing vitamins

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -579,7 +579,7 @@
     "fun": -50,
     "flags": [ "IS_BLOOD" ],
     "drop_action": { "type": "emit_actor", "emits": [ "emit_drop_blood" ], "scale_qty": true },
-    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ], [ "vitA", 26 ], [ "vitC", 12 ], [ "calcium", 1 ], [ "iron", 4 ], [ "vitB", 6 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -603,7 +603,7 @@
     "fun": -50,
     "flags": [ "IS_BLOOD", "NO_COOKING_BUFF" ],
     "drop_action": { "type": "emit_actor", "emits": [ "emit_drop_blood" ], "scale_qty": true },
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "vitA", 26 ], [ "vitC", 12 ], [ "calcium", 1 ], [ "iron", 4 ], [ "vitB", 6 ] ]
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -579,7 +579,15 @@
     "fun": -50,
     "flags": [ "IS_BLOOD" ],
     "drop_action": { "type": "emit_actor", "emits": [ "emit_drop_blood" ], "scale_qty": true },
-    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ], [ "vitA", 26 ], [ "vitC", 12 ], [ "calcium", 1 ], [ "iron", 4 ], [ "vitB", 6 ] ]
+    "vitamins": [
+      [ "meat_allergen", 1 ],
+      [ "human_flesh_vitamin", 100 ],
+      [ "vitA", 26 ],
+      [ "vitC", 12 ],
+      [ "calcium", 1 ],
+      [ "iron", 4 ],
+      [ "vitB", 6 ]
+    ]
   },
   {
     "type": "COMESTIBLE",


### PR DESCRIPTION
## Purpose of change (The Why)

I noticed that blood soup doesn't give the vitamins it is supposed to, despite being theoretically a good recipe for the rather rare vitamin A
cf https://cataclysmbn-guide.com/stable/item/soup_blood
This is because `blood` and `animal_blood` don't have any vitamins

## Describe the solution (The How)

Add the vitamins to blood and animal blood to match the blood soup recipe (as close as possible with rounding differences)

## Testing

Spawn blood, it has vitamins
Craft concentrated blood, craft blood soup, it has vitamins now.
<img width="414" height="653" alt="image" src="https://github.com/user-attachments/assets/d8f217f1-a8b9-4626-9c74-a595cf80881d" />
