### PR TITLE
build: restore MSVC ccache without breaking release PDBs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
             windows-${{ matrix.artifact }}-${{ github.ref_name }}
             windows-${{ matrix.artifact }}-main
             windows-${{ matrix.artifact }}-
-          max-size: 500M
+          max-size: 1G
           verbose: 2
           save: ${{ github.event_name != 'pull_request' }}
 
@@ -212,6 +212,7 @@ jobs:
           echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $env:GITHUB_ENV
           echo "CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros,pch_defines" >> $env:GITHUB_ENV
           echo "CCACHE_NOHASHDIR=1" >> $env:GITHUB_ENV
+          echo "CCACHE_COMPILERCHECK=content" >> $env:GITHUB_ENV
 
       # Linux setup
       - name: Install dependencies (Linux)

--- a/build-scripts/MSVC.cmake
+++ b/build-scripts/MSVC.cmake
@@ -33,13 +33,15 @@ C++ flags used by all builds:
 /Zc:inline    Remove unreferenced COMDAT
 /Zc:wchar_t   wchar_t Is Native Type
 
-Additional C++ flags used by RelWithDebInfo builds:
+Additional C++ flags used by optimized builds:
 
+/Z7  Generate embedded CodeView debug information
 /Ob1 Inline Function Expansion (1 = only when marked as such)
 /Oi  Generate Intrinsic Functions
 
 Linker flags used by all builds:
 
+/DEBUG       emit program database (.pdb) files for release artifacts
 /OPT:REF  remove unreferenced COMDATs
 /OPT:ICF  folds identical COMDATs
 /DYNAMICBASE  does this app really need ASLR ?
@@ -49,6 +51,8 @@ No need to force /TLBID:1 because is default
 #]=======================================================================]
 
 # Path has changed, so this configure run will find cl.exe
+set(CMAKE_POLICY_DEFAULT_CMP0141 NEW)
+set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
 set(CMAKE_C_COMPILER   cl.exe)
 set(CMAKE_CXX_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_CXX_FLAGS_INIT "\
@@ -56,8 +60,7 @@ set(CMAKE_CXX_FLAGS_INIT "\
 /wd4068 /wd4146 /wd4819 /wd6237 /wd6319 /wd26444 /wd26451 /wd26495 /WX- /W1 \
 /TP /Zc:forScope /Zc:inline /Zc:wchar_t"
 )
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "/Zi /Oi")
-set(CMAKE_CXX_FLAGS_RELEASE_INIT "/Zi")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "/Oi")
 add_compile_definitions(
     _SCL_SECURE_NO_WARNINGS
     _CRT_SECURE_NO_WARNINGS

--- a/build-scripts/windows-tiles-sounds-x64-msvc.cmake
+++ b/build-scripts/windows-tiles-sounds-x64-msvc.cmake
@@ -50,7 +50,6 @@ find_program(CCACHE_EXE ccache)
 if(CCACHE_EXE)
     set(CMAKE_C_COMPILER_LAUNCHER   ccache)
     set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
-    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 endif()
 
 # Automatic gettext setup for Windows


### PR DESCRIPTION
## Purpose of change (The Why)

Restore the MSVC ccache fix without regressing release packaging.

`build: improve MSVC build speed` fixed cacheability for PR builds, but it also stopped producing `cataclysm-bn-tiles.pdb` in Release builds, which broke the Windows PDB archive/upload path used by nightly/manual releases.

## Describe the solution (The How)

- switch MSVC debug information to CMake's `Embedded` format so optimized builds use `/Z7` instead of `/Zi`
- keep the Windows release linker emitting PDBs via `/DEBUG`
- restore the Windows ccache tuning from the reverted change:
  - `CCACHE_COMPILERCHECK=content`
  - 1 GiB cache size
- keep the CMake debug-information setting in the MSVC toolchain so release and CI builds use the same behavior

## Describe alternatives you've considered

- Reapplying the previous PR as-is: rejected because it still drops the release PDB.
- Keeping `/Zi`: rejected because ccache still treats MSVC invocations as unsupported.

## Testing

- [x] `git diff --check`
- [x] `actionlint .github/workflows/build.yml .github/workflows/manual-release.yml`
- [x] Manual release on this branch: <https://github.com/scarf005/Cataclysm-BN/actions/runs/25981933115>
  - Windows job completed successfully
  - `Locate PDB` found `out/build/windows-tiles-sounds-x64-msvc/src/cataclysm-bn-tiles.pdb`
  - release assets include both `cbn-windows-tiles-x64-msvc-v99.0.517.zip` and `cbn-windows-tiles-x64-msvc-v99.0.517-pdb.zip`
- [x] Draft verification release: <https://github.com/scarf005/Cataclysm-BN/releases/tag/untagged-e6970b7db4f735ff6644>

## Additional context

No closing issue.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] No relevant issues were found to link.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit.

<sup>PR opened by gpt-5 high on pi</sup>
