### PR TITLE
fix: farm zones can use the no seed option again

### DIFF
--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -527,7 +527,7 @@ plot_options::query_seed_result plot_options::query_seed()
     std::vector<seed_tuple> seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), itype_id( "null" ), _( "No seed" ), 0 );
 
-    int seed_index = iexamine::query_seed( seed_entries );
+    int seed_index = iexamine::query_seed( seed_entries, 0 );
 
     if( seed_index > 0 && seed_index < static_cast<int>( seed_entries.size() ) ) {
         const auto &seed_entry = seed_entries[seed_index];


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/8751

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

https://github.com/cataclysmbn/Cataclysm-BN/pull/7396 added an optional field to iexamine::query_seed to enforce a minimum seed count requirement instead of always allowing each option to be picked

The no seed option uses the itype_id( "null" ) of which you (hopefully) cant get any of, so we need to pass 0 as the min_req argument when querying the user to pick a seed type for a farm zone

## Describe alternatives you've considered

- Not doing this?

## Testing

Booted up the game, placed a farm zone with no seed selected, gave myself barley seeds and verified placing a farm zone of barley seeds worked still


## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
