### PR TITLE
feat: set resizable flag to clothing that should have it

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -266,7 +266,8 @@
       "draw_cost": 40,
       "flags": [ "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER" ]
     },
-    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "COMPACT", "VARSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "COMPACT" ],
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "modularvest",

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -64,7 +64,7 @@
       ],
       "draw_cost": 35
     },
-    "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY", "COMPACT" ]
+    "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY", "COMPACT", "VARSIZE" ]
   },
   {
     "id": "ammo_satchel",
@@ -96,7 +96,7 @@
       "flags": [ "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "ALLOWS_WINGS" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "chestpouch",
@@ -127,7 +127,7 @@
       "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "ALLOWS_WINGS" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "chestrig",
@@ -158,7 +158,7 @@
       "flags": [ "MAG_COMPACT", "MAG_BULKY", "SPEEDLOADER" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "ALLOWS_WINGS" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "javelin_bag",
@@ -188,7 +188,7 @@
       "draw_cost": 30,
       "flags": [ "JAVELIN" ]
     },
-    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "COMPACT" ]
+    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "COMPACT", "VARSIZE" ]
   },
   {
     "id": "legpouch",
@@ -217,7 +217,7 @@
       "draw_cost": 40,
       "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
     },
-    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES", "COMPACT" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES", "COMPACT", "VARSIZE" ]
   },
   {
     "id": "legpouch_large",
@@ -248,7 +248,7 @@
       "draw_cost": 40,
       "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
     },
-    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "COMPACT", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "COMPACT", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "mag_satchel_leg",
@@ -266,7 +266,7 @@
       "draw_cost": 40,
       "flags": [ "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER" ]
     },
-    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "COMPACT" ]
+    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "COMPACT", "VARSIZE" ]
   },
   {
     "id": "modularvest",
@@ -429,7 +429,7 @@
     "encumbrance": 3,
     "material_thickness": 1,
     "use_action": { "type": "bandolier", "capacity": 20, "ammo": [ "arrow", "bolt" ], "draw_cost": 20 },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "quiver_birchbark",
@@ -549,7 +549,7 @@
       "flags": [ "MAG_COMPACT", "MAG_BULKY", "SPEEDLOADER" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "ALLOWS_WINGS" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "xlkevlar",
@@ -649,6 +649,6 @@
       ],
       "draw_cost": 35
     },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   }
 ]

--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -22,7 +22,7 @@
       "ammo": [ "32", "38", "357mag", "357sig", "380", "40", "10mm", "44", "45", "45colt", "9mm" ],
       "draw_cost": 20
     },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE", "FANCY" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE", "FANCY", "VARSIZE" ]
   },
   {
     "id": "bandolier_rifle",
@@ -47,7 +47,7 @@
       "ammo": [ "22", "223", "300blk", "5x50", "3006", "308", "300", "762", "762R", "8x40mm", "4570", "50" ],
       "draw_cost": 20
     },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "bandolier_shotgun",
@@ -67,7 +67,7 @@
     "encumbrance": 2,
     "material_thickness": 1,
     "use_action": { "type": "bandolier", "capacity": 25, "ammo": [ "410shot", "shot", "20x66mm", "signal_flare" ], "draw_cost": 25 },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "torso_bandolier_shotgun",
@@ -87,7 +87,7 @@
     "encumbrance": 3,
     "material_thickness": 1,
     "use_action": { "type": "bandolier", "capacity": 50, "ammo": [ "410shot", "shot", "20x66mm", "signal_flare" ], "draw_cost": 35 },
-    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED" ]
+    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED", "VARSIZE" ]
   },
   {
     "id": "flintlock_pouch",
@@ -112,7 +112,7 @@
       "ammo": [ "flintlock", "flintlockshot", "36paper", "44paper", "blunderbuss", "shotcanister", "shotpaper" ],
       "draw_cost": 20
     },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "bandolier_wrist",
@@ -138,7 +138,7 @@
       "draw_cost": 20
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS", "VARSIZE" ]
   },
   {
     "id": "grenade_pouch",
@@ -158,7 +158,7 @@
     "encumbrance": 4,
     "material_thickness": 1,
     "use_action": { "type": "bandolier", "capacity": 6, "ammo": [ "40x46mm", "40x53mm" ], "draw_cost": 20 },
-    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "stone_pouch",
@@ -179,7 +179,7 @@
     "encumbrance": 4,
     "material_thickness": 1,
     "use_action": { "type": "bandolier", "capacity": 20, "ammo": [ "rock" ], "draw_cost": 20 },
-    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "grenadebandolier",
@@ -209,7 +209,7 @@
       "flags": [ "GRENADE" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "bandolier_grenade",
@@ -229,7 +229,7 @@
     "encumbrance": 1,
     "material_thickness": 1,
     "use_action": { "type": "bandolier", "capacity": 12, "ammo": [ "40x46mm", "40x53mm" ], "draw_cost": 20 },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "bandolier_knife",
@@ -259,6 +259,6 @@
       "draw_cost": 50,
       "flags": [ "SHEATH_KNIFE" ]
     },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE", "VARSIZE" ]
   }
 ]

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -55,7 +55,8 @@
     "type": "ARMOR",
     "name": { "str": "black belt" },
     "description": "A belt worn by martial arts practitioners, advertising a master.",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "judo_belt_blue",
@@ -63,7 +64,8 @@
     "type": "ARMOR",
     "name": { "str": "blue belt" },
     "description": "A belt worn by martial arts practitioners, advertising a strong intermediate.",
-    "color": "blue"
+    "color": "blue",
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "judo_belt_brown",
@@ -71,7 +73,8 @@
     "type": "ARMOR",
     "name": { "str": "brown belt" },
     "description": "A belt worn by martial arts practitioners, advertising a near-master.",
-    "color": "brown"
+    "color": "brown",
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "judo_belt_green",
@@ -79,7 +82,8 @@
     "type": "ARMOR",
     "name": { "str": "green belt" },
     "description": "A belt worn by martial arts practitioners, advertising an intermediate.",
