### PR TITLE
feat: add vehicle palette for wooden vehicles

### DIFF
--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -287,5 +287,48 @@
         ]
       }
     ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "wooden_standard",
+    "palette": [
+      {
+        "fuzzy_ids": [
+          "woodboard",
+          "woodhalfboard",
+          "boat_board",
+          "raft_board",
+          "wing_wood",
+          "windshield",
+          "wood box",
+          "travois",
+          "seat_wood",
+          "wooden_aisle",
+          "door_wood",
+          "roof_wood"
+        ],
+        "colors": [
+          { "color": "Green beige", "weight": 5 },
+          { "color": "Beige", "weight": 5 },
+          { "color": "Brown beige", "weight": 5 },
+          { "color": "Broom yellow", "weight": 5 },
+          { "color": "Brown red", "weight": 5 },
+          { "color": "Beige red", "weight": 5 },
+          { "color": "Olive grey", "weight": 5 },
+          { "color": "Beige grey", "weight": 5 },
+          { "color": "Khaki grey", "weight": 5 },
+          { "color": "Green brown", "weight": 5 },
+          { "color": "Ochre brown", "weight": 5 },
+          { "color": "Clay brown", "weight": 5 },
+          { "color": "Olive brown", "weight": 5 },
+          { "color": "Nut brown", "weight": 5 },
+          { "color": "Sepia brown", "weight": 5 },
+          { "color": "Chestnut brown", "weight": 5 },
+          { "color": "Mahogany brown", "weight": 5 },
+          { "color": "Chocolate brown", "weight": 5 },
+          { "color": "Beige brown", "weight": 5 }
+        ]
+      }
+    ]
   }
 ]

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -331,7 +331,7 @@
         ]
       },
       {
-        "fuzzy_ids": [ "clothboard", "cloth_halfboard", "roof_cloth", "cargo_bag", "sail" ],
+        "fuzzy_ids": [ "clothboard", "cloth_halfboard", "roof_cloth", "cargo_bag" ],
         "colors": [
           { "color": "Oyster white", "weight": 5 },
           { "color": "Ivory", "weight": 5 },

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -80,7 +80,7 @@
     "id": "military_fighter",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "trunk_carbon_flat", "hatch" ],
+        "fuzzy_ids": [ "board", "wing", "propeller", "windshield", "door", "roof", "trunk_flat", "trunk_carbon_flat", "hatch" ],
         "colors": [
           { "color": "Telegrey 1", "weight": 20, "//": "Federal Standard 36176" },
           { "color": "Pastel turquoise", "weight": 10 },
@@ -97,7 +97,7 @@
     "id": "military_heli",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "fuzzy_ids": [ "board", "wing", "rotor", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "Cataclysm Green", "weight": 20 },
           { "color": "Black grey", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
@@ -257,7 +257,7 @@
     "id": "aircraft_standard",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "fuzzy_ids": [ "board", "wing", "rotor", "propeller", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "Pigeon Blue", "weight": 10 },
           { "color": "Black grey", "weight": 5 },
@@ -276,7 +276,7 @@
     "id": "aircraft_commercial",
     "palette": [
       {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "fuzzy_ids": [ "board", "wing", "rotor", "propeller", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "White aluminium", "weight": 15 },
           { "color": "Gentian blue", "weight": 10 },
@@ -299,6 +299,7 @@
           "boat_board",
           "raft_board",
           "wing_wood",
+          "propeller_wood",
           "windshield",
           "wood box",
           "travois",
@@ -330,13 +331,7 @@
         ]
       },
       {
-        "fuzzy_ids": [
-          "clothboard",
-          "cloth_halfboard",
-          "roof_cloth",
-          "cargo_bag",
-          "sail"
-        ],
+        "fuzzy_ids": [ "clothboard", "cloth_halfboard", "roof_cloth", "cargo_bag", "sail" ],
         "colors": [
           { "color": "Oyster white", "weight": 5 },
           { "color": "Ivory", "weight": 5 },

--- a/data/json/vehicle_palette.json
+++ b/data/json/vehicle_palette.json
@@ -328,6 +328,30 @@
           { "color": "Chocolate brown", "weight": 5 },
           { "color": "Beige brown", "weight": 5 }
         ]
+      },
+      {
+        "fuzzy_ids": [
+          "clothboard",
+          "cloth_halfboard",
+          "roof_cloth",
+          "cargo_bag",
+          "sail"
+        ],
+        "colors": [
+          { "color": "Oyster white", "weight": 5 },
+          { "color": "Ivory", "weight": 5 },
+          { "color": "Light ivory", "weight": 5 },
+          { "color": "Grey beige", "weight": 5 },
+          { "color": "Grey blue", "weight": 5 },
+          { "color": "Silver grey", "weight": 5 },
+          { "color": "Beige grey", "weight": 5 },
+          { "color": "Black grey", "weight": 5 },
+          { "color": "Light grey", "weight": 5 },
+          { "color": "Cream", "weight": 5 },
+          { "color": "Grey white", "weight": 5 },
+          { "color": "Papyrus white", "weight": 5 },
+          { "color": "Flame red", "weight": 5, "//": "Red Baron" }
+        ]
       }
     ]
   }

--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -189,6 +189,8 @@
       [ "     |   " ],
       [ "     |   " ]
     ],
