### PR TITLE
ci: build draft PR artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,6 @@ env:
 
 jobs:
   builds:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main]
     paths-ignore: [docs/**, scripts/**, "**.md", "**.mdx"]
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 # Cancel all previous instances in favor of latest revision of a PR.
@@ -68,7 +68,7 @@ jobs:
       ZSTD_CLEVEL: 3
       TILES: ${{ matrix.tiles }}
       TEST_STAGE: ${{ matrix.test-stage }}
-      SKIP: ${{ matrix.always-run != true && ( github.event.pull_request.draft == true || needs.skip-duplicates.outputs.should_skip_code == true || needs.skip-duplicates.outputs.should_skip_data == true ) }}
+      SKIP: ${{ matrix.always-run != true && ( needs.skip-duplicates.outputs.should_skip_code == true || needs.skip-duplicates.outputs.should_skip_data == true ) }}
 
     steps:
       - name: checkout repository
@@ -199,7 +199,7 @@ jobs:
 
   builds:
     needs: skip-duplicates
-    if: ${{ github.event_name != 'push' && ( github.event_name != 'pull_request' || ( github.event.pull_request.draft != true && needs.skip-duplicates.outputs.should_skip_platform != 'true' ) ) }}
+    if: ${{ github.event_name != 'push' && needs.skip-duplicates.outputs.should_skip_platform != 'true' }}
     uses: ./.github/workflows/build.yml
     with:
       version-label: experimental


### PR DESCRIPTION
## Purpose of change (The Why)

Draft PRs need playtest artifacts too. Stale draft PRs often stay stale because testers cannot easily get builds.

Related: #8921, #8969, #8980
Motivated by #8976 exposing draft PR artifact rows as failed because draft builds were skipped.

## Describe the solution (The How)

- Run Linux tiles artifacts for draft PRs.
- Run platform artifact builds for draft PRs.
- Remove the `ready_for_review` matrix trigger because the same head SHA is already built while draft.

## Describe alternatives you've considered

Keeping draft artifacts disabled and relying on ready-for-review builds, but that blocks playtesting during the draft phase.

## Testing

- `actionlint .github/workflows/matrix.yml .github/workflows/build.yml`

## Additional context

Recent matrix history suggests enabling full draft artifacts adds roughly 130-140 runner-minutes per successful draft run.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the relevant workflow validation. No code formatter applies to this workflow-only change.
- [x] I linked relevant PRs in [Summary of the PR](#purpose-of-change-the-why); no closing issue was found.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7c8b7a0](https://github.com/cataclysmbn/Cataclysm-BN/commit/7c8b7a0a8457f0ab461770c6152c5e9869311414) (ci: build draft PR artifacts) on 2026-05-21 03:20:02

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26201706089/artifacts/7126140546)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26201706089/artifacts/7126468375)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26201706089/artifacts/7126265866)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26201706089/artifacts/7126233612)
<!-- END artifact comment -->