### PR TITLE
docs: mention llvm packages for Linux CMake builds

### DIFF
--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -51,11 +51,13 @@ Obtain packages specified above with your system package manager.
 - For Ubuntu-based distros (24.04 onwards):
 
 ```sh
-sudo apt install git cmake ninja-build mold g++-14 clang-20 ccache \
+sudo apt install git cmake ninja-build mold g++-14 clang-20 llvm-20 ccache \
 libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \
 libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
 ```
+
+The Linux presets use `llvm-ar` and `llvm-ranlib` for static libraries, so the matching `llvm-20` package is required alongside `clang-20` on Ubuntu.
 
 - For Fedora-based distros:
 
@@ -113,6 +115,14 @@ Configuration file: /etc/clang/x86_64-redhat-linux-gnu-clang++.cfg
 > ```sh
 > sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
 > sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
+> ```
+>
+> If Ubuntu only installs versioned LLVM binutils such as `llvm-ar-20` and
+> `llvm-ranlib-20`, register those names too:
+>
+> ```sh
+> sudo update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-20 100
+> sudo update-alternatives --install /usr/bin/llvm-ranlib llvm-ranlib /usr/bin/llvm-ranlib-20 100
 > ```
 
 ### macOS Environment

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -62,11 +62,13 @@ The Linux presets use `llvm-ar` and `llvm-ranlib` for static libraries, so the m
 - For Fedora-based distros:
 
 ```sh
-sudo dnf install git cmake ninja-build mold clang ccache \
+sudo dnf install git cmake ninja-build mold clang llvm ccache \
 SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
 freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel \
 sqlite-devel zlib-devel
 ```
+
+On Fedora, the same presets require the `llvm` package because it provides `llvm-ar` and `llvm-ranlib`.
 
 #### Verifying Compiler Version
 

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -57,8 +57,6 @@ libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
 ```
 
-The Linux presets use `llvm-ar` and `llvm-ranlib` for static libraries, so the matching `llvm-20` package is required alongside `clang-20` on Ubuntu.
-
 - For Fedora-based distros:
 
 ```sh
@@ -67,8 +65,6 @@ SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
 freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel \
 sqlite-devel zlib-devel
 ```
-
-On Fedora, the same presets require the `llvm` package because it provides `llvm-ar` and `llvm-ranlib`.
 
 #### Verifying Compiler Version
 

--- a/docs/ja/dev/guides/building/cmake.md
+++ b/docs/ja/dev/guides/building/cmake.md
@@ -56,8 +56,6 @@ libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
 ```
 
-Linux 用プリセットは静的ライブラリの作成に `llvm-ar` と `llvm-ranlib` を使用するため、Ubuntu では `clang-20` とあわせて対応する `llvm-20` パッケージが必要です。
-
 - Fedora ベースのディストリビューション:
 
 ```sh
@@ -66,8 +64,6 @@ SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
 freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel \
 sqlite-devel zlib-devel
 ```
-
-Fedora でも同じプリセットが `llvm-ar` と `llvm-ranlib` を必要とするため、これらを提供する `llvm` パッケージが必要です。
 
 #### コンパイラバージョンの確認
 

--- a/docs/ja/dev/guides/building/cmake.md
+++ b/docs/ja/dev/guides/building/cmake.md
@@ -56,16 +56,18 @@ libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
 ```
 
-Linux 用プリセットは静的ライブラリの作成に `llvm-ar` と `llvm-ranlib` を使用するため、Ubuntu では `clang-20` とあわせて対応する `llvm-20` パッケージが必要です.
+Linux 用プリセットは静的ライブラリの作成に `llvm-ar` と `llvm-ranlib` を使用するため、Ubuntu では `clang-20` とあわせて対応する `llvm-20` パッケージが必要です。
 
 - Fedora ベースのディストリビューション:
 
 ```sh
-sudo dnf install git cmake ninja-build mold clang ccache \
+sudo dnf install git cmake ninja-build mold clang llvm ccache \
 SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
 freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel \
 sqlite-devel zlib-devel
 ```
+
+Fedora でも同じプリセットが `llvm-ar` と `llvm-ranlib` を必要とするため、これらを提供する `llvm` パッケージが必要です。
 
 #### コンパイラバージョンの確認
 

--- a/docs/ja/dev/guides/building/cmake.md
+++ b/docs/ja/dev/guides/building/cmake.md
@@ -50,11 +50,13 @@ cd Cataclysm-BN
 - Ubuntu ベースのディストリビューション (24.04 以降):
 
 ```sh
-sudo apt install git cmake ninja-build mold g++-14 clang-20 ccache \
+sudo apt install git cmake ninja-build mold g++-14 clang-20 llvm-20 ccache \
 libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \
 libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
 ```
+
+Linux 用プリセットは静的ライブラリの作成に `llvm-ar` と `llvm-ranlib` を使用するため、Ubuntu では `clang-20` とあわせて対応する `llvm-20` パッケージが必要です.
 
 - Fedora ベースのディストリビューション:
 
@@ -112,6 +114,13 @@ Configuration file: /etc/clang/x86_64-redhat-linux-gnu-clang++.cfg
 > ```sh
 > sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
 > sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
