### PR TITLE
fix: clamp vehicle hull coverage for water drag

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4969,7 +4969,8 @@ double vehicle::coeff_water_drag() const
     if( hull_indices.empty() ) {
         hull_coverage = 0;
     } else {
-        hull_coverage = static_cast<double>( floating.size() ) / hull_indices.size();
+        hull_coverage = std::clamp( static_cast<double>( floating.size() ) / hull_indices.size(), 0.0,
+                                    1.0 );
     }
 
     std::set<int> occupied_y;

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -168,6 +168,27 @@ static void test_vehicle_drag(
     }
 }
 
+TEST_CASE( "water drag remains positive with excess floating parts", "[vehicle] [engine]" )
+{
+    clear_game_drag( ter_id( "t_pavement" ) );
+
+    auto *const veh_ptr = get_map().add_vehicle( vproto_id( "none" ), tripoint_bub_ms( 60, 60, 0 ),
+                          0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    REQUIRE( veh_ptr->install_part( tripoint_mnt_veh( 0, 0, 0 ), vpart_id( "frame_vertical" ),
+                                    true ) >= 0 );
+    REQUIRE( veh_ptr->install_part( tripoint_mnt_veh( 0, 0, 0 ), vpart_id( "boat_board" ),
+                                    true ) >= 0 );
+    REQUIRE( veh_ptr->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "sea_scooter_hull" ),
+                                    true ) >= 0 );
+    REQUIRE( veh_ptr->install_part( tripoint_mnt_veh( 2, 0, 0 ), vpart_id( "sea_scooter_hull" ),
+                                    true ) >= 0 );
+
+    CHECK( veh_ptr->coeff_water_drag() > 0.0 );
+    CHECK( veh_ptr->water_hull_height() == Approx( 0.8 ) );
+}
+
 std::vector<std::string> vehs_to_test_drag = {
     {
         "bicycle_test",


### PR DESCRIPTION
## Purpose of change (The Why)

Prevent vehicles with more `FLOATS` parts than underbody hull parts from getting negative water drag, negative water speeds, and excessive fuel drain.

<img width="850" height="477" alt="image" src="https://github.com/user-attachments/assets/f38a8292-9e4e-475f-b47f-bb243c2ff3f4" />

External report: https://m.dcinside.com/board/rlike/517917

Related: #8217, #8772

## Describe the solution (The How)

Clamp hull coverage at 100% before deriving water drag and hull height.

## Describe alternatives you've considered

Counting only underbody `FLOATS` parts would be stricter, but clamping preserves buoyancy contributions from existing non-underbody floating parts while preventing negative drag.

## Testing

- `cmake --preset linux-curses`
- `cmake --build out/build/linux-curses --target cata_test -j$(nproc)`
- `./out/build/linux-curses/tests/cata_test "water drag remains positive with excess floating parts"`
- `./out/build/linux-curses/tests/cata_test "[vehicle] [engine]"`
- `cmake --preset linux-full`
- `cmake --build --preset linux-full --target cata_test-tiles -j$(nproc)`
- `./out/build/linux-full/tests/cata_test-tiles "water drag remains positive with excess floating parts"`
- `./out/build/linux-full/tests/cata_test-tiles "[vehicle] [engine]"`

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [37b6821](https://github.com/cataclysmbn/Cataclysm-BN/commit/37b682196fa8d3e210f73116838ed371b07754d3) (fix: clamp vehicle hull coverage for water drag) on 2026-05-21 09:52:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26215934029/artifacts/7131657895)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26215934029/artifacts/7132415011)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26215934029/artifacts/7131503543)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26215934029/artifacts/7131861958)
<!-- END artifact comment -->