### PR TITLE
perf: fix lag when flying at zlevel 10

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -593,6 +593,7 @@ void map::generate_lightmap_worker( const int zlev )
     ZoneScoped;
     auto &map_cache = get_cache( zlev );
     auto &lm = map_cache.lm;
+    auto &outside_cache = map_cache.outside_cache;
     auto &prev_floor_cache = get_cache( clamp( zlev + 1, -OVERMAP_DEPTH, OVERMAP_DEPTH ) ).floor_cache;
     auto &prev_vehicle_floor_cache = get_cache( clamp( zlev + 1, -OVERMAP_DEPTH,
                                      OVERMAP_DEPTH ) ).vehicle_floor_cache;
@@ -665,13 +666,13 @@ void map::generate_lightmap_worker( const int zlev )
                         auto has_floor_above = [&]( int idx ) {
                             return prev_floor_cache[idx] || prev_vehicle_floor_cache[idx];
                         };
-                        if( top_floor || has_floor_above( map_cache.idx( p.x, p.y ) ) ) {
+                        if( !outside_cache[map_cache.idx( p.x, p.y )] || ( !top_floor &&
+                                has_floor_above( map_cache.idx( p.x, p.y ) ) ) ) {
                             // Apply light sources for external/internal divide.
-                            // A neighbour is an outdoor light source if it has no floor above it
-                            // and is part of a genuine outdoor area (not an isolated skylight hole).
-                            // An isolated skylight has no adjacent open-sky neighbours, so we
-                            // require at least one cardinal neighbour of `nb` (other than p) that
-                            // also has no floor above.
+                            // Skip outdoor tiles (outside_cache=true) unless they have a ceiling;
+                            // without this guard every z=10 tile (all outside) enters the loop.
+                            // A neighbour qualifies as an outdoor source only if it's in a genuine
+                            // open-sky area (not an isolated 1-tile skylight hole).
                             for( int i = 0; i < 4; ++i ) {
                                 const point neighbour = p.xy() + point( dir_x[i], dir_y[i] );
                                 if( neighbour.x < 0 || neighbour.y < 0 ||

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -669,10 +669,13 @@ void map::generate_lightmap_worker( const int zlev )
                         if( !outside_cache[map_cache.idx( p.x, p.y )] || ( !top_floor &&
                                 has_floor_above( map_cache.idx( p.x, p.y ) ) ) ) {
                             // Apply light sources for external/internal divide.
-                            // Skip outdoor tiles (outside_cache=true) unless they have a ceiling;
+                            // Skip outdoor tiles (outside_cache=true) unless they have a ceiling above
                             // without this guard every z=10 tile (all outside) enters the loop.
-                            // A neighbour qualifies as an outdoor source only if it's in a genuine
-                            // open-sky area (not an isolated 1-tile skylight hole).
+                            // A neighbour is an outdoor light source if it has no floor above it
+                            // and is part of a genuine outdoor area (not an isolated skylight hole).
+                            // An isolated skylight has no adjacent open-sky neighbours, so we
+                            // require at least one cardinal neighbour of `nb` (other than p) that
+                            // also has no floor above.
                             for( int i = 0; i < 4; ++i ) {
                                 const point neighbour = p.xy() + point( dir_x[i], dir_y[i] );
                                 if( neighbour.x < 0 || neighbour.y < 0 ||


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves https://github.com/cataclysmbn/Cataclysm-BN/issues/8625

## Describe the solution (The How)
Restore outside_cache guard in generate_lightmap_worker.
From what I understand, the problem is that the outside tiles were not properly excluded without the cache guard.


## Describe alternatives you've considered

## Testing

Activated debug noclip, went to zlevel 10, noticed the lag, applied fix, walked around some more and saw the difference.

## Additional context

I am not sure if this has other side effects, would appreciate someone else's input on this.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
