### PR TITLE
fix: resolve roof part color rendering errors

### DIFF
--- a/src/cata_tiles_color.cpp
+++ b/src/cata_tiles_color.cpp
@@ -142,7 +142,7 @@ auto cata_tiles::get_vpart_color(
             auto &veh = vp->vehicle();
             const auto part_idx = veh.roof_at_part( vp->part_index() );
             if( part_idx != -1 ) {
-                auto [bg, fg] = veh.get_part_hack( part_idx ).get_color();
+                auto [bg, fg] = veh.part(part_idx).get_color();
                 return {bg, fg};
             }
         }

--- a/src/cata_tiles_color.cpp
+++ b/src/cata_tiles_color.cpp
@@ -142,7 +142,7 @@ auto cata_tiles::get_vpart_color(
             auto &veh = vp->vehicle();
             const auto part_idx = veh.roof_at_part( vp->part_index() );
             if( part_idx != -1 ) {
-                auto [bg, fg] = veh.part(part_idx).get_color();
+                auto [bg, fg] = veh.part( part_idx ).get_color();
                 return {bg, fg};
             }
         }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<img width="1105" height="442" alt="image" src="https://github.com/user-attachments/assets/ee33943e-c76d-4934-87b6-2183ded36ebf" />

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Fix

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

* Fly over a car crash (must see vehicle crash from above)
* No errors shown
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.