### PR TITLE
fix(UI): morale message from hallucinogenic mushrooms is no longer malformed

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1105,9 +1105,9 @@ void Character::modify_morale( item &food, int nutr )
 
     if( food.has_flag( flag_HIDDEN_HALLU ) ) {
         if( has_trait( trait_SPIRITUAL ) ) {
-            add_morale( MORALE_FOOD_GOOD, 36, 72, 2_hours, 1_hours, false );
+            add_morale( MORALE_FEELING_GOOD, 36, 72, 2_hours, 1_hours, false );
         } else {
-            add_morale( MORALE_FOOD_GOOD, 18, 36, 1_hours, 30_minutes, false );
+            add_morale( MORALE_FEELING_GOOD, 18, 36, 1_hours, 30_minutes, false );
         }
     }
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

fix https://github.com/cataclysmbn/Cataclysm-BN/issues/8840

Despite what this bug report says, the malformed mood bonus message is not from the artifact the player has on them
It is instead from some of the mushrooms they have in their inventory, this can be confirmed by loading up the provided save file, debugging all player skills to 10 and inspecting the stack of 7 mushrooms they have in their inventory which will now display `On closer inspection, this appears to be <neutral>hallucinogenic</neutral>.`

The morale message is malformed because `MORALE_FOOD_GOOD` expects an item name to be passed to the add_morale() function to use in its message (e.g "Enjoyed mushrooms") but no item name is provided when applying the effect


## Describe the solution (The How)

Change the MORALE_FOOD_GOOD morale message to a generic MORALE_FEELING_GOOD (displays as "Good feeling" in morale menu)

## Describe alternatives you've considered

- Instead passing MORALE_FOOD_GOOD with food.type as the item resulting in a "Enjoyed mushrooms" morale message

Ive opted to not do this as I assume the original intent here was to obscure the fact that the mushrooms the player had just consumed were infact hallucinogenic  

## Testing

Ate a mushroom with the HIDDEN_HALLU flag on it and observed the morale message displaying "Good feeling"

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

