### PR TITLE
fix: prevent large sprites from getting clipped

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3392,97 +3392,97 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
             }
         }
 
-    auto compare_z = [&]( tile_render_info a, tile_render_info b ) -> bool {
-        return ( a.pos.z < b.pos.z );
-    };
+        auto compare_z = [&]( tile_render_info a, tile_render_info b ) -> bool {
+            return ( a.pos.z < b.pos.z );
+        };
 
-    const std::array<decltype( &cata_tiles::draw_furniture ), 3> base_drawing_layers = {{
-            &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap
-        }
-    };
-    struct zlevel_layer {
-        bool hide_unseen;
-        decltype( &cata_tiles::draw_furniture ) function;
-    };
-    const std::array<zlevel_layer, 3> zlevel_drawing_layers = {{
-            {true, &cata_tiles::draw_field_or_item}, {false, &cata_tiles::draw_vpart}, {true, &cata_tiles::draw_critter_at}
-        }
-    };
-    const std::array<decltype( &cata_tiles::draw_furniture ), 2> final_drawing_layers = {{
-            &cata_tiles::draw_zone_mark, &cata_tiles::draw_zombie_revival_indicators
-        }
-    };
+        const std::array<decltype( &cata_tiles::draw_furniture ), 3> base_drawing_layers = {{
+                &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap
+            }
+        };
+        struct zlevel_layer {
+            bool hide_unseen;
+            decltype( &cata_tiles::draw_furniture ) function;
+        };
+        const std::array<zlevel_layer, 3> zlevel_drawing_layers = {{
+                {true, &cata_tiles::draw_field_or_item}, {false, &cata_tiles::draw_vpart}, {true, &cata_tiles::draw_critter_at}
+            }
+        };
+        const std::array<decltype( &cata_tiles::draw_furniture ), 2> final_drawing_layers = {{
+                &cata_tiles::draw_zone_mark, &cata_tiles::draw_zombie_revival_indicators
+            }
+        };
 