+    "color_palette": "wooden_standard",
+    "//": "TODO: If someday we get support for layering multiple palettes on the same vehicle, add a second palette for the cloth parts.",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_light_cross", "seat_wood_light", "controls", "dashboard", "roof_cloth" ] },
       {
@@ -364,6 +366,7 @@
       "  OOOOOOOOOOOOOOOOOO  ",
       "    OOOOOOOOOOOOOO    "
     ],
+    "color_palette": "wooden_standard",
     "blueprint_origin": { "x": 13, "y": 5 },
     "palette": {
       "^": [ "frame_wood_cross", "seat_wood", "controls", "airship_balloon" ],
@@ -423,6 +426,7 @@
       " OO3-+-9OOO ",
       "  OOOOOOOO  "
     ],
+    "color_palette": "wooden_standard",
     "blueprint_origin": { "x": 6, "y": 2 },
     "palette": {
       "^": [ "frame_wood_cross", "seat_wood", "controls", "airship_balloon" ],
@@ -459,6 +463,7 @@
     "id": "aircanoe",
     "name": "aircanoe",
     "blueprint": [ [ "<OO>" ] ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_horizontal", "seat_wood_light", "sail_large", "airship_balloon" ] },
       { "x": 1, "y": 0, "parts": [ "frame_wood_horizontal", "wood box", "airship_balloon" ] },

--- a/data/json/vehicles/aircraft_other.json
+++ b/data/json/vehicles/aircraft_other.json
@@ -190,7 +190,6 @@
       [ "     |   " ]
     ],
     "color_palette": "wooden_standard",
-    "//": "TODO: If someday we get support for layering multiple palettes on the same vehicle, add a second palette for the cloth parts.",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_light_cross", "seat_wood_light", "controls", "dashboard", "roof_cloth" ] },
       {

--- a/data/json/vehicles/boats.json
+++ b/data/json/vehicles/boats.json
@@ -4,6 +4,7 @@
     "type": "vehicle",
     "name": "canoe",
     "blueprint": [ [ "<OO>" ] ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_horizontal", "seat_wood_light", "hand_paddles", "boat_board" ] },
       { "x": 1, "y": 0, "parts": [ "frame_wood_horizontal", "boat_board", "seat_wood_light" ] },
@@ -165,6 +166,7 @@
       [ "OO" ],
       [ "OO" ]
     ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "hand_paddles", "raft_board" ] },
       { "x": 1, "y": 0, "parts": [ "frame_wood_cross", "raft_board" ] },
@@ -283,6 +285,7 @@
       [ "|OO|" ],
       [ "\\--/" ]
     ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "seat_wood", "hand_paddles", "boat_board" ] },
       { "x": 0, "y": 1, "parts": [ "frame_wood_cross", "seat_wood", "boat_board" ] },
@@ -318,6 +321,7 @@
       [ "||##==|______|| " ],
       [ " ||||||||++|||  " ]
     ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": -9, "y": 0, "parts": [ "frame_wood_horizontal", "windshield", "v_curtain", "boat_board" ] },
       { "x": -8, "y": 0, "parts": [ "frame_wood_vertical", "wooden_aisle_vertical", "roof_wood", "boat_board" ] },
@@ -457,6 +461,7 @@
       [ "||##__|_____t||  " ],
       [ " ||||||||++|||   " ]
     ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": -9, "y": 0, "parts": [ "frame_wood_horizontal", "woodboard_horizontal", "plating_wood", "boat_board" ] },
       { "x": -8, "y": 0, "parts": [ "frame_wood_vertical", "wood box", "roof_wood", "boat_board" ] },

--- a/data/json/vehicles/carts.json
+++ b/data/json/vehicles/carts.json
@@ -285,6 +285,7 @@
     "type": "vehicle",
     "name": "Dogsled",
     "blueprint": [  ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_light_vertical", "wood box" ] },
       { "x": -1, "y": 0, "parts": [ "frame_wood_light_vertical", "wood box" ] },

--- a/data/json/vehicles/farm.json
+++ b/data/json/vehicles/farm.json
@@ -236,6 +236,7 @@
       [ "oHo" ],
       [ "oHo" ]
     ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "wooden_aisle_vertical" ] },
       { "x": 0, "y": 1, "parts": [ "frame_wood_cross", "wood box" ] },
