### PR TITLE
build: fix MSVC ccache policy setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
             windows-${{ matrix.artifact }}-${{ github.ref_name }}
             windows-${{ matrix.artifact }}-main
             windows-${{ matrix.artifact }}-
-          max-size: 1G
+          max-size: 3G
           verbose: 2
           save: ${{ github.event_name != 'pull_request' }}
 
@@ -406,6 +406,20 @@ jobs:
             --config Release `
             --target $targets
 
+      - name: Verify ccache compatibility (windows msvc)
+        if: runner.os == 'Windows'
+        run: |
+          $stats = ccache -s -vv 2>&1
+          $stats
+          $cacheable = [int64](($stats | Select-String 'Cacheable calls:\s+(\d+)').Matches[0].Groups[1].Value)
+          $unsupported = [int64](($stats | Select-String 'Unsupported compiler option:\s+(\d+)').Matches[0].Groups[1].Value)
+          if ($cacheable -le 100) {
+            throw "ccache did not see enough cacheable MSVC compile calls"
+          }
+          if ($unsupported -ge $cacheable) {
+            throw "ccache saw more unsupported MSVC compiler options than cacheable calls"
+          }
+
       - name: Create distribution package (windows msvc)
         if: runner.os == 'Windows' && inputs.package-artifacts && (!inputs.upload-artifacts || matrix.upload-artifact == true)
         run: |
@@ -420,9 +434,15 @@ jobs:
       - name: Archive PDB (windows msvc)
         if: runner.os == 'Windows' && inputs.package-artifacts && (!inputs.upload-artifacts || matrix.upload-artifact == true)
         run: |
-          Compress-Archive -Force `
-            -Path "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc/src/cataclysm-bn-tiles.pdb" `
-            -DestinationPath "cbn-${{ matrix.artifact }}-${{ inputs.version-label }}-pdb.zip"
+          $pdb = "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc/src/cataclysm-bn-tiles.pdb"
+          $archive = "cbn-${{ matrix.artifact }}-${{ inputs.version-label }}-pdb.zip"
+          if (!(Test-Path $pdb)) {
+            throw "Missing Windows release PDB: $pdb"
+          }
+          Compress-Archive -Force -Path $pdb -DestinationPath $archive
+          if (!(Test-Path $archive)) {
+            throw "Missing Windows release PDB archive: $archive"
+          }
 
       - name: Configure and Build with CMake (macOS)
         if: runner.os == 'macOS'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.24)
 
+if (POLICY CMP0141)
+    cmake_policy(SET CMP0141 NEW)
+endif ()
+
 project(CataclysmBN C CXX)
 
 list(APPEND CMAKE_MODULE_PATH

--- a/build-scripts/MSVC.cmake
+++ b/build-scripts/MSVC.cmake
@@ -51,7 +51,7 @@ No need to force /TLBID:1 because is default
 #]=======================================================================]
 
 # Path has changed, so this configure run will find cl.exe
-set(CMAKE_POLICY_DEFAULT_CMP0141 NEW)
+# CMP0141 is set before project() in CMakeLists.txt so this variable is honored.
 set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
 set(CMAKE_C_COMPILER   cl.exe)
 set(CMAKE_CXX_COMPILER ${CMAKE_C_COMPILER})


### PR DESCRIPTION
## Purpose of change (The Why)

_AAAAAAA CCACHE ON WINDOWS AAAAAAAAAAAAAAA_

Attempts to (finally) fix MSVC ccache setup after #8915 left Windows builds effectively uncached.

Related: #8823, #8836, #8915, #8933.

## Describe the solution (The How)

- Set CMake policy `CMP0141` before `project()` so `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded` is honored.
- Keep MSVC debug info in `/Z7`-compatible form for ccache and release PDB generation.
- Add Windows MSVC ccache stats verification.
- Keep Windows PDB archiving/upload on the shared build workflow used by nightly, manual, and experimental releases.
- Increase Windows ccache size to avoid immediate cleanup.

## Describe alternatives you've considered

Keeping the policy in the toolchain file was ineffective because it runs too late for language enablement.

## Testing

- `actionlint .github/workflows/build.yml`
- `git diff --check`
- Local CMake configure check for `windows-tiles-sounds-x64-msvc` policy/debug-info behavior
- Fork CI: https://github.com/scarf005/Cataclysm-BN/actions/runs/26032359701
  - Windows MSVC job succeeded: 76521432648
  - `Cacheable calls: 600 / 604`, `Hits: 196 / 600`, `Unsupported compiler option: 2 / 4`
  - PDB found and archived: `src/cataclysm-bn-tiles.pdb`
  - Windows artifact uploaded and downloaded; zip contains `cataclysm-bn-tiles.exe` and `VERSION.txt`
  - Windows tests passed

## Additional context

Nightly, manual, and experimental releases all call `.github/workflows/build.yml` with `upload-to-release: true`; the Windows MSVC PDB upload step uses that shared path.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This is a PR that modifies build process or code organization.
  - [x] No docs update: this only repairs CI/release workflow behavior.

<sup>PR opened by gpt-5.5 high on pi</sup>

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26035295294/artifacts/7058920678)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26035295294/artifacts/7059619616)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26035295294/artifacts/7058673100)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26035295294/artifacts/7058946932)
<!-- END artifact comment -->