### PR TITLE
fix: complete targeted craft activity item

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2072,8 +2072,13 @@ craft_activity_actor::craft_activity_actor(
     is_valid( rec != nullptr )
 {}
 
-item *craft_activity_actor::find_in_progress_craft( Character &who ) const
+auto craft_activity_actor::find_in_progress_craft( const player_activity &act, Character &who ) const -> item * // *NOPAD*
 {
+    if( !act.targets.empty() && act.targets.front() && act.targets.front()->is_craft() &&
+        &act.targets.front()->get_making() == rec ) {
+        return &*act.targets.front();
+    }
+
     item *result = nullptr;
     who.visit_items( [&]( item * it ) {
         if( it->is_craft() && &it->get_making() == rec ) {
@@ -2110,7 +2115,7 @@ void craft_activity_actor::calc_all_moves( player_activity &act, Character &who 
     // Catch-up: apply time elapsed while NPC was outside the reality bubble.
     // last_turn_nr >= 0 means start() already ran in a previous session.
     if( last_turn_nr >= 0 && current_turn > last_turn_nr ) {
-        item *craft_item = find_in_progress_craft( who );
+        item *craft_item = find_in_progress_craft( act, who );
         if( craft_item ) {
             const int elapsed_turns = current_turn - last_turn_nr;
             const double base_total_moves = std::max( 1, rec->batch_time( batch_size, 1.0f, 0 ) );
@@ -2150,7 +2155,7 @@ void craft_activity_actor::calc_all_moves( player_activity &act, Character &who 
 
     // Re-build progress counter after deserialization if catch-up didn't already do it
     if( activity_actor::progress.empty() ) {
-        item *craft_item = find_in_progress_craft( who );
+        item *craft_item = find_in_progress_craft( act, who );
         const std::string name = craft_item ? craft_item->tname() : rec->result_name();
         const int base_total = std::max( 1, rec->batch_time( batch_size, 1.0f, 0 ) );
         const int remaining = std::max( 1, static_cast<int>(
@@ -2158,7 +2163,7 @@ void craft_activity_actor::calc_all_moves( player_activity &act, Character &who 
         activity_actor::progress.emplace( name, base_total, remaining );
     }
 
-    item *craft_item = find_in_progress_craft( who );
+    item *craft_item = find_in_progress_craft( act, who );
     if( craft_item ) {
         refresh_speed( act, who, *craft_item );
     }
@@ -2199,7 +2204,7 @@ void craft_activity_actor::start( player_activity &act, Character &who )
         return;
     }
 
-    item *craft_item = find_in_progress_craft( who );
+    item *craft_item = find_in_progress_craft( act, who );
     if( !craft_item ) {
         who.add_msg_player_or_npc(
             _( "You lost your in progress %s and had to stop crafting." ),
@@ -2225,7 +2230,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &who )
         return;
     }
 
-    item *craft_item = find_in_progress_craft( who );
+    item *craft_item = find_in_progress_craft( act, who );
     if( !craft_item ) {
         who.add_msg_player_or_npc(
             _( "You no longer have the in progress craft in your possession.  "
@@ -2314,9 +2319,9 @@ void craft_activity_actor::finish( player_activity &act, Character &who )
     do_complete_craft( act, who );
 }
 
-void craft_activity_actor::do_complete_craft( player_activity &/*act*/, Character &who )
+void craft_activity_actor::do_complete_craft( player_activity &act, Character &who )
 {
-    item *craft_item = find_in_progress_craft( who );
+    item *craft_item = find_in_progress_craft( act, who );
     if( !craft_item ) {
         debugmsg( "craft_activity_actor::do_complete_craft: no craft item found for %s",
                   rec ? rec->result_name() : "unknown" );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2072,7 +2072,8 @@ craft_activity_actor::craft_activity_actor(
     is_valid( rec != nullptr )
 {}
 
-auto craft_activity_actor::find_in_progress_craft( const player_activity &act, Character &who ) const -> item * // *NOPAD*
+auto craft_activity_actor::find_in_progress_craft( const player_activity &act,
+        Character &who ) const -> item * // *NOPAD*
 {
     if( !act.targets.empty() && act.targets.front() && act.targets.front()->is_craft() &&
         &act.targets.front()->get_making() == rec ) {

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -175,7 +175,8 @@ class craft_activity_actor final : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
 
     private:
-        auto find_in_progress_craft( const player_activity &act, Character &who ) const -> item *; // *NOPAD*
+        auto find_in_progress_craft( const player_activity &act,
+                                     Character &who ) const -> item *; // *NOPAD*
         void do_complete_craft( player_activity &act, Character &who );
         void refresh_speed( player_activity &act, const Character &who, const item &craft_item,
                             std::optional<bench_location> bench = std::nullopt ) const;

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -175,7 +175,7 @@ class craft_activity_actor final : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
 
     private:
-        item *find_in_progress_craft( Character &who ) const;
+        auto find_in_progress_craft( const player_activity &act, Character &who ) const -> item *; // *NOPAD*
         void do_complete_craft( player_activity &act, Character &who );
         void refresh_speed( player_activity &act, const Character &who, const item &craft_item,
                             std::optional<bench_location> bench = std::nullopt ) const;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -815,7 +815,9 @@ item *Character::start_craft( craft_command &command, const tripoint & )
                      craft_in_world->get_var( "craft_tools_fully_prepaid", 0 ) == 1,
                      command.is_long()
                  );
-    assign_activity( std::make_unique<player_activity>( std::move( actor ) ) );
+    auto craft_activity = std::make_unique<player_activity>( std::move( actor ) );
+    craft_activity->targets.emplace_back( craft_in_world );
+    assign_activity( std::move( craft_activity ) );
 
     add_msg_player_or_npc(
         pgettext( "in progress craft", "You start working on the %s." ),

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -535,38 +535,38 @@ static int resume_craft()
 static auto make_food_craft( const recipe &recipe_to_make,
                              const bool with_pine_nuts ) -> detached_ptr<item>
 {
-    auto components = std::vector<detached_ptr<item>>{};
+    auto components = std::vector<detached_ptr<item>> {};
     if( with_pine_nuts ) {
         components.push_back( item::spawn( "pine_nuts", calendar::turn, 1 ) );
     } else {
         components.push_back( item::spawn( "meat_smoked" ) );
     }
-    return item::spawn( &recipe_to_make, 1, std::move( components ), std::vector<item_comp>{} );
+    return item::spawn( &recipe_to_make, 1, std::move( components ), std::vector<item_comp> {} );
 }
 
 static auto has_component( const item &crafted, const itype_id &type ) -> bool
 {
     const auto components = crafted.get_components().as_vector();
     return std::ranges::any_of( components,
-    [&type]( const item *component ) { return component->typeId() == type; } );
+    [&type]( const item * component ) { return component->typeId() == type; } );
 }
 
 static auto finished_sandwiches( Character &you ) -> std::vector<item *>
 {
-    return you.items_with( []( const item &it ) { return it.typeId() == itype_id( "sandwich_pb" ); } );
+    return you.items_with( []( const item & it ) { return it.typeId() == itype_id( "sandwich_pb" ); } );
 }
 
 static auto in_progress_crafts( Character &you ) -> std::vector<item *>
 {
-    return you.items_with( []( const item &it ) { return it.is_craft(); } );
+    return you.items_with( []( const item & it ) { return it.is_craft(); } );
 }
 
 static auto assign_completed_craft_activity( Character &you, const recipe &recipe_to_make,
         item *target = nullptr ) -> void
 {
     auto actor = std::make_unique<craft_activity_actor>( &recipe_to_make, 1, 10'000'000,
-                 you.pos(), std::vector<comp_selection<item_comp>>{},
-                 std::vector<comp_selection<tool_comp>>{}, true, false );
+                 you.pos(), std::vector<comp_selection<item_comp>> {},
+                 std::vector<comp_selection<tool_comp>> {}, true, false );
     auto act = std::make_unique<player_activity>( std::move( actor ) );
     if( target != nullptr ) {
         act->targets.emplace_back( *target );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "avatar_functions.h"
 #include "calendar.h"
@@ -529,6 +530,117 @@ static int resume_craft()
         you.activity->do_turn( you );
     }
     return turns;
+}
+
+static auto make_food_craft( const recipe &recipe_to_make,
+                             const bool with_pine_nuts ) -> detached_ptr<item>
+{
+    auto components = std::vector<detached_ptr<item>>{};
+    if( with_pine_nuts ) {
+        components.push_back( item::spawn( "pine_nuts", calendar::turn, 1 ) );
+    } else {
+        components.push_back( item::spawn( "meat_smoked" ) );
+    }
+    return item::spawn( &recipe_to_make, 1, std::move( components ), std::vector<item_comp>{} );
+}
+
+static auto has_component( const item &crafted, const itype_id &type ) -> bool
+{
+    const auto components = crafted.get_components().as_vector();
+    return std::ranges::any_of( components,
+    [&type]( const item *component ) { return component->typeId() == type; } );
+}
+
+static auto finished_sandwiches( Character &you ) -> std::vector<item *>
+{
+    return you.items_with( []( const item &it ) { return it.typeId() == itype_id( "sandwich_pb" ); } );
+}
+
+static auto in_progress_crafts( Character &you ) -> std::vector<item *>
+{
+    return you.items_with( []( const item &it ) { return it.is_craft(); } );
+}
+
+static auto assign_completed_craft_activity( Character &you, const recipe &recipe_to_make,
+        item *target = nullptr ) -> void
+{
+    auto actor = std::make_unique<craft_activity_actor>( &recipe_to_make, 1, 10'000'000,
+                 you.pos(), std::vector<comp_selection<item_comp>>{},
+                 std::vector<comp_selection<tool_comp>>{}, true, false );
+    auto act = std::make_unique<player_activity>( std::move( actor ) );
+    if( target != nullptr ) {
+        act->targets.emplace_back( *target );
+    }
+    you.assign_activity( std::move( act ) );
+}
+
+static auto finish_craft_activity( avatar &you ) -> void
+{
+    REQUIRE( you.activity->id() == activity_id( "ACT_CRAFT" ) );
+    you.set_moves( 100 );
+    you.activity->do_turn( you );
+    REQUIRE( you.activity->id() == activity_id::NULL_ID() );
+}
+
+TEST_CASE( "craft activity completes the targeted in-progress craft", "[crafting][food]" )
+{
+    clear_all_state();
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    auto &here = get_map();
+    const auto &sandwich_recipe = recipe_id( "sandwich_pb" ).obj();
+
+    SECTION( "targeted map craft wins over inventory craft with the same recipe" ) {
+        you.i_add( make_food_craft( sandwich_recipe, false ) );
+        here.add_item( you.pos(), make_food_craft( sandwich_recipe, true ) );
+        auto &target_craft = here.i_at( you.pos() ).only_item();
+        target_craft.set_counter( 10'000'000 );
+
+        assign_completed_craft_activity( you, sandwich_recipe, &target_craft );
+        finish_craft_activity( you );
+
+        const auto sandwiches = finished_sandwiches( you );
+        REQUIRE( sandwiches.size() == 1 );
+        CHECK( has_component( *sandwiches.front(), itype_id( "pine_nuts" ) ) );
+        CHECK( !has_component( *sandwiches.front(), itype_id( "meat_smoked" ) ) );
+        CHECK( you.compute_effective_nutrients( *sandwiches.front() ).kcal == 51 );
+        CHECK( in_progress_crafts( you ).size() == 1 );
+        CHECK( here.i_at( you.pos() ).empty() );
+    }
+
+    SECTION( "targeted inventory craft is preserved when a map craft has the same recipe" ) {
+        auto &target_craft = you.i_add( make_food_craft( sandwich_recipe, false ) );
+        target_craft.set_counter( 10'000'000 );
+        here.add_item( you.pos(), make_food_craft( sandwich_recipe, true ) );
+
+        assign_completed_craft_activity( you, sandwich_recipe, &target_craft );
+        finish_craft_activity( you );
+
+        const auto sandwiches = finished_sandwiches( you );
+        REQUIRE( sandwiches.size() == 1 );
+        CHECK( has_component( *sandwiches.front(), itype_id( "meat_smoked" ) ) );
+        CHECK( !has_component( *sandwiches.front(), itype_id( "pine_nuts" ) ) );
+        CHECK( you.compute_effective_nutrients( *sandwiches.front() ).kcal == 101 );
+        CHECK( in_progress_crafts( you ).empty() );
+        REQUIRE( here.i_at( you.pos() ).size() == 1 );
+        CHECK( here.i_at( you.pos() ).only_item().is_craft() );
+    }
+
+    SECTION( "missing target falls back to an available matching craft" ) {
+        auto &fallback_craft = you.i_add( make_food_craft( sandwich_recipe, true ) );
+        fallback_craft.set_counter( 10'000'000 );
+
+        assign_completed_craft_activity( you, sandwich_recipe );
+        finish_craft_activity( you );
+
+        const auto sandwiches = finished_sandwiches( you );
+        REQUIRE( sandwiches.size() == 1 );
+        CHECK( has_component( *sandwiches.front(), itype_id( "pine_nuts" ) ) );
+        CHECK( you.compute_effective_nutrients( *sandwiches.front() ).kcal == 51 );
+        CHECK( in_progress_crafts( you ).empty() );
+    }
 }
 
 static void verify_inventory( const std::vector<std::string> &has,


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #8867.

#8812 moved player crafting onto `craft_activity_actor`, but the actor only looked up crafts by recipe. If another in-progress craft with the same recipe existed first, completion could finish the wrong craft and preserve the wrong food components, changing crafted food calories.

## Describe the solution (The How)

Store the started craft as the activity target and make `craft_activity_actor` prefer that target before falling back to recipe lookup.

## Testing

- `cmake --preset linux-full`
- `git diff --check`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles -j2`
- `./out/build/linux-full/tests/cata_test-tiles "craft activity completes the targeted in-progress craft"`
- `cmake --build --preset linux-full --target astyle` failed because `~/.local/bin/astyle` calls missing `/usr/bin/distrobox-enter`.

## Additional context

Regression context: #8812.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sup>PR opened by gpt-5.4 high on pi</sup>
