### PR TITLE
fix: invalidate lightmap cache when moving vehicles

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -901,7 +901,7 @@ void map::on_vehicle_moved( const point sm_min, const point sm_max, const int sm
         return;
     }
     level_cache &ch = get_cache( smz );
-
+    invalidate_lightmap_caches();
     // Mark dirty only the submaps the vehicle actually occupies (union of old
     // and new footprint), rather than the entire z-level.
     for( int smx = sm_min.x; smx <= sm_max.x; ++smx ) {
@@ -1102,7 +1102,9 @@ void map::vehmove()
     // neighbours reachable but not in the set get on_map=false as before.
     std::set<vehicle *> all_veh_ptrs;
     std::ranges::for_each( vehicle_list, [&]( const wrapped_vehicle & w ) {
-        all_veh_ptrs.insert( w.v );
+        if (loaded_vehicles.contains(w.v)) {
+            all_veh_ptrs.insert( w.v );
+        }
     } );
     std::map<vehicle *, bool> connected_vehicles;
     vehicle::enumerate_vehicles( connected_vehicles, all_veh_ptrs );
@@ -1426,7 +1428,6 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
         inp_mngr.pump_events();
         ui_manager::redraw_invalidated();
         refresh_display();
-        invalidate_lightmap_caches();
     }
     return &veh;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1426,6 +1426,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
         inp_mngr.pump_events();
         ui_manager::redraw_invalidated();
         refresh_display();
+        invalidate_lightmap_caches();
     }
     return &veh;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1102,7 +1102,7 @@ void map::vehmove()
     // neighbours reachable but not in the set get on_map=false as before.
     std::set<vehicle *> all_veh_ptrs;
     std::ranges::for_each( vehicle_list, [&]( const wrapped_vehicle & w ) {
-        if (loaded_vehicles.contains(w.v)) {
+        if( loaded_vehicles.contains( w.v ) ) {
             all_veh_ptrs.insert( w.v );
         }
     } );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/8668
related #8878

## Describe the solution (The How)

invaldiate lightmap cache when moving vehicle
## Describe alternatives you've considered

- Not doing this

## Testing

Spawned an armored car, set time to night, turned on headlights and drove around at a high speed

## Additional context

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] If this PR used AI assistance, I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
