### PR TITLE
docs: require AI assistance disclosure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,6 +31,7 @@ NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive
 - [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
 - [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
 - [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
+- [ ] If this PR used AI assistance, I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
 
 ### Optional
 

--- a/docs/en/contribute/contributing.md
+++ b/docs/en/contribute/contributing.md
@@ -271,6 +271,21 @@ for it, and will prevent anything that isn't completely ready from being merged 
 It is not required to solve or reference an open issue to file a PR, however, if you do so, you need
 to explain the problem your PR is solving in full detail.
 
+### AI-assisted pull requests
+
+If AI coding assistants contributed to a PR, the PR description must disclose the use of AI.
+
+Each commit that was written, generated, or substantively revised with AI assistance must include an
+`Assisted-by:` trailer in the Linux kernel format described in
+[AI Coding Assistants](https://docs.kernel.org/process/coding-assistants.html) and
+[Submitting patches](https://docs.kernel.org/process/submitting-patches.html#using-assisted-by).
+
+Example:
+
+```text
+Assisted-by: Claude:claude-3-opus coccinelle sparse
+```
+
 ### Closing issues using keywords
 
 One more thing: when marking your PR as closing, fixing, or resolving issues, please include this


### PR DESCRIPTION
## Purpose of change (The Why)

Knowing that a contribution is made with AI makes life easier for both reviewer and PR author.

## Describe the solution (The How)

- add contributor guidance requiring AI-assisted PRs to disclose AI use
- require `Assisted-by:` trailers on AI-assisted commits using the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html)
- add a mandatory PR checklist item covering both requirements

## Testing

- `deno fmt .github/pull_request_template.md docs/en/contribute/contributing.md`
- `git diff --check`

## Additional context

- reference: [Linux kernel submitting patches: Using Assisted-by](https://docs.kernel.org/process/submitting-patches.html#using-assisted-by)
- Yes, this PR _itself_ was written by AI; ah, the irony.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] If this PR used AI assistance, I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit.

<sup>PR opened by ChatGPT medium on pi</sup>
