### PR TITLE
feat(UI): camera photo menu can scroll and better photo descriptions

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -10,7 +10,7 @@
     "type": "field_type",
     "legacy_enum_id": 1,
     "intensity_levels": [ { "name": "blood splatter", "color": "red" }, { "name": "blood stain" }, { "name": "puddle of blood" } ],
-    "description_affix": "covered_in",
+    "description_affix": "covered_in_a",
     "underwater_age_speedup": "25 minutes",
     "decay_amount_factor": 2,
     "is_splattering": true,
@@ -24,7 +24,7 @@
     "type": "field_type",
     "legacy_enum_id": 2,
     "intensity_levels": [ { "name": "bile splatter", "color": "pink" }, { "name": "bile stain" }, { "name": "puddle of bile" } ],
-    "description_affix": "covered_in",
+    "description_affix": "covered_in_a",
     "underwater_age_speedup": "25 minutes",
     "decay_amount_factor": 2,
     "is_splattering": true,
@@ -101,7 +101,7 @@
       { "name": "slime stain" },
       { "name": "puddle of slime", "color": "green" }
     ],
-    "description_affix": "covered_in",
+    "description_affix": "covered_in_a",
     "decay_amount_factor": 2,
     "apply_slime_factor": 10,
     "is_splattering": true,
@@ -120,7 +120,7 @@
       { "name": "acid streak" },
       { "name": "pool of acid", "color": "green" }
     ],
-    "description_affix": "covered_in",
+    "description_affix": "covered_in_a",
     "immunity_data": { "traits": [ "ACIDPROOF" ] },
     "underwater_age_speedup": "2 minutes",
     "has_acid": true,
@@ -191,7 +191,7 @@
         ]
       }
     ],
-    "description_affix": "covered_in",
+    "description_affix": "covered_in_a",
     "is_splattering": true,
     "priority": 2,
     "half_life": "2 minutes",
@@ -208,7 +208,7 @@
       { "name": "sludge trail", "color": "dark_gray" },
       { "name": "thick sludge trail" }
     ],
-    "description_affix": "covered_in",
+    "description_affix": "covered_in_a",
     "is_splattering": true,
     "accelerated_decay": true,
     "priority": 2,
@@ -736,7 +736,7 @@
       { "name": "plant sap stain" },
       { "name": "puddle of resin" }
     ],
-    "description_affix": "covered_in",
+    "description_affix": "covered_in_a",
     "underwater_age_speedup": "25 minutes",
     "decay_amount_factor": 2,
     "is_splattering": true,
@@ -751,7 +751,7 @@
     "type": "field_type",
     "legacy_enum_id": 29,
     "intensity_levels": [ { "name": "bug blood splatter", "color": "green" }, { "name": "bug blood stain" }, { "name": "puddle of bug blood" } ],
-    "description_affix": "covered_in",
+    "description_affix": "covered_in_a",
     "underwater_age_speedup": "25 minutes",
     "decay_amount_factor": 2,
     "is_splattering": true,
@@ -770,7 +770,7 @@
       { "name": "hemolymph stain" },
       { "name": "puddle of hemolymph" }
     ],
-    "description_affix": "covered_in",
+    "description_affix": "covered_in_a",
     "underwater_age_speedup": "25 minutes",
     "decay_amount_factor": 2,
     "is_splattering": true,

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -44,6 +44,7 @@ std::string enum_to_string<description_affix>( description_affix data )
         // *INDENT-OFF*
         case description_affix::DESCRIPTION_AFFIX_IN: return "in";
         case description_affix::DESCRIPTION_AFFIX_COVERED_IN: return "covered_in";