-    "color": "green"
+    "color": "green",
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "judo_belt_orange",
@@ -87,7 +91,8 @@
     "type": "ARMOR",
     "name": { "str": "orange belt" },
     "description": "A belt worn by martial arts practitioners, advertising a fresh intermediate.",
-    "color": "light_red"
+    "color": "light_red",
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "judo_belt_white",
@@ -95,7 +100,8 @@
     "type": "ARMOR",
     "name": { "str": "white belt" },
     "description": "A belt worn by martial arts practitioners, advertising a novice.",
-    "color": "white"
+    "color": "white",
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "judo_belt_yellow",
@@ -103,7 +109,8 @@
     "type": "ARMOR",
     "name": { "str": "yellow belt" },
     "description": "A belt worn by martial arts practitioners, advertising a moderate novice.",
-    "color": "yellow"
+    "color": "yellow",
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "leather_belt",
@@ -130,7 +137,7 @@
       "flags": [ "BELT_CLIP" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "obi_gi",
@@ -145,7 +152,8 @@
     "to_hit": -1,
     "material": [ "cotton" ],
     "symbol": "[",
-    "color": "dark_gray"
+    "color": "dark_gray",
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "police_belt",
@@ -205,7 +213,7 @@
       "max_weight": "2500 g",
       "flags": [ "BELT_CLIP", "SHEATH_KNIFE", "SHEATH_SWORD" ]
     },
-    "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST", "COMPACT", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST", "COMPACT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "tool_belt",
@@ -238,7 +246,7 @@
       "flags": [ "BELT_CLIP", "SHEATH_KNIFE" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "webbing_belt",

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -56,7 +56,7 @@
     "name": { "str": "black belt" },
     "description": "A belt worn by martial arts practitioners, advertising a master.",
     "color": "dark_gray",
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "judo_belt_blue",
@@ -65,7 +65,7 @@
     "name": { "str": "blue belt" },
     "description": "A belt worn by martial arts practitioners, advertising a strong intermediate.",
     "color": "blue",
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "judo_belt_brown",
@@ -74,7 +74,7 @@
     "name": { "str": "brown belt" },
     "description": "A belt worn by martial arts practitioners, advertising a near-master.",
     "color": "brown",
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "judo_belt_green",
@@ -83,7 +83,7 @@
     "name": { "str": "green belt" },
     "description": "A belt worn by martial arts practitioners, advertising an intermediate.",
     "color": "green",
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "judo_belt_orange",
@@ -92,7 +92,7 @@
     "name": { "str": "orange belt" },
     "description": "A belt worn by martial arts practitioners, advertising a fresh intermediate.",
     "color": "light_red",
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "judo_belt_white",
@@ -101,7 +101,7 @@
     "name": { "str": "white belt" },
     "description": "A belt worn by martial arts practitioners, advertising a novice.",
     "color": "white",
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "judo_belt_yellow",
@@ -110,7 +110,7 @@
     "name": { "str": "yellow belt" },
     "description": "A belt worn by martial arts practitioners, advertising a moderate novice.",
     "color": "yellow",
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "leather_belt",

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -471,7 +471,8 @@
       "multi": 2,
       "skills": [ "pistol" ]
     },
-    "extend": { "flags": [ "FANCY" ] }
+    "extend": { "flags": [ "FANCY" ] },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "boots_winter",
@@ -713,7 +714,7 @@
     "coverage": 65,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES", "VARSIZE" ]
   },
   {
     "id": "footrags_fur",
@@ -733,7 +734,7 @@
     "encumbrance": 4,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES", "VARSIZE" ]
   },
   {
     "id": "footrags_leather",
@@ -753,7 +754,7 @@
     "encumbrance": 3,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES", "VARSIZE" ]
   },
   {
     "id": "footrags_wool",
@@ -773,7 +774,7 @@
     "encumbrance": 2,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES", "VARSIZE" ]
   },
   {
     "id": "geta",
@@ -1375,7 +1376,8 @@
     "material": [ "wool" ],
     "color": "blue",
     "encumbrance": 7,
-    "warmth": 40
+    "warmth": 40,
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "stockings_tent_legs",
@@ -1406,7 +1408,8 @@
     "proportional": { "weight": 2, "volume": 2, "encumbrance": 2, "warmth": 2, "material_thickness": 2 },
     "coverage": 90,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded" ],
-    "extend": { "flags": [ "ALLOWS_TAIL_SNAKE" ] }
+    "extend": { "flags": [ "ALLOWS_TAIL_SNAKE" ] },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "stockings_snake_tail_fur",
@@ -1416,7 +1419,8 @@
     "description": "An oversized leg warmer made of fur.  Clearly designed for legless mutants, or an awkward tube skirt for more normal survivors.",
     "material": [ "fur" ],
     "proportional": { "weight": 2, "volume": 2, "encumbrance": 2, "warmth": 2.5 },
-    "extend": { "flags": [ "WATERPROOF" ] }
+    "extend": { "flags": [ "WATERPROOF" ] },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "stockings_snake_tail_leather",
@@ -1426,7 +1430,8 @@
     "description": "An oversized leg warmer made of leather.  Clearly designed for legless mutants, or an awkward tube skirt for more normal survivors.",
     "material": [ "leather" ],
     "proportional": { "weight": 1.5, "volume": 1.5, "encumbrance": 1.5, "warmth": 1.5 },
-    "extend": { "flags": [ "WATERPROOF" ] }
+    "extend": { "flags": [ "WATERPROOF" ] },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "stockings_snake_tail_wool",
@@ -1435,7 +1440,8 @@
     "name": { "str": "wool tail warmer" },
     "description": "An oversized leg warmer made of wool.  Clearly designed for legless mutants, or an awkward tube skirt for more normal survivors.",
     "material": [ "wool" ],
-    "proportional": { "weight": 1.25, "volume": 1.25, "encumbrance": 1.25, "warmth": 2 }
+    "proportional": { "weight": 1.25, "volume": 1.25, "encumbrance": 1.25, "warmth": 2 },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "tabi_dress",
@@ -1504,7 +1510,8 @@
     "looks_like": "socks",
     "warmth": 15,
     "material_thickness": 2,
-    "encumbrance": 3
+    "encumbrance": 3,
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "carbon_boots",

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -58,7 +58,8 @@
     "color": "dark_gray",
     "covers": [ "feet" ],
     "encumbrance": 16,
-    "flags": [ "VARSIZE", "WATERPROOF" ]
+    "flags": [ "WATERPROOF" ],
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "boots_bunker",
@@ -471,8 +472,7 @@
       "multi": 2,
       "skills": [ "pistol" ]
     },
