### PR TITLE
fix: typo in crafting menu: Reasonabe => Reasonable

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -518,7 +518,7 @@ static std::vector<std::string> recipe_info(
                           recp.has_flag( flag_BLIND_HARD ) ? _( "Awkward" ) :
                           recp.has_flag( flag_BLIND_NEARLY_IMPOSSIBLE ) ? _( "Very Hard" ) :
                           recp.has_flag( flag_BLIND_IMPOSSIBLE ) ? _( "Impossible" ) :
-                          _( "Reasonabe" ) );
+                          _( "Reasonable" ) );
 
     std::string nearby_string;
     const inventory &crafting_inv = crafter.crafting_inventory();


### PR DESCRIPTION
## Purpose of change (The Why)

It's a typo.

## Describe the solution (The How)

I fixed the typo.

## Testing

Typo gone.

## Additional context

Typo bad.

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

