### PR TITLE
fix(UI): allow wait menu while flying vehicles

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -96,6 +96,7 @@
 #include "veh_type.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
+#include "vehicle_wait.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 #include "weather.h"
@@ -916,9 +917,10 @@ static void wait()
     player &u = g->u;
     bool setting_alarm = false;
     map &here = get_map();
+    const auto player_vehicle = here.veh_at( u.pos() );
 
-    if( u.controlling_vehicle && ( here.veh_at( u.pos() )->vehicle().velocity ||
-                                   here.veh_at( u.pos() )->vehicle().cruise_velocity ) && u.pos().z < 4 ) {
+    if( u.controlling_vehicle && player_vehicle &&
+        vehicle_wait::is_wait_blocked_by_movement( player_vehicle->vehicle() ) ) {
         popup( _( "You can't pass time while controlling a moving vehicle." ) );
         return;
     }
@@ -960,7 +962,8 @@ static void wait()
             as_m.addentry( 12, true, 'w', _( "Wait until you catch your breath" ) );
             durations.emplace( 12, 15_minutes ); // to hide it from showing
         }
-        if( u.controlling_vehicle && u.pos().z > 3 ) {
+        if( u.controlling_vehicle && player_vehicle &&
+            vehicle_wait::should_offer_flying_wait_durations( player_vehicle->vehicle() ) ) {
             add_menu_item( 14, 'x', "", 10_seconds );
             add_menu_item( 15, 'y', "", 30_seconds );
             add_menu_item( 16, 'z', "", 1_minutes );

--- a/src/vehicle_wait.cpp
+++ b/src/vehicle_wait.cpp
@@ -1,0 +1,18 @@
+#include "vehicle_wait.h"
+
+#include "vehicle.h"
+
+namespace vehicle_wait
+{
+
+auto is_wait_blocked_by_movement( const vehicle &veh ) -> bool
+{
+    return ( veh.velocity != 0 || veh.cruise_velocity != 0 ) && !veh.is_flying_in_air();
+}
+
+auto should_offer_flying_wait_durations( const vehicle &veh ) -> bool
+{
+    return veh.is_flying_in_air();
+}
+
+} // namespace vehicle_wait

--- a/src/vehicle_wait.h
+++ b/src/vehicle_wait.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class vehicle;
+
+namespace vehicle_wait
+{
+
+auto is_wait_blocked_by_movement( const vehicle &veh ) -> bool;
+auto should_offer_flying_wait_durations( const vehicle &veh ) -> bool;
+
+} // namespace vehicle_wait

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -23,6 +23,7 @@
 #include "type_id.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
+#include "vehicle_wait.h"
 #include "vpart_position.h"
 #include "veh_type.h"
 
@@ -158,6 +159,23 @@ TEST_CASE( "taking_control_of_vehicle_without_engine", "[vehicle]" )
     CHECK( player_character.controlling_vehicle );
     CHECK_FALSE( veh_ptr->engine_on );
     CHECK( !player_character.activity );
+}
+
+TEST_CASE( "moving_flying_vehicle_can_use_wait_menu", "[vehicle][wait]" )
+{
+    clear_all_state();
+    const auto origin = tripoint( 60, 60, 0 );
+
+    auto *veh_ptr = get_map().add_vehicle( vproto_id( "plane_small" ), origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    veh_ptr->velocity = 100;
+    CHECK( vehicle_wait::is_wait_blocked_by_movement( *veh_ptr ) );
+    CHECK_FALSE( vehicle_wait::should_offer_flying_wait_durations( *veh_ptr ) );
+
+    veh_ptr->set_flying( true );
+    CHECK_FALSE( vehicle_wait::is_wait_blocked_by_movement( *veh_ptr ) );
+    CHECK( vehicle_wait::should_offer_flying_wait_durations( *veh_ptr ) );
 }
 
 TEST_CASE( "horde_spawns_skip_owned_vehicle_tiles", "[horde][vehicle][monster]" )


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #8853.

## Describe the solution (The How)

Use the vehicle flying state, not z-level, to allow the wait menu and short flying wait durations.

## Testing

- `cmake --preset linux-full`
- `/tmp/astyle-wrapper --options=.astylerc -n src/handle_action.cpp src/vehicle_wait.cpp src/vehicle_wait.h tests/vehicle_test.cpp`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "moving_flying_vehicle_can_use_wait_menu"`
- `XDG_DATA_HOME=/tmp/pi-cata-data XDG_CONFIG_HOME=/tmp/pi-cata-config cmake --build --preset linux-full --target cataclysm-bn-tiles`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sup>PR opened by gpt-5.4 high on pi</sup>