@@ -265,6 +266,7 @@
       [ "oHo" ],
       [ "oHo" ]
     ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "wooden_aisle_vertical" ] },
       { "x": 0, "y": 1, "parts": [ "frame_wood_cross", "wood box" ] },

--- a/data/json/vehicles/military.json
+++ b/data/json/vehicles/military.json
@@ -1253,6 +1253,7 @@
     "type": "vehicle",
     "name": "Scorpio ballista",
     "blueprint": [ [ "-U" ] ],
+    "color_palette": "wooden_standard",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "turret_mount_manual_wood", "mounted_launcher_ballista" ] },
       { "x": -1, "y": 0, "parts": [ "frame_wood_handle" ] }

--- a/data/mods/MoreVehicleColors/vehicle_palette.json
+++ b/data/mods/MoreVehicleColors/vehicle_palette.json
@@ -354,6 +354,30 @@
           { "color": "Light Oak Brown", "weight": 5 },
           { "color": "Smoked Oak Brown", "weight": 5 }
         ]
+      },
+      {
+        "fuzzy_ids": [
+          "clothboard",
+          "cloth_halfboard",
+          "roof_cloth",
+          "cargo_bag",
+          "sail"
+        ],
+        "colors": [
+          { "color": "Steel Grey", "weight": 5 },
+          { "color": "Light Grey", "weight": 5 },
+          { "color": "Shadow White", "weight": 5 },
+          { "color": "Winter White", "weight": 5 },
+          { "color": "Dull Dusky Pink", "weight": 5 },
+          { "color": "Antique White", "weight": 5 },
+          { "color": "Nomad Grey", "weight": 5 },
+          { "color": "Natural White", "weight": 5 },
+          { "color": "Oilcloth Green", "weight": 5 },
+          { "color": "Linen Grey", "weight": 5 },
+          { "color": "Linen Blue", "weight": 5 },
+          { "color": "Cotton White", "weight": 5 },
+          { "color": "Vibrant Red", "weight": 5, "//": "Red Baron" }
+        ]
       }
     ]
   }

