### PR TITLE
feat(UI): add per vehicle autodrive speed option

### DIFF
--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build-translations:
-
     runs-on: ubuntu-latest
     steps:
       - name: Install gettext

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2733,14 +2733,6 @@ void options_manager::add_options_debug()
 
     add_empty_line();
 
-    add( "MIN_AUTODRIVE_SPEED", debug, translate_marker( "Minimum auto-drive speed" ),
-         translate_marker( "Set the minimum speed for the auto-drive feature.  In tiles/s.  Default is 1 (6 km/h or 4 mph)." ),
-         1, 100, 1 );
-
-    add( "MAX_AUTODRIVE_SPEED", debug, translate_marker( "Maximum auto-drive speed" ),
-         translate_marker( "Set the maximum speed for the auto-drive feature.  In tiles/s.  Default is 9 (57 km/h or 36 mph)." ),
-         1, 100, 9 );
-
     add( "LIMITED_BAYONETS", debug, translate_marker( "New bayonet system" ),
          translate_marker( "If true, bayonets replace weapon attack instead of adding to it.  WIP feature, weakens bayonets heavily at the moment." ),
          false );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8384,9 +8384,9 @@ void vehicle::set_cruise_control_speed()
     }
     const auto takeoff = get_takeoff_speed( "t/t" );
     if( takeoff > 0 && takeoff > min_autodrive_speed * 0.8 ) {
-        popup( "Warning: Minimum speed is less then safe speed for autodrive to use" );
+        popup( "Warning: Minimum speed is less than safe flight speed );
     }
     if( takeoff > 0 && takeoff > max_autodrive_speed * 0.5 ) {
-        popup( "Warning: Maximum speed is less then safe speed for autodrive to use" );
+        popup( "Warning: Maximum speed is less then safe flight speed" );
     }
 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8384,7 +8384,7 @@ void vehicle::set_cruise_control_speed()
     }
     const auto takeoff = get_takeoff_speed( "t/t" );
     if( takeoff > 0 && takeoff > min_autodrive_speed * 0.8 ) {
-        popup( "Warning: Minimum speed is less than safe flight speed );
+        popup( "Warning: Minimum speed is less than safe flight speed" );
     }
     if( takeoff > 0 && takeoff > max_autodrive_speed * 0.5 ) {
         popup( "Warning: Maximum speed is less then safe flight speed" );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -68,6 +68,7 @@
 #include "sounds.h"
 #include "string_formatter.h"
 #include "string_id.h"
+#include "string_input_popup.h"
 #include "submap.h"
 #include "translations.h"
 #include "units_utility.h"
@@ -4863,7 +4864,7 @@ double vehicle::total_lift( const bool fuelled, const bool safe, const bool idea
     }
 }
 
-int vehicle::get_takeoff_speed() const
+int vehicle::get_takeoff_speed( std::string speed_type ) const
 {
     const int needed_force = to_newton( total_mass() ) - thrust_of_rotorcraft( true, false, true ) -
                              total_balloon_lift();
@@ -4874,10 +4875,15 @@ int vehicle::get_takeoff_speed() const
         // m^2 area is always 1
         return acc + ( 0.5 * liftcoff );
     } );
+    if( liftwithoutspeed < 1 ) {
+        return 0;
+    }
     const double needed_met_sec_squared = needed_force / liftwithoutspeed;
     const double needed_met_sec = std::sqrt( needed_met_sec_squared );
     const double needed_km_hour = needed_met_sec / 1000 * 3600;
-    std::string speed_type = get_option<std::string>( "USE_METRIC_SPEEDS" );
+    if( speed_type == "default" ) {
+        speed_type = get_option<std::string>( "USE_METRIC_SPEEDS" );
+    }
     if( speed_type == "km/h" ) {
         return ceil( needed_km_hour );
     } else if( speed_type == "mph" ) {
@@ -8354,4 +8360,33 @@ void vehicle::item_dropper_drop_all( )
     }
 
     item_dropper_drop( ret, false );