-    "extend": { "flags": [ "FANCY" ] },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "FANCY", "VARSIZE" ] }
   },
   {
     "id": "boots_winter",
@@ -1377,7 +1377,7 @@
     "color": "blue",
     "encumbrance": 7,
     "warmth": 40,
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "stockings_tent_legs",
@@ -1408,8 +1408,7 @@
     "proportional": { "weight": 2, "volume": 2, "encumbrance": 2, "warmth": 2, "material_thickness": 2 },
     "coverage": 90,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded" ],
-    "extend": { "flags": [ "ALLOWS_TAIL_SNAKE" ] },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "ALLOWS_TAIL_SNAKE", "VARSIZE" ] }
   },
   {
     "id": "stockings_snake_tail_fur",
@@ -1419,8 +1418,7 @@
     "description": "An oversized leg warmer made of fur.  Clearly designed for legless mutants, or an awkward tube skirt for more normal survivors.",
     "material": [ "fur" ],
     "proportional": { "weight": 2, "volume": 2, "encumbrance": 2, "warmth": 2.5 },
-    "extend": { "flags": [ "WATERPROOF" ] },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "WATERPROOF", "VARSIZE" ] }
   },
   {
     "id": "stockings_snake_tail_leather",
@@ -1430,8 +1428,7 @@
     "description": "An oversized leg warmer made of leather.  Clearly designed for legless mutants, or an awkward tube skirt for more normal survivors.",
     "material": [ "leather" ],
     "proportional": { "weight": 1.5, "volume": 1.5, "encumbrance": 1.5, "warmth": 1.5 },
-    "extend": { "flags": [ "WATERPROOF" ] },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "WATERPROOF", "VARSIZE" ] }
   },
   {
     "id": "stockings_snake_tail_wool",
@@ -1441,7 +1438,7 @@
     "description": "An oversized leg warmer made of wool.  Clearly designed for legless mutants, or an awkward tube skirt for more normal survivors.",
     "material": [ "wool" ],
     "proportional": { "weight": 1.25, "volume": 1.25, "encumbrance": 1.25, "warmth": 2 },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "tabi_dress",
@@ -1511,7 +1508,7 @@
     "warmth": 15,
     "material_thickness": 2,
     "encumbrance": 3,
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "carbon_boots",

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -65,7 +65,7 @@
     "encumbrance": 4,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "BELTED" ]
