### PR TITLE
fix: correct volume of makeshift 120mm tank gun

### DIFF
--- a/data/json/items/gun/tankguns.json
+++ b/data/json/items/gun/tankguns.json
@@ -165,7 +165,7 @@
     "skill": "launcher",
     "ammo": "120mm_usable",
     "weight": "1000 kg",
-    "volume": "87500 L",
+    "volume": "87500 ml",
     "bashing": 12,
     "to_hit": -6,
     "ranged_damage": { "damage_type": "bullet", "amount": -15, "armor_penetration": -15 },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

<img width="630" height="220" alt="image" src="https://github.com/user-attachments/assets/be51e663-9904-42fd-adf4-eb912b25e5f0" />

The 120mm makeshift tank gun is far too large.

<img width="398" height="244" alt="image" src="https://github.com/user-attachments/assets/dd2fb25c-85f5-4c85-bb55-944b14703b3f" />

The factory-made 120mm tank gun has 2 orders of magnitude less volume in liters than the 120mm makeshift tank gun.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Change the unit of volume from liters (L) to mililiters (ml), leading to the gun taking up 100x less volume which seems to be consistent with the factory-made tank gun.

<img width="462" height="236" alt="image" src="https://github.com/user-attachments/assets/efc6e463-846c-4368-870c-197b8c0cd517" />


## Describe alternatives you've considered

Creating an issue.

Not fixing this issue.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Built, spawned the gun, took the screenshot of the solution pictured above.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.