+}
+void vehicle::set_cruise_control_speed()
+{
+    const auto requested_min_autodrive_speed = string_input_popup()
+            .title( _( "Minumum Speed in tiles per tick? ( 6 km/hr and 4 mph per )" ) )
+            .text( std::to_string( min_autodrive_speed ) )
+            .only_digits( true )
+            .max_length( 3 )
+            .query_int();
+    min_autodrive_speed = requested_min_autodrive_speed > 0 ? requested_min_autodrive_speed :
+                          min_autodrive_speed;
+    const auto requested_max_autodrive_speed = string_input_popup()
+            .title( _( "Maxumum Speed in tiles per tick? ( 6 km/hr and 4 mph per )" ) )
+            .text( std::to_string( max_autodrive_speed ) )
+            .only_digits( true )
+            .max_length( 3 )
+            .query_int();
+    max_autodrive_speed = requested_max_autodrive_speed > 0 ? requested_max_autodrive_speed :
+                          max_autodrive_speed;
+    if( max_autodrive_speed < min_autodrive_speed ) {
+        max_autodrive_speed = min_autodrive_speed;
+    }
+    const auto takeoff = get_takeoff_speed( "t/t" );
+    if( takeoff > 0 && takeoff > min_autodrive_speed * 0.8 ) {
+        popup( "Warning: Minimum speed is less then safe speed for autodrive to use" );
+    }
+    if( takeoff > 0 && takeoff > max_autodrive_speed * 0.5 ) {
+        popup( "Warning: Maximum speed is less then safe speed for autodrive to use" );
+    }
 }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1151,7 +1151,7 @@ class vehicle
         /**
          * speed needed for aircraft takeoff
          */
-        int get_takeoff_speed() const;
+        int get_takeoff_speed( std::string speed_type = "default" ) const;
         /**
          * total area of every propeller in m^2
          */
@@ -1842,6 +1842,10 @@ class vehicle
         bool is_following = false;
         int follow_distance = 0;
         bool is_patrolling = false;
+        // Autodrive speed
+        int min_autodrive_speed = 1;
+        int max_autodrive_speed = 9;
+
         // TODO: change these to a bitset + enum?
         // cruise control on/off
         bool cruise_on = true;
@@ -1880,6 +1884,9 @@ class vehicle
         // Returns debug data to overlay on the screen, a vector of {map tile position
         // relative to vehicle pos, color and text}.
         std::vector<std::tuple<point, int, std::string>> get_debug_overlay_data() const;
+
+        // Set cruise control
+        void set_cruise_control_speed();
 };
 
 namespace rot

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -789,7 +789,7 @@ void vehicle::autodrive_controller::compute_goal_zone()
 void vehicle::autodrive_controller::precompute_data()
 {
 
-    const int MAX_SPEED_TPS = get_option<int>( "MAX_AUTODRIVE_SPEED" );
+    const int MAX_SPEED_TPS = driven_veh.max_autodrive_speed;
     const tripoint_abs_omt current_omt = driven_veh.global_omt_location();
     const tripoint_abs_omt next_omt = driver.omt_path.back();
     const tripoint_abs_omt next_next_omt = driver.omt_path.size() >= 2 ?
@@ -1078,14 +1078,14 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
 
 void vehicle::autodrive_controller::reduce_speed()
 {
-    const int MIN_SPEED_TPS = get_option<int>( "MIN_AUTODRIVE_SPEED" );
+    const int MIN_SPEED_TPS = driven_veh.min_autodrive_speed;
     data.max_speed_tps = MIN_SPEED_TPS;
 }
 
 std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step()
 {
     precompute_data();
-    const int MIN_SPEED_TPS = get_option<int>( "MIN_AUTODRIVE_SPEED" );
+    const int MIN_SPEED_TPS = driven_veh.min_autodrive_speed;
     const tripoint_abs_ms veh_pos = driven_veh.global_square_location();
     while( !data.path.empty() && data.path.back().pos != veh_pos ) {
         data.path.pop_back();
@@ -1222,11 +1222,6 @@ autodrive_result vehicle::do_autodrive( Character &driver )
     }
     active_autodrive_controller->check_safe_speed();
     std::optional<navigation_step> next_step = active_autodrive_controller->compute_next_step();
-    if( has_part( VPFLAG_WING ) && is_flying_in_air() ) {
-        driver.add_msg_if_player( _( "Autodrive is not good enough for flying planes." ) );
-        stop_autodriving( false );
-        return autodrive_result::abort;
-    }
     if( !next_step ) {
         // message handles pathfinding failure either due to obstacles or inability to see
         driver.add_msg_if_player( _( "Can't see a path forward." ) );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -832,6 +832,11 @@ void vehicle::use_controls( const tripoint &pos )
         refresh();
     } );
 
+    options.emplace_back( _( "Adjust vehicle autodrive speed" ) );
+    actions.emplace_back( [&] {
+        set_cruise_control_speed();
+    } );
+
     options.emplace_back( brake_hold_toggle_string(), 'b' );
     actions.emplace_back( [&] {
         toggle_brake_hold();


### PR DESCRIPTION
## Purpose of change (The Why)
Resolves #8853 how chaos wants it to be resolved
It also allows players to have different autodrive speed so their blimp can go fast but not their car and so on

## Describe the solution (The How)
Add per vehicle autodrive speed option
Add warnings when using planes under safe speeds
I have not crashed when outside those bounds

## Describe alternatives you've considered
None

## Testing
Spawned f-15, 20-30/30-40 all works safely

## Additional context
Autodrive errors a lot at these speeds, mainly usable for straight shots

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.