### PR TITLE
feat(balance): lower maximum morale malus for high severity additions to speed, crack, and cocaine

### DIFF
--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -195,10 +195,10 @@ void addict_effect( Character &u, addiction &add )
             }
             if( dice( 2, 100 ) < in ) {
                 u.add_msg_if_player( m_warning, _( "You feel depressed.  Speed would help." ) );
-                u.add_morale( MORALE_CRAVING_SPEED, -25, -20 * in );
+                u.add_morale( MORALE_CRAVING_SPEED, -25, -50 - 10 * in );
             } else if( one_in( 10 ) && dice( 2, 80 ) < in ) {
                 u.add_msg_if_player( m_bad, _( "Your hands start shaking… you need a pick-me-up." ) );
-                u.add_morale( MORALE_CRAVING_SPEED, -25, -20 * in );
+                u.add_morale( MORALE_CRAVING_SPEED, -25, -50 - 10 * in );
                 u.add_effect( effect_shakes, in * 2_minutes );
             } else if( one_in( 50 ) && dice( 2, 100 ) < in ) {
                 u.add_msg_if_player( m_bad, _( "You stop suddenly, feeling bewildered." ) );
@@ -220,11 +220,11 @@ void addict_effect( Character &u, addiction &add )
             u.mod_per_bonus( -1 );
             if( one_in( 900 - 30 * in ) ) {
                 u.add_msg_if_player( m_warning, cur_msg );
-                u.add_morale( morale_type, -20, -15 * in );
+                u.add_morale( morale_type, -20, -50 - 10 * in );
             }
             if( dice( 2, 80 ) <= in ) {
                 u.add_msg_if_player( m_warning, cur_msg );
-                u.add_morale( morale_type, -20, -15 * in );
+                u.add_morale( morale_type, -20, -50 - 10 * in );
                 if( current_stim > -150 ) {
                     u.mod_stim( -3 );
                 }


### PR DESCRIPTION
…to speed, crack, and cocaine

## Purpose of change (The Why)

Currently the Tweaker start starts the player with a 30 intensity addiction to crack. Currently the morale maluses for addiction to these drugs scale incredibly hard with severity, up to -300 morale malus for days on end.
As the player cannot craft when under -200 morale, this takes gameplay engagement away from the player. The addiction effects are already debilitating enough: you have no focus (so you can't learn anything), and get a great penalty to speed (so exploration is risky even at night, and everything you do is slower, including crafting). Not being able to craft (not even clean water) on top of this makes this profession start boring and unengaging instead of interesting. The solution would be to just stand around for a few days drinking and eating whatever you find, until the morale malus goes above -200.

## Describe the solution (The How)

Changing the max morale malus for these addictions to the formula `-50 - 10 * in` where `in`  is the current intensity of the addiction. This is effect-wise capped at 20 (but the addiction can progress more severely).
This causes the maximum morale maluses for these addiction to be -250, which is still  under minimum crafting level, but is (somewhat) more manageable if you can get your mood up through other means.

Note that the morale malus for these addictions will be HIGHER at lower levels with this change, but will scale slower.

## Describe alternatives you've considered

Reworking the manner addiction levels apply and scale, but as my issue is the inability to craft and producing a more engaging profession start, just reducing the max malus seems to be fine.

## Testing

Started a game, waited a few hours, morale malus quickly went up to -250. After waiting much longer, morale malus became -240, -230, and so on.

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26132912115/artifacts/7098407330)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26132912115/artifacts/7098761610)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26132912115/artifacts/7098392812)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26132912115/artifacts/7098528446)
<!-- END artifact comment -->