### PR TITLE
feat: no_thirst mutation prevents bloating from drinking liquids, engorged hunger state is now pink

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5166,7 +5166,7 @@ std::pair<std::string, nc_color> Character::get_hunger_description() const
     nc_color hunger_color = c_white;
     if( days_left >= days_max ) {
         hunger_string = _( "Engorged" );
-        hunger_color = c_green;
+        hunger_color = c_pink;
     } else if( days_max - days_left < 0.5f ) {
         hunger_string = _( "Sated" );
         hunger_color = c_green;

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1266,7 +1266,8 @@ bool Character::consume_effects( item &food )
     mod_thirst( -contained_food.type->comestible->quench );
 
 
-    if( ( excess_kcal > 0 || ( excess_quench > 0 && !has_trait( trait_NO_THIRST ) ) ) && !food.has_flag( flag_NO_BLOAT ) &&
+    if( ( excess_kcal > 0 || ( excess_quench > 0 && !has_trait( trait_NO_THIRST ) ) ) &&
+        !food.has_flag( flag_NO_BLOAT ) &&
         !has_trait( trait_GOURMAND ) ) {
         add_effect( effect_bloated, 5_minutes );
     }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -99,6 +99,7 @@ static const trait_id trait_M_IMMUNE( "M_IMMUNE" );
 static const trait_id trait_MANDIBLES( "MANDIBLES" );
 static const trait_id trait_MEATARIAN( "MEATARIAN" );
 static const trait_id trait_MOUTH_TENTACLES( "MOUTH_TENTACLES" );
+static const trait_id trait_NO_THIRST( "NO_THIRST" );
 static const trait_id trait_PARAIMMUNE( "PARAIMMUNE" );
 static const trait_id trait_POISRESIST( "POISRESIST" );
 static const trait_id trait_PROBOSCIS( "PROBOSCIS" );
@@ -1265,7 +1266,7 @@ bool Character::consume_effects( item &food )
     mod_thirst( -contained_food.type->comestible->quench );
 
 
-    if( ( excess_kcal > 0 || excess_quench > 0 ) && !food.has_flag( flag_NO_BLOAT ) &&
+    if( ( excess_kcal > 0 || ( excess_quench > 0 && !has_trait( trait_NO_THIRST ) ) ) && !food.has_flag( flag_NO_BLOAT ) &&
         !has_trait( trait_GOURMAND ) ) {
         add_effect( effect_bloated, 5_minutes );
     }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -790,7 +790,7 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
         ( ( food_kcal > 0 &&
             get_stored_kcal() + stomach.get_calories() + food_kcal
             > max_stored_kcal() ) ||
-          ( comest->quench > 0 && get_thirst() < comest->quench ) ) ) {
+          ( comest->quench > 0 && get_thirst() < comest->quench && !has_trait( trait_NO_THIRST ) ) ) ) {
         add_consequence( _( "You're full already and the excess food will be wasted." ),
                          edible_rating::too_full );
     }


### PR DESCRIPTION
## Purpose of change (The Why)

If you have a character that had the no_thirst mutation (metabolic rehydration) but did not have gourmand, consuming any food that would restore any amount of thirst would bloat you, effectively making eating a large number of foods a massive pain in the ass, because the no thirst trait locks your thirst to 0
really annoying for a trait worth +6 points

additionally, if a player uses the bar health display style and decides to eat more food then they can store, the sidebar will display the "engorged" status instead of sated, which is useful

unfortunately for players who use the numerical health display style, there is no easy way to tell if you are currently engorged or not unless you decide to memorise the exact kcal threshold for engorged
poor ux to say the least

## Describe the solution (The How)

A player with the metabolic rehydration trait cannot become bloated from consuming liquids (they will still become bloated from consuming too much regular food however)

additionally the engorged status effect is now colored pink instead of green, color chosen as it is what all food gets colored when you have the bloated status effect

## Describe alternatives you've considered

- Not doing this

## Testing

Gave a character diminutive and metabolic rehydration, consumed 50 bottles of clean water, observed no bloating status effect
Consumed food until my character was above 17500kcal (without eater of the dead/hypermetabolism) and observed the hunger display now read engorged and was also pink

## Additional context

the no_thirst change should mostly be meaningless as you usually will have gourmand by the time you get it, unless you happen to get really unlucky in which case this is just preventing things becoming miserable until you can get gourmand

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26059426049/artifacts/7068942459)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26059426049/artifacts/7069587938)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26059426049/artifacts/7069182692)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26059426049/artifacts/7069139379)
<!-- END artifact comment -->