### PR TITLE
fix(UI): ensure crafting speed modifiers are shown

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2157,6 +2157,39 @@ void craft_activity_actor::calc_all_moves( player_activity &act, Character &who 
                                             base_total * ( 1.0 - craft_counter / 10'000'000.0 ) ) );
         activity_actor::progress.emplace( name, base_total, remaining );
     }
+
+    item *craft_item = find_in_progress_craft( who );
+    if( craft_item ) {
+        refresh_speed( act, who, *craft_item );
+    }
+}
+
+void craft_activity_actor::refresh_speed( player_activity &act, const Character &who,
+        const item &craft_item, std::optional<bench_location> bench ) const
+{
+    const bench_location resolved_bench = bench ? *bench : find_best_bench( who, craft_item );
+    const recipe &making = *rec;
+    const float tools_mult = crafting_tools_speed_multiplier( who, making );
+    act.speed.light        = lighting_crafting_speed_multiplier( who, making );
+    act.speed.bench_factor = workbench_crafting_speed_multiplier( craft_item, resolved_bench );
+    act.speed.morale       = morale_crafting_speed_multiplier( who, making );
+    act.speed.tools        = tools_mult;
+    act.speed.player_speed = who.get_speed() / 100.0f;
+    const int assistants   = who.available_assistant_count( making );
+    if( assistants > 0 ) {
+        const double base_no_assist   = std::max( 1, making.batch_time( batch_size, 1.0f, 0 ) );
+        const double base_with_assist = std::max( 1, making.batch_time( batch_size, 1.0f, assistants ) );
+        act.speed.assist = static_cast<float>( base_no_assist / base_with_assist );
+    } else {
+        act.speed.assist = 1.0f;
+    }
+    // Mutation and game-option multipliers have no dedicated speed field; fold them
+    // into skills so act.speed.total() matches the actual crafting rate.
+    const float mutation_mult = who.mutation_value( "crafting_speed_modifier" );
+    const float game_opt_mult = get_option<int>( "CRAFTING_SPEED_MULT" ) == 0
+                                ? 9999.0f
+                                : 100.0f / static_cast<float>( get_option<int>( "CRAFTING_SPEED_MULT" ) );
+    act.speed.skills = mutation_mult * game_opt_mult;
 }
 
 void craft_activity_actor::start( player_activity &act, Character &who )
@@ -2206,8 +2239,8 @@ void craft_activity_actor::do_turn( player_activity &act, Character &who )
 
     const recipe &making = *rec;
     const bench_location bench = find_best_bench( who, *craft_item );
-    const float tools_mult = crafting_tools_speed_multiplier( who, making );
-    const float crafting_speed = crafting_speed_multiplier( who, *craft_item, bench, tools_mult );
+    refresh_speed( act, who, *craft_item, bench );
+    const float crafting_speed = crafting_speed_multiplier( who, *craft_item, bench, act.speed.tools );
     const int assistants = who.available_assistant_count( making );
 
     if( crafting_speed <= 0.0f ) {

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -177,6 +177,8 @@ class craft_activity_actor final : public activity_actor
     private:
         item *find_in_progress_craft( Character &who ) const;
         void do_complete_craft( player_activity &act, Character &who );
+        void refresh_speed( player_activity &act, const Character &who, const item &craft_item,
+                            std::optional<bench_location> bench = std::nullopt ) const;
 
 };
 


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves https://github.com/cataclysmbn/Cataclysm-BN/issues/8844

## Describe the solution (The How)

Ensure the speed is properly calculated and updated each turn.
Shoved that in craft_activity_actor to avoid duplication.


## Describe alternatives you've considered

## Testing

Spawned hammer and scrap metal to craft lockpick in daylight, then did the same in darkness to see the difference.
It seems alright.

Spawned human corpse, butchered, seems alright.

Made npc craft cudgel, still works.

## Additional context
<img width="1276" height="703" alt="image" src="https://github.com/user-attachments/assets/5eb04530-42c9-4420-9849-cd4fe968d016" />

<img width="367" height="307" alt="image" src="https://github.com/user-attachments/assets/4a128699-7b6c-4853-ad5f-2e69e07fe331" />



## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