+        case description_affix::DESCRIPTION_AFFIX_COVERED_IN_A: return "covered_in_a";
         case description_affix::DESCRIPTION_AFFIX_ON: return "on";
         case description_affix::DESCRIPTION_AFFIX_UNDER: return "under";
         case description_affix::DESCRIPTION_AFFIX_ILLUMINTED_BY: return "illuminated_by";

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -30,6 +30,7 @@ enum body_part : int;
 enum class description_affix : int {
     DESCRIPTION_AFFIX_IN,
     DESCRIPTION_AFFIX_COVERED_IN,
+    DESCRIPTION_AFFIX_COVERED_IN_A,
     DESCRIPTION_AFFIX_ON,
     DESCRIPTION_AFFIX_UNDER,
     DESCRIPTION_AFFIX_ILLUMINTED_BY,
@@ -49,6 +50,7 @@ struct hash<description_affix> {
 static const std::unordered_map<description_affix, std::string> description_affixes = {
     { description_affix::DESCRIPTION_AFFIX_IN, translate_marker( " in %s" ) },
     { description_affix::DESCRIPTION_AFFIX_COVERED_IN, translate_marker( " covered in %s" ) },
+    { description_affix::DESCRIPTION_AFFIX_COVERED_IN_A, translate_marker( " covered in a %s" ) },
     { description_affix::DESCRIPTION_AFFIX_ON, translate_marker( " on %s" ) },
     { description_affix::DESCRIPTION_AFFIX_UNDER, translate_marker( " under %s" ) },
     { description_affix::DESCRIPTION_AFFIX_ILLUMINTED_BY, translate_marker( " in %s" ) },

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -391,7 +391,7 @@ struct extended_photo_def : public JsonDeserializer, public JsonSerializer {
     }
 };
 
-static std::vector<std::string> describe_character(Character *guy);
+static std::vector<std::string> describe_character( Character *guy );
 static void item_save_monsters( player &p, item &it, const std::vector<monster *> &monster_vec,
                                 int photo_quality );
 static bool show_photo_selection( player &p, item &it, const std::string &var_name );
@@ -6738,7 +6738,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
                 } else {
                     pose = _( "is standing" );
                 }
-                const std::vector<std::string> vec = describe_character(guy);
+                const std::vector<std::string> vec = describe_character( guy );
                 figure_appearance = join( vec, "\n\n" );
                 figure_name = guy->name;
                 pronoun_sex = guy->male ? _( "He" ) : _( "She" );
@@ -6926,15 +6926,15 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
         } else if( is_dusk( calendar::turn ) ) {
             time_string = _( "<color_magenta>sunset</color>" );
         } else if( is_night( calendar::turn ) ) {
-            if (hour == 0) {
+            if( hour == 0 ) {
                 time_string = _( "<color_dark_gray>midnight</color>" );
             } else {
                 time_string = _( "<color_gray>night</color>" );
             }
         } else {
-            if (hour < 12) {
+            if( hour < 12 ) {
                 time_string = _( "<color_cyan>morning</color>" );
-            } else if (hour > 12) {
+            } else if( hour > 12 ) {
                 time_string = _( "<color_light_red>afternoon</color>" );
             } else {
                 time_string = _( "<color_light_blue>midday</color>" );
@@ -6959,13 +6959,13 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
     return photo;
 }
 
-static std::vector<std::string> describe_character(Character *guy)
+static std::vector<std::string> describe_character( Character *guy )
 {
     std::vector<std::string> result;
     std::string pronoun = guy->male ? _( "He" ) : _( "She" );
 
     if( guy->is_armed() ) {
-        result.push_back( pronoun + " " + _( "is wielding a " ) + guy->primary_weapon().tname() + ".");
+        result.push_back( pronoun + " " + _( "is wielding a " ) + guy->primary_weapon().tname() + "." );
     }
 
     const std::string worn_str = enumerate_as_string( guy->worn.begin(), guy->worn.end(),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -15,6 +15,7 @@
 #include <ranges>
 #include <set>
 #include <sstream>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -390,6 +391,7 @@ struct extended_photo_def : public JsonDeserializer, public JsonSerializer {
     }
 };
 
+static std::vector<std::string> describe_character(Character *guy);
 static void item_save_monsters( player &p, item &it, const std::vector<monster *> &monster_vec,
                                 int photo_quality );
 static bool show_photo_selection( player &p, item &it, const std::string &var_name );
@@ -6652,7 +6654,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
             }
         }
 
-        const char *transl_str = pgettext( "someone stands/sits *on* something", " on a %s." );
+        const char *transl_str = pgettext( "someone stands/sits *on* something", " on %s." );
         if( !description_part_on_figure.empty() ) {
             ret_obj.figure_text = string_format( transl_str, description_part_on_figure );
         } else {
@@ -6732,11 +6734,11 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
                     continue; // do not include hallucinations
                 }
                 if( guy->movement_mode_is( CMM_CROUCH ) ) {
-                    pose = _( "sits" );
+                    pose = _( "is sitting" );
                 } else {
-                    pose = _( "stands" );
+                    pose = _( "is standing" );
                 }
-                const std::vector<std::string> vec = guy->short_description_parts();
+                const std::vector<std::string> vec = describe_character(guy);
                 figure_appearance = join( vec, "\n\n" );
                 figure_name = guy->name;
                 pronoun_sex = guy->male ? _( "He" ) : _( "She" );
@@ -6746,7 +6748,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
                 if( mon->is_hallucination() || mon->type->in_species( HALLUCINATION ) ) {
                     continue; // do not include hallucinations
                 }
-                pose = _( "stands" );
+                pose = _( "is standing" );
                 figure_appearance = "\"" + mon->type->get_description() + "\"";
                 figure_name = mon->name();
                 pronoun_sex = pgettext( "Pronoun", "It" );
@@ -6886,7 +6888,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
     }
     if( !obj_coll.terrain.empty() ) {
         std::string obj_list = enumerate_as_string( obj_coll.terrain.begin(), obj_coll.terrain.end(),
-                               format_object_pair_article );
+                               format_object_pair_no_article );
         photo_text += "\n\n" + string_format( vgettext( "There is %s in the background.",
                                               "There are %s in the background.", num_of( obj_coll.terrain ) ),
                                               obj_list );
