### PR TITLE
feat: add bathtub construction recipe

### DIFF
--- a/data/json/construction/construct_furn.json
+++ b/data/json/construction/construct_furn.json
@@ -939,9 +939,9 @@
     "group": "build_bathtub",
     "category": "FURN",
     "required_skills": [ [ "fabrication", 3 ] ],
-	"using": [ [ "earthenware_firing", 120 ], [ "glazing", 2 ] ],
+    "using": [ [ "earthenware_firing", 120 ], [ "glazing", 2 ] ],
     "time": "150 m",
-	"components": [ [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
+    "components": [ [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
     "dark_craftable": true,
     "pre_special": "check_empty",
     "post_furniture": "f_bathtub"

--- a/data/json/construction/construct_furn.json
+++ b/data/json/construction/construct_furn.json
@@ -941,7 +941,11 @@
     "required_skills": [ [ "fabrication", 3 ] ],
     "using": [ [ "earthenware_firing", 120 ], [ "glazing", 2 ] ],
     "time": "150 m",
+<<<<<<< Updated upstream
     "components": [ [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
+=======
+	"components": [ [ [ "water_faucet", 1 ] ], [ [ "cu_pipe", 1 ] ], [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
+>>>>>>> Stashed changes
     "dark_craftable": true,
     "pre_special": "check_empty",
     "post_furniture": "f_bathtub"

--- a/data/json/construction/construct_furn.json
+++ b/data/json/construction/construct_furn.json
@@ -941,11 +941,7 @@
     "required_skills": [ [ "fabrication", 3 ] ],
     "using": [ [ "earthenware_firing", 120 ], [ "glazing", 2 ] ],
     "time": "150 m",
-<<<<<<< Updated upstream
-    "components": [ [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
-=======
-	"components": [ [ [ "water_faucet", 1 ] ], [ [ "cu_pipe", 1 ] ], [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
->>>>>>> Stashed changes
+	  "components": [ [ [ "water_faucet", 1 ] ], [ [ "cu_pipe", 1 ] ], [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
     "dark_craftable": true,
     "pre_special": "check_empty",
     "post_furniture": "f_bathtub"

--- a/data/json/construction/construct_furn.json
+++ b/data/json/construction/construct_furn.json
@@ -941,7 +941,7 @@
     "required_skills": [ [ "fabrication", 3 ] ],
     "using": [ [ "earthenware_firing", 120 ], [ "glazing", 2 ] ],
     "time": "150 m",
-	  "components": [ [ [ "water_faucet", 1 ] ], [ [ "cu_pipe", 1 ] ], [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
+    "components": [ [ [ "water_faucet", 1 ] ], [ [ "cu_pipe", 1 ] ], [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
     "dark_craftable": true,
     "pre_special": "check_empty",
     "post_furniture": "f_bathtub"

--- a/data/json/construction/construct_furn.json
+++ b/data/json/construction/construct_furn.json
@@ -932,5 +932,18 @@
     "pre_furniture": "f_bathtub_money",
     "byproducts": [ { "item": "money_pile" } ],
     "post_furniture": "f_bathtub"
+  },
+  {
+    "type": "construction",
+    "id": "constr_bathtub",
+    "group": "build_bathtub",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 3 ] ],
+	"using": [ [ "earthenware_firing", 120 ], [ "glazing", 2 ] ],
+    "time": "150 m",
+	"components": [ [ [ "clay_lump", 40 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ],
+    "dark_craftable": true,
+    "pre_special": "check_empty",
+    "post_furniture": "f_bathtub"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1878,5 +1878,11 @@
     "type": "construction_group",
     "id": "place_roulette",
     "name": "Place Roulette Table"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_bathtub",
+    "name": "Build Bathtub"
   }
+  
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1884,5 +1884,4 @@
     "id": "build_bathtub",
     "name": "Build Bathtub"
   }
-  
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

Bathtubs are one of the few furnitures that can 'catch' liquids when poured or leaked. I wanted to mess around with this functionality so making them constructible seemed fun.

## Describe the solution (The How)

Added a construction recipe requiring clay lumps, glazing, water, and kiln.

## Describe alternatives you've considered

## Testing

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.
