### PR TITLE
fix: fix dda tilesets part 2

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2156,14 +2156,14 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck,
     for( const JsonObject &curr_info : config.get_array( "tile_info" ) ) {
         ts.tile_height = curr_info.get_int( "height" );
         ts.tile_width = curr_info.get_int( "width" );
-        //ts.zlevel_height = curr_info.get_int( "zlevel_height", 0 );
-        ts.zlevel_height = 0;
+        ts.zlevel_height = curr_info.get_int( "zlevel_height", 0 );
+        zlevel_height = 0;
         tile_iso = curr_info.get_bool( "iso", false );
         ts.tile_pixelscale = curr_info.get_float( "pixelscale", 1.0f );
-        //ts.prevent_occlusion_min_dist = curr_info.get_float( "retract_dist_min", -1.0f );
-        //ts.prevent_occlusion_max_dist = curr_info.get_float( "retract_dist_max", 0.0f );
-        ts.prevent_occlusion_min_dist = -1.0f;
-        ts.prevent_occlusion_max_dist = 0.0f;
+        ts.prevent_occlusion_min_dist = curr_info.get_float( "retract_dist_min", -1.0f );
+        prevent_occlusion_min_dist = -1.0f;
+        ts.prevent_occlusion_max_dist = curr_info.get_float( "retract_dist_max", 0.0f );
+        prevent_occlusion_max_dist = 0.0f;
     }
 
     if( precheck ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2157,13 +2157,13 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck,
         ts.tile_height = curr_info.get_int( "height" );
         ts.tile_width = curr_info.get_int( "width" );
         ts.zlevel_height = curr_info.get_int( "zlevel_height", 0 );
-        zlevel_height = 0;
+        ts.zlevel_height = 0;
         tile_iso = curr_info.get_bool( "iso", false );
         ts.tile_pixelscale = curr_info.get_float( "pixelscale", 1.0f );
         ts.prevent_occlusion_min_dist = curr_info.get_float( "retract_dist_min", -1.0f );
-        prevent_occlusion_min_dist = -1.0f;
+        ts.prevent_occlusion_min_dist = -1.0f;
         ts.prevent_occlusion_max_dist = curr_info.get_float( "retract_dist_max", 0.0f );
-        prevent_occlusion_max_dist = 0.0f;
+        ts.prevent_occlusion_max_dist = 0.0f;
     }
 
     if( precheck ) {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

#8918

fixes getting spammed with unvisited errors by making the thing actually read the dda metadata then disregarding it
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Lets the code read the dda metadata first so that there aren't any "unvisited" errors, then sets those values to default so the rendering disregards them
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Big error
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26148072296/artifacts/7104050433)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26148072296/artifacts/7104686216)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26148072296/artifacts/7103929813)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26148072296/artifacts/7104248992)
<!-- END artifact comment -->