### PR TITLE
test: suppress Catch2 C2y warnings

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,9 +10,13 @@ if (BUILD_TESTING)
     # This needs to include catch.h with different macro switch
     set_source_files_properties(test_main.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 
+    # Catch2 v2 uses __COUNTER__, which Clang 22 reports under -Wpedantic.
+    set(CATCH2_COMPILE_OPTIONS $<$<CXX_COMPILER_ID:Clang>:-Wno-c2y-extensions>)
+
     if (TILES)
         add_executable(cata_test-tiles ${CATACLYSM_BN_TEST_SOURCES})
         target_link_libraries(cata_test-tiles PRIVATE cataclysm-bn-tiles-common)
+        target_compile_options(cata_test-tiles PRIVATE ${CATCH2_COMPILE_OPTIONS})
 
         add_test(
             NAME test-tiles
@@ -30,6 +34,7 @@ if (BUILD_TESTING)
     if (CURSES)
         add_executable(cata_test ${CATACLYSM_BN_TEST_SOURCES})
         target_link_libraries(cata_test PRIVATE cataclysm-bn-common)
+        target_compile_options(cata_test PRIVATE ${CATCH2_COMPILE_OPTIONS})
 
         add_test(
             NAME test


### PR DESCRIPTION
## Purpose of change (The Why)

Clang 22 reports Catch2 v2 `__COUNTER__` macro expansions as C2y extension warnings across test builds.

No related issue or PR found.

## Describe the solution (The How)

Adds a Clang-only warning suppression to the Catch2 test targets.

## Testing

- `cmake --preset linux-full`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- verified the build log contains no `c2y-extensions` / `__COUNTER__ is a C2y extension` warnings
- `./out/build/linux-full/tests/cata_test-tiles --rng-seed time`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style). No CMake formatter is configured.
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why), if any.

<sup>PR opened by gpt-5.1 high on pi</sup>