+> ```
+>
+> Ubuntu で `llvm-ar-20` と `llvm-ranlib-20` のようなバージョン付き LLVM binutils だけがインストールされる場合は、これらの名前も登録してください:
+>
+> ```sh
+> sudo update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-20 100
+> sudo update-alternatives --install /usr/bin/llvm-ranlib llvm-ranlib /usr/bin/llvm-ranlib-20 100
 > ```
 
 ### Windows Subsystem for Linux (WSL)

--- a/docs/ko/dev/guides/building/cmake.md
+++ b/docs/ko/dev/guides/building/cmake.md
@@ -60,11 +60,13 @@ Linux 프리셋은 정적 라이브러리를 만들 때 `llvm-ar`와 `llvm-ranli
 - Fedora 기반 배포판:
 
 ```sh
-sudo dnf install git cmake ninja-build mold clang ccache \
+sudo dnf install git cmake ninja-build mold clang llvm ccache \
 SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
 freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel \
 sqlite-devel zlib-devel
 ```
+
+Fedora에서도 같은 프리셋이 `llvm-ar`와 `llvm-ranlib`를 필요로 하므로, 이를 제공하는 `llvm` 패키지가 필요합니다.
 
 #### 컴파일러 버전 확인
 

--- a/docs/ko/dev/guides/building/cmake.md
+++ b/docs/ko/dev/guides/building/cmake.md
@@ -49,11 +49,13 @@ cd Cataclysm-BN
 - Ubuntu 기반 배포판 (24.04 이상):
 
 ```sh
-sudo apt install git cmake ninja-build mold g++-14 clang-20 ccache \
+sudo apt install git cmake ninja-build mold g++-14 clang-20 llvm-20 ccache \
 libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \
 libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
 ```
+
+Linux 프리셋은 정적 라이브러리를 만들 때 `llvm-ar`와 `llvm-ranlib`를 사용하므로, Ubuntu에서는 `clang-20`과 함께 같은 버전의 `llvm-20` 패키지도 필요합니다.
 
 - Fedora 기반 배포판:
 
@@ -111,6 +113,13 @@ Configuration file: /etc/clang/x86_64-redhat-linux-gnu-clang++.cfg
 > ```sh
 > sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
 > sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
+> ```
+>
+> Ubuntu가 `llvm-ar-20`, `llvm-ranlib-20`처럼 버전이 붙은 LLVM binutils 이름만 설치하는 경우에는 이 이름도 등록하세요:
+>
+> ```sh
+> sudo update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-20 100
+> sudo update-alternatives --install /usr/bin/llvm-ranlib llvm-ranlib /usr/bin/llvm-ranlib-20 100
 > ```
 
 ### Windows Subsystem for Linux (WSL)

--- a/docs/ko/dev/guides/building/cmake.md
+++ b/docs/ko/dev/guides/building/cmake.md
@@ -55,8 +55,6 @@ libfreetype-dev bzip2 zlib1g-dev libvorbis-dev libncurses-dev \
 gettext libflac++-dev libsqlite3-dev zlib1g-dev
 ```
 
-Linux 프리셋은 정적 라이브러리를 만들 때 `llvm-ar`와 `llvm-ranlib`를 사용하므로, Ubuntu에서는 `clang-20`과 함께 같은 버전의 `llvm-20` 패키지도 필요합니다.
-
 - Fedora 기반 배포판:
 
 ```sh
@@ -65,8 +63,6 @@ SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
 freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel \
 sqlite-devel zlib-devel
 ```
-
-Fedora에서도 같은 프리셋이 `llvm-ar`와 `llvm-ranlib`를 필요로 하므로, 이를 제공하는 `llvm` 패키지가 필요합니다.
 
 #### 컴파일러 버전 확인
 


### PR DESCRIPTION
## Purpose of change (The Why)

Document the missing LLVM packages required by the Linux CMake presets on Ubuntu/WSL and Fedora.

## Describe the solution (The How)

Add `llvm-20` to the Ubuntu install command in the English, Japanese, and Korean CMake build guides, and document the `llvm-ar` / `llvm-ranlib` `update-alternatives` setup when Ubuntu only installs versioned binaries.

Add `llvm` to the Fedora install command in the same guides.

## Describe alternatives you've considered

Mentioning only WSL was possible, but the requirement comes from the shared Linux presets, so the Linux build guide is the right place.

## Testing

- Verified `CMakePresets.json` sets `CMAKE_AR=llvm-ar` and `CMAKE_RANLIB=llvm-ranlib` for the Linux presets.
- Verified `/usr/bin/llvm-ar` is provided by the Fedora `llvm` package in the local environment.
- Ran `git diff --check`.

## Additional context

- AI assistance was used for this PR.

## Checklist

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sup>PR opened by gpt-5 high on pi</sup>