@@ -6915,21 +6917,37 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
 
     if( g->get_levz() >= 0 && need_store_weather ) {
         photo_text += "\n\n";
+
+        int hour = hour_of_day<int>( calendar::turn );
+        std::string time_string;
+
         if( is_dawn( calendar::turn ) ) {
-            photo_text += _( "It is <color_yellow>sunrise</color>. " );
+            time_string = _( "<color_yellow>sunrise</color>" );
         } else if( is_dusk( calendar::turn ) ) {
-            photo_text += _( "It is <color_light_red>sunset</color>. " );
+            time_string = _( "<color_magenta>sunset</color>" );
         } else if( is_night( calendar::turn ) ) {
-            photo_text += _( "It is <color_dark_gray>night</color>. " );
+            if (hour == 0) {
+                time_string = _( "<color_dark_gray>midnight</color>" );
+            } else {
+                time_string = _( "<color_gray>night</color>" );
+            }
         } else {
-            photo_text += _( "It is day. " );
+            if (hour < 12) {
+                time_string = _( "<color_cyan>morning</color>" );
+            } else if (hour > 12) {
+                time_string = _( "<color_light_red>afternoon</color>" );
+            } else {
+                time_string = _( "<color_light_blue>midday</color>" );
+            }
         }
+
+        photo_text += string_format( _( "It is %s. " ), time_string );
         photo_text += string_format( _( "The weather is %s." ), colorize( get_weather().weather_id->name,
                                      get_weather().weather_id->color ) );
     }
 
     for( const auto &figure : description_figures_appearance ) {
-        photo_text += "\n\n" + string_format( _( "%s appearance:" ),
+        photo_text += "\n\n" + string_format( _( "%s's appearance:" ),
                                               colorize( figure.first, c_light_blue ) ) + "\n" + figure.second;
     }
 
@@ -6939,6 +6957,30 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
     photo.description = photo_text;
 
     return photo;
+}
+
+static std::vector<std::string> describe_character(Character *guy)
+{
+    std::vector<std::string> result;
+    std::string pronoun = guy->male ? _( "He" ) : _( "She" );
+
+    if( guy->is_armed() ) {
+        result.push_back( pronoun + " " + _( "is wielding a " ) + guy->primary_weapon().tname() + ".");
+    }
+
+    const std::string worn_str = enumerate_as_string( guy->worn.begin(), guy->worn.end(),
+    []( const item * const & it ) {
+        return it->tname();
+    } );
+    if( !worn_str.empty() ) {
+        result.push_back( pronoun + " " + _( "is wearing: " ) + worn_str );
+    }
+    const int visibility_cap = 0;
+    const auto trait_str = guy->visible_mutations( visibility_cap );
+    if( !trait_str.empty() ) {
+        result.push_back( _( "Traits: " ) + trait_str );
+    }
+    return result;
 }
 
 static void item_save_monsters( player &p, item &it, const std::vector<monster *> &monster_vec,
@@ -7065,7 +7107,30 @@ static bool show_photo_selection( player &p, item &it, const std::string &var_na
         if( choice < 0 ) {
             break;
         }
-        popup( "%s", descriptions[choice].c_str() );
+        auto desc = descriptions[choice];
+
+        //calc window size
+        //more or less the same logic as popups
+        const auto new_win = [&desc]() {
+
+            auto folded_msg = foldstring( desc, FULL_SCREEN_WIDTH - 1 * 2 );
+            int msg_width = 0;
+            int msg_height = folded_msg.size();
+
+            for( const auto &line : folded_msg ) {
+                msg_width = std::max( msg_width, utf8_width( line, true ) );
+            }
+
+            const int win_width = std::min( TERMX, msg_width + 1 * 2 );
+            const int win_height = std::min( TERMY, msg_height + 1 * 2 );
+            const int win_x = ( TERMX - win_width ) / 2;
+            const int win_y = ( TERMY - win_height ) / 2;
+
+
+            return catacurses::newwin( win_height, win_width, point( win_x, win_y ) );
+        };
+
+        scrollable_text( new_win, "", desc.c_str() );
 
     } while( true );
     return true;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -6974,6 +6974,8 @@ static std::vector<std::string> describe_character(Character *guy)
     } );
     if( !worn_str.empty() ) {
         result.push_back( pronoun + " " + _( "is wearing: " ) + worn_str );
+    } else {
+        result.push_back( pronoun + " " + _( "is not wearing anything." ) );
     }
     const int visibility_cap = 0;
     const auto trait_str = guy->visible_mutations( visibility_cap );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Now that the camera can actually take photos of npcs its possible with ~5-10 npcs or so to have the photo's description extend past what the screen can fit

Also the description of the photos could be better

## Describe the solution (The How)

The photo description menu can now actually scroll if all the text wont fit on screen

Additionally a few changes have been made to the photos description

"stands on a grass" is now "is standing on grass"
"covered in blood stain" is now "covered in a bloodstain"

the time of day is now slightly more specific, now listing morning/noon/afternoon instead of just 'day' and also listing midnight in addition to 'night'

character descriptions have also changed (see example below)

<img width="1252" height="634" alt="comparison" src="https://github.com/user-attachments/assets/587a024a-1650-419f-8a68-944e76f2e534" />

## Describe alternatives you've considered

- Not doing this at all

## Testing

spawned an npc and zombie, killed the zombie, wielded a weapon, threw  some items on the floor, spawned in a table and then spawned in a fox and then took a photo (the above example photo)

Spawned in 10 npcs, took a selfie with them and verified the photo description menu scrolling worked

## Additional context

Might make the character description properly describe haircolor, eyecolor and skincolor as a followup? dunno

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] If this PR used AI assistance, I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).