### PR TITLE
fix: remove underscore from NBC seal item name

### DIFF
--- a/data/json/items/vehicle/armor.json
+++ b/data/json/items/vehicle/armor.json
@@ -35,7 +35,7 @@
     "id": "NBC_seal",
     "type": "GENERIC",
     "category": "veh_parts",
-    "name": { "str": "NBC_seal" },
+    "name": { "str": "NBC seal" },
     "description": "A series of lead-based gaskets, seals and other things meant to keep all Nuclear, Biological, and Chemical contaminants out of a vehicle.  Installing this on a tile will protect people seated there from toxic gas and radiation.",
     "weight": "8000 g",
     "volume": "1 L",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Single-line typofix in an item name.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

`"name": { "str": "NBC_seal" }` -> `"name": { "str": "NBC seal" }`

## Describe alternatives you've considered

Accepting that underscores deserve love too.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Demonstrated elementary-level reading skills.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