--- a/data/mods/MoreVehicleColors/vehicle_palette.json
+++ b/data/mods/MoreVehicleColors/vehicle_palette.json
@@ -88,7 +88,7 @@
     "clear": true,
     "palette": [
       {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "trunk_carbon_flat", "hatch" ],
+        "fuzzy_ids": [ "board", "wing", "propeller", "windshield", "door", "roof", "trunk_flat", "trunk_carbon_flat", "hatch" ],
         "colors": [
           { "color": "Noble Grey", "weight": 20, "//": "Federal Standard 36176" },
           { "color": "Baby Blue", "weight": 10 },
@@ -106,7 +106,7 @@
     "clear": true,
     "palette": [
       {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "fuzzy_ids": [ "board", "wing", "rotor", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "Cataclysm Green", "weight": 20 },
           { "color": "Onyx Black", "weight": 10, "//": "CARC Black (Federal Standard 37030)" },
@@ -278,7 +278,7 @@
     "clear": true,
     "palette": [
       {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "fuzzy_ids": [ "board", "wing", "rotor", "propeller", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "Prince Grey", "weight": 10 },
           { "color": "Ink Black", "weight": 5 },
@@ -298,7 +298,7 @@
     "clear": true,
     "palette": [
       {
-        "fuzzy_ids": [ "board", "wing", "windshield", "door", "roof", "trunk_flat", "hatch" ],
+        "fuzzy_ids": [ "board", "wing", "rotor", "propeller", "windshield", "door", "roof", "trunk_flat", "hatch" ],
         "colors": [
           { "color": "White aluminium", "weight": 15 },
           { "color": "British Mauve", "weight": 10 },
@@ -322,6 +322,7 @@
           "boat_board",
           "raft_board",
           "wing_wood",
+          "propeller_wood",
           "windshield",
           "wood box",
           "travois",
@@ -356,13 +357,7 @@
         ]
       },
       {
-        "fuzzy_ids": [
-          "clothboard",
-          "cloth_halfboard",
-          "roof_cloth",
-          "cargo_bag",
-          "sail"
-        ],
+        "fuzzy_ids": [ "clothboard", "cloth_halfboard", "roof_cloth", "cargo_bag", "sail" ],
         "colors": [
           { "color": "Steel Grey", "weight": 5 },
           { "color": "Light Grey", "weight": 5 },

--- a/data/mods/MoreVehicleColors/vehicle_palette.json
+++ b/data/mods/MoreVehicleColors/vehicle_palette.json
@@ -357,7 +357,7 @@
         ]
       },
       {
-        "fuzzy_ids": [ "clothboard", "cloth_halfboard", "roof_cloth", "cargo_bag", "sail" ],
+        "fuzzy_ids": [ "clothboard", "cloth_halfboard", "roof_cloth", "cargo_bag" ],
         "colors": [
           { "color": "Steel Grey", "weight": 5 },
           { "color": "Light Grey", "weight": 5 },

--- a/data/mods/MoreVehicleColors/vehicle_palette.json
+++ b/data/mods/MoreVehicleColors/vehicle_palette.json
@@ -366,7 +366,7 @@
           { "color": "Dull Dusky Pink", "weight": 5 },
           { "color": "Antique White", "weight": 5 },
           { "color": "Nomad Grey", "weight": 5 },
-          { "color": "Natural White", "weight": 5 },
+          { "color": "Smoky White", "weight": 5 },
           { "color": "Oilcloth Green", "weight": 5 },
           { "color": "Linen Grey", "weight": 5 },
           { "color": "Linen Blue", "weight": 5 },

--- a/data/mods/MoreVehicleColors/vehicle_palette.json
+++ b/data/mods/MoreVehicleColors/vehicle_palette.json
@@ -309,5 +309,52 @@
         ]
       }
     ]
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "wooden_standard",
+    "//": "Expands existing palette instead of overriding.",
+    "palette": [
+      {
+        "fuzzy_ids": [
+          "woodboard",
+          "woodhalfboard",
+          "boat_board",
+          "raft_board",
+          "wing_wood",
+          "windshield",
+          "wood box",
+          "travois",
+          "seat_wood",
+          "wooden_aisle",
+          "door_wood",
+          "roof_wood"
+        ],
+        "colors": [
+          { "color": "Cherry Black", "weight": 5 },
+          { "color": "Dark Mahogany", "weight": 5 },
+          { "color": "Wood-Black Red", "weight": 5 },
+          { "color": "Chestnut Red", "weight": 5 },
+          { "color": "Brown Magenta", "weight": 5 },
+          { "color": "Rust Brown", "weight": 5 },
+          { "color": "Old Mahogany", "weight": 5 },
+          { "color": "Deep Brown", "weight": 5 },
+          { "color": "Dark Red Brown", "weight": 5 },
+          { "color": "Rosewood Apricot", "weight": 5 },
+          { "color": "Laurel Nut Brown", "weight": 5 },
+          { "color": "Maple Red", "weight": 5 },
+          { "color": "Maple Beige", "weight": 5 },
+          { "color": "Tropical Wood Brown", "weight": 5 },
+          { "color": "Rosewood Brown", "weight": 5 },
+          { "color": "Teakwood Brown", "weight": 5 },
+          { "color": "Sandalwood Beige", "weight": 5 },
+          { "color": "Boxwood Yellow", "weight": 5 },
+          { "color": "Moor Oak Grey", "weight": 5 },
+          { "color": "Oak Brown", "weight": 5 },
+          { "color": "Light Oak Brown", "weight": 5 },
+          { "color": "Smoked Oak Brown", "weight": 5 }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This expands on color variety for vehicles, expanding it to cover wooden vehicles. :D

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Defined vehicle palette `wooden_standard`, which specifically uses `fuzzy_ids` matching wooden vehicle parts so that it won't accidentally color non-wood parts on affected vehicles, and a separate set of fuzzy IDs for cloth parts (mainly colored different shades of white-grey but a small chance of Red Baron coloration).
2. Applied new palette to most wooden vehicles.
3. Set it so the color expansion mod adds a wider variety of assorted RAL Design++ colors onto the existing selection, as opposed to a full override.
4. Misc: Set aircraft palettes to also color propellers and rotors.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Load-tested in compiled test build.
2. Spawned a bunch of canoes, each time editing the weight of one specific color to be jacked up like crazy so I can get the whole palette.

<img width="681" height="229" alt="image" src="https://github.com/user-attachments/assets/cce20e89-b881-48a7-b134-65a794a452ed" />
<img width="1065" height="181" alt="image" src="https://github.com/user-attachments/assets/ab11c2e1-12ca-48ab-944d-123e3a37b178" />
<img width="321" height="385" alt="image" src="https://github.com/user-attachments/assets/8508a1e0-2ceb-40f7-a5d1-66c6432112dc" />
<img width="251" height="289" alt="image" src="https://github.com/user-attachments/assets/c3899c96-ea69-46d5-bc65-39c743c23df6" />


## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26072113921/artifacts/7073613297)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26072113921/artifacts/7073890850)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26072113921/artifacts/7073548616)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26072113921/artifacts/7073704268)
<!-- END artifact comment -->