### PR TITLE
build: remove build warnings

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -589,8 +589,6 @@ bool can_butcher_at( const tripoint &p )
     const int factor = you.max_quality( qual_BUTCHER );
     const int factorD = you.max_quality( qual_CUT_FINE );
     map_stack items = get_map().i_at( p );
-    bool has_item = false;
-    bool has_corpse = false;
 
     const inventory &crafting_inv = you.crafting_inventory();
     for( item *&items_it : items ) {
@@ -1188,7 +1186,6 @@ std::optional<std::pair<tripoint, tripoint>> choose_area( const std::string &mes
 {
 
     auto &u = g->u;
-    map &m = get_map();
     ui_adaptor ui;
 
     on_out_of_scope invalidate_current_ui( [&]() { ui.mark_resize(); } );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -245,8 +245,7 @@ auto list_nested( const list_nested_options &opts ) -> std::string
 auto ensure_availability( Character &crafter,
                           const recipe *rec,
                           std::unordered_map<const recipe *, availability> &availability_cache,
-                          const recipe_subset &available_recipes,
-                          bool show_unavailable ) -> availability & // *NOPAD*
+                          const recipe_subset &available_recipes ) -> availability & // *NOPAD*
 {
     if( !availability_cache.contains( rec ) ) {
         const auto known = available_recipes.contains( *rec );
@@ -280,8 +279,7 @@ auto update_nested_can_craft( Character &crafter,
     const recipe_id & nested_id ) {
         const auto *nested_rec = &nested_id.obj();
         auto &nested_avail = ensure_availability( crafter, nested_rec, availability_cache,
-                             available_recipes,
-                             show_unavailable );
+                             available_recipes );
         if( nested_rec->is_nested() ) {
             nested_avail.can_craft = update_nested_can_craft( crafter, *nested_rec, availability_cache,
                                      nested_can_craft_cache, visiting, available_recipes, show_unavailable );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -450,8 +450,6 @@ void iexamine::nanoforge( player &p, const tripoint &examp )
         return;
     }
 
-    int item_count = 1;
-
     detached_ptr<item> new_item = item::spawn( itype_id( chosen_recipe ), calendar::turn );
 
     auto qty = 1;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8761,7 +8761,7 @@ int iuse::strong_antibiotic( player *p, item *it, bool, const tripoint & )
     return it->type->charges_to_use();
 }
 
-int iuse::craft( player *p, item *it, bool, const tripoint &pos )
+int iuse::craft( player *p, item *it, bool, const tripoint & )
 {
     if( p->is_mounted() ) {
         p->add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@ class ui_adaptor;
 
 #if defined(TILES)
 #   define SDL_MAIN_HANDLED
+#   include <SDL3/SDL_main.h>
 #   include "sdl_wrappers.h"
 #endif
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1140,7 +1140,7 @@ void npc::do_npc_read()
 }
 
 
-void npc::do_npc_craft( const std::optional<tripoint> &loc )
+void npc::do_npc_craft( const std::optional<tripoint> & )
 {
     uilist menu;
     menu.text = _( "Craft what?" );

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -348,7 +348,6 @@ double trap::funnel_turns_per_charge( double rain_depth_mm_per_hour ) const
 static void fill_water_collectors( int mmPerHour, bool acid )
 {
     ZoneScopedN( "fill_water_collectors" );
-    const auto abs_sub = g->m.get_abs_sub();
     auto &mbuf = MAPBUFFER_REGISTRY.get( g->m.get_bound_dimension() );
     std::ranges::for_each( g->m.get_funnel_locations(), [&]( const std::pair<tripoint, point> &entry ) {
         const auto sm_abs = tripoint_abs_sm( entry.first );


### PR DESCRIPTION
## Purpose of change (The Why)

Remove compiler warnings from unused locals, parameters, and the SDL main-handling macro.

## Describe the solution (The How)

- Removed unused local variables.
- Removed unused parameter names and an unused helper argument.
- Included `SDL3/SDL_main.h` so `SDL_MAIN_HANDLED` is consumed by SDL.

## Describe alternatives you've considered

Avoided warning-suppression pragmas because the unused code can be removed directly.

## Testing

- [x] `cmake --preset linux-full`
- [x] `cmake --build --preset linux-full --target format`
- [x] `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] No relevant issues were found to link.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an `Assisted-by:` trailer to every AI-assisted commit.

<sup>PR opened by gpt-5.4 high on pi</sup>
