### PR TITLE
fix: remove self aware from npc trait groups

### DIFF
--- a/data/mods/Aftershock/npcs/Backgrounds/trait_groups.json
+++ b/data/mods/Aftershock/npcs/Backgrounds/trait_groups.json
@@ -371,7 +371,6 @@
     "traits": [
       { "trait": "FASTHEALER", "prob": 50 },
       { "trait": "POISRESIST", "prob": 50 },
-      { "trait": "SELFAWARE", "prob": 50 },
       { "trait": "MASOCHIST", "prob": 50 },
       { "trait": "ROBUST", "prob": 50 },
       { "trait": "HEAVYSLEEPER", "prob": 50 },
@@ -891,7 +890,6 @@
       { "trait": "PAINRESIST", "prob": 10 },
       { "trait": "QUICK", "prob": 10 },
       { "trait": "ROBUST", "prob": 10 },
-      { "trait": "SELFAWARE", "prob": 10 },
       { "trait": "SPIRITUAL", "prob": 10 },
       { "trait": "UNSTYLISH", "prob": 10 },
       { "trait": "ALBINO", "prob": 5 },

--- a/data/mods/Aftershock/npcs/mutant_npcs/trait_groups.json
+++ b/data/mods/Aftershock/npcs/mutant_npcs/trait_groups.json
@@ -377,7 +377,6 @@
     "traits": [
       { "trait": "FASTHEALER", "prob": 50 },
       { "trait": "POISRESIST", "prob": 50 },
-      { "trait": "SELFAWARE", "prob": 50 },
       { "trait": "MASOCHIST", "prob": 50 },
       { "trait": "ROBUST", "prob": 50 },
       { "trait": "HEAVYSLEEPER", "prob": 50 },
@@ -897,7 +896,6 @@
       { "trait": "PAINRESIST", "prob": 10 },
       { "trait": "QUICK", "prob": 10 },
       { "trait": "ROBUST", "prob": 10 },
-      { "trait": "SELFAWARE", "prob": 10 },
       { "trait": "SPIRITUAL", "prob": 10 },
       { "trait": "UNSTYLISH", "prob": 10 },
       { "trait": "ALBINO", "prob": 5 },

--- a/data/mods/CRT_EXPANSION/scenarios/crt_op_classes.json
+++ b/data/mods/CRT_EXPANSION/scenarios/crt_op_classes.json
@@ -149,7 +149,6 @@
       "DEFT",
       "STRONGBACK",
       "FLIMSY",
-      "SELFAWARE",
       "MYOPIC",
       "CANNIBAL",
       "LIAR",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

self aware as a trait does absolutely nothing and its deprecated, despite this its still in trait_group_medical, trait_mutant_npc_common and also the C.R.I.T. Night Walker scenario

## Describe the solution (The How)

remove the self aware trait from these trait groups and also C.R.I.T. Night Walker

## Describe alternatives you've considered

- Not doing this

## Testing

Game doesnt immediately explode when loading and the json looks aight

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] If this PR used AI assistance, I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