-    std::ranges::stable_sort( draw_points, compare_z );
+        std::ranges::stable_sort( draw_points, compare_z );
         for( tile_render_info &p : draw_points ) {
-        draw_terrain( p.pos, p.ll, p.height_3d, p.invisible, center.z - p.pos.z );
-        if( p.pos.z == center.z ) {
-            const point screen_tl = player_to_screen( p.pos.xy() );
-            const SDL_Rect tile_rect{ screen_tl.x, screen_tl.y, tile_width, tile_height };
-            const bool in_selected_zone = has_selected_zone && p.pos.z == selected_z &&
-                                          ( has_custom_selected_zone
-                                            ? zone_point_lookup.contains( p.pos )
-                                            : ( p.pos.x >= selected_min.x && p.pos.x <= selected_max.x &&
-                                                p.pos.y >= selected_min.y && p.pos.y <= selected_max.y ) );
-            bool selected_drawn = false;
-            if( show_zones_overlay ) {
-                for( const zone_render_data &zone : zones_to_draw ) {
-                    if( !zone.tiles.contains( p.pos.xy() ) ) {
-                        continue;
+            draw_terrain( p.pos, p.ll, p.height_3d, p.invisible, center.z - p.pos.z );
+            if( p.pos.z == center.z ) {
+                const point screen_tl = player_to_screen( p.pos.xy() );
+                const SDL_Rect tile_rect{ screen_tl.x, screen_tl.y, tile_width, tile_height };
+                const bool in_selected_zone = has_selected_zone && p.pos.z == selected_z &&
+                                              ( has_custom_selected_zone
+                                                ? zone_point_lookup.contains( p.pos )
+                                                : ( p.pos.x >= selected_min.x && p.pos.x <= selected_max.x &&
+                                                    p.pos.y >= selected_min.y && p.pos.y <= selected_max.y ) );
+                bool selected_drawn = false;
+                if( show_zones_overlay ) {
+                    for( const zone_render_data &zone : zones_to_draw ) {
+                        if( !zone.tiles.contains( p.pos.xy() ) ) {
+                            continue;
+                        }
+                        draw_zone_overlay( {
+                            .renderer = renderer,
+                            .rect = tile_rect,
+                            .color = zone.color,
+                            .overlay_strings = overlay_strings,
+                            .alpha = in_selected_zone ? 128 : 64,
+                            .draw_label = false
+                        } );
+                        selected_drawn = selected_drawn || in_selected_zone;
                     }
+                }
+                if( in_selected_zone && !selected_drawn ) {
                     draw_zone_overlay( {
                         .renderer = renderer,
                         .rect = tile_rect,
-                        .color = zone.color,
+                        .color = curses_color_to_SDL( c_light_green ),
                         .overlay_strings = overlay_strings,
-                        .alpha = in_selected_zone ? 128 : 64,
+                        .alpha = 128,
                         .draw_label = false
                     } );
-                    selected_drawn = selected_drawn || in_selected_zone;
                 }
             }
-            if( in_selected_zone && !selected_drawn ) {
-                draw_zone_overlay( {
-                    .renderer = renderer,
-                    .rect = tile_rect,
-                    .color = curses_color_to_SDL( c_light_green ),
-                    .overlay_strings = overlay_strings,
-                    .alpha = 128,
-                    .draw_label = false
-                } );
-            }
         }
-    }
 
-    for( int z = min_z; z <= center.z; z++ ) {
-        for( tile_render_info &p : draw_points ) {
-            if( p.pos.z > z ) {
-                break;
-            }
-            if( p.pos.z == z ) {
-                for( decltype( &cata_tiles::draw_furniture ) f : base_drawing_layers ) {
-                    ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, center.z - p.pos.z );
+        for( int z = min_z; z <= center.z; z++ ) {
+            for( tile_render_info &p : draw_points ) {
+                if( p.pos.z > z ) {
+                    break;
                 }
-            }
-            const auto &ch = here.access_cache( z );
-            for( const zlevel_layer &f : zlevel_drawing_layers ) {
-                if( here.inbounds( p.pos ) && z != p.pos.z ) {
-                    const auto z_ll = ch.inbounds( {p.pos.x, p.pos.y} )
-                                      ? ch.visibility_cache[ch.idx( p.pos.x, p.pos.y )]
-                                      : lit_level::BLANK;
-                    if( !f.hide_unseen || z_ll != lit_level::BLANK ) {
-                        const bool ( invis )[5] = {false, false, false, false, false};
-                        ( this->*( f.function ) )( {p.pos.xy(), z}, z_ll, p.height_3d, invis, center.z - z );
+                if( p.pos.z == z ) {
+                    for( decltype( &cata_tiles::draw_furniture ) f : base_drawing_layers ) {
+                        ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, center.z - p.pos.z );
                     }
-                } else {
-                    ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, p.invisible, center.z - z );
+                }
+                const auto &ch = here.access_cache( z );
+                for( const zlevel_layer &f : zlevel_drawing_layers ) {
+                    if( here.inbounds( p.pos ) && z != p.pos.z ) {
+                        const auto z_ll = ch.inbounds( {p.pos.x, p.pos.y} )
+                                          ? ch.visibility_cache[ch.idx( p.pos.x, p.pos.y )]
+                                          : lit_level::BLANK;
+                        if( !f.hide_unseen || z_ll != lit_level::BLANK ) {
+                            const bool ( invis )[5] = {false, false, false, false, false};
+                            ( this->*( f.function ) )( {p.pos.xy(), z}, z_ll, p.height_3d, invis, center.z - z );
+                        }
+                    } else {
+                        ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, p.invisible, center.z - z );
+                    }
                 }
             }
         }
-    }
-    for( tile_render_info &p : draw_points ) {
-        for( decltype( &cata_tiles::draw_furniture ) f : final_drawing_layers ) {
-            ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, 0 );
+        for( tile_render_info &p : draw_points ) {
+            for( decltype( &cata_tiles::draw_furniture ) f : final_drawing_layers ) {
+                ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, 0 );
             }
         }
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3076,10 +3076,10 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
 
     std::vector<tile_render_info> &draw_points = *draw_points_cache;
     int min_z = OVERMAP_HEIGHT;
-    draw_points.clear();
 
     for( int row = min_row; row < max_row; row ++ ) {
-        // draw_points accumulates across all rows; rendering happens after the loop
+
+        draw_points.clear();
         for( int col = min_col; col < max_col; col ++ ) {
             int temp_x;
             int temp_y;
@@ -3392,18 +3392,8 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
             }
         }
 
-    }
-
-    // Sort globally by (z, y): all z=0 tiles render before z=1 tiles across every row,
-    // so tall z=0 sprites (e.g. tree canopies) never overdraw z=1 entities at adjacent
-    // tiles. Within the same z-level, y-ascending order (north before south) preserves
-    // the intended "tree canopy over player to the north" effect at equal z.
-    auto compare_z_y = []( const tile_render_info & a, const tile_render_info & b ) -> bool {
-        if( a.pos.z != b.pos.z )
-        {
-            return a.pos.z < b.pos.z;
-        }
-        return a.pos.y < b.pos.y;
+    auto compare_z = [&]( tile_render_info a, tile_render_info b ) -> bool {
+        return ( a.pos.z < b.pos.z );
     };
 
     const std::array<decltype( &cata_tiles::draw_furniture ), 3> base_drawing_layers = {{
@@ -3423,67 +3413,18 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
         }
     };
 
-    std::ranges::stable_sort( draw_points, compare_z_y );
-
-    for( int z = min_z; z <= center.z; z++ ) {
+    std::ranges::stable_sort( draw_points, compare_z );
         for( tile_render_info &p : draw_points ) {
-            if( p.pos.z > z ) {
-                break;
-            }
-            if( p.pos.z == z ) {
-                draw_terrain( p.pos, p.ll, p.height_3d, p.invisible, center.z - z );
-
-                for( decltype( &cata_tiles::draw_furniture ) f : base_drawing_layers ) {
-                    ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, center.z - z );
-                }
-            }
-            const auto &ch = here.access_cache( z );
-
-            for( const zlevel_layer &f : zlevel_drawing_layers ) {
-                if( here.inbounds( p.pos ) && z != p.pos.z ) {
-                    const auto z_ll = ch.inbounds( {p.pos.x, p.pos.y} )
-                                      ? ch.visibility_cache[ch.idx( p.pos.x, p.pos.y )]
-                                      : lit_level::BLANK;
-                    if( !f.hide_unseen || z_ll != lit_level::BLANK ) {
-                        // When the player is looking down from above (z_drop > 0), a BLANK
-                        // visibility at the cross-z level means the surface is part of a vehicle
-                        // body that the 3D FOV can't see through — but the surface itself should
-                        // still render as a visible floor/roof from above (z_drop > 0).
-                        // Only hide the tile when the player is at the same z-level (z_drop == 0)
-                        // and truly can't see it, which is the "enclosed interior" case.
-                        const int z_drop_here = center.z - z;
-                        const bool ( invis )[5] = {z_ll == lit_level::BLANK &&z_drop_here == 0,
-                                                   false, false, false, false
-                                                  };
-                        ( this->*( f.function ) )( {p.pos.xy(), z}, z_ll, p.height_3d, invis, z_drop_here );
-                    }
-                } else {
-                    ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, p.invisible, center.z - z );
-                }
-            }
-        }
-    }
-
-    for( tile_render_info &p : draw_points ) {
-        for( decltype( &cata_tiles::draw_furniture ) f : final_drawing_layers ) {
-            ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, 0 );
-        }
-    }
-
-    // Draw zone overlays over all other stuff
-    for( const tile_render_info &p : draw_points ) {
+        draw_terrain( p.pos, p.ll, p.height_3d, p.invisible, center.z - p.pos.z );
         if( p.pos.z == center.z ) {
             const point screen_tl = player_to_screen( p.pos.xy() );
             const SDL_Rect tile_rect{ screen_tl.x, screen_tl.y, tile_width, tile_height };
-
             const bool in_selected_zone = has_selected_zone && p.pos.z == selected_z &&
                                           ( has_custom_selected_zone
                                             ? zone_point_lookup.contains( p.pos )
                                             : ( p.pos.x >= selected_min.x && p.pos.x <= selected_max.x &&
                                                 p.pos.y >= selected_min.y && p.pos.y <= selected_max.y ) );
-
             bool selected_drawn = false;
-
             if( show_zones_overlay ) {
                 for( const zone_render_data &zone : zones_to_draw ) {
                     if( !zone.tiles.contains( p.pos.xy() ) ) {
@@ -3509,6 +3450,39 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                     .alpha = 128,
                     .draw_label = false
                 } );
+            }
+        }
+    }
+
+    for( int z = min_z; z <= center.z; z++ ) {
+        for( tile_render_info &p : draw_points ) {
+            if( p.pos.z > z ) {
+                break;
+            }
+            if( p.pos.z == z ) {
+                for( decltype( &cata_tiles::draw_furniture ) f : base_drawing_layers ) {
+                    ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, center.z - p.pos.z );
+                }
+            }
+            const auto &ch = here.access_cache( z );
+            for( const zlevel_layer &f : zlevel_drawing_layers ) {
+                if( here.inbounds( p.pos ) && z != p.pos.z ) {
+                    const auto z_ll = ch.inbounds( {p.pos.x, p.pos.y} )
+                                      ? ch.visibility_cache[ch.idx( p.pos.x, p.pos.y )]
+                                      : lit_level::BLANK;
+                    if( !f.hide_unseen || z_ll != lit_level::BLANK ) {
+                        const bool ( invis )[5] = {false, false, false, false, false};
+                        ( this->*( f.function ) )( {p.pos.xy(), z}, z_ll, p.height_3d, invis, center.z - z );
+                    }
+                } else {
+                    ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, p.invisible, center.z - z );
+                }
+            }
+        }
+    }
+    for( tile_render_info &p : draw_points ) {
+        for( decltype( &cata_tiles::draw_furniture ) f : final_drawing_layers ) {
+            ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, 0 );
             }
         }
     }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/8684

## Describe the solution (The How)

[this](https://github.com/cataclysmbn/Cataclysm-BN/pull/8586/changes/52e1cf415d93ef6267598c9297cf1cc6507a3ef7) changes the ordering of tile drawing such that for any given tile, the terrain of tile to the right of it is drawn after everything on the current tile, thereby eating the edges of large sprites

So reorder tile drawing back to how it was (i.e instead of drawing everything on one tile and then moving to the next tile, draw all terrain on a row beforehand in one pass, and then draw everything else in that row next)

The unfortunate side effect of this is that trees are now always drawn over your character as that is what the reordering was trying to solve (see below)
<img width="236" height="194" alt="2026-05-15-07:01:15" src="https://github.com/user-attachments/assets/448e3740-01c3-4de5-a761-5a0b990554eb" />

I spent a good long while trying to see if I could have both issues fixed at once but I have had pretty much no success in that regard, so here we are

If someone knows a way to do that tho, do feel free to pr it instead idk

## Describe alternatives you've considered

- Not doing this

## Testing

It does indeed work I guess

## Additional context

This is just like lightmap hell again but with tile drawing
god I hate lightmaps

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.