### PR TITLE
fix: noclip no longer lets you try walking outside of the world

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12731,7 +12731,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         }
 
         if( m.impassable( dest ) || !dest_is_air ) {
-            if( !can_noclip ) {
+            if( !can_noclip ) { //zz
                 for( const trait_id &tid : mutations ) {
                     const auto &mdata = tid.obj();
                     if( mdata.flags.contains( trait_flag_MUTATION_FLIGHT ) ) {
@@ -12740,6 +12740,11 @@ void game::vertical_move( int movez, bool force, bool peeking )
                 }
                 add_msg( m_info, _( "There is something above blocking your way." ) );
                 return;
+            } else {
+                if( dest.z > OVERMAP_HEIGHT ) {
+                    add_msg( m_info, _( "Tried to move outside of zlevel world bounds." ) );
+                    return;
+                }
             }
         }
 
@@ -12771,14 +12776,20 @@ void game::vertical_move( int movez, bool force, bool peeking )
             return;
         }
 
-        if( ( m.impassable( dest ) || !standing_on_air ) && !can_noclip ) {
-            add_msg( m_info, _( "You can't go down here!" ) );
-            if( !m.has_flag( "GOES_UP", u.pos() ) ) {
-                suggest_auto_walk_to_stairs( u, m, "down" );
+        if( m.impassable( dest ) || !standing_on_air  ) {
+            if( !can_noclip ) {
+                add_msg( m_info, _( "You can't go down here!" ) );
+                if( !m.has_flag( "GOES_UP", u.pos() ) ) {
+                    suggest_auto_walk_to_stairs( u, m, "down" );
+                }
+                return;
+            } else {
+                if( dest.z < -OVERMAP_DEPTH ) {
+                    add_msg( m_info, _( "Tried to move outside of zlevel world bounds." ) );
+                    return;
+                }
             }
-            return;
         }
-
     }
 
     if( force ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12731,7 +12731,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         }
 
         if( m.impassable( dest ) || !dest_is_air ) {
-            if( !can_noclip ) { //zz
+            if( !can_noclip ) {
                 for( const trait_id &tid : mutations ) {
                     const auto &mdata = tid.obj();
                     if( mdata.flags.contains( trait_flag_MUTATION_FLIGHT ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12776,7 +12776,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
             return;
         }
 
-        if( m.impassable( dest ) || !standing_on_air  ) {
+        if( m.impassable( dest ) || !standing_on_air ) {
             if( !can_noclip ) {
                 add_msg( m_info, _( "You can't go down here!" ) );
                 if( !m.has_flag( "GOES_UP", u.pos() ) ) {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

the debug noclip trait lets you attempt to walk outside of the world (i.e to zlevel 11 or -11)
this probably has no negative effect besides throwing an error but its annoying so uhhhh

## Describe the solution (The How)

within vertical_move, if we have the noclip trait and our dest is impassable, check to see if its outside of  -OVERMAP_DEPTH, OVERMAP_HEIGHT and return if so

## Describe alternatives you've considered

- Not doing this

## Testing

<img width="242" height="167" alt="2026-05-15-15:36:24" src="https://github.com/user-attachments/assets/c99ac44a-b11e-455a-88b3-7e5595e66494" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Another very meaningless fix no one besides me cares about probably?

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
