### PR TITLE
fix: item UNDERSIZE message no longer displayed erroniously and size now matters on clothing with encumber = 0 and max_encumber > 0

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2547,7 +2547,7 @@ detached_ptr<item> Character::wear_item( detached_ptr<item> &&wear,
                                _( "This %s is too big to wear comfortably!  Maybe it could be refitted." ),
                                to_wear.tname() );
         } else if( size_matters && !supertinymouse && ( to_wear.has_flag( flag_UNDERSIZE ) ||
-                                        to_wear.has_flag( flag_resized_small ) ) ) {
+                   to_wear.has_flag( flag_resized_small ) ) ) {
             add_msg_if_player( m_warning,
                                _( "This %s is too small to wear comfortably!  Maybe it could be refitted." ),
                                to_wear.tname() );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2516,6 +2516,7 @@ detached_ptr<item> Character::wear_item( detached_ptr<item> &&wear,
 
     const bool was_deaf = is_deaf();
     const bool supertinymouse = get_size() == creature_size::tiny;
+    const bool size_matters = to_wear.get_sizing( *this ) != item::sizing::ignore;
     last_item = to_wear.typeId();
 
 
@@ -2540,12 +2541,12 @@ detached_ptr<item> Character::wear_item( detached_ptr<item> &&wear,
         if( !was_deaf && is_deaf() ) {
             add_msg_if_player( m_info, _( "You're deafened!" ) );
         }
-        if( supertinymouse && !to_wear.has_flag( flag_UNDERSIZE ) &&
+        if( size_matters && supertinymouse && !to_wear.has_flag( flag_UNDERSIZE ) &&
             !to_wear.has_flag( flag_resized_small ) ) {
             add_msg_if_player( m_warning,
                                _( "This %s is too big to wear comfortably!  Maybe it could be refitted." ),
                                to_wear.tname() );
-        } else if( !supertinymouse && ( to_wear.has_flag( flag_UNDERSIZE ) ||
+        } else if( size_matters && !supertinymouse && ( to_wear.has_flag( flag_UNDERSIZE ) ||
                                         to_wear.has_flag( flag_resized_small ) ) ) {
             add_msg_if_player( m_warning,
                                _( "This %s is too small to wear comfortably!  Maybe it could be refitted." ),

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1337,7 +1337,7 @@ item::sizing item::get_sizing( const Character &who ) const
     }
     bool to_ignore = true;
     for( const armor_portion_data &piece : armor_data->data ) {
-        if( piece.encumber != 0 ) {
+        if( piece.encumber != 0 || piece.max_encumber != 0 ) {
             to_ignore = false;
         }
     }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

If you are a tiny mutant and happen to wear lets say a wrist watch, or a t-shirt, you will get a chat message saying `This %s is too big to wear comfortably!`.
The article of clothing in question will not have (too big) next to its name, nor will it apply any extra encumbrance to you and you cannot resize it to fit you.

This is because the sizing of clothing items with 0 encumbrance is entirely ignored in all parts of this game except for this one chat message

Additionally, because the sizing of clothing items with 0 encumbrance is entirely ignored, items that happen to fit that criteria but also posses a max encumbrance greater than zero (axe ring, baldric, spear sling and the arcana satchel of eternity) cannot ever be too big or too small for the player

Given that those items happen to all have the OVERSIZE flag, I assume that to be a bug

## Describe the solution (The How)

The `This %s is too big to wear comfortably!` chat message is now only displayed if `get_sizing()` does not return `item::sizing::ignore`

Additionally `get_sizing()` only returns `item::sizing::ignore` when both encumbrance and max encumbrance are zero

All of the items affected by the max encumbrance bug already possess the OVERSIZE flag so these items are already compatible with the XS clothing mod, so changing any of those items is unneeded

## Describe alternatives you've considered

- Not doing this

## Testing

Putting on a t-shirt as a tiny mutant no longer displays a chat message
The baldric holster is now shown as (huge!) when inspecting it as a tiny muntant
XS mod can still correctly be applied to the baldric holster to make it fit a tiny muntant

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.