### PR TITLE
fix: Add save graveyard related tests and small path fix

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3045,7 +3045,7 @@ void game::win_screen()
 void game::move_save_to_graveyard( const std::string &dirname )
 {
     const std::string save_dir           = get_active_world()->info->folder_path();
-    const std::string graveyard_dir      = PATH_INFO::graveyarddir() + "/";
+    const std::string graveyard_dir      = PATH_INFO::graveyarddir();
     const std::string graveyard_save_dir = graveyard_dir + dirname + "/";
     const std::string &prefix            = base64_encode( u.get_save_id() ) + ".";
 
@@ -3064,7 +3064,7 @@ void game::move_save_to_graveyard( const std::string &dirname )
 
     for( const auto &src_path : save_files ) {
         const std::string dst_path = graveyard_save_dir +
-                                     src_path.substr( src_path.rfind( '/' ), std::string::npos );
+                                     src_path.substr( src_path.rfind( '/' ) + 1, std::string::npos );
 
         if( rename_file( src_path, dst_path ) ) {
             continue;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3057,6 +3057,10 @@ void game::move_save_to_graveyard( const std::string &dirname )
         debugmsg( "could not create graveyard path '%s'", graveyard_save_dir );
     }
 
+    // Close the player SQLite handle before moving files — on Windows, MoveFileExW
+    // fails (ERROR_SHARING_VIOLATION) if the file is open without FILE_SHARE_DELETE.
+    get_active_world()->release_player_db();
+
     const auto save_files = get_files_from_path( prefix, save_dir );
     if( save_files.empty() ) {
         debugmsg( "could not find save files in '%s'", save_dir );
@@ -3070,13 +3074,15 @@ void game::move_save_to_graveyard( const std::string &dirname )
             continue;
         }
 
-        debugmsg( "could not rename file '%s' to '%s'", src_path, dst_path );
-
-        if( remove_file( src_path ) ) {
+        // rename() fails across filesystems (EXDEV); fall back to copy then delete
+        if( copy_file( src_path, dst_path ) ) {
+            if( !remove_file( src_path ) ) {
+                debugmsg( "could not remove file '%s' after copying to graveyard", src_path );
+            }
             continue;
         }
 
-        debugmsg( "could not remove file '%s'", src_path );
+        debugmsg( "could not move file '%s' to graveyard '%s'", src_path, dst_path );
     }
 }
 

--- a/src/game.h
+++ b/src/game.h
@@ -1038,6 +1038,7 @@ class game : public submap_load_listener
         void disp_NPCs();        // Currently for debug use.  Lists global NPCs.
 
         void list_missions();       // Listed current, completed and failed missions (mission_ui.cpp)
+        void move_save_to_graveyard( const std::string &dirname );
     private:
         void quickload();        // Loads the previously saved game if it exists
 
@@ -1076,7 +1077,6 @@ class game : public submap_load_listener
 
         Creature *is_hostile_within( int distance );
 
-        void move_save_to_graveyard( const std::string &dirname );
         bool save_player_data();
         bool save_uistate_data() const;
         // ########################## DATA ################################

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -433,6 +433,15 @@ world::~world()
     }
 }
 
