### PR TITLE
ci: mark stale PR artifacts on new commits

### DIFF
--- a/.github/workflows/pr-artifact-stale.yml
+++ b/.github/workflows/pr-artifact-stale.yml
@@ -1,0 +1,76 @@
+name: PR Artifact Stale Marker
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-artifact-stale-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  mark-stale:
+    if: github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark existing artifacts stale
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          body=$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')
+          if ! grep -q '<!-- BEGIN artifact comment -->' <<< "$body"; then
+            exit 0
+          fi
+
+          new_body=$(BODY="$body" HEAD_SHA="$HEAD_SHA" python3 - <<'PY'
+          import os
+          import re
+
+          body = os.environ["BODY"]
+          head_sha = os.environ["HEAD_SHA"]
+          pattern = re.compile(r"(?s)<!-- BEGIN artifact comment -->.*?<!-- END artifact comment -->")
+          match = pattern.search(body)
+          if not match:
+              print(body, end="")
+              raise SystemExit
+
+          block = match.group(0)
+          if f"/commit/{head_sha}" in block:
+              print(body, end="")
+              raise SystemExit
+
+          stale_block = re.sub(
+              r"- \[✅ ([^\]\n]+?) — download\]\(([^)\n]+)\)",
+              r"- [⏳ \1 — stale](\2)",
+              block,
+          )
+          if stale_block == block:
+              print(body, end="")
+              raise SystemExit
+
+          stale_block = re.sub(
+              r"^PR build for commit (.+)$",
+              r"Stale PR build for commit \1; waiting for a build from the latest commit.",
+              stale_block,
+              flags=re.MULTILINE,
+          )
+          print(body[:match.start()] + stale_block + body[match.end():], end="")
+          PY
+          )
+
+          if [ "$new_body" = "$body" ]; then
+            exit 0
+          fi
+
+          jq -n --arg body "$new_body" '{body: $body}' > "$RUNNER_TEMP/pr-body.json"
+          gh api -X PATCH "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --input "$RUNNER_TEMP/pr-body.json" >/dev/null


### PR DESCRIPTION
## Purpose of change (The Why)

> Build artifacts should either be deleted on commit, or better yet noted as stale as of commit ##### in the PR message.
> That way people don't grab a build artifact thinking it's up to date while someone is working  on it faster than the runner can compile.
on
 https://discord.com/channels/830879262763909202/830916451517857894/1506751377781817437 by @AzmodiusX


Continuation of #8969. PR artifact links should stop looking current after a new commit is pushed.

## Describe the solution (The How)

Add a `pull_request_target` workflow for `synchronize` events that marks existing artifact download links as stale with `⏳` when the artifact block belongs to an older commit.

## Describe alternatives you've considered

None.

## Testing

- `git diff --check`
- `actionlint .github/workflows/pr-artifact-publish.yml .github/workflows/pr-artifact-stale.yml`


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style). YAML-only change; no formatter was run.
- [x] I linked relevant issues/PRs in [Summary of the PR](#purpose-of-change-the-why).

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1d0abb3](https://github.com/cataclysmbn/Cataclysm-BN/commit/1d0abb37f9f965c478ae26b1d4e22a9fc60e1574) (ci: mark stale PR artifacts on new commits) on 2026-05-21 01:29:00

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26198139140/artifacts/7124847480)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26198139140/artifacts/7125257405)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26198139140/artifacts/7124845075)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26198139140/artifacts/7124964800)
<!-- END artifact comment -->