### PR TITLE
feat(UI): can apply clothing mods to clothing on nearby ground

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -295,10 +295,10 @@ void game_menus::inv::common( avatar &you )
 }
 
 item *game_menus::inv::titled_filter_menu( const item_filter &filter, avatar &you,
-        const std::string &title, const std::string &none_message )
+        const std::string &title, const std::string &none_message, int radius )
 {
     return inv_internal( you, inventory_filter_preset( filter ),
-                         title, -1, none_message );
+                         title, radius, none_message );
 }
 
 item *game_menus::inv::titled_menu( avatar &you, const std::string &title,

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -28,7 +28,7 @@ item *titled_menu( avatar &you, const std::string &title,
                    const std::string &none_message = "" );
 // item selector for items in @you's inventory with a filter
 item *titled_filter_menu( const item_filter &filter, avatar &you,
-                          const std::string &title, const std::string &none_message = "" );
+                          const std::string &title, const std::string &none_message = "", int radius = -1 );
 
 /**
 * @name Customized inventory menus

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5134,7 +5134,7 @@ int sew_advanced_actor::use( player &p, item &it, bool, const tripoint & ) const
     };
     // note: if !p.is_npc() then p is avatar.
     item *loc = game_menus::inv::titled_filter_menu(
-                    filter, *p.as_avatar(), _( "Enhance which clothing?" ) );
+                    filter, *p.as_avatar(), _( "Enhance which clothing?" ), "", 1 );
     if( !loc ) {
         p.add_msg_if_player( m_info, _( "You do not have that item!" ) );
         return 0;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

The tailors kit allows repairing items on the ground nearby the player, however applying clothing mods is limited to the items in your immediate inventory

This is poor ux as a user would intuitively expect them to follow the same rules
and also just not having to pick up the item your trying to apply a clothing mod to is good qol if its something really big and heavy like power armor

## Describe the solution (The How)

titled_filter_menu now allows specifying the radius and defaults to -1, instead of always setting the radius to -1

and the tailor kit clothing mod menu now specifies a radius of 1 (same as repairing) for parity

## Describe alternatives you've considered

- Not doing this?

## Testing

Spawned in a tailors kit, threw some clothing on the ground and verified I could apply a clothing mod to it while its on the ground

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
