### PR TITLE
fix: prevent crafting without power

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2238,43 +2238,9 @@ void craft_activity_actor::do_turn( player_activity &act, Character &who )
     if( five_percent_steps > 0 ) {
         who.craft_skill_gain( *craft_item, five_percent_steps );
 
-        if( !tools_prepaid ) {
-            inventory map_inv;
-            map_inv.form_from_map( who.pos(), PICKUP_RANGE, &who );
-            for( const comp_selection<tool_comp> &tool_sel : tool_selections ) {
-                if( tool_sel.comp.count <= 0 ) {
-                    continue;
-                }
-                const int full_cost = tool_sel.comp.count * batch_size;
-                const int step_cost = crafting::charges_for_continuing( full_cost ) * five_percent_steps;
-                const itype_id &type = tool_sel.comp.type;
-                bool has_enough = false;
-                switch( tool_sel.use_from ) {
-                    case usage_from::player:
-                        has_enough = who.has_charges( type, step_cost );
-                        break;
-                    case usage_from::map:
-                        has_enough = map_inv.has_charges( type, step_cost );
-                        break;
-                    case usage_from::both:
-                        has_enough = who.charges_of( type ) + map_inv.charges_of( type ) >= step_cost;
-                        break;
-                    default:
-                        has_enough = true;
-                        break;
-                }
-                if( !has_enough ) {
-                    who.add_msg_player_or_npc( m_bad,
-                                               _( "You have insufficient %s charges and have to stop crafting." ),
-                                               _( "<npcname> has insufficient %s charges and has to stop crafting." ),
-                                               item::nname( type ) );
-                    act.set_to_null();
-                    return;
-                }
-                comp_selection<tool_comp> to_consume = tool_sel;
-                to_consume.comp.count = step_cost;
-                who.consume_tools( to_consume, 1 );
-            }
+        if( !tools_prepaid && !who.craft_consume_tools( *craft_item, five_percent_steps, false ) ) {
+            act.set_to_null();
+            return;
         }
     }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2237,6 +2237,45 @@ void craft_activity_actor::do_turn( player_activity &act, Character &who )
 
     if( five_percent_steps > 0 ) {
         who.craft_skill_gain( *craft_item, five_percent_steps );
+
+        if( !tools_prepaid ) {
+            inventory map_inv;
+            map_inv.form_from_map( who.pos(), PICKUP_RANGE, &who );
+            for( const comp_selection<tool_comp> &tool_sel : tool_selections ) {
+                if( tool_sel.comp.count <= 0 ) {
+                    continue;
+                }
+                const int full_cost = tool_sel.comp.count * batch_size;
+                const int step_cost = crafting::charges_for_continuing( full_cost ) * five_percent_steps;
+                const itype_id &type = tool_sel.comp.type;
+                bool has_enough = false;
+                switch( tool_sel.use_from ) {
+                    case usage_from::player:
+                        has_enough = who.has_charges( type, step_cost );
+                        break;
+                    case usage_from::map:
+                        has_enough = map_inv.has_charges( type, step_cost );
+                        break;
+                    case usage_from::both:
+                        has_enough = who.charges_of( type ) + map_inv.charges_of( type ) >= step_cost;
+                        break;
+                    default:
+                        has_enough = true;
+                        break;
+                }
+                if( !has_enough ) {
+                    who.add_msg_player_or_npc( m_bad,
+                                               _( "You have insufficient %s charges and have to stop crafting." ),
+                                               _( "<npcname> has insufficient %s charges and has to stop crafting." ),
+                                               item::nname( type ) );
+                    act.set_to_null();
+                    return;
+                }
+                comp_selection<tool_comp> to_consume = tool_sel;
+                to_consume.comp.count = step_cost;
+                who.consume_tools( to_consume, 1 );
+            }
+        }
     }
 
     // Keep the progress_counter in sync so the UI shows correct values

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -275,6 +275,7 @@ detached_ptr<item> craft_command::create_in_progress_craft()
     new_craft->set_cached_tool_selections( tool_selections );
     new_craft->set_tools_to_continue( true );
 
+    bool can_fully_prepay = true;
     for( const comp_selection<tool_comp> &tool_sel : tool_selections ) {
         const auto type = tool_sel.comp.type;
         if( tool_sel.comp.count > 0 ) {
@@ -282,17 +283,17 @@ detached_ptr<item> craft_command::create_in_progress_craft()
             switch( tool_sel.use_from ) {
                 case usage_from::player:
                     if( !crafter->has_charges( type, full_cost ) ) {
-                        return detached_ptr<item>();
+                        can_fully_prepay = false;
                     }
                     break;
                 case usage_from::map:
                     if( !map_inv.has_charges( type, full_cost ) ) {
-                        return detached_ptr<item>();
+                        can_fully_prepay = false;
                     }
                     break;
                 case usage_from::both:
                     if( crafter->charges_of( type ) + map_inv.charges_of( type ) < full_cost ) {
-                        return detached_ptr<item>();
+                        can_fully_prepay = false;
                     }
                     break;
                 case usage_from::none:
@@ -324,15 +325,55 @@ detached_ptr<item> craft_command::create_in_progress_craft()
             }
         }
     }
-    for( const comp_selection<tool_comp> &tool : tool_selections ) {
-        if( tool.comp.count <= 0 ) {
-            continue;
+
+    if( can_fully_prepay ) {
+        for( const comp_selection<tool_comp> &tool : tool_selections ) {
+            if( tool.comp.count <= 0 ) {
+                continue;
+            }
+            auto to_consume = tool;
+            to_consume.comp.count *= batch_size;
+            crafter->consume_tools( to_consume, 1 );
         }
-        auto to_consume = tool;
-        to_consume.comp.count *= batch_size;
-        crafter->consume_tools( to_consume, 1 );
+        new_craft->set_var( "craft_tools_fully_prepaid", 1 );
+    } else {
+        // Consume only the starting fraction; the rest will be paid per 5% step during crafting.
+        for( const comp_selection<tool_comp> &tool_sel : tool_selections ) {
+            if( tool_sel.comp.count <= 0 ) {
+                continue;
+            }
+            const auto full_cost = tool_sel.comp.count * batch_size;
+            const auto start_cost = crafting::charges_for_starting( full_cost );
+            bool has_start = false;
+            switch( tool_sel.use_from ) {
+                case usage_from::player:
+                    has_start = crafter->has_charges( tool_sel.comp.type, start_cost );
+                    break;
+                case usage_from::map:
+                    has_start = map_inv.has_charges( tool_sel.comp.type, start_cost );
+                    break;
+                case usage_from::both:
+                    has_start = crafter->charges_of( tool_sel.comp.type ) +
+                                map_inv.charges_of( tool_sel.comp.type ) >= start_cost;
+                    break;
+                default:
+                    has_start = true;
+                    break;
+            }
+            if( !has_start ) {
+                return detached_ptr<item>();
+            }
+        }
+        for( const comp_selection<tool_comp> &tool_sel : tool_selections ) {
+            if( tool_sel.comp.count <= 0 ) {
+                continue;
+            }
+            auto to_consume = tool_sel;
+            to_consume.comp.count = crafting::charges_for_starting( tool_sel.comp.count * batch_size );
+            crafter->consume_tools( to_consume, 1 );
+        }
+        // craft_tools_fully_prepaid is intentionally NOT set; do_turn will consume per step.
     }
-    new_craft->set_var( "craft_tools_fully_prepaid", 1 );
     new_craft->set_next_failure_point( *crafter );
 
     return new_craft;

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -119,19 +119,19 @@ void craft_command::execute( const tripoint &new_loc )
         }
     }
 
-    if( need_selections ) {
-        if( !crafter->can_make( rec, batch_size ) ) {
-            if( crafter->can_start_craft( rec, recipe_filter_flags::none, batch_size ) ) {
-                if( !query_yn( _( "You don't have enough charges to complete the %s.\n"
-                                  "Start crafting anyway?" ), rec->result_name() ) ) {
-                    return;
-                }
-            } else {
-                debugmsg( "Tried to start craft without sufficient charges" );
+    if( !crafter->can_make( rec, batch_size ) ) {
+        if( crafter->can_start_craft( rec, recipe_filter_flags::none, batch_size ) ) {
+            if( !query_yn( _( "You don't have enough charges to complete the %s.\n"
+                              "Start crafting anyway?" ), rec->result_name() ) ) {
                 return;
             }
+        } else {
+            debugmsg( "Tried to start craft without sufficient charges" );
+            return;
         }
+    }
 
+    if( need_selections ) {
         flags = recipe_filter_flags::no_rotten;
 
         if( !crafter->can_start_craft( rec, flags, batch_size ) ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8706,10 +8706,6 @@ int iuse::craft( player *p, item *it, bool, const tripoint &pos )
         return 0;
     }
 
-    if( it->get_var( "craft_tools_fully_prepaid", 0 ) == 0 ) {
-        it->set_var( "craft_tools_fully_prepaid", 1 );
-    }
-
     bench_location best_bench = find_best_bench( *p, *it );
     p->add_msg_player_or_npc(
         pgettext( "in progress craft", "You start working on the %s." ),


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Resolves https://github.com/cataclysmbn/Cataclysm-BN/issues/8360

## Describe the solution (The How)

Ensure only the starting cost is consumed when calling create_in_progress_craft()
Call craft_consume_tools in do_turn() to use the cost as the craft progresses.

## Describe alternatives you've considered

## Testing

Spawned 3 laptops, one full, one at 115/120, one at zero.
Full laptop successfully crafted
One at 115 popped confirmation and stopped at zero, not finishing the craft.
The one at zero did not start at all
Asked an NPC to craft it, got message "No nearby npc has the necessary components to craft that."
Took in progress craft near the full laptop, resume craft, full laptop charges were reduced.

## Additional context

<img width="489" height="311" alt="image" src="https://github.com/user-attachments/assets/178c855e-27ab-4cbf-ba1d-61ce724fc64a" />

<img width="623" height="306" alt="image" src="https://github.com/user-attachments/assets/743079d7-0fac-4ad2-8217-ae651a5f53b8" />



## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
