### PR TITLE
feat(balance): reduce Barrett M107A1 weight from 12602g to 12500g

### DIFF
--- a/data/json/items/gun/50.json
+++ b/data/json/items/gun/50.json
@@ -6,7 +6,7 @@
     "name": { "str_sp": "Barrett M107A1" },
     "//": "Price based on unit cost quote for fiscal year 2005 listed at inetres.com, with gunmod modifiers to be added later.",
     "description": "A large, shoulder-fired, .50 caliber anti-materiel rifle.  Its large size, recoil, and noise is offset by its damage and range.",
-    "weight": "12602 g",
+    "weight": "12500 g",
     "volume": "3500 ml",
     "price": "14833 USD",
     "price_postapoc": "120 USD",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

The weight of the Barrett M107A1 is for some reason 12602g exactly

This is a weirdly specific number and I cannot find a single source that lists the weight of it as specifically that

the closest number I could find is a listing for 12500g (12.5kg) in the operators manual (pictured below)
<img width="471" height="158" alt="2026-05-12-23:42:06" src="https://github.com/user-attachments/assets/255fa33d-af61-4211-abce-b88832d8d690" />


## Describe the solution (The How)

Reduce the weight of the Barrett M107A1 by an entire 102g to 12500g (12.5kg)
Which probably has no actual impact in game balance as a whole :P

## Describe alternatives you've considered

- Not doing this

- Instead reducing it by an entire 2g to 12600g (12.6kg)
I dont think 100g is really going to make a difference either way when the guns as bulky as it is honestly, eh

## Testing

Booted up the game, spawned in a Barrett M107A1 and removed all the mods from it and noticed that its weight is now 12.5kg (its 13.95kg with mods, 15.82kg with a mag in it)

## Additional context


## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.