### PR TITLE
ci: add commit metadata to build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -542,9 +542,10 @@ jobs:
         run: |
           if [ "${{ inputs.version-label }}" = "experimental" ]; then
             SHA_SHORT=$(git rev-parse --short HEAD)
-            TIMESTAMP=$(date "+%F %T")
+            COMMIT_SUBJECT=$(git log -1 --pretty=%s)
+            TIMESTAMP=$(date -u "+%F %T")
             gh release upload experimental --clobber cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.${{ matrix.ext }}
-            gh release edit experimental --title "Experimental @ $TIMESTAMP ($SHA_SHORT)" --notes "Experimental build for commit $SHA_SHORT on $TIMESTAMP"
+            gh release edit experimental --title "Experimental @ $TIMESTAMP ($SHA_SHORT)" --notes "Experimental build for commit $SHA_SHORT ($COMMIT_SUBJECT) on $TIMESTAMP"
           else
             gh release upload ${{ inputs.release-tag }} --clobber cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.${{ matrix.ext }}
           fi

--- a/.github/workflows/pr-artifact-publish.yml
+++ b/.github/workflows/pr-artifact-publish.yml
@@ -57,6 +57,7 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
@@ -80,6 +81,10 @@ jobs:
             fi
           }
 
+          sha_short=${HEAD_SHA:0:7}
+          commit_subject=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.head_commit.message // "" | split("\n")[0]')
+          timestamp=$(date -u "+%F %T")
+
           artifact_label="pr-${PR_NUMBER}"
           linux_url=$(artifact_url "linux-tiles-x64-${artifact_label}")
           windows_url=$(artifact_url "windows-tiles-x64-msvc-${artifact_label}")
@@ -89,6 +94,8 @@ jobs:
           {
             echo 'content<<EOF'
             echo '## Build Artifacts'
+            echo
+            echo "PR build for commit [${sha_short}](https://github.com/${REPOSITORY}/commit/${HEAD_SHA}) (${commit_subject}) on ${timestamp}"
             echo
             artifact_line 'Linux tiles' "$linux_url"
             artifact_line 'Windows tiles' "$windows_url"


### PR DESCRIPTION
## Purpose of change (The Why)

Build artifacts should show which commit they were generated from, including the commit subject, SHA, and timestamp.

Related: #8921, #6568, #6380, #3895

## Describe the solution (The How)

- Add the commit subject to experimental release notes.
- Add commit SHA link, commit subject, and UTC timestamp to the PR build artifact block.

## Describe alternatives you've considered

None.

## Testing

- `git diff --check`
- `actionlint .github/workflows/build.yml .github/workflows/pr-artifact-publish.yml`

## Additional context

AI assistance was used. Commit trailers include `Assisted-by:`.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style). YAML-only change; no formatter was run.
- [x] I linked relevant issues/PRs in [Summary of the PR](#purpose-of-change-the-why).

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sup>PR opened by gpt-5.5 unknown on pi</sup>

<!-- BEGIN artifact comment -->

## Build Artifacts

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26153889761/artifacts/7106560831)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26153889761/artifacts/7107268251)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26153889761/artifacts/7106505937)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26153889761/artifacts/7106755336)
<!-- END artifact comment -->
