### PR TITLE
fix: don't allow trying to reload vehicle-mounted lasers

### DIFF
--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -231,7 +231,7 @@ bool turret_data::can_reload() const
     if( !veh || !part || part->info().has_flag( "USE_TANKS" ) ) {
         return false;
     }
-    if( !part->base->magazine_integral() ) {
+    if( part->base->magazine_default() ) {
         // always allow changing of magazines
         return true;
     }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This fixes an issue where the game lets you offer to reload a vehicle-mounted A7 or other UPS-only weapons, despite not having any way to reload them.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In turret.cpp, changed `turret_data::can_reload` so that the "always allow reloading mag-fed guns" section is handled by checking for `magazine_default()` instead of the absence of `magazine_integral()`, since obviously a laser gun would accidentally return true with that since it technically also doesn't have clip size.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->


1. Compiled and load-tested.
2. Slapped an A7 on a vehicle, reload option correctly no longer shows up.
3. Spawned in a humvee, confirmed I can still take out and reload the belt on its M240.
4. Removed the mounted M240 and replaced it with a mounted G80 railgun, confirmed I can still reload it.
5. Slapped on a repeating crossbow and a TOW, both can be reloaded still.

Side note: magazine-fed mounted weapons don't work with partial reloads for some reason, requiring you to unload the mag and then reload it yourself (autoloads may or may not do this for you, haven't tested). I temporarily added some extra debug messages for testing and confirmed it's this part of `item::reload` specifically:
```C++
    if( !is_reloadable_with( ammo->typeId() ) ) {
        return false;
    }
```

Tested on 5/16 and it was still present, so I can confirm it's not somehow caused by this change.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26060799425/artifacts/7069462657)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26060799425/artifacts/7069983695)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26060799425/artifacts/7069597393)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26060799425/artifacts/7069636336)
<!-- END artifact comment -->