### PR TITLE
fix: include recursive MSVC project sources

### DIFF
--- a/.github/workflows/legacy-msvc.yml
+++ b/.github/workflows/legacy-msvc.yml
@@ -1,0 +1,53 @@
+name: Legacy MSVC
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore: [main]
+    paths:
+      - ".github/workflows/legacy-msvc.yml"
+      - "msvc-full-features/**"
+      - "src/**/*.cpp"
+      - "src/**/*.h"
+  pull_request:
+    paths:
+      - ".github/workflows/legacy-msvc.yml"
+      - "msvc-full-features/**"
+      - "src/**/*.cpp"
+      - "src/**/*.h"
+
+permissions: { contents: read }
+
+concurrency:
+  group: legacy-msvc-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build legacy Visual Studio project
+    runs-on: windows-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with: { arch: x64 }
+
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@main
+        with: { vcpkgDirectory: "${{ github.workspace }}/../b/vcpkg" }
+
+      - name: Integrate vcpkg
+        run: vcpkg integrate install
+
+      - name: Build Cataclysm legacy MSVC project
+        run: >-
+          msbuild msvc-full-features\Cataclysm-vcpkg-static.vcxproj
+          /m
+          /p:Configuration=Release
+          /p:Platform=x64
+          /p:VcpkgTriplet=x64-windows-static
+          /p:VcpkgUseStatic=true

--- a/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
@@ -142,11 +142,11 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\src\*.h" Exclude ="..src\message.h" />
+    <ClInclude Include="..\src\**\*.h" Exclude="..\src\lua\**\*.h;..\src\sol\**\*.h;..\src\third-party\**\*.h;..\src\messages.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\*.cpp" Exclude="..\src\main.cpp;..\src\messages.cpp" />
+    <ClCompile Include="..\src\**\*.cpp" Exclude="..\src\lua\**\*.cpp;..\src\sol\**\*.cpp;..\src\third-party\**\*.cpp;..\src\main.cpp;..\src\messages.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>


### PR DESCRIPTION
## Purpose of change (The Why)

The legacy Visual Studio project only included `src/*.cpp`, so source files in subdirectories such as `src/utils/url.cpp` were omitted. That leaves calls to `open_url` without the implementation and causes MSVC link failures.

No related issue found.

## Describe the solution (The How)

Use recursive `src\**\*.cpp` and `src\**\*.h` globs in the legacy MSVC library project while preserving exclusions for `main.cpp`, `messages.cpp`, and vendored/source subdirectories handled separately.

Add a focused legacy MSVC GitHub Actions workflow so the `.vcxproj` path is testable on Windows instead of relying on the existing CMake/Ninja MSVC CI.

## Describe alternatives you've considered

Adding only `src/utils/url.cpp` would fix the current link error, but would leave the same project-file bug for future source subdirectories.

## Testing

- Parsed `msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj` as XML.
- Verified the recursive source set includes `src/utils/url.cpp` and excludes `src/main.cpp` / `src/messages.cpp`.
- Ran `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check upstream/main..HEAD`.
- Fork CI: [Legacy MSVC run](https://github.com/scarf005/Cataclysm-BN/actions/runs/26013605399) is currently running on `scarf005:fix/msvc-recursive-sources`.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the code formatter where applicable; no formatter applies to this `.vcxproj`/workflow YAML-only change.
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why), or confirmed no related issue was found.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This is a PR that modifies build process or code organization.
  - [x] This fixes source inclusion in the existing legacy MSVC project and adds focused CI coverage for that path.

AI assistance was used to investigate and prepare this change.

<sup>PR opened by gpt-5.4 high on pi</sup>

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26013607195/artifacts/7049695295)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26013607195/artifacts/7049985052)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26013607195/artifacts/7049653000)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26013607195/artifacts/7049776944)
<!-- END artifact comment -->