+void world::release_player_db()
+{
+    if( save_db ) {
+        sqlite3_close( save_db );
+        save_db = nullptr;
+        last_save_id.clear();
+    }
+}
+
 void world::start_save_tx()
 {
     if( save_tx_start_ts != 0 ) {

--- a/src/world.h
+++ b/src/world.h
@@ -101,6 +101,7 @@ class world
         /**@{*/
         void start_save_tx();
         int64_t commit_save_tx();
+        void release_player_db();
         /**@}*/
 
         /*

--- a/tests/graveyard_test.cpp
+++ b/tests/graveyard_test.cpp
@@ -9,6 +9,7 @@
 #include "fstream_utils.h"
 #include "game.h"
 #include "path_info.h"
+#include "point.h"
 #include "world.h"
 
 static void write_dummy_file( const std::string &path )
@@ -118,5 +119,43 @@ TEST_CASE( "move_save_to_graveyard_creates_directories", "[graveyard]" )
     CHECK( dir_exist( dest_dir ) );
 
     remove_file( file1 );
+    remove_graveyard_subdir( graveyard_dir, dest_dir );
+}
+
+// Regression test: on Windows, MoveFileExW fails (ERROR_SHARING_VIOLATION) when
+// SQLite has the player db open without FILE_SHARE_DELETE.  The fix closes the
+// handle via release_player_db() before attempting any rename.  This test
+// reproduces the scenario by opening the player db through a normal write, then
+// immediately calling move_save_to_graveyard.
+TEST_CASE( "move_save_to_graveyard_with_open_player_db", "[graveyard]" )
+{
+    world *w = g->get_active_world();
+    // Player db only exists in V2 saves; assert rather than silently pass on V1.
+    REQUIRE( w->info->world_save_format == save_format::V2_COMPRESSED_SQLITE3 );
+
+    const std::string save_dir      = w->info->folder_path() + "/";
+    const std::string prefix        = base64_encode( g->u.get_save_id() ) + ".";
+    const std::string graveyard_dir = PATH_INFO::graveyarddir();
+    const std::string dirname       = "test_open_db_" + get_pid_string();
+    const std::string dest_dir      = graveyard_dir + dirname + "/";
+
+    // Open the player SQLite db by writing map-memory data, mirroring what the
+    // game does during normal play before the character dies.
+    w->write_player_mm_quad( tripoint_zero, []( std::ostream & out ) {
+        out << "{}";
+    } );
+
+    const std::string sqlite_src = save_dir + prefix + "sqlite3";
+    REQUIRE( file_exist( sqlite_src ) );
+
+    remove_graveyard_subdir( graveyard_dir, dest_dir );
+    REQUIRE( !dir_exist( dest_dir ) );
+
+    g->move_save_to_graveyard( dirname );
+
+    // The sqlite3 file must be in the graveyard, not lost or left in save dir.
+    CHECK( file_exist( dest_dir + prefix + "sqlite3" ) );
+    CHECK( !file_exist( sqlite_src ) );
+
     remove_graveyard_subdir( graveyard_dir, dest_dir );
 }

--- a/tests/graveyard_test.cpp
+++ b/tests/graveyard_test.cpp
@@ -92,7 +92,6 @@ TEST_CASE( "move_save_to_graveyard_ignores_unrelated_files", "[graveyard]" )
     // Unrelated file must still exist in save dir
     CHECK( file_exist( unrelated ) );
 
-    // Cleanup
     remove_file( unrelated );
     remove_graveyard_subdir( graveyard_dir, dest_dir );
 }
@@ -118,7 +117,6 @@ TEST_CASE( "move_save_to_graveyard_creates_directories", "[graveyard]" )
     CHECK( dir_exist( graveyard_dir ) );
     CHECK( dir_exist( dest_dir ) );
 
-    // Cleanup
     remove_file( file1 );
     remove_graveyard_subdir( graveyard_dir, dest_dir );
 }

--- a/tests/graveyard_test.cpp
+++ b/tests/graveyard_test.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "avatar.h"
 #include "catacharset.h"
 #include "filesystem.h"
 #include "fstream_utils.h"
@@ -16,6 +17,17 @@ static void write_dummy_file( const std::string &path )
         out << "test";
     };
     REQUIRE( write_to_file( path, writer, nullptr ) );
+}
+
+// Asserts dest is a direct child of graveyard_dir before recursively deleting it,
+// preventing accidental deletion of the graveyard root or unrelated paths.
+static void remove_graveyard_subdir( const std::string &graveyard_dir,
+                                     const std::string &dest_dir )
+{
+    REQUIRE( !dest_dir.empty() );
+    REQUIRE( dest_dir != graveyard_dir );
+    REQUIRE( dest_dir.rfind( graveyard_dir, 0 ) == 0 );
+    remove_tree( dest_dir );
 }
 
 TEST_CASE( "graveyarddir_returns_user_dir_graveyard", "[graveyard]" )
@@ -39,7 +51,8 @@ TEST_CASE( "move_save_to_graveyard_moves_character_files", "[graveyard]" )
     write_dummy_file( file2 );
 
     // Ensure graveyard destination does not pre-exist
-    REQUIRE( remove_tree( dest_dir ) );
+    remove_graveyard_subdir( graveyard_dir, dest_dir );
+    REQUIRE( !dir_exist( dest_dir ) );
 
     g->move_save_to_graveyard( dirname );
 
@@ -52,30 +65,36 @@ TEST_CASE( "move_save_to_graveyard_moves_character_files", "[graveyard]" )
     CHECK( !file_exist( file2 ) );
 
     // Cleanup
-    remove_tree( dest_dir );
+    remove_graveyard_subdir( graveyard_dir, dest_dir );
 }
 
 TEST_CASE( "move_save_to_graveyard_ignores_unrelated_files", "[graveyard]" )
 {
     const std::string save_dir  = g->get_active_world()->info->folder_path() + "/";
+    const std::string prefix    = base64_encode( g->u.get_save_id() ) + ".";
     const std::string graveyard_dir = PATH_INFO::graveyarddir();
     const std::string dirname   = "test_unrelated_" + get_pid_string();
     const std::string dest_dir  = graveyard_dir + dirname + "/";
+
+    // A character file must be present so save_files is non-empty
+    const std::string char_file = save_dir + prefix + "unrelated_test_char";
+    write_dummy_file( char_file );
 
     // An unrelated file with a different prefix
     const std::string unrelated = save_dir + "unrelated_file_graveyard_test.sav";
     write_dummy_file( unrelated );
 
-    REQUIRE( remove_tree( dest_dir ) );
+    remove_graveyard_subdir( graveyard_dir, dest_dir );
+    REQUIRE( !dir_exist( dest_dir ) );
 
     g->move_save_to_graveyard( dirname );
 
-    // Unrelated file must still exist
+    // Unrelated file must still exist in save dir
     CHECK( file_exist( unrelated ) );
 
     // Cleanup
     remove_file( unrelated );
-    remove_tree( dest_dir );
+    remove_graveyard_subdir( graveyard_dir, dest_dir );
 }
 
 TEST_CASE( "move_save_to_graveyard_creates_directories", "[graveyard]" )
@@ -87,7 +106,8 @@ TEST_CASE( "move_save_to_graveyard_creates_directories", "[graveyard]" )
     const std::string dest_dir  = graveyard_dir + dirname + "/";
 
     // Ensure the graveyard subtree does not exist beforehand
-    REQUIRE( remove_tree( dest_dir ) );
+    remove_graveyard_subdir( graveyard_dir, dest_dir );
+    REQUIRE( !dir_exist( dest_dir ) );
 
     // At least one matching file so the function has something to move
     const std::string file1 = save_dir + prefix + "graveyard_mkdir_test";
@@ -100,5 +120,5 @@ TEST_CASE( "move_save_to_graveyard_creates_directories", "[graveyard]" )
 
     // Cleanup
     remove_file( file1 );
-    remove_tree( dest_dir );
+    remove_graveyard_subdir( graveyard_dir, dest_dir );
 }

--- a/tests/graveyard_test.cpp
+++ b/tests/graveyard_test.cpp
@@ -1,0 +1,104 @@
+#include "catch/catch.hpp"
+
+#include <string>
+#include <vector>
+
+#include "catacharset.h"
+#include "filesystem.h"
+#include "fstream_utils.h"
+#include "game.h"
+#include "path_info.h"
+#include "world.h"
+
+static void write_dummy_file( const std::string &path )
+{
+    const auto writer = []( std::ostream & out ) {
+        out << "test";
+    };
+    REQUIRE( write_to_file( path, writer, nullptr ) );
+}
+
+TEST_CASE( "graveyarddir_returns_user_dir_graveyard", "[graveyard]" )
+{
+    const std::string expected = PATH_INFO::user_dir() + "graveyard/";
+    CHECK( PATH_INFO::graveyarddir() == expected );
+}
+
+TEST_CASE( "move_save_to_graveyard_moves_character_files", "[graveyard]" )
+{
+    const std::string save_dir = g->get_active_world()->info->folder_path() + "/";
+    const std::string prefix   = base64_encode( g->u.get_save_id() ) + ".";
+    const std::string graveyard_dir = PATH_INFO::graveyarddir();
+    const std::string dirname  = "test_char_" + get_pid_string();
+    const std::string dest_dir = graveyard_dir + dirname + "/";
+
+    // Create dummy save files with the character's prefix
+    const std::string file1 = save_dir + prefix + "sav";
+    const std::string file2 = save_dir + prefix + "map";
+    write_dummy_file( file1 );
+    write_dummy_file( file2 );
+
+    // Ensure graveyard destination does not pre-exist
+    REQUIRE( remove_tree( dest_dir ) );
+
+    g->move_save_to_graveyard( dirname );
+
+    // Files should be in the graveyard subdirectory
+    CHECK( file_exist( dest_dir + prefix + "sav" ) );
+    CHECK( file_exist( dest_dir + prefix + "map" ) );
+
+    // Source files should no longer exist in save dir
+    CHECK( !file_exist( file1 ) );
+    CHECK( !file_exist( file2 ) );
+
+    // Cleanup
+    remove_tree( dest_dir );
+}
+
+TEST_CASE( "move_save_to_graveyard_ignores_unrelated_files", "[graveyard]" )
+{
+    const std::string save_dir  = g->get_active_world()->info->folder_path() + "/";
+    const std::string graveyard_dir = PATH_INFO::graveyarddir();
+    const std::string dirname   = "test_unrelated_" + get_pid_string();
+    const std::string dest_dir  = graveyard_dir + dirname + "/";
+
+    // An unrelated file with a different prefix
+    const std::string unrelated = save_dir + "unrelated_file_graveyard_test.sav";
+    write_dummy_file( unrelated );
+
+    REQUIRE( remove_tree( dest_dir ) );
+
+    g->move_save_to_graveyard( dirname );
+
+    // Unrelated file must still exist
+    CHECK( file_exist( unrelated ) );
+
+    // Cleanup
+    remove_file( unrelated );
+    remove_tree( dest_dir );
+}
+
+TEST_CASE( "move_save_to_graveyard_creates_directories", "[graveyard]" )
+{
+    const std::string save_dir  = g->get_active_world()->info->folder_path() + "/";
+    const std::string prefix    = base64_encode( g->u.get_save_id() ) + ".";
+    const std::string graveyard_dir = PATH_INFO::graveyarddir();
+    const std::string dirname   = "test_mkdir_" + get_pid_string();
+    const std::string dest_dir  = graveyard_dir + dirname + "/";
+
+    // Ensure the graveyard subtree does not exist beforehand
+    REQUIRE( remove_tree( dest_dir ) );
+
+    // At least one matching file so the function has something to move
+    const std::string file1 = save_dir + prefix + "graveyard_mkdir_test";
+    write_dummy_file( file1 );
+
+    g->move_save_to_graveyard( dirname );
+
+    CHECK( dir_exist( graveyard_dir ) );
+    CHECK( dir_exist( dest_dir ) );
+
+    // Cleanup
+    remove_file( file1 );
+    remove_tree( dest_dir );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

The graveyard feature broke, it had no tests. Now it does.

## Describe the solution (The How)

Add tests

## Describe alternatives you've considered

## Testing

Self testing code!
Seriously tho, tested it manually anyway just to be sure since there's a small fix in there,
made a character eat mycus related food until it became one then had him killed, checked graveyard.
Works


## Additional context
My guy after eating and vomitting for 10 minutes straight
<img width="90" height="90" alt="image" src="https://github.com/user-attachments/assets/59b90c7f-c8c9-4710-af7c-23d6d0e929d1" />

Was helped by claude

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26132849961/artifacts/7098641934)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26132849961)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26132849961)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26132849961)
<!-- END artifact comment -->