### PR TITLE
build: change ffile-prefix-map to make gdb work again on local builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,7 @@ if (NOT MSVC)
         # Use debug prefix map for ccache compatibility with git worktrees
         # see https://ccache.dev/manual/latest.html#_compiling_in_different_directories
         file(RELATIVE_PATH REL_SRC_PATH "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
-        set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -ffile-prefix-map=${REL_SRC_PATH}=.")
+        set(CATA_OTHER_FLAGS "${CATA_OTHER_FLAGS} -ffile-prefix-map=${REL_SRC_PATH}=/")
     endif()
     # Compact the whitespace in the warning string
     string(REGEX REPLACE "[\t ]+" " " CATA_WARNINGS "${CATA_WARNINGS}")


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

fix oversight on 
* #7678

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

`REL_SRC_PATH` has a leading slash, and mapping to with `.` eats the leading slash, causing gdb/lldb to fail to find sources, as it would now look for, e.g `.src/achievements.cpp` (inside a folder named `.src` )instead of `/src/achievements.cpp`

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Set prefix map to `./` instead, but `/` seems to make gdb find the sources correctly without an explicit `set substitute-path` in .gdbinit already

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
* Attach debugger
* Create breakpoint
* No errors about missing source files

## Additional context

Before:
<img width="587" height="134" alt="image" src="https://github.com/user-attachments/assets/b9eb6c62-2a77-415b-b17b-8273e191744b" />

After:
<img width="541" height="96" alt="image" src="https://github.com/user-attachments/assets/aef4e4ba-e561-41b2-9e41-1520c4235290" />



<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26153409257/artifacts/7106350651)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26153409257/artifacts/7107061456)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26153409257/artifacts/7106235455)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26153409257/artifacts/7106606384)
<!-- END artifact comment -->