### PR TITLE
feat(balance): increase ranged weapon skills of military professions, nerf major general, add flavor items to elite operator

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1438,10 +1438,11 @@
       { "level": 1, "name": "swimming" },
       { "level": 1, "name": "firstaid" },
       { "level": 2, "name": "gun" },
-      { "level": 1, "name": "rifle" },
+      { "level": 2, "name": "rifle" },
       { "level": 2, "name": "melee" },
       { "level": 1, "name": "stabbing" },
-      { "level": 1, "name": "dodge" }
+      { "level": 1, "name": "dodge" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -1487,7 +1488,8 @@
       { "level": 2, "name": "rifle" },
       { "level": 2, "name": "melee" },
       { "level": 1, "name": "stabbing" },
-      { "level": 1, "name": "dodge" }
+      { "level": 1, "name": "dodge" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -1532,11 +1534,12 @@
       { "level": 1, "name": "swimming" },
       { "level": 1, "name": "firstaid" },
       { "level": 2, "name": "gun" },
-      { "level": 1, "name": "rifle" },
-      { "level": 1, "name": "launcher" },
+      { "level": 2, "name": "rifle" },
+      { "level": 2, "name": "launcher" },
       { "level": 2, "name": "melee" },
       { "level": 1, "name": "stabbing" },
-      { "level": 1, "name": "dodge" }
+      { "level": 1, "name": "dodge" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -1580,10 +1583,11 @@
       { "level": 1, "name": "swimming" },
       { "level": 1, "name": "firstaid" },
       { "level": 3, "name": "gun" },
-      { "level": 2, "name": "rifle" },
+      { "level": 3, "name": "rifle" },
       { "level": 2, "name": "melee" },
       { "level": 1, "name": "stabbing" },
-      { "level": 1, "name": "dodge" }
+      { "level": 1, "name": "dodge" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -1638,8 +1642,9 @@
       { "level": 2, "name": "computer" },
       { "level": 2, "name": "traps" },
       { "level": 2, "name": "gun" },
-      { "level": 1, "name": "rifle" },
-      { "level": 1, "name": "dodge" }
+      { "level": 2, "name": "rifle" },
+      { "level": 1, "name": "dodge" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -1685,13 +1690,14 @@
     "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 2, "name": "swimming" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "smg" },
+      { "level": 4, "name": "gun" },
+      { "level": 4, "name": "smg" },
       { "level": 3, "name": "survival" },
       { "level": 2, "name": "cutting" },
       { "level": 2, "name": "melee" },
       { "level": 2, "name": "dodge" },
-      { "level": 1, "name": "firstaid" }
+      { "level": 1, "name": "firstaid" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -1733,14 +1739,15 @@
     "points": 5,
     "traits": [ "PROF_MILITARY", "PROF_SWIMMER" ],
     "skills": [
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "smg" },
+      { "level": 4, "name": "gun" },
+      { "level": 4, "name": "smg" },
       { "level": 3, "name": "swimming" },
       { "level": 2, "name": "cutting" },
       { "level": 2, "name": "melee" },
       { "level": 2, "name": "dodge" },
       { "level": 1, "name": "firstaid" },
-      { "level": 1, "name": "survival" }
+      { "level": 1, "name": "survival" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -1785,8 +1792,9 @@
       { "level": 1, "name": "firstaid" },
       { "level": 4, "name": "computer" },
       { "level": 3, "name": "gun" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "speech" }
+      { "level": 3, "name": "pistol" },
+      { "level": 2, "name": "speech" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -1831,10 +1839,11 @@
       { "level": 1, "name": "swimming" },
       { "level": 1, "name": "firstaid" },
       { "level": 2, "name": "gun" },
-      { "level": 1, "name": "rifle" },
+      { "level": 2, "name": "rifle" },
       { "level": 2, "name": "melee" },
       { "level": 1, "name": "stabbing" },
-      { "level": 2, "name": "mechanics" }
+      { "level": 2, "name": "mechanics" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -1909,7 +1918,7 @@
       { "level": 2, "name": "electronics" },
       { "level": 2, "name": "computer" },
       { "level": 2, "name": "gun" },
-      { "level": 1, "name": "rifle" },
+      { "level": 2, "name": "rifle" },
       { "level": 1, "name": "dodge" }
     ],
     "items": {
@@ -1958,7 +1967,7 @@
       { "level": 2, "name": "electronics" },
       { "level": 2, "name": "computer" },
       { "level": 2, "name": "gun" },
-      { "level": 1, "name": "rifle" },
+      { "level": 2, "name": "rifle" },
       { "level": 1, "name": "dodge" }
     ],
     "items": {
@@ -3651,9 +3660,10 @@
       { "level": 1, "name": "firstaid" },
       { "level": 2, "name": "gun" },
       { "level": 2, "name": "melee" },
-      { "level": 1, "name": "rifle" },
+      { "level": 2, "name": "rifle" },
       { "level": 1, "name": "stabbing" },
-      { "level": 1, "name": "dodge" }
+      { "level": 1, "name": "dodge" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -3711,11 +3721,12 @@
       { "level": 1, "name": "swimming" },
       { "level": 1, "name": "firstaid" },
       { "level": 5, "name": "gun" },
-      { "level": 4, "name": "rifle" },
+      { "level": 5, "name": "rifle" },
       { "level": 2, "name": "pistol" },
       { "level": 2, "name": "survival" },
       { "level": 1, "name": "cooking" },
-      { "level": 1, "name": "fabrication" }
+      { "level": 1, "name": "fabrication" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -3766,13 +3777,14 @@
     "CBMs": [ "bio_cqb", "bio_carbon", "bio_night_vision", "bio_torsionratchet", "bio_claws", "bio_power_storage_mkII" ],
     "skills": [
       { "level": 2, "name": "swimming" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "smg" },
+      { "level": 4, "name": "gun" },
+      { "level": 4, "name": "smg" },
       { "level": 3, "name": "survival" },
       { "level": 2, "name": "cutting" },
       { "level": 2, "name": "melee" },
       { "level": 2, "name": "dodge" },
-      { "level": 1, "name": "firstaid" }
+      { "level": 1, "name": "firstaid" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -5099,10 +5111,11 @@
       { "level": 1, "name": "swimming" },
       { "level": 4, "name": "survival" },
       { "level": 4, "name": "gun" },
-      { "level": 3, "name": "rifle" },
+      { "level": 4, "name": "rifle" },
       { "level": 2, "name": "melee" },
       { "level": 2, "name": "stabbing" },
-      { "level": 1, "name": "firstaid" }
+      { "level": 1, "name": "firstaid" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -6551,8 +6564,8 @@
       { "level": 1, "name": "swimming" },
       { "level": 1, "name": "firstaid" },
       { "level": 5, "name": "driving" },
-      { "level": 1, "name": "pistol" },
-      { "level": 1, "name": "launcher" },
+      { "level": 3, "name": "pistol" },
+      { "level": 3, "name": "launcher" },
       { "level": 3, "name": "mechanics" },
       { "level": 3, "name": "gun" }
     ],
@@ -6959,10 +6972,11 @@
       { "level": 1, "name": "swimming" },
       { "level": 1, "name": "firstaid" },
       { "level": 2, "name": "gun" },
-      { "level": 1, "name": "rifle" },
+      { "level": 2, "name": "rifle" },
       { "level": 2, "name": "melee" },
       { "level": 1, "name": "stabbing" },
-      { "level": 1, "name": "dodge" }
+      { "level": 1, "name": "dodge" },
+      { "level": 1, "name": "throw" }
     ],
     "items": {
       "both": {
@@ -7475,13 +7489,12 @@
     "skills": [
       { "level": 1, "name": "swimming" },
       { "level": 6, "name": "speech" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "rifle" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 1, "name": "throw" }
+      { "level": 1, "name": "gun" },
+      { "level": 1, "name": "rifle" },
+      { "level": 1, "name": "pistol" },
+      { "level": 1, "name": "melee" },
+      { "level": 1, "name": "stabbing" },
+      { "level": 1, "name": "firstaid" }
     ],
     "traits": [ "PROF_MILITARY" ],
     "items": {
@@ -7834,10 +7847,11 @@
       { "level": 3, "name": "cutting" },
       { "level": 4, "name": "melee" },
       { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" }
+      { "level": 3, "name": "firstaid" },
+      { "level": 3, "name": "throw" }
     ],
     "items": {
-      "both": { "items": [ "pants_army", "tshirt", "jacket_army", "socks", "boots_combat" ] },
+      "both": { "items": [ "pants_army", "tshirt", "jacket_army", "socks", "boots_combat", "wristwatch", "smart_phone" ] },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
     }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Military professions were fairly all over the place as far as skills go. Some professions had marksmanship skill matching their weapon skills, others had lower weapon skill than marksmanship skill despite their melee skills matching, meanwhile only one profession had throwing skill despite it being one of the only ones to spawn without hand grenades, and the general profession had better combat skills than grunts despite being flavored as rusty.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added 1 throwing skill to most military professions, excluding pilot-type professions and the trainee.
2. Bumped other ranged weapon skills for standard military professions from 1 to 2.
3. Bumped designated marksman's rifle skill from 2 to 3.
4. Bumped marksman and ranged weapon skills of special operator, bionic operator, and military holdout from 3 to 4.
5. Bumped bionic sniper's rifle skill up from 4 to 5.
6. Bumped fighter pilot's ranged weapon skills up from 1 to 3, to match heli pilots.
7. Conversely, nerfed ranged skills of major general from 2 to 1 to actually make them look rusty compared to normal military professions, and removed throwing skill.
8. Added level 3 throwing skill to Elite Operator since their gimmick is supposed to be being the ultimate soldier skill-wise but having fuck-all starting gear.
9. Misc: Also gave the Elite Operator a beret, wrist watch, and smartphone for flavor.

## Describe alternatives you've considered

Just nerfing the shit out of the major general.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b07a78a](https://github.com/cataclysmbn/Cataclysm-BN/commit/b07a78a11c0a0b2298621d1ab14e4bec7bd5fd93) (feat(balance): increase ranged weapon skills of military professions, nerf major general, add flavor items to elite operator) on 2026-05-20 17:25:37

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26175972443/artifacts/7115960223)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26175972443/artifacts/7116605503)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26175972443/artifacts/7115831349)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26175972443/artifacts/7116169277)
<!-- END artifact comment -->