### PR TITLE
fix: invalidate lightmap cache when setting terrain

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2549,7 +2549,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
     tripoint above( p.xy(), p.z + 1 );
     // Make sure that if we supported something and no longer do so, it falls down
     support_dirty( above );
- 
+
     invalidate_lightmap_caches();
 
     return true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2549,6 +2549,8 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
     tripoint above( p.xy(), p.z + 1 );
     // Make sure that if we supported something and no longer do so, it falls down
     support_dirty( above );
+ 
+    invalidate_lightmap_caches();
 
     return true;
 }
@@ -5027,7 +5029,6 @@ bool map::open_door(
     if( vp ) {
         return open_door_veh( who, vp, p, inside );
     }
-
     return false;
 }
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/8667

## Describe the solution (The How)

Invalidate lightmap cache when setting terrain (i.e, opening a door)

## Describe alternatives you've considered

- Not doing this

## Testing

Spent literally 5 minutes opening and closing a curtain and I couldnt replicate the bug anymore, but who knows if that was a fluke or not

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.


