### PR TITLE
fix: nested recipes ignore availability when show_unavailable is set

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -344,6 +344,13 @@ auto expand_nested_recipes( std::vector<const recipe *> &out_current,
                                          opts.crafter, *nested_rec, availability_cache, opts.nested_can_craft_cache,
                                          opts.visiting_nested, opts.available_recipes, opts.show_unavailable );
         }
+        // When not showing unavailable recipes, drop leaf children the player
+        // doesn't know. Nested children are kept so we can still descend into
+        // categories whose own descendants are known.
+        if( !opts.show_unavailable && !nested_rec->is_nested() &&
+            !opts.available_recipes.contains( *nested_rec ) ) {
+            return;
+        }
         children.push_back( nested_rec );
     } );
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -249,7 +249,7 @@ auto ensure_availability( Character &crafter,
                           bool show_unavailable ) -> availability & // *NOPAD*
 {
     if( !availability_cache.contains( rec ) ) {
-        const auto known = !show_unavailable || available_recipes.contains( *rec );
+        const auto known = available_recipes.contains( *rec );
         availability_cache.emplace( rec, availability( crafter, rec, 1, known ) );
     }
     return availability_cache.at( rec );
@@ -313,7 +313,7 @@ auto expand_nested_recipes( std::vector<const recipe *> &out_current,
 {
     auto &availability_cache = opts.availability_cache;
     if( !availability_cache.contains( recp ) ) {
-        const auto known = !opts.show_unavailable || opts.available_recipes.contains( *recp );
+        const auto known = opts.available_recipes.contains( *recp );
         availability_cache.emplace( recp, availability( opts.crafter, recp, 1, known ) );
     }
 
@@ -335,7 +335,7 @@ auto expand_nested_recipes( std::vector<const recipe *> &out_current,
     std::ranges::for_each( recp->nested_category_data, [&]( const recipe_id & nested_id ) {
         const auto *nested_rec = &nested_id.obj();
         if( !availability_cache.contains( nested_rec ) ) {
-            const auto known = !opts.show_unavailable || opts.available_recipes.contains( *nested_rec );
+            const auto known = opts.available_recipes.contains( *nested_rec );
             availability_cache.emplace( nested_rec, availability( opts.crafter, nested_rec, 1, known ) );
         }
         if( nested_rec->is_nested() ) {
@@ -1050,7 +1050,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
                 for( int i = 1; i <= 50; i++ ) {
                     current.push_back( chosen );
                     available.emplace_back( crafter, chosen, i,
-                                            !show_unavailable || available_recipes.contains( *chosen ) );
+                                            available_recipes.contains( *chosen ) );
                 }
             } else {
                 std::vector<const recipe *> picking;
@@ -1180,7 +1180,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
                 for( const recipe *e : current ) {
                     if( !availability_cache.contains( e ) ) {
                         availability_cache.emplace( e, availability( crafter, e, 1,
-                                                    !show_unavailable || available_recipes.contains( *e ) ) );
+                                                    available_recipes.contains( *e ) ) );
                     }
                 }
 

--- a/tests/nested_recipe_test.cpp
+++ b/tests/nested_recipe_test.cpp
@@ -1,0 +1,48 @@
+#include "catch/catch.hpp"
+
+#include "avatar.h"
+#include "calendar.h"
+#include "inventory.h"
+#include "item.h"
+#include "player_helpers.h"
+#include "recipe.h"
+#include "recipe_dictionary.h"
+#include "state_helpers.h"
+#include "type_id.h"
+
+// Test that nested recipes correctly check if child recipes are known
+TEST_CASE( "nested_recipe_known_check", "[crafting][nested][recipe]" )
+{
+    clear_all_state();
+    avatar &dummy = get_avatar();
+    clear_character( dummy );
+
+    // backpack_hiking has difficulty 4 and autolearn: true
+    // This means it requires tailor skill 4 to be "known" via autolearn
+    const recipe *hiking_backpack = &recipe_id( "backpack_hiking" ).obj();
+
+    GIVEN( "character with no skills" ) {
+        // Ensure character has zero tailor skill
+        dummy.set_skill_level( skill_id( "tailor" ), 0 );
+
+        // Get the character's available recipes (recipes they know)
+        inventory crafting_inv = dummy.crafting_inventory();
+        const recipe_subset &available = dummy.get_available_recipes( crafting_inv );
+
+        THEN( "hiking backpack should NOT be in available recipes" ) {
+            CHECK_FALSE( available.contains( *hiking_backpack ) );
+        }
+    }
+
+    GIVEN( "character with tailor skill 4" ) {
+        // Set tailor skill to 4 (meets difficulty requirement for autolearn)
+        dummy.set_skill_level( skill_id( "tailor" ), 4 );
+
+        inventory crafting_inv = dummy.crafting_inventory();
+        const recipe_subset &available = dummy.get_available_recipes( crafting_inv );
+
+        THEN( "hiking backpack should be in available recipes" ) {
+            CHECK( available.contains( *hiking_backpack ) );
+        }
+    }
+}


### PR DESCRIPTION
## Purpose of change (The Why)

closes #8735

When "show unavailable recipes" is enabled, nested recipes incorrectly mark all child recipes as "known" regardless of whether the player has learned them. The `known` variable short-circuits to `true` whenever `show_unavailable` is `true`, skipping the actual availability check.

## Describe the solution (The How)

Removed the `!show_unavailable ||` guard from all 5 call sites in `crafting_gui.cpp`. The `show_unavailable` flag controls whether recipes are displayed, not whether they are known. The `availability` constructor handles display filtering separately.

## Describe alternatives you've considered

Could have threaded a separate `show_unavailable` parameter into the `availability` constructor, but that would conflate display logic with knowledge checks further.

## Testing

- Added `tests/nested_recipe_test.cpp` verifying recipe knowledge depends on skill level, not display settings.
- Run: `./tests/cata_test "[crafting][nested][recipe]"`
- In-game: enable "show unavailable recipes", open a nested crafting category, confirm unknown recipes show as unavailable (not craftable).

## Additional context

None.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.