+    "flags": [ "OVERSIZE", "BELTED", "VARSIZE" ]
   },
   {
     "id": "cloak",
@@ -87,7 +87,7 @@
     "warmth": 30,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "cloak_fur",
@@ -109,7 +109,7 @@
     "warmth": 60,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "cloak_leather",
@@ -131,7 +131,7 @@
     "warmth": 40,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "cloak_wool",
@@ -153,7 +153,7 @@
     "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "OVERSIZE", "HOOD", "OUTER", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "jedi_cloak",
@@ -176,7 +176,7 @@
     "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 5,
-    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "ALLOWS_TAIL_SNAKE", "ALLOWS_HOOVES" ]
+    "flags": [ "OVERSIZE", "OUTER", "HELMET_COMPAT", "ALLOWS_TAIL_SNAKE", "ALLOWS_HOOVES", "VARSIZE" ]
   },
   {
     "id": "optical_cloak",
@@ -270,7 +270,7 @@
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_TAIL_SNAKE" ],
+    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_TAIL_SNAKE", "VARSIZE" ],
     "qualities": [ [ "SLEEP_AID", 4 ] ]
   }
 ]

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -404,7 +404,7 @@
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "OUTER", "OVERSIZE", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "jacket_army",
@@ -473,7 +473,7 @@
     "warmth": 25,
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "POCKETS", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF", "COLLAR", "ALLOWS_WINGS" ]
+    "flags": [ "POCKETS", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF", "COLLAR", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "jacket_flannel",
@@ -1290,7 +1290,7 @@
     "encumbrance": 5,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "OVERSIZE", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "tux",

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -80,8 +80,9 @@
     "material": [ "faux_fur", "cotton" ],
     "color": "pink",
     "covers": [ "torso", "arms" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "SUPER_FANCY", "ALLOWS_WINGS" ],
-    "warmth": 70
+    "flags": [ "POCKETS", "OUTER", "SUPER_FANCY", "ALLOWS_WINGS" ],
+    "warmth": 70,
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "coat_fur_sf",
@@ -256,8 +257,9 @@
     "description": "A thick faux fur duster, falling below your knees.  Has many pockets for storing things.",
     "material": [ "faux_fur", "cotton" ],
     "covers": [ "torso", "arms", "legs" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY", "ALLOWS_TAIL_SNAKE", "ALLOWS_WINGS" ],
-    "warmth": 40
+    "flags": [ "POCKETS", "OUTER", "FANCY", "ALLOWS_TAIL_SNAKE", "ALLOWS_WINGS" ],
+    "warmth": 40,
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "duster_leather",
@@ -925,8 +927,9 @@
     "description": "A thick, sleeveless faux fur duster, falling below your knees.  Has many pockets for storing things.",
     "material": [ "faux_fur", "cotton" ],
     "covers": [ "torso", "legs" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY", "ALLOWS_TAIL_SNAKE", "ALLOWS_WINGS" ],
-    "warmth": 40
+    "flags": [ "POCKETS", "OUTER", "FANCY", "ALLOWS_TAIL_SNAKE", "ALLOWS_WINGS" ],
+    "warmth": 40,
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "sleeveless_duster_leather",
@@ -1047,8 +1050,9 @@
     "description": "A thick faux fur trenchcoat without sleeves.  Has plenty of storage space, and looks pretty good.",
     "material": [ "faux_fur", "cotton" ],
     "covers": [ "torso" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY", "ALLOWS_WINGS" ],
-    "warmth": 40
+    "flags": [ "POCKETS", "OUTER", "FANCY", "ALLOWS_WINGS" ],
+    "warmth": 40,
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "sleeveless_trenchcoat_leather",
@@ -1200,8 +1204,9 @@
     "description": "A thick faux fur trenchcoat, lined with pockets.  Great for storage, and makes you the talk of the town.",
     "material": [ "faux_fur", "cotton" ],
     "covers": [ "torso", "arms" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "FANCY", "ALLOWS_WINGS" ],
-    "warmth": 40
+    "flags": [ "POCKETS", "OUTER", "FANCY", "ALLOWS_WINGS" ],
+    "warmth": 40,
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "trenchcoat_leather",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -322,8 +322,7 @@
     "coverage": 50,
     "warmth": 28,
     "encumbrance": 20,
-    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ] },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS", "VARSIZE" ] }
   },
   {
     "id": "gloves_hsurvivor",
@@ -436,8 +435,7 @@
     "coverage": 50,
     "warmth": 8,
     "encumbrance": 0,
-    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ] },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS", "VARSIZE" ] }
   },
   {
     "id": "gloves_liner",
@@ -474,7 +472,7 @@
     "warmth": 45,
     "material_thickness": 2,
     "delete": { "flags": [ "WATER_FRIENDLY" ] },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "gloves_lsurvivor",
@@ -701,8 +699,7 @@
     "coverage": 50,
     "warmth": 24,
     "encumbrance": 7,
-    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ] },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS", "VARSIZE" ] }
   },
   {
     "id": "gloves_work",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -145,7 +145,7 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY", "VARSIZE" ]
   },
   {
     "id": "gauntlet_fencing_l",
@@ -168,7 +168,7 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
-    "flags": [ "STURDY" ]
+    "flags": [ "STURDY", "VARSIZE" ]
   },
   {
     "id": "gauntlets_larmor",
@@ -306,7 +306,8 @@
     "encumbrance": 30,
     "warmth": 70,
     "material_thickness": 3,
-    "valid_mods": [ "resized_large", "resized_small" ]
+    "valid_mods": [ "resized_large", "resized_small" ],
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "gloves_fur_fingerless",
@@ -321,7 +322,8 @@
     "coverage": 50,
     "warmth": 28,
     "encumbrance": 20,
-    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ] }
+    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ] },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "gloves_hsurvivor",
@@ -419,7 +421,7 @@
     "warmth": 20,
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY" ]
+    "flags": [ "WATER_FRIENDLY", "VARSIZE" ]
   },
   {
     "id": "gloves_light_fingerless",
@@ -434,7 +436,8 @@
     "coverage": 50,
     "warmth": 8,
     "encumbrance": 0,
-    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ] }
+    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ] },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "gloves_liner",
@@ -470,7 +473,8 @@
     "encumbrance": 5,
     "warmth": 45,
     "material_thickness": 2,
-    "delete": { "flags": [ "WATER_FRIENDLY" ] }
+    "delete": { "flags": [ "WATER_FRIENDLY" ] },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "gloves_lsurvivor",
@@ -660,7 +664,8 @@
     "encumbrance": 40,
     "warmth": 70,
     "material_thickness": 4,
-    "valid_mods": [ "resized_large", "resized_small" ]
+    "valid_mods": [ "resized_large", "resized_small" ],
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "gloves_wool",
@@ -696,7 +701,8 @@
     "coverage": 50,
     "warmth": 24,
     "encumbrance": 7,
