### PR TITLE
fix: on wear hook fixes

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11071,7 +11071,7 @@ void Character::use_fire( const int quantity )
 }
 
 
-void Character::on_item_wear( const item &it )
+void Character::on_item_wear( item &it )
 {
     for( const trait_id &mut : it.mutations_from_wearing( *this ) ) {
         mutation_effect( mut );
@@ -11084,9 +11084,12 @@ void Character::on_item_wear( const item &it )
         }
     }
     morale->on_item_wear( it );
+    if( it.type->iwearable_callbacks ) {
+        it.type->iwearable_callbacks->call_on_wear( *this, it );
+    }
 }
 
-void Character::on_item_takeoff( const item &it )
+void Character::on_item_takeoff( item &it )
 {
     for( const trait_id &mut : it.mutations_from_wearing( *this ) ) {
         mutation_loss_effect( mut );
@@ -11097,6 +11100,9 @@ void Character::on_item_takeoff( const item &it )
         }
     }
     morale->on_item_takeoff( it );
+    if( it.type->iwearable_callbacks ) {
+        it.type->iwearable_callbacks->call_on_takeoff( *this, it );
+    }
 }
 
 void Character::on_effect_int_change( const efftype_id &effect_type, int intensity,

--- a/src/character.h
+++ b/src/character.h
@@ -1918,9 +1918,9 @@ class Character : public Creature, public location_visitable<Character>
     public:
 
         /** Called when an item is worn */
-        void on_item_wear( const item &it );
+        void on_item_wear( item &it );
         /** Called when an item is taken off */
-        void on_item_takeoff( const item &it );
+        void on_item_takeoff( item &it );
         /** Called when effect intensity has been changed */
         void on_effect_int_change( const efftype_id &effect_type, int intensity,
                                    const bodypart_str_id &bp ) override;


### PR DESCRIPTION
## Purpose of change (The Why)
On activating or unactivating worn items these hooks didn't trigger
I cwave my clairvoyance hat of pain and suffering

## Describe the solution (The How)
Trigger these hooks then

## Describe alternatives you've considered
Add more hooks

## Testing
My local CRIT clairvoyance hat now causes immense pain and suffering

## Additional context
Must make lua content

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e79a679](https://github.com/cataclysmbn/Cataclysm-BN/commit/e79a679a1a6fbce3fce90cf1e909b92e05726330) (fix: on wear hook fixes) on 2026-05-21 19:07:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26244133928/artifacts/7144420695)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26244133928/artifacts/7144621129)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26244133928/artifacts/7144155668)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26244133928/artifacts/7143999046)
<!-- END artifact comment -->