### PR TITLE
fix: mounted creatures no longer make non-ambient sounds

### DIFF
--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build-translations:
-
     runs-on: ubuntu-latest
     steps:
       - name: Install gettext

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11410,7 +11410,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
                 if( mons->has_flag( MF_LOUDMOVES ) ) {
                     volume += 6;
                 }
-                sounds::sound( dest_loc, volume, sounds::sound_t::movement, mons->type->get_footsteps(), false,
+                sounds::sound( dest_loc, volume, sounds::sound_t::movement, mons->type->get_footsteps(), true,
                                "none", "none" );
             } else {
                 sounds::sound( dest_loc, volume, sounds::sound_t::movement, _( "footsteps" ), true,


### PR DESCRIPTION
## Purpose of change (The Why)
Resolves #8854

## Describe the solution (The How)
Make mount footsteps ambient like player footsteps

## Describe alternatives you've considered
Fixitate blame

## Testing
Ran mech through forest
No more gears messages

## Additional context
This most certainly isn't a new issue...
It's been around since 2019 :P

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.