### PR TITLE
fix: use local aircraft part positions in mapgen

### DIFF
--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -597,9 +597,20 @@ static bool mx_aircraft( map &m, const tripoint_abs_sm &abs_sub )
     vehicle *wreckage = m.add_vehicle(
                             crashed_hull, tripoint_bub_ms( x1, y1, abs_sub.z() ), dir1, rng( 1, 33 ), 1 );
 
-    const auto controls_at = []( vehicle * wreckage, const tripoint_bub_ms & pos ) {
-        return !wreckage->get_parts_at( pos, "CONTROLS", part_status_flag::any ).empty() ||
-               !wreckage->get_parts_at( pos, "CTRL_ELECTRONIC", part_status_flag::any ).empty();
+    // During mapgen, m may be a tinymap while vpart_position::pos() uses get_map().
+    const auto local_part_pos = [&m]( const vehicle & wreckage,
+    const vpart_reference & vp ) {
+        return m.abs_to_bub( wreckage.abs_part_location( vp.part() ) );
+    };
+
+    const auto controls_at = []( vehicle * wreckage, const tripoint_mnt_veh & mount ) {
+        const std::vector<int> parts_at_mount = wreckage->parts_at_relative( mount, true );
+        return std::ranges::any_of( parts_at_mount, [&]( const int part_index ) {
+            const vehicle_part &part = wreckage->part( part_index );
+            return !part.removed &&
+                   ( part.info().has_flag( "CONTROLS" ) ||
+                     part.info().has_flag( "CTRL_ELECTRONIC" ) );
+        } );
     };
 
     if( wreckage != nullptr ) {
@@ -611,9 +622,9 @@ static bool mx_aircraft( map &m, const tripoint_abs_sm &abs_sub )
             case 3:
                 // Full clown car
                 for( const vpart_reference &vp : wreckage->get_any_parts( VPFLAG_SEATBELT ) ) {
-                    const auto pos = vp.pos();
+                    const auto pos = local_part_pos( *wreckage, vp );
                     // Spawn pilots in seats with controls.CTRL_ELECTRONIC
-                    if( controls_at( wreckage, pos ) ) {
+                    if( controls_at( wreckage, vp.mount() ) ) {
                         m.add_spawn( mon_zombie_military_pilot, 1, pos );
                     } else {
                         if( one_in( 5 ) ) {
@@ -639,9 +650,9 @@ static bool mx_aircraft( map &m, const tripoint_abs_sm &abs_sub )
             case 5:
                 // 2/3rds clown car
                 for( const vpart_reference &vp : wreckage->get_any_parts( VPFLAG_SEATBELT ) ) {
-                    const auto pos = vp.pos();
+                    const auto pos = local_part_pos( *wreckage, vp );
                     // Spawn pilots in seats with controls.
-                    if( controls_at( wreckage, pos ) ) {
+                    if( controls_at( wreckage, vp.mount() ) ) {
                         m.add_spawn( mon_zombie_military_pilot, 1, pos );
                     } else {
                         if( !one_in( 3 ) ) {
@@ -662,7 +673,8 @@ static bool mx_aircraft( map &m, const tripoint_abs_sm &abs_sub )
             case 6:
                 // Just pilots
                 for( const vpart_reference &vp : wreckage->get_any_parts( VPFLAG_CONTROLS ) ) {
-                    m.add_spawn( mon_zombie_military_pilot, 1, vp.pos() );
+                    const tripoint_bub_ms pos = local_part_pos( *wreckage, vp );
+                    m.add_spawn( mon_zombie_military_pilot, 1, pos );
 
                     // Delete the items that would have spawned here from a "corpse"
                     for( auto sp : wreckage->parts_at_relative( vp.mount(), true ) ) {


### PR DESCRIPTION
## Purpose of change (The Why)

Split from #8951 after `gcc, curses` exposed an unrelated curses CI initialization failure.

Fixes `mx_aircraft` passing global-map vehicle part positions to a tinymap `add_spawn` call.

Related: #8951

## Describe the solution (The How)

Use the map extra's local map instance to convert aircraft part absolute positions back to local bubble coordinates before spawning pilots. Check cockpit controls by vehicle mount instead of global-map position.

## Describe alternatives you've considered

None.

## Testing

- `git diff --check`
- `cmake --build --preset linux-curses --target cata_test -j8`
- `./out/build/linux-curses/tests/cata_test "~*"`

## Additional context

The failure logged `centadodecamonant doesn't exist in grid; within add_spawn(...)` during PR #8951 test initialization.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why). (No related issue found.)

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and used the configured assisted-by automation for commit metadata.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e5338b4](https://github.com/cataclysmbn/Cataclysm-BN/commit/e5338b4f40cbaf2a9607349baa0ebc183eeb9f7a) (fix: use local aircraft part positions in mapgen) on 2026-05-21 14:49:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26230168465/artifacts/7137864108)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26230168465/artifacts/7138772367)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26230168465/artifacts/7137793172)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26230168465/artifacts/7138125427)
<!-- END artifact comment -->