### PR TITLE
feat: Add mortician profession

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -7864,7 +7864,7 @@
           "syringe",
           "scalpel"
         ],
-        "entries": [ { "item": "shovel", "custom_flags": [ "auto_wield" ] } ]
+        "entries": [ { "item": "shovel", "custom-flags": [ "auto_wield" ] } ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -7847,7 +7847,7 @@
     "id": "mortician",
     "name": "Mortician",
     "description": "Before the Cataclysm, you used to embalm and bury bodies. Nowadays, there is no more room in hell, so you're putting them down instead.",
-    "points": 0
+    "points": 0,
     "skills": [
       { "level": 1, "name": "swimming"},
       { "level": 1, "name": "firstaid"}

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -7841,7 +7841,7 @@
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
     }
-  }
+  },
   {
     "type": "profession",
     "id": "mortician",
@@ -7854,7 +7854,7 @@
     ],
     "items": {
       "both": {
-        "items" [
+        "items": [
           "suit",
           "socks",
           "dress_shoes",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -7842,4 +7842,33 @@
       "female": [ "sports_bra", "boxer_shorts" ]
     }
   }
+  {
+    "type": "profession",
+    "id": "mortician",
+    "name": "Mortician",
+    "description": "Before the Cataclysm, you used to embalm and bury bodies. Nowadays, there is no more room in hell, so you're putting them down instead.",
+    "points": 0
+    "skills": [
+      { "level": 1, "name": "swimming"},
+      { "level": 1, "name": "firstaid"}
+    ],
+    "items": {
+      "both": {
+        "items" [
+          "suit",
+          "socks",
+          "dress_shoes",
+          "knit_scarf",
+          "smart_phone",
+          "wristwatch",
+          "syringe",
+          "scalpel"
+        ],
+        "entries": [ { "item": "shovel", "custom_flags": [ "auto_wield" ] } ]
+      },
+      "male": [ "briefs" ],
+      "female": [ "bra", "panties" ]
+     }
+  }
 ]
+

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -7848,27 +7848,14 @@
     "name": "Mortician",
     "description": "Before the Cataclysm, you used to embalm and bury bodies. Nowadays, there is no more room in hell, so you're putting them down instead.",
     "points": 0,
-    "skills": [
-      { "level": 1, "name": "swimming"},
-      { "level": 1, "name": "firstaid"}
-    ],
+    "skills": [ { "level": 1, "name": "swimming" }, { "level": 1, "name": "firstaid" } ],
     "items": {
       "both": {
-        "items": [
-          "suit",
-          "socks",
-          "dress_shoes",
-          "knit_scarf",
-          "smart_phone",
-          "wristwatch",
-          "syringe",
-          "scalpel"
-        ],
+        "items": [ "suit", "socks", "dress_shoes", "knit_scarf", "smart_phone", "wristwatch", "syringe", "scalpel" ],
         "entries": [ { "item": "shovel", "custom-flags": [ "auto_wield" ] } ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
-     }
+    }
   }
 ]
-


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

We could use a low-cost profession that starts off with a scalpel. Plus, we have cemeteries, but we don't have a profession for somebody who'd work there.

## Describe the solution (The How)

Added the Mortician as a profession. They have a shovel for burying bodies (which also serves as a great starting weapon), along with a scalpel and a syringe for embalming, and Level 1 in Athletics (as digging graves is hard work) and First Aid (embalming requires a small amount of medical knowledge). However, their clothes don't have much storage or protection, and the suit is a bit encumbering, so they're a 0-point job. 

## Describe alternatives you've considered

If the profession is too weak:
* Assume that they build coffins, and thus give them Fabrication 1, along with a hammer and wood saw.

If the profession is too strong:
* Raise the cost to 1 point. 

## Testing

Started a new world, created a mortician character (after several failed attempts due to screwing up the JSON formatting), and made sure that they have all of their skills and gear.

## Additional context

None necessary. 

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26144983175/artifacts/7102781655)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26144983175/artifacts/7103255374)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26144983175/artifacts/7102689875)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26144983175/artifacts/7102914113)
<!-- END artifact comment -->