### PR TITLE
perf: fix crafting speed loss

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2173,9 +2173,7 @@ void craft_activity_actor::calc_all_moves( player_activity &act, Character &who 
 void craft_activity_actor::refresh_speed( player_activity &act, const Character &who,
         const item &craft_item, std::optional<bench_location> bench ) const
 {
-    const bench_location resolved_bench = bench ? *bench
-                                         : cached_bench ? *cached_bench
-                                         : find_best_bench( who, craft_item );
+    const bench_location resolved_bench = bench ? *bench : find_best_bench( who, craft_item );
     const recipe &making = *rec;
     const float tools_mult = cached_tools_mult != 0.0f ? cached_tools_mult
                              : crafting_tools_speed_multiplier( who, making );
@@ -2218,7 +2216,6 @@ void craft_activity_actor::start( player_activity &act, Character &who )
         return;
     }
 
-    cached_bench = find_best_bench( who, *craft_item );
     cached_tools_mult = crafting_tools_speed_multiplier( who, *rec );
     craft_counter = craft_item->get_counter();
     last_turn_nr = to_turn<int>( calendar::turn );  // mark fresh start so calc_all_moves skips catch-up
@@ -2249,14 +2246,12 @@ void craft_activity_actor::do_turn( player_activity &act, Character &who )
     }
 
     const recipe &making = *rec;
-    if( !cached_bench ) {
-        cached_bench = find_best_bench( who, *craft_item );
-    }
     if( cached_tools_mult == 0.0f ) {
         cached_tools_mult = crafting_tools_speed_multiplier( who, making );
     }
-    refresh_speed( act, who, *craft_item, cached_bench );
-    const float crafting_speed = crafting_speed_multiplier( who, *craft_item, *cached_bench, act.speed.tools );
+    const bench_location bench = find_best_bench( who, *craft_item );
+    refresh_speed( act, who, *craft_item, bench );
+    const float crafting_speed = crafting_speed_multiplier( who, *craft_item, bench, act.speed.tools );
     const int assistants = who.available_assistant_count( making );
 
     if( crafting_speed <= 0.0f ) {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2173,9 +2173,12 @@ void craft_activity_actor::calc_all_moves( player_activity &act, Character &who 
 void craft_activity_actor::refresh_speed( player_activity &act, const Character &who,
         const item &craft_item, std::optional<bench_location> bench ) const
 {
-    const bench_location resolved_bench = bench ? *bench : find_best_bench( who, craft_item );
+    const bench_location resolved_bench = bench ? *bench
+                                         : cached_bench ? *cached_bench
+                                         : find_best_bench( who, craft_item );
     const recipe &making = *rec;
-    const float tools_mult = crafting_tools_speed_multiplier( who, making );
+    const float tools_mult = cached_tools_mult != 0.0f ? cached_tools_mult
+                             : crafting_tools_speed_multiplier( who, making );
     act.speed.light        = lighting_crafting_speed_multiplier( who, making );
     act.speed.bench_factor = workbench_crafting_speed_multiplier( craft_item, resolved_bench );
     act.speed.morale       = morale_crafting_speed_multiplier( who, making );
@@ -2215,6 +2218,8 @@ void craft_activity_actor::start( player_activity &act, Character &who )
         return;
     }
 
+    cached_bench = find_best_bench( who, *craft_item );
+    cached_tools_mult = crafting_tools_speed_multiplier( who, *rec );
     craft_counter = craft_item->get_counter();
     last_turn_nr = to_turn<int>( calendar::turn );  // mark fresh start so calc_all_moves skips catch-up
     const int base_total = std::max( 1, rec->batch_time( batch_size, 1.0f, 0 ) );
@@ -2244,9 +2249,14 @@ void craft_activity_actor::do_turn( player_activity &act, Character &who )
     }
 
     const recipe &making = *rec;
-    const bench_location bench = find_best_bench( who, *craft_item );
-    refresh_speed( act, who, *craft_item, bench );
-    const float crafting_speed = crafting_speed_multiplier( who, *craft_item, bench, act.speed.tools );
+    if( !cached_bench ) {
+        cached_bench = find_best_bench( who, *craft_item );
+    }
+    if( cached_tools_mult == 0.0f ) {
+        cached_tools_mult = crafting_tools_speed_multiplier( who, making );
+    }
+    refresh_speed( act, who, *craft_item, cached_bench );
+    const float crafting_speed = crafting_speed_multiplier( who, *craft_item, *cached_bench, act.speed.tools );
     const int assistants = who.available_assistant_count( making );
 
     if( crafting_speed <= 0.0f ) {

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -127,6 +127,8 @@ class craft_activity_actor final : public activity_actor
         bool is_long = false;
         bool is_valid = false;
         int last_turn_nr = -1;  // turn# when last do_turn ran; -1 = never set
+        float cached_tools_mult = 0.0f;   // 0 = not yet computed; set once in start()
+        std::optional<bench_location> cached_bench;
 
         bool can_resume_with_internal( const activity_actor &other, const Character & ) const override {
             const auto &c_actor = static_cast<const craft_activity_actor &>( other );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -128,7 +128,6 @@ class craft_activity_actor final : public activity_actor
         bool is_valid = false;
         int last_turn_nr = -1;  // turn# when last do_turn ran; -1 = never set
         float cached_tools_mult = 0.0f;   // 0 = not yet computed; set once in start()
-        std::optional<bench_location> cached_bench;
 
         bool can_resume_with_internal( const activity_actor &other, const Character & ) const override {
             const auto &c_actor = static_cast<const craft_activity_actor &>( other );


### PR DESCRIPTION
## Purpose of change (The Why)

Crafting changes have caused a speed regression

## Describe the solution (The How)

Cache the crafting tools multiplier, to avoid having to recompute that all the time.

## Describe alternatives you've considered

## Testing

Crafted a tuxedo with fix, compared to crafting a tuxedo without fix.
Seems slightly faster

## Additional context

Was reported by someone running on an older laptop, slowdown most likely much noticeable.

fyi claude helped out
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] If this PR used AI assistance, I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