-    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ] }
+    "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_CLAWS" ] },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "gloves_work",
@@ -762,7 +768,7 @@
     "coverage": 50,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS", "VARSIZE" ]
   },
   {
     "id": "gloves_wraps_fur",
@@ -783,7 +789,7 @@
     "encumbrance": 4,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS", "VARSIZE" ]
   },
   {
     "id": "gloves_wraps_leather",
@@ -804,7 +810,7 @@
     "encumbrance": 3,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "VARSIZE" ]
   },
   {
     "id": "gloves_wraps_wool",
@@ -825,7 +831,7 @@
     "encumbrance": 2,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "VARSIZE" ]
   },
   {
     "id": "gloves_wsurvivor",
@@ -889,7 +895,7 @@
     "encumbrance": 30,
     "warmth": 70,
     "material_thickness": 4,
-    "flags": [ "OVERSIZE", "OUTER" ]
+    "flags": [ "OVERSIZE", "OUTER", "VARSIZE" ]
   },
   {
     "id": "nomex_gloves",
@@ -972,7 +978,8 @@
     "encumbrance": 20,
     "warmth": 50,
     "material_thickness": 4,
-    "valid_mods": [ "resized_large", "resized_small" ]
+    "valid_mods": [ "resized_large", "resized_small" ],
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "gloves_golf",

--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -142,7 +142,7 @@
     "encumbrance": 10,
     "warmth": 4,
     "material_thickness": 1,
-    "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS" ],
+    "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS", "VARSIZE" ],
     "valid_mods": [ "resized_large", "resized_small" ]
   },
   {
@@ -188,7 +188,7 @@
     "material_thickness": 1,
     "environmental_protection": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "SUN_GLASSES", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS" ]
+    "flags": [ "SUN_GLASSES", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS", "VARSIZE" ]
   },
   {
     "id": "hat_chef",
@@ -210,7 +210,8 @@
     "warmth": 5,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "valid_mods": [ "resized_large", "resized_small" ]
+    "valid_mods": [ "resized_large", "resized_small" ],
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "hat_cotton",
@@ -249,7 +250,8 @@
     "encumbrance": 10,
     "warmth": 70,
     "material_thickness": 3,
-    "valid_mods": [ "resized_large", "resized_small" ]
+    "valid_mods": [ "resized_large", "resized_small" ],
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "hat_faux_fur",
@@ -260,7 +262,7 @@
     "description": "A stylish hat made of faux fur.  Like real fur, but without the suffering, if the tag is to be believed.  Very warm.",
     "material": [ "faux_fur", "cotton" ],
     "covers": [ "head" ],
-    "flags": [ "FANCY" ],
+    "flags": [ "FANCY", "VARSIZE" ],
     "warmth": 60
   },
   {
@@ -274,7 +276,7 @@
     "volume": "1500 ml",
     "price": "100 USD",
     "color": "black",
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY", "VARSIZE" ]
   },
   {
     "id": "hat_hard",
@@ -422,7 +424,7 @@
     "material_thickness": 2,
     "environmental_protection": 4,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "FANCY", "OUTER", "SUN_GLASSES" ]
+    "flags": [ "FANCY", "OUTER", "SUN_GLASSES", "VARSIZE" ]
   },
   {
     "id": "kippah",
@@ -443,7 +445,7 @@
     "warmth": 3,
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "HELMET_COMPAT", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS" ]
+    "flags": [ "HELMET_COMPAT", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS", "VARSIZE" ]
   },
   {
     "id": "kufi",
@@ -466,7 +468,7 @@
     "material_thickness": 1,
     "environmental_protection": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS" ]
+    "flags": [ "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS", "VARSIZE" ]
   },
   {
     "id": "maid_hat",
@@ -532,7 +534,7 @@
     "material_thickness": 1,
     "environmental_protection": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "SUN_GLASSES", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS" ]
+    "flags": [ "SUN_GLASSES", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS", "VARSIZE" ]
   },
   {
     "id": "straw_hat",
@@ -636,7 +638,7 @@
     "encumbrance": 5,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "VARSIZE" ]
   },
   {
     "id": "hat_golf",
@@ -660,6 +662,6 @@
     "material_thickness": 1,
     "environmental_protection": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "SUN_GLASSES", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS" ]
+    "flags": [ "SUN_GLASSES", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HORNS", "VARSIZE" ]
   }
 ]

--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -262,8 +262,9 @@
     "description": "A stylish hat made of faux fur.  Like real fur, but without the suffering, if the tag is to be believed.  Very warm.",
     "material": [ "faux_fur", "cotton" ],
     "covers": [ "head" ],
-    "flags": [ "FANCY", "VARSIZE" ],
-    "warmth": 60
+    "flags": [ "FANCY" ],
+    "warmth": 60,
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "bearskin_hat",
@@ -276,7 +277,8 @@
     "volume": "1500 ml",
     "price": "100 USD",
     "color": "black",
-    "flags": [ "FANCY", "VARSIZE" ]
+    "flags": [ "FANCY" ],
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "hat_hard",

--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -23,7 +23,7 @@
       "draw_cost": 150,
       "skills": [ "smg", "shotgun", "rifle", "launcher" ]
     },
-    "flags": [ "BELTED", "COMPACT", "OVERSIZE" ]
+    "flags": [ "BELTED", "COMPACT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "bootstrap",
@@ -42,7 +42,7 @@
     "coverage": 5,
     "encumbrance": 2,
     "material_thickness": 1,
-    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES" ],
+    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_HOOVES", "VARSIZE" ],
     "use_action": {
       "type": "holster",
       "max_volume": "500 ml",
@@ -79,7 +79,7 @@
       "skills": [ "pistol" ],
       "flags": [ "HOLSTER_PISTOL" ]
     },
-    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY", "VARSIZE" ]
   },
   {
     "id": "bow_sling",
@@ -98,7 +98,7 @@
     "coverage": 5,
     "encumbrance": 4,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "WAIST", "COMPACT" ],
+    "flags": [ "OVERSIZE", "WAIST", "COMPACT", "VARSIZE" ],
     "use_action": { "type": "holster", "max_volume": "10 L", "min_volume": "500 ml", "skills": [ "archery" ] }
   },
   {
@@ -125,7 +125,7 @@
       "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ],
       "flags": [ "HOLSTER_PISTOL" ]
     },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "sholster",
@@ -142,7 +142,8 @@
       "draw_cost": 80,
       "skills": [ "pistol" ],
       "flags": [ "HOLSTER_PISTOL" ]
-    }
+    },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "bholster",
@@ -167,7 +168,7 @@
       "flags": [ "HOLSTER_PISTOL" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "SKINTIGHT", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "shoulder_holster",
@@ -180,7 +181,7 @@
     "price": "100 USD",
     "price_postapoc": "8 USD",
     "covers": [ "arm_either" ],
-    "flags": [ "BELTED", "COMPACT", "OVERSIZE" ]
+    "flags": [ "BELTED", "COMPACT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "survivor_vest",
@@ -212,7 +213,7 @@
       "skills": [ "smg", "shotgun", "rifle", "launcher", "pistol" ]
     },
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST", "COMPACT", "ALLOWS_WINGS" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST", "COMPACT", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "baldric_holster",
@@ -241,7 +242,7 @@
       "flags": [ "HOLSTER_PISTOL" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "COMPACT", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "COMPACT", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "XL_holster",
@@ -267,6 +268,6 @@
       "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ],
       "flags": [ "HOLSTER_PISTOL" ]
     },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   }
 ]

--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -143,7 +143,7 @@
       "skills": [ "pistol" ],
       "flags": [ "HOLSTER_PISTOL" ]
     },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "bholster",
@@ -168,7 +168,8 @@
       "flags": [ "HOLSTER_PISTOL" ]
     },
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "SKINTIGHT", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS" ],
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "shoulder_holster",
@@ -181,7 +182,8 @@
     "price": "100 USD",
     "price_postapoc": "8 USD",
     "covers": [ "arm_either" ],
-    "flags": [ "BELTED", "COMPACT", "OVERSIZE", "VARSIZE" ]
+    "flags": [ "BELTED", "COMPACT", "OVERSIZE" ],
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "survivor_vest",

--- a/data/json/items/armor/hoods.json
+++ b/data/json/items/armor/hoods.json
@@ -105,7 +105,7 @@
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "WATERPROOF", "OUTER", "OVERSIZE", "HELMET_COMPAT" ]
+    "flags": [ "WATERPROOF", "OUTER", "OVERSIZE", "HELMET_COMPAT", "VARSIZE" ]
   },
   {
     "id": "hood_survivor",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -87,7 +87,7 @@
     "warmth": 10,
     "material_thickness": 3,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
-    "flags": [ "OUTER", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "OUTER", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "fencing_pants",
@@ -377,7 +377,8 @@
     "material": [ "leather" ],
     "looks_like": "skirt",
     "encumbrance": 7,
-    "warmth": 8
+    "warmth": 8,
+    "flags": [ "VARSIZE" ]
   },
   {
     "copy-from": "skirt_armor",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -378,7 +378,7 @@
     "looks_like": "skirt",
     "encumbrance": 7,
     "warmth": 8,
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "copy-from": "skirt_armor",

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -441,7 +441,8 @@
     "description": "A pair of long cotton pants lined with warm imitation fur.",
     "material": [ "faux_fur", "cotton" ],
     "covers": [ "legs" ],
-    "warmth": 70
+    "warmth": 70,
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "pants_leather",

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -442,7 +442,7 @@
     "material": [ "faux_fur", "cotton" ],
     "covers": [ "legs" ],
     "warmth": 70,
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "pants_leather",

--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -82,7 +82,7 @@
       "target": "bandana",
       "msg": "You adjust the %s to cover your mouth."
     },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "bondage_mask",
@@ -120,13 +120,14 @@
     "name": { "str": "bondage mask (zipped)", "str_pl": "bondage masks (zipped)" },
     "description": "A tight mask made of black leather.  The eyes and mouth have been zipped closed.",
     "looks_like": "bondage_mask",
-    "flags": [ "VARSIZE", "BLIND" ],
+    "flags": [ "BLIND" ],
     "use_action": {
       "menu_text": "Unzip",
       "type": "transform",
       "target": "bondage_mask",
       "msg": "You unzip the eyes and mouth of the bondage mask."
-    }
+    },
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "fencing_mask",

--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -37,7 +37,7 @@
     "encumbrance": 40,
     "warmth": 65,
     "material_thickness": 3,
-    "flags": [ "OVERSIZE", "OUTER" ]
+    "flags": [ "OVERSIZE", "OUTER", "VARSIZE" ]
   },
   {
     "id": "bandana",
@@ -59,7 +59,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE" ],
+    "flags": [ "OVERSIZE", "VARSIZE" ],
     "use_action": {
       "menu_text": "Cover head",
       "type": "transform",
@@ -81,7 +81,8 @@
       "type": "transform",
       "target": "bandana",
       "msg": "You adjust the %s to cover your mouth."
-    }
+    },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "bondage_mask",
@@ -146,7 +147,8 @@
     "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 2,
-    "valid_mods": [ "resized_large", "resized_small" ]
+    "valid_mods": [ "resized_large", "resized_small" ],
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "mask_bal",
@@ -295,6 +297,6 @@
     "warmth": 10,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "HELMET_COMPAT" ]
+    "flags": [ "OVERSIZE", "HELMET_COMPAT", "VARSIZE" ]
   }
 ]

--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -115,7 +115,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY", "VARSIZE" ]
   },
   {
     "id": "sleeping_bag_roll",
@@ -206,7 +206,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "black",
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY", "VARSIZE" ]
   },
   {
     "id": "tie_clipon",
@@ -234,7 +234,7 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY", "VARSIZE" ]
   },
   {
     "id": "veil_wedding",
@@ -256,7 +256,7 @@
     "encumbrance": 5,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "SUPER_FANCY", "OUTER", "OVERSIZE", "ALLOWS_MUZZLE" ]
+    "flags": [ "SUPER_FANCY", "OUTER", "OVERSIZE", "ALLOWS_MUZZLE", "VARSIZE" ]
   },
   {
     "id": "tarp",

--- a/data/json/items/armor/scarfs.json
+++ b/data/json/items/armor/scarfs.json
@@ -73,6 +73,6 @@
     "description": "A simple cloth scarf worn by Marloss Voices.  Wherever the Voices go, long sought peace soon follows, for better or for worse.",
     "color": "cyan",
     "covers": [ "mouth" ],
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   }
 ]

--- a/data/json/items/armor/scarfs.json
+++ b/data/json/items/armor/scarfs.json
@@ -18,7 +18,7 @@
     "encumbrance": 20,
     "warmth": 40,
     "material_thickness": 3,
-    "flags": [ "OVERSIZE", "HOOD", "FANCY", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "HOOD", "FANCY", "ALLOWS_NATURAL_ATTACKS", "VARSIZE" ]
   },
   {
     "id": "headscarf",
@@ -40,7 +40,7 @@
     "encumbrance": 4,
     "warmth": 7,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "VARSIZE" ]
   },
   {
     "id": "keffiyeh",
@@ -62,7 +62,7 @@
     "warmth": 30,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "OVERSIZE", "HOOD", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "HOOD", "ALLOWS_NATURAL_ATTACKS", "VARSIZE" ]
   },
   {
     "id": "marloss_scarf",
@@ -72,6 +72,7 @@
     "name": { "str": "cyan scarf" },
     "description": "A simple cloth scarf worn by Marloss Voices.  Wherever the Voices go, long sought peace soon follows, for better or for worse.",
     "color": "cyan",
-    "covers": [ "mouth" ]
+    "covers": [ "mouth" ],
+    "flags": [ "VARSIZE" ]
   }
 ]

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -52,7 +52,7 @@
       "max_volume": "3 L",
       "flags": [ "SHEATH_SWORD" ]
     },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "VARSIZE" ]
   },
   {
     "id": "bootsheath",
@@ -81,7 +81,7 @@
       "draw_cost": 150,
       "flags": [ "SHEATH_KNIFE" ]
     },
