### PR TITLE
ci: disable format targets in build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,6 +295,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ${{ matrix.tiles && 'dist-tiles' || 'dist-curses' }}
+          configurePresetAdditionalArgs: "['-DCATA_FORMAT_TARGETS=OFF']"
           buildPreset: ${{ matrix.tiles && 'dist-tiles' || 'dist-curses' }}
 
       - name: Setup Deno (Lua docs)
@@ -393,6 +394,7 @@ jobs:
             "-DTESTS=$tests" `
             "-DRELEASE=$release" `
             -DJSON_FORMAT=OFF `
+            -DCATA_FORMAT_TARGETS=OFF `
             -DCMAKE_INSTALL_MESSAGE=NEVER
 
       - name: Build CBN (windows msvc)
@@ -449,6 +451,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ${{ matrix.preset }}
+          configurePresetAdditionalArgs: "['-DCATA_FORMAT_TARGETS=OFF']"
           buildPreset: ${{ matrix.preset }}
 
       - name: Rename distribution package (macOS)

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -142,7 +142,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ${{ matrix.preset }}
-          configurePresetAdditionalArgs: "['-DUSE_PREFIX_DATA_DIR=OFF']"
+          configurePresetAdditionalArgs: "['-DUSE_PREFIX_DATA_DIR=OFF', '-DCATA_FORMAT_TARGETS=OFF']"
           buildPreset: ${{ matrix.preset }}
           buildPresetAdditionalArgs: "['-j', '2']"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,10 @@ if (NOT VCPKG_MANIFEST_MODE)
 endif()
 
 
-include(FormatSource)
+option(CATA_FORMAT_TARGETS "Enable C++ formatting targets" ON)
+if (CATA_FORMAT_TARGETS)
+    include(FormatSource)
+endif ()
 include(FetchContent)
 
 set(CMAKE_TLS_VERIFY ON)


### PR DESCRIPTION
## Purpose of change (The Why)

Prevent build-matrix configure warnings for missing `clang-format` and `astyle`, as seen while investigating #8978.

Related: #8978

## Describe the solution (The How)

Add `CATA_FORMAT_TARGETS` to gate `FormatSource`, and disable it in build CI configure calls. `autofix.ci` keeps formatter targets enabled.

## Describe alternatives you've considered

Linking format tools into every build job would add setup work to jobs that do not run formatting.

## Testing

- `git diff --check`
- `cmake -S . -B /tmp/cbn-format-off -DCATA_FORMAT_TARGETS=OFF -DCURSES=OFF -DTILES=OFF -DSOUND=OFF -DTESTS=OFF -DJSON_FORMAT=OFF -DLUA_DOCS_ON_BUILD=OFF`
- `cmake -S . -B /tmp/cbn-format-on -DCURSES=OFF -DTILES=OFF -DSOUND=OFF -DTESTS=OFF -DJSON_FORMAT=OFF -DLUA_DOCS_ON_BUILD=OFF && cmake --build /tmp/cbn-format-on --target help | rg 'format|astyle'`
- `actionlint .github/workflows/build.yml .github/workflows/matrix.yml`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style) or confirmed no formatted source files were changed.
- [x] I linked the related PR.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6832a26](https://github.com/cataclysmbn/Cataclysm-BN/commit/6832a26e7b66222c6df7cd343ca3ba347f56c231) (ci: disable format targets in build jobs) on 2026-05-21 01:19:18

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26197732381/artifacts/7124758159)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26197732381/artifacts/7125133499)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26197732381/artifacts/7124785856)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26197732381/artifacts/7124882500)
<!-- END artifact comment -->