### PR TITLE
fix: arrows can embed in targets again

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -623,6 +623,11 @@ auto projectile_attack( const projectile &proj_arg, const tripoint &source,
                 has_momentum = proj.impact.total_damage() > 0 && is_bullet;
 
                 apply_overpenetration_penalty( is_projectile_modify_overpenetration );
+                // Force embed based on damage after overpenetration penalties
+                if( thrown_item != &null_item_reference() && rng( 1, 100 ) > proj.impact.total_damage() ) {
+                    has_momentum = false;
+                    apply_overpenetration_penalty( 0.0 );
+                }
             } else {
                 attack.missed_by = aim.missed_by;
             }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This moves a change initially in https://github.com/cataclysmbn/Cataclysm-BN/pull/8859 out to a separate PR to reimplement arrow embedding, because that PR got scope creep'd by immortal roofs while this is a super basic if statement.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In ballistics.cpp, projectile_attack now also checks during creature overpenetration if the projectile would drop anything (e.g. arrows, flares, etc) and if so it rolls a random chance against the current damage (after applying losses from overpenetration penalties), if it procs it stops the projectile early so it'll call drop_or_embed_projectile on the last target hit. This fixes an annoyance introduced with monster overpenetration where the "arrow can embed in targets" feature became vanishingly rare, only ever triggering if you hit something at the exact edge, which has led to player complaints about having to chase after their arrows constantly. I wanted overpenetration to still POTENTIALLY be a thing even for arrows but did want to make it less of a constant headache for players, I feel randomizing it based on how powerful a bow you're shooting them with makes for a good compromise there.

## Describe alternatives you've considered

Adding `NO_PENETRATE_OBSTACLES` to arrows instead. Main reason I'm not doing this, aside from as stated wanting arrows to be able to engage with both overpenteration and embed mechanics, is this does fun stupid shit like make them magically no longer able to go through windows and other super-fragile things.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Fired off arrows at a line of zombies, confirmed it randomly stops early and embeds, and does so more reliably with lower-damage shots.
3. Fired a regular gun through them to confirm it wasn't doing this sorta thing with normal guns.

Saiga vs crossbow, including a temporarily-added test message:
<img width="612" height="247" alt="image" src="https://github.com/user-attachments/assets/4c4ea627-cc63-49e1-91ef-6f07e76928d3" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] If this PR used AI assistance, I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

This PR coded with 100% USDA pure meatspace brain, smooth as a glass marble, with no AI ensmoothing. It was literally a single if statement.

We should probably have the checklist specify to contributors to leave that unchecked if no AI was used but again, no one actually reads the checklist so changes are anyone who needs to be told to disclose their slopslinging probably will just forget to disclose and leave it unchecked...