-    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY", "ALLOWS_HOOVES" ]
+    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY", "ALLOWS_HOOVES", "VARSIZE" ]
   },
   {
     "id": "wristsheath",
@@ -110,7 +110,7 @@
       "draw_cost": 50,
       "flags": [ "SHEATH_KNIFE" ]
     },
-    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY", "VARSIZE" ]
   },
   {
     "id": "bscabbard",
@@ -140,7 +140,7 @@
       "draw_cost": 150,
       "flags": [ "SHEATH_SWORD" ]
     },
-    "flags": [ "BELTED", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "VARSIZE" ]
   },
   {
     "id": "scabbard",
@@ -169,7 +169,7 @@
       "max_volume": "2750 ml",
       "flags": [ "SHEATH_SWORD" ]
     },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "sheath",
@@ -196,7 +196,7 @@
       "draw_cost": 80,
       "flags": [ "SHEATH_KNIFE" ]
     },
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "sheath_birchbark",
@@ -235,6 +235,6 @@
       "draw_cost": 150,
       "flags": [ "SHEATH_SPEAR", "SHEATH_AXE" ]
     },
-    "flags": [ "BELTED", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "WATER_FRIENDLY", "VARSIZE" ]
   }
 ]

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -21,7 +21,7 @@
     "warmth": 6,
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "backpack_hiking",
@@ -54,7 +54,7 @@
       "draw_cost": 150,
       "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD" ]
     },
-    "flags": [ "BELTED", "WATERPROOF", "ONLY_ONE", "OVERSIZE" ]
+    "flags": [ "BELTED", "WATERPROOF", "ONLY_ONE", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "backpack_giant",
@@ -79,7 +79,7 @@
     "warmth": 5,
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "ALLOWS_TAIL_SNAKE", "ALLOWS_TAIL", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "ALLOWS_TAIL_SNAKE", "ALLOWS_TAIL", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "backpack_leather",
@@ -103,7 +103,7 @@
     "warmth": 9,
     "material_thickness": 3,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "backpack_tactical_large",
@@ -126,7 +126,7 @@
     "storage": "65 L",
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "BELTED", "WATERPROOF", "ONLY_ONE", "OVERSIZE" ]
+    "flags": [ "BELTED", "WATERPROOF", "ONLY_ONE", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "basket_laundry",
@@ -171,7 +171,7 @@
     "storage": "80 L",
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "BELTED", "WATERPROOF", "ONLY_ONE", "OVERSIZE" ]
+    "flags": [ "BELTED", "WATERPROOF", "ONLY_ONE", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "bindle",
@@ -287,7 +287,7 @@
     "max_encumbrance": 20,
     "storage": "24 L",
     "warmth": 5,
-    "flags": [ "BELTED", "OVERSIZE", "STURDY" ]
+    "flags": [ "BELTED", "OVERSIZE", "STURDY", "VARSIZE" ]
   },
   {
     "id": "dive_bag",
@@ -311,7 +311,7 @@
     "storage": "12 L",
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_WINGS" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "duffelbag",
@@ -335,7 +335,7 @@
     "warmth": 10,
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "dump_pouch",
@@ -359,7 +359,7 @@
     "storage": "3 L",
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "fanny",
@@ -382,7 +382,7 @@
     "storage": "3 L",
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "golf_bag",
@@ -406,7 +406,7 @@
     "storage": "18 L",
     "warmth": 5,
     "material_thickness": 3,
-    "flags": [ "BELTED", "OVERSIZE" ],
+    "flags": [ "BELTED", "OVERSIZE", "VARSIZE" ],
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath golf club",
@@ -513,7 +513,7 @@
     "max_encumbrance": 6,
     "storage": "3 L",
     "material_thickness": 1,
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "VARSIZE" ]
   },
   {
     "id": "legrig",
@@ -534,7 +534,7 @@
     "storage": "3 L",
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "ALLOWS_TAIL_SNAKE" ]
+    "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT", "ALLOWS_TAIL_SNAKE", "VARSIZE" ]
   },
   {
     "id": "makeshift_knapsack",
@@ -558,7 +558,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "makeshift_sling",
@@ -582,7 +582,7 @@
     "storage": "10 L",
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "BELTED", "WATER_FRIENDLY", "VARSIZE" ]
   },
   {
     "id": "mbag",
@@ -609,7 +609,7 @@
     "storage": "6 L",
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "molle_pack",
@@ -634,7 +634,7 @@
     "warmth": 10,
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ],
     "use_action": {
       "type": "holster",
       "holster_prompt": "Stow gear",
@@ -669,7 +669,7 @@
     "properties": [ [ "creature_size_capacity", "SMALL" ] ],
     "use_action": "CAPTURE_MONSTER_ACT",
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "WATERPROOF", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "WATERPROOF", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "plastic_shopping_bag",
@@ -715,7 +715,7 @@
     "storage": "5 L",
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "FANCY", "BELTED", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "FANCY", "BELTED", "COMPACT", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "ragpouch",
@@ -737,7 +737,7 @@
     "max_encumbrance": 4,
     "storage": "2 L",
     "material_thickness": 1,
-    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "VARSIZE" ]
   },
   {
     "id": "rucksack",
@@ -762,7 +762,7 @@
     "warmth": 8,
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "runner_bag",
@@ -815,7 +815,7 @@
     "warmth": 2,
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "WATER_FRIENDLY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "straw_basket",
@@ -931,7 +931,7 @@
       "draw_cost": 120,
       "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD" ]
     },
