### PR TITLE
feat(mods): add mod conflicts for mainlined mods

### DIFF
--- a/data/mods/bn/modinfo.json
+++ b/data/mods/bn/modinfo.json
@@ -8,6 +8,11 @@
     "core": true,
     "lua_api_version": 2,
     "loading_images": [ "loading/" ],
-    "path": "../../json"
+    "path": "../../json",
+    "conflicts": [
+      "Tankmod_Revived",
+      "Heavy miners",
+      "Mining_Mod"
+    ]
   }
 ]

--- a/data/mods/bn/modinfo.json
+++ b/data/mods/bn/modinfo.json
@@ -9,10 +9,6 @@
     "lua_api_version": 2,
     "loading_images": [ "loading/" ],
     "path": "../../json",
-    "conflicts": [
-      "Tankmod_Revived",
-      "Heavy miners",
-      "Mining_Mod"
-    ]
+    "conflicts": [ "Tankmod_Revived", "Heavy miners", "Mining_Mod" ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)
People still use them
I'm tired of it
#8323 Mainlined `Heavy Miners`
#8292 Mainlined `Tankmod_Revived`
#6931 Mainlined `Mining_Mod`

## Describe the solution (The How)
Add conflicts to bn for each of those mods

## Describe alternatives you've considered
Add conflicts with aftershock and blazemod because it currently overwrites and blows up aftershock vehicle parts

## Testing
Added mining mod modinfo and it conflicts

## Additional context
Maybe we should add a step when porting all contents from mods to do this
I might also be missing mods which we have mainlined

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.