### PR TITLE
build: Reduce Path Lengths

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -4,7 +4,7 @@
       "name": "Debug",
       "generator": "Ninja",
       "configurationType": "Debug",
-      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-debug",
+      "buildRoot": "${projectDir}/out/build/win-debug",
       "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "variables": [
@@ -26,7 +26,7 @@
       "name": "RelWithDebInfo",
       "generator": "Ninja",
       "configurationType": "RelWithDebInfo",
-      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-relwithdebinfo",
+      "buildRoot": "${projectDir}/out/build/win-rel-deb",
       "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "variables": [
@@ -48,7 +48,7 @@
       "name": "Release",
       "generator": "Ninja",
       "configurationType": "Release",
-      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-release",
+      "buildRoot": "${projectDir}/out/build/win-release",
       "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "variables": [
@@ -70,7 +70,7 @@
       "name": "Tests",
       "generator": "Ninja",
       "configurationType": "RelWithDebInfo",
-      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-tests",
+      "buildRoot": "${projectDir}/out/build/win-tests",
       "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "variables": [
@@ -92,7 +92,7 @@
       "name": "Tracy",
       "generator": "Ninja",
       "configurationType": "Release",
-      "buildRoot": "${projectDir}/out/build/windows-tiles-sounds-x64-msvc-tracy",
+      "buildRoot": "${projectDir}/out/build/win-tracy",
       "installRoot": "${projectDir}/out/install/windows-tiles-sounds-x64-msvc",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "variables": [

--- a/docs/en/dev/guides/building/vs_cmake.md
+++ b/docs/en/dev/guides/building/vs_cmake.md
@@ -229,10 +229,10 @@ make sure to run it from the project root directory:
 
 ```powershell
 # Correct — run from the project root
-.\out\build\windows-tiles-sounds-x64-msvc-relwithdebinfo\src\cataclysm-bn-tiles.exe
+.\out\build\win-rel-deb\src\cataclysm-bn-tiles.exe
 
 # Wrong — game can't find ./data/
-cd out\build\windows-tiles-sounds-x64-msvc-relwithdebinfo\src
+cd out\build\win-rel-deb\src
 .\cataclysm-bn-tiles.exe
 ```
 


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves partially: #8930

## Describe the solution (The How)

Shorten path lengths for local builds.
Workflows are (at least currently) safe from this being required.
This effects anyone with their working directory even as shallow as my documents.

## Describe alternatives you've considered

## Testing

@chaosvolt

## Additional Information

Steps to clear out everything after this PR:
-Close VS
-Wait a few seconds
-Delete .vs/
-Delete out/
-Wait a few seconds
-Open VS with no project
-Open Cataclysm-BN directory in VS
-Wait until it stops churning
-Project->Configure Cache