-    "flags": [ "ONLY_ONE", "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE" ]
+    "flags": [ "ONLY_ONE", "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "survivor_duffel_bag",
@@ -953,7 +953,7 @@
     "max_encumbrance": 28,
     "storage": "38 L",
     "material_thickness": 2,
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "survivor_pack",
@@ -976,7 +976,7 @@
     "storage": "16 L",
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "ALLOWS_WINGS" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "survivor_rucksack",
@@ -998,7 +998,7 @@
     "max_encumbrance": 19,
     "storage": "25 L",
     "material_thickness": 2,
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "survivor_runner_pack",
@@ -1021,7 +1021,7 @@
     "storage": "8 L",
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "ALLOWS_WINGS" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "swag_bag",
@@ -1042,7 +1042,7 @@
     "encumbrance": 100,
     "storage": "15 L",
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "WATER_FRIENDLY" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "WATER_FRIENDLY", "VARSIZE" ]
   },
   {
     "id": "travelpack",
@@ -1066,7 +1066,7 @@
     "warmth": 8,
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "BELTED", "WATERPROOF", "ALLOWS_WINGS" ]
+    "flags": [ "BELTED", "WATERPROOF", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "vest",

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -103,7 +103,7 @@
     "name": { "str": "Hub 01 jumpsuit" },
     "description": "A brown jumpsuit worn by the staff of Hub 01.",
     "color": "brown",
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "subsuit_xl",

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -69,7 +69,7 @@
     "material_thickness": 5,
     "environmental_protection": 2,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
-    "flags": [ "OUTER" ],
+    "flags": [ "OUTER", "VARSIZE" ],
     "qualities": [ [ "SLEEP_AID", 4 ] ]
   },
   {
@@ -102,7 +102,8 @@
     "looks_like": "jumpsuit",
     "name": { "str": "Hub 01 jumpsuit" },
     "description": "A brown jumpsuit worn by the staff of Hub 01.",
-    "color": "brown"
+    "color": "brown",
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "subsuit_xl",
@@ -169,7 +170,7 @@
     "material_thickness": 7,
     "environmental_protection": 2,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
-    "flags": [ "OUTER" ],
+    "flags": [ "OUTER", "VARSIZE" ],
     "qualities": [ [ "SLEEP_AID", 4 ] ]
   },
   {

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -40,7 +40,8 @@
     "encumbrance": 12,
     "warmth": 15,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded" ],
-    "flags": [ "VARSIZE", "STURDY" ]
+    "flags": [ "STURDY" ],
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "armor_lamellar_plated",

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -216,7 +216,7 @@
     "warmth": 25,
     "material_thickness": 3,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
-    "flags": [ "STURDY", "ALLOWS_WINGS" ]
+    "flags": [ "STURDY", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "jacket_leather_mod",
@@ -400,7 +400,7 @@
     "coverage": 65,
     "warmth": 5,
     "material_thickness": 3,
-    "flags": [ "SKINTIGHT", "ALLOWS_WINGS" ]
+    "flags": [ "SKINTIGHT", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "plastron_plastic",

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -21,7 +21,7 @@
     "material_thickness": 3,
     "environmental_protection": 1,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
-    "flags": [ "POCKETS", "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE", "ALLOWS_WINGS" ]
+    "flags": [ "POCKETS", "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE", "ALLOWS_WINGS", "VARSIZE" ]
   },
   {
     "id": "blazer",
@@ -617,7 +617,8 @@
         "text": "A short-sleeved cotton shirt with the text \"chown -R us ~your/base\" printed on the front."
       }
     ],
-    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" },
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "tshirt_tour",
@@ -663,7 +664,8 @@
         "id": "mil_punk",
         "text": "A short-sleeved cotton shirt with an AK-47 on the front.  It is held up by a clenched fist around its forestock, the fingers covered in crude looking tattoos."
       }
-    ]
+    ],
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "hoodie_drugrug",
@@ -696,7 +698,8 @@
         "id": "desert_dream",
         "text": "Tan and teal stripes dance across the weave of this soft, oversized hoodie.  Looks perfect for stargazing in the desert."
       }
-    ]
+    ],
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "vest_leather",

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -368,7 +368,8 @@
         "text": "A t-shirt with the Debian logo on it, underneath it says \"The Universal Operating System\""
       }
     ],
-    "flags": [ "VARSIZE", "SNIPPET_NEEDS_LITERACY" ]
+    "flags": [ "SNIPPET_NEEDS_LITERACY" ],
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "longshirt",
@@ -617,8 +618,7 @@
         "text": "A short-sleeved cotton shirt with the text \"chown -R us ~your/base\" printed on the front."
       }
     ],
-    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" },
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "SNIPPET_NEEDS_LITERACY", "VARSIZE" ] }
   },
   {
     "id": "tshirt_tour",
@@ -665,7 +665,7 @@
         "text": "A short-sleeved cotton shirt with an AK-47 on the front.  It is held up by a clenched fist around its forestock, the fingers covered in crude looking tattoos."
       }
     ],
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "hoodie_drugrug",
@@ -699,7 +699,7 @@
         "text": "Tan and teal stripes dance across the weave of this soft, oversized hoodie.  Looks perfect for stargazing in the desert."
       }
     ],
-    "flags": [ "VARSIZE" ]
+    "extend": { "flags": [ "VARSIZE" ] }
   },
   {
     "id": "vest_leather",

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -18,7 +18,7 @@
     "warmth": 20,
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "SKINTIGHT" ]
+    "flags": [ "SKINTIGHT", "VARSIZE" ]
   },
   {
     "id": "army_top",
@@ -246,7 +246,7 @@
     "coverage": 25,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "chestwrap_fur",
@@ -266,7 +266,7 @@
     "encumbrance": 5,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "chestwrap_leather",
@@ -286,7 +286,7 @@
     "encumbrance": 5,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "chestwrap_wool",
@@ -306,7 +306,7 @@
     "encumbrance": 5,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "VARSIZE" ]
   },
   {
     "id": "corset",
@@ -351,7 +351,7 @@
     "warmth": 20,
     "material_thickness": 1,
     "valid_mods": [ "resized_large", "resized_small" ],
-    "flags": [ "SKINTIGHT" ]
+    "flags": [ "SKINTIGHT", "VARSIZE" ]
   },
   {
     "id": "leg_warmers_f",


### PR DESCRIPTION
## Purpose of change (The Why)

Many items of clothing and containers were missing the resizable flag (VARSIZE), this means a mutated character with a very small size would barely be able to wear anything, even with 10 in tailoring, which makes no sense to me.

## Describe the solution (The How)

Add VARSIZE to items

## Describe alternatives you've considered

Suffering

## Testing

Compiled, ran game, set tailoring to 10, spawned items and small mutation, resized.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
