### PR TITLE
feat: revamp old guard doctor mission 1

### DIFF
--- a/data/json/npcs/NC_SCAVENGER_DOCMISSION.json
+++ b/data/json/npcs/NC_SCAVENGER_DOCMISSION.json
@@ -45,17 +45,12 @@
     "type": "item_group",
     "id": "NC_SCAVENGER_DOCMISSION_misc",
     "subtype": "collection",
-    "entries": [
-      { "group": "scavenger_medical_supplies", "prob": 100, "count": 5 }
-    ]
+    "entries": [ { "group": "scavenger_medical_supplies", "prob": 100, "count": 5 } ]
   },
   {
     "type": "item_group",
     "id": "scavenger_medical_supplies",
     "subtype": "distribution",
-    "entries": [
-      { "item": "microcentrifuge", "prob": 100 },
-      { "group": "tools_medical", "prob": 100 }
-    ]
+    "entries": [ { "item": "microcentrifuge", "prob": 100 }, { "group": "tools_medical", "prob": 100 } ]
   }
 ]

--- a/data/json/npcs/NC_SCAVENGER_DOCMISSION.json
+++ b/data/json/npcs/NC_SCAVENGER_DOCMISSION.json
@@ -1,0 +1,61 @@
+[
+  {
+    "type": "item_group",
+    "id": "NC_SCAVENGER_DOCMISSION_gloves",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 30 },
+      { "item": "gloves_leather", "prob": 20 },
+      { "item": "gloves_work", "prob": 20 },
+      { "item": "gloves_fingerless", "prob": 50 },
+      { "item": "gloves_fingerless_mod", "prob": 20 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_SCAVENGER_DOCMISSION_archery",
+    "subtype": "distribution",
+    "entries": [ { "item": "shortbow", "prob": 5 }, { "item": "crossbow", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_SCAVENGER_DOCMISSION_pistols",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "usp_45", "prob": 30 },
+      { "item": "sw_619", "prob": 30 },
+      { "item": "colt_python", "prob": 15 },
+      { "item": "sw_610", "prob": 30 },
+      { "item": "ruger_redhawk", "prob": 5 },
+      { "item": "m9", "prob": 50 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_SCAVENGER_DOCMISSION_rifle",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "browning_blr", "prob": 35 },
+      { "item": "remington_700", "prob": 35 },
+      { "item": "m1a", "prob": 35 },
+      { "item": "m1903", "prob": 15 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_SCAVENGER_DOCMISSION_misc",
+    "subtype": "collection",
+    "entries": [
+      { "group": "scavenger_medical_supplies", "prob": 100, "count": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "scavenger_medical_supplies",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "microcentrifuge", "prob": 100 },
+      { "group": "tools_medical", "prob": 100 }
+    ]
+  }
+]

--- a/data/json/npcs/classes.json
+++ b/data/json/npcs/classes.json
@@ -240,6 +240,21 @@
   },
   {
     "type": "npc_class",
+    "id": "NC_SCAVENGER_DOCMISSION",
+    "name": { "str": "Scavenger" },
+    "job_description": "I'm just trying to survive.",
+    "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "common": false,
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 0, 3 ] } },
+      { "skill": "archery", "bonus": { "rng": [ 0, 3 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
     "id": "NC_WANDERING_SCAVENGER",
     "name": { "str": "Wandering Scavenger" },
     "//": "spawns in the res_lawn_randomnpc nested mapgen",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -67,7 +67,7 @@
     "goal": "MGOAL_FIND_ITEM",
     "description": "Find a <color_light_blue>microcentrifuge</color>. The doctor knows of a <color_red>medical supply drop</color> where one could likely be found.",
     "difficulty": 2,
-    "value": 20000,
+    "value": 0,
     "item": "microcentrifuge",
     "start": {
       "assign_mission_target": { "om_terrain": "field", "reveal_radius": 1, "random": true, "search_range": 60 },
@@ -106,6 +106,9 @@
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_SCIENCE_REP_2",
+    "end": {
+      "effect": { "u_buy_item": "1st_aid" }
+    },
     "dialogue": {
       "describe": "It could be very informative to perform an analysis of zombie blood…",
       "offer": "We don't have the equipment for real analysis here so I'll need you to get some.  Critically, I'm missing a microcentrifuge with which I could perform an analysis of zombie blood.  I need you to procure a microcentrifuge and bring it to me.",
@@ -113,7 +116,7 @@
       "rejected": "Are you sure?  The scientific value of that blood data could be priceless…",
       "advice": "The supply drop should be unguarded, but watch your back.",
       "inquire": "Well, do you have the microcentrifuge yet?",
-      "success": "Excellent!  This may be the key to removing the infection.",
+      "success": "Excellent!  This may be the key to removing the infection.  I don't have much to spare, but take this as thanks.",
       "success_lie": "Wait, this isn't a centrifuge!  Liar!",
       "failure": "What a shame, that equipment could have proved invaluable…"
     }

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -63,28 +63,59 @@
   {
     "id": "MISSION_SCIENCE_REP_1",
     "type": "mission_definition",
-    "name": { "str": "Analyze Zombie Blood" },
+    "name": { "str": "Find a Microcentrifuge" },
     "goal": "MGOAL_FIND_ITEM",
-    "description": "Use a <color_light_blue>blood draw kit</color> to extract <color_red>tainted blood</color> from a zombie, then bring the blood sample to a <color_red>hospital</color> and locate a centrifuge to analyze the blood with.",
-    "difficulty": 5,
-    "value": 50000,
-    "item": "software_blood_data",
+    "description": "Find a <color_light_blue>microcentrifuge</color>. The doctor knows of a <color_red>medical supply drop</color> where one could likely be found.",
+    "difficulty": 2,
+    "value": 20000,
+    "item": "microcentrifuge",
     "start": {
-      "effect": [ { "u_buy_item": "vacutainer" }, { "u_buy_item": "usb_drive" } ],
-      "assign_mission_target": { "om_terrain": "hospital_2", "om_special": "hospital", "reveal_radius": 3 }
+      "assign_mission_target": { "om_terrain": "field", "reveal_radius": 1, "random": true, "search_range": 60 },
+      "update_mapgen": {
+        "rows": [
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                 a      ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "        a               ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "           a            ",
+          "                        ",
+          "                        ",
+          "      a                 ",
+          "                        ",
+          "                 a      ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        "
+        ],
+        "furniture": { "a": "f_crate_o" },
+        "place_npcs": [
+          { "class": "NPC_scavenger_docmission", "x": 15, "y": 7 }
+        ]
+      }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_SCIENCE_REP_2",
     "dialogue": {
       "describe": "It could be very informative to perform an analysis of zombie blood…",
-      "offer": "We don't have the equipment for real analysis here so it'll need to be done in the field.  I need you to get a fresh sample of zombie blood, take it to a hospital, and perform a centrifuge analysis of it.",
-      "accepted": "Excellent.  Take this blood draw kit; once you've found a zombie corpse, use it to extract blood from the body, then take it to a hospital for analysis.",
+      "offer": "We don't have the equipment for real analysis here so I'll need you to get some.  Critically, I'm missing a microcentrifuge with which I could perform an analysis of zombie blood.  I need you to procure a microcentrifuge and bring it to me.",
+      "accepted": "Excellent.  I happen to know of the location of a nearby supply drop of medical equipment, which likely contains a microcentrifuge.  Otherwise, you should try your luck at research locations.",
       "rejected": "Are you sure?  The scientific value of that blood data could be priceless…",
-      "advice": "The centrifuge is a bit technical; you might want to study up on the usage of computers before completing that part.",
-      "inquire": "Well, do you have the data yet?",
+      "advice": "The supply drop should be unguarded, but watch your back.",
+      "inquire": "Well, do you have the microcentrifuge yet?",
       "success": "Excellent!  This may be the key to removing the infection.",
-      "success_lie": "Wait, you couldn't possibly have the data!  Liar!",
-      "failure": "What a shame, that data could have proved invaluable…"
+      "success_lie": "Wait, this isn't a centrifuge!  Liar!",
+      "failure": "What a shame, that equipment could have proved invaluable…"
     }
   },
   {

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -99,16 +99,12 @@
           "                        "
         ],
         "furniture": { "a": "f_crate_o" },
-        "place_npcs": [
-          { "class": "NPC_scavenger_docmission", "x": 15, "y": 7 }
-        ]
+        "place_npcs": [ { "class": "NPC_scavenger_docmission", "x": 15, "y": 7 } ]
       }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_SCIENCE_REP_2",
-    "end": {
-      "effect": { "u_buy_item": "1st_aid" }
-    },
+    "end": { "effect": { "u_buy_item": "1st_aid" } },
     "dialogue": {
       "describe": "It could be very informative to perform an analysis of zombie blood…",
       "offer": "We don't have the equipment for real analysis here so I'll need you to get some.  Critically, I'm missing a microcentrifuge with which I could perform an analysis of zombie blood.  I need you to procure a microcentrifuge and bring it to me.",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_scavenger_docmission.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_scavenger_docmission.json
@@ -15,7 +15,11 @@
     "type": "talk_topic",
     "dynamic_line": "Oh. Hi there. I hope you aren't planning any trouble...",
     "responses": [
-      { "text": "What are you doing?", "topic": "TALK_DESCRIBE_SUPPLYDROP", "condition": { "u_has_mission": "MISSION_SCIENCE_REP_1" } },
+      {
+        "text": "What are you doing?",
+        "topic": "TALK_DESCRIBE_SUPPLYDROP",
+        "condition": { "u_has_mission": "MISSION_SCIENCE_REP_1" }
+      },
       {
         "text": "Care to trade?",
         "topic": "TRADE_HALLU",
@@ -31,9 +35,7 @@
     "id": [ "TALK_DESCRIBE_SUPPLYDROP" ],
     "type": "talk_topic",
     "dynamic_line": "Um, well I just searched these crates, and they were full of medical tools.",
-    "responses": [
-      { "text": "Do you have a microcentrifuge?", "topic": "TALK_DESCRIBE_SUPPLYDROP_CHECK" }
-    ]
+    "responses": [ { "text": "Do you have a microcentrifuge?", "topic": "TALK_DESCRIBE_SUPPLYDROP_CHECK" } ]
   },
   {
     "id": [ "TALK_DESCRIBE_SUPPLYDROP_CHECK" ],
@@ -47,7 +49,11 @@
           "difficulty": 45,
           "mod": [ [ "BRAVERY", 1 ], [ "AGGRESSION", -3 ], [ "ALTRUISM", 2 ], [ "FEAR", -2 ], [ "TRUST", 3 ] ]
         },
-        "success": { "topic": "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_SUCCESS", "effect": { "u_buy_item": "microcentrifuge" }, "opinion": { "trust": 1, "fear": -1 } },
+        "success": {
+          "topic": "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_SUCCESS",
+          "effect": { "u_buy_item": "microcentrifuge" },
+          "opinion": { "trust": 1, "fear": -1 }
+        },
         "failure": { "topic": "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_FAILURE", "opinion": { "trust": -2, "anger": 2 } }
       },
       {
@@ -57,10 +63,20 @@
           "difficulty": 65,
           "mod": [ [ "BRAVERY", 1 ], [ "AGGRESSION", -3 ], [ "ALTRUISM", 2 ], [ "FEAR", -2 ], [ "TRUST", 3 ] ]
         },
-        "success": { "topic": "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_SUCCESS", "effect": { "u_buy_item": "microcentrifuge" }, "opinion": { "trust": -2, "fear": 1, "anger": 1 } },
+        "success": {
+          "topic": "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_SUCCESS",
+          "effect": { "u_buy_item": "microcentrifuge" },
+          "opinion": { "trust": -2, "fear": 1, "anger": 1 }
+        },
         "failure": { "topic": "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_FAILURE", "opinion": { "trust": -2, "anger": 2 } }
       },
-      { "text": "Ok, I'll buy it off you.", "topic": "TALK_DONE", "effect": "start_trade", "switch": true, "default": false },
+      {
+        "text": "Ok, I'll buy it off you.",
+        "topic": "TALK_DONE",
+        "effect": "start_trade",
+        "switch": true,
+        "default": false
+      },
       { "text": "I'll get back to you about that.", "topic": "TALK_DONE" }
     ]
   },
@@ -68,32 +84,24 @@
     "id": [ "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_SUCCESS" ],
     "type": "talk_topic",
     "dynamic_line": "Wow, could it really do that?  Ok, please take it, and make sure to mention me when you save the world!",
-    "responses": [
-      { "text": "Yeah, I'll make sure to do that.", "topic": "TALK_DONE" }
-    ]
+    "responses": [ { "text": "Yeah, I'll make sure to do that.", "topic": "TALK_DONE" } ]
   },
   {
     "id": [ "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_SUCCESS" ],
     "type": "talk_topic",
     "dynamic_line": "O-ok no need to get violent, just take it!",
-    "responses": [
-      { "text": "Good.", "topic": "TALK_DONE" }
-    ]
+    "responses": [ { "text": "Good.", "topic": "TALK_DONE" } ]
   },
   {
     "id": [ "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_FAILURE" ],
     "type": "talk_topic",
     "dynamic_line": "Uh, I'd love to help, but I gotta surive out here too you know.",
-    "responses": [
-      { "text": "Ok, bye.", "topic": "TALK_DONE" }
-    ]
+    "responses": [ { "text": "Ok, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": [ "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_FAILURE" ],
     "type": "talk_topic",
     "dynamic_line": "I-I don't think so, you better leave me alone!",
-    "responses": [
-      { "text": "Ok, bye.", "topic": "TALK_DONE" }
-    ]
+    "responses": [ { "text": "Ok, bye.", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/refugee_center/surface_staff/NPC_scavenger_docmission.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_scavenger_docmission.json
@@ -1,0 +1,99 @@
+[
+  {
+    "type": "npc",
+    "id": "NPC_scavenger_docmission",
+    "name_suffix": "wandering survivor",
+    "//": "spawns at the medical supply drop from the doctor mission 1",
+    "class": "NC_SCAVENGER_DOCMISSION",
+    "attitude": 0,
+    "mission": 8,
+    "chat": "TALK_SCAVENGER_DOCMISSION",
+    "faction": "no_faction"
+  },
+  {
+    "id": [ "TALK_SCAVENGER_DOCMISSION" ],
+    "type": "talk_topic",
+    "dynamic_line": "Oh. Hi there. I hope you aren't planning any trouble...",
+    "responses": [
+      { "text": "What are you doing?", "topic": "TALK_DESCRIBE_SUPPLYDROP", "condition": { "u_has_mission": "MISSION_SCIENCE_REP_1" } },
+      {
+        "text": "Care to trade?",
+        "topic": "TRADE_HALLU",
+        "condition": { "npc_has_trait": "HALLUCINATION" },
+        "switch": true,
+        "default": false
+      },
+      { "text": "Care to trade?", "topic": "TALK_DONE", "effect": "start_trade", "switch": true, "default": false },
+      { "text": "Well, bye.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": [ "TALK_DESCRIBE_SUPPLYDROP" ],
+    "type": "talk_topic",
+    "dynamic_line": "Um, well I just searched these crates, and they were full of medical tools.",
+    "responses": [
+      { "text": "Do you have a microcentrifuge?", "topic": "TALK_DESCRIBE_SUPPLYDROP_CHECK" }
+    ]
+  },
+  {
+    "id": [ "TALK_DESCRIBE_SUPPLYDROP_CHECK" ],
+    "type": "talk_topic",
+    "dynamic_line": "Um, like this thing?  Well I just, I just found it, and it might be worth a lot, I can't just give it away...",
+    "responses": [
+      {
+        "text": "Please, this equipment could be the key to stopping the zombies.",
+        "trial": {
+          "type": "PERSUADE",
+          "difficulty": 45,
+          "mod": [ [ "BRAVERY", 1 ], [ "AGGRESSION", -3 ], [ "ALTRUISM", 2 ], [ "FEAR", -2 ], [ "TRUST", 3 ] ]
+        },
+        "success": { "topic": "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_SUCCESS", "effect": { "u_buy_item": "microcentrifuge" }, "opinion": { "trust": 1, "fear": -1 } },
+        "failure": { "topic": "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_FAILURE", "opinion": { "trust": -2, "anger": 2 } }
+      },
+      {
+        "text": "We can do this the easy way or the hard way.",
+        "trial": {
+          "type": "INTIMIDATE",
+          "difficulty": 65,
+          "mod": [ [ "BRAVERY", 1 ], [ "AGGRESSION", -3 ], [ "ALTRUISM", 2 ], [ "FEAR", -2 ], [ "TRUST", 3 ] ]
+        },
+        "success": { "topic": "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_SUCCESS", "effect": { "u_buy_item": "microcentrifuge" }, "opinion": { "trust": -2, "fear": 1, "anger": 1 } },
+        "failure": { "topic": "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_FAILURE", "opinion": { "trust": -2, "anger": 2 } }
+      },
+      { "text": "Ok, I'll buy it off you.", "topic": "TALK_DONE", "effect": "start_trade", "switch": true, "default": false },
+      { "text": "I'll get back to you about that.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": [ "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_SUCCESS" ],
+    "type": "talk_topic",
+    "dynamic_line": "Wow, could it really do that?  Ok, please take it, and make sure to mention me when you save the world!",
+    "responses": [
+      { "text": "Yeah, I'll make sure to do that.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": [ "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_SUCCESS" ],
+    "type": "talk_topic",
+    "dynamic_line": "O-ok no need to get violent, just take it!",
+    "responses": [
+      { "text": "Good.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": [ "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_FAILURE" ],
+    "type": "talk_topic",
+    "dynamic_line": "Uh, I'd love to help, but I gotta surive out here too you know.",
+    "responses": [
+      { "text": "Ok, bye.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": [ "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_FAILURE" ],
+    "type": "talk_topic",
+    "dynamic_line": "I-I don't think so, you better leave me alone!",
+    "responses": [
+      { "text": "Ok, bye.", "topic": "TALK_DONE" }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The doctor's first mission has always been horribly unbalanced for what is supposed to be a starter mission which doesn't give you anything. The hospital he sends you to is almost always extremely far away and in a city full of zombies, so much so that it's usually easier to go to a lab to find a centrifuge.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Revamps the doctor's first mission:
The objective is changed to finding a microcentrifuge
The quest spawns a medical supply drop which has a microcentrifuge near the center.
When you arrive at the drop, you find a scavenger who has already looted it.
You can then persuade, intmidate, rob, or buy the centrifuge off the scavenger.
As a reward, you get a first aid kit.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Bad missions
## Testing
Did the mission, everything works correctly
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Part of my plan to revamp all the missions to follow proper progression and be more than just fetch items.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f95ff4f](https://github.com/cataclysmbn/Cataclysm-BN/commit/f95ff4f3f92b5cccb69ac31edef754f2d3941f81) (style(autofix.ci): automated formatting) on 2026-05-20 23:43:58

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26194403755/artifacts/7123506676)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26194403755/artifacts/7123939190)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26194403755/artifacts/7123457051)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26194403755/artifacts/7123653890)
<!-- END artifact comment -->