### PR TITLE
feat(port): Camera can take photos of NPCs and better selfie message

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -427,7 +427,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
         std::unordered_set<const vehicle *> &vehicles_recorded );
 static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
         const tripoint &camera_pos,
-        std::vector<monster *> &monster_vec, std::vector<player *> &player_vec );
+        std::vector<monster *> &monster_vec, std::vector<Character *> &character_vec );
 
 static const std::vector<std::string> camera_ter_whitelist_flags = {
     "HIDE_PLACE", "FUNGUS", "TREE", "PERMEABLE", "SHRUB",
@@ -6674,7 +6674,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
 
 static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
         const tripoint &camera_pos,
-        std::vector<monster *> &monster_vec, std::vector<player *> &player_vec )
+        std::vector<monster *> &monster_vec, std::vector<Character *> &character_vec )
 {
     // look for big items on top of stacks in the background for the selfie description
     const units::volume min_visible_volume = 490_ml;
@@ -6710,7 +6710,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
             continue; // disallow photos with non-visible objects
         }
         monster *const mon = g->critter_at<monster>( current, false );
-        avatar *guy = g->critter_at<avatar>( current );
+        Character *guy = g->critter_at<Character>( current );
 
         total_tiles_num++;
         if( g->m.is_outside( current ) ) {
@@ -6741,7 +6741,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
                 figure_name = guy->name;
                 pronoun_sex = guy->male ? _( "He" ) : _( "She" );
                 creature = guy;
-                player_vec.push_back( guy );
+                character_vec.push_back( guy );
             } else {
                 if( mon->is_hallucination() || mon->type->in_species( HALLUCINATION ) ) {
                     continue; // do not include hallucinations
@@ -7190,9 +7190,9 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
 
                 std::vector<extended_photo_def> extended_photos;
                 std::vector<monster *> monster_vec;
-                std::vector<player *> player_vec;
+                std::vector<Character *> character_vec;
                 extended_photo_def photo = photo_def_for_camera_point( trajectory_point, p->pos(), monster_vec,
-                                           player_vec );
+                                           character_vec );
                 photo.quality = photo_quality;
 
                 try {
@@ -7204,9 +7204,10 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
                               e.c_str() );
                 }
 
-                const bool selfie = std::ranges::contains( player_vec, p );
+                const bool selfie = std::ranges::contains( character_vec, p );
 
                 if( selfie ) {
+
                     p->add_msg_if_player( _( "You took a selfie." ) );
                 } else {
                     if( p->is_blind() ) {
@@ -7222,10 +7223,10 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
                             blinded_names.push_back( monster_p->name() );
                         }
                     }
-                    for( player * const &player_p : player_vec ) {
-                        if( dist < 4 && one_in( dist + 2 ) && !player_p->is_blind() ) {
-                            player_p->add_effect( effect_blind, rng( 5_turns, 10_turns ) );
-                            blinded_names.push_back( player_p->name );
+                    for( Character * const &character_p : character_vec ) {
+                        if( dist < 4 && one_in( dist + 2 ) && !character_p->is_blind() ) {
+                            character_p->add_effect( effect_blind, rng( 5_turns, 10_turns ) );
+                            blinded_names.push_back( character_p->name );
                         }
                     }
                     if( !blinded_names.empty() ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7209,7 +7209,7 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
                 if( selfie ) {
                     auto name = photo.name;
 
-                    if ( photo.name == colorize( p->name, c_light_blue ) ) {
+                    if( name == colorize( p->name, c_light_blue ) ) {
                         p->add_msg_if_player( _( "You took a selfie." ) );
                     } else {
                         size_t index = name.find( p->name );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7207,8 +7207,17 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
                 const bool selfie = std::ranges::contains( character_vec, p );
 
                 if( selfie ) {
+                    auto name = photo.name;
 
-                    p->add_msg_if_player( _( "You took a selfie." ) );
+                    if ( photo.name == colorize( p->name, c_light_blue ) ) {
+                        p->add_msg_if_player( _( "You took a selfie." ) );
+                    } else {
+                        size_t index = name.find( p->name );
+                        if( index != std::string::npos ) {
+                            name.replace( index, p->name.length(), _( "Yourself" ) );
+                        }
+                        p->add_msg_if_player( _( "You took a selfie with %1$s." ), name );
+                    }
                 } else {
                     if( p->is_blind() ) {
                         p->add_msg_if_player( _( "You took a photo of %s." ), photo.name );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/7861

## Describe the solution (The How)

ports https://github.com/CleverRaven/Cataclysm-DDA/pull/49067

Which allows taking photos of npcs at all by replacing instances of player with character in the iuse

And then ontop of that pr modifies the message displayed when taking a selfie
Previously the behavior would be simply always printing "You took a selfie." if the player character was within the photo at all

Now the behaviour is printing "You took a selfie." if the player is the only thing in the photo
If the player is not the only thing in the photo you will instead get a message along the lines of "You took a selfie with Yourself, John NPC and deer." if the photo also had an npc and a deer in it

## Describe alternatives you've considered

- Not doing this

## Testing

Gave myself a camera, spawned in an npc and teleported myself next to the npc, then spawned a fox next to me
<img width="225" height="46" alt="2026-05-15-01:30:16" src="https://github.com/user-attachments/assets/362a11a5-e527-4c85-b744-b1e9d26b41cb" />


## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [x] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [x] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [x] I have linked the URL of original PR(s) in the description.