### PR TITLE
fix: clear loading splash after use

### DIFF
--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -455,7 +455,12 @@ loading_image_splash::loading_image_splash()
 }
 #endif
 
-loading_image_splash::~loading_image_splash() = default;
+loading_image_splash::~loading_image_splash()
+{
+#if defined( TILES )
+    clear_sdl_display_buffer_before_redraw();
+#endif
+}
 
 loading_ui::loading_ui( bool display )
 {


### PR DESCRIPTION
## Purpose of change (The Why)

- closes #8903
- continuation of #8617, #8794
- Loading splash images can remain in the SDL display buffer after the splash UI is destroyed, leaving artifacts behind the game UI.

## Describe the solution (The How)

Clear the SDL display buffer before the next redraw when `loading_image_splash` is destroyed.

## Describe alternatives you've considered

Keep the cleanup only in `loading_ui`, but `loading_image_splash` is also used independently during world creation.

## Testing

- `git diff --check`
- `cmake --preset linux-full -DLANGUAGES=none`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[loading_ui]"`

## Additional context

AI assistance was used for this PR. Commits include `Assisted-by:` trailers.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sup>PR opened by gpt-5.4 high on pi</sup>
