### PR TITLE
fix: invalid vehicles in vehicle groups now emit debugmsg

### DIFF
--- a/data/json/vehicles/trucks.json
+++ b/data/json/vehicles/trucks.json
@@ -511,6 +511,66 @@
     }
   },
   {
+    "id": "afs_beer_tanker",
+    "type": "vehicle",
+    "name": "Beer Tanker",
+    "blueprint": [
+      "Y-ww-----U",
+      "|FWWFFFFF|",
+      "|FFFFFFFF|",
+      "|FFFFFFFF|",
+      "|FWWFFFFF|",
+      "B-ww-----N"
+    ],
+    "blueprint_origin": { "x": 4, "y": 3 },
+    "palette": {
+      "F": [ "hdframe_cross", { "fuel": "beer", "part": "afs_mounted_external_tank" } ],
+      "-": [ "hdframe_vertical" ],
+      "|": [ "hdframe_horizontal" ],
+      "W": [
+        "hdframe_horizontal",
+        "wheel_mount_medium",
+        "wheel_wide",
+        { "fuel": "beer", "part": "afs_mounted_external_tank" }
+      ],
+      "w": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ],
+      "B": [ "hdframe_se" ],
+      "Y": [ "hdframe_sw" ],
+      "N": [ "hdframe_ne" ],
+      "U": [ "hdframe_nw" ]
+    }
+  },
+  {
+    "id": "afs_hydrogen_peroxide_tanker",
+    "type": "vehicle",
+    "name": "Hydrogen Peroxide Tanker",
+    "blueprint": [
+      "Y-ww-----U",
+      "|FWWFFFFF|",
+      "|FFFFFFFF|",
+      "|FFFFFFFF|",
+      "|FWWFFFFF|",
+      "B-ww-----N"
+    ],
+    "blueprint_origin": { "x": 4, "y": 3 },
+    "palette": {
+      "F": [ "hdframe_cross", { "fuel": "chem_hydrogen_peroxide", "part": "afs_mounted_external_tank" } ],
+      "-": [ "hdframe_vertical" ],
+      "|": [ "hdframe_horizontal" ],
+      "W": [
+        "hdframe_horizontal",
+        "wheel_mount_medium",
+        "wheel_wide",
+        { "fuel": "chem_hydrogen_peroxide", "part": "afs_mounted_external_tank" }
+      ],
+      "w": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ],
+      "B": [ "hdframe_se" ],
+      "Y": [ "hdframe_sw" ],
+      "N": [ "hdframe_ne" ],
+      "U": [ "hdframe_nw" ]
+    }
+  },
+  {
     "id": "afs_sewage_tanker",
     "type": "vehicle",
     "name": "Sewage Tanker",

--- a/data/json/vehicles/trucks.json
+++ b/data/json/vehicles/trucks.json
@@ -527,12 +527,7 @@
       "F": [ "hdframe_cross", { "fuel": "beer", "part": "afs_mounted_external_tank" } ],
       "-": [ "hdframe_vertical" ],
       "|": [ "hdframe_horizontal" ],
-      "W": [
-        "hdframe_horizontal",
-        "wheel_mount_medium",
-        "wheel_wide",
-        { "fuel": "beer", "part": "afs_mounted_external_tank" }
-      ],
+      "W": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide", { "fuel": "beer", "part": "afs_mounted_external_tank" } ],
       "w": [ "hdframe_horizontal", "wheel_mount_medium", "wheel_wide" ],
       "B": [ "hdframe_se" ],
       "Y": [ "hdframe_sw" ],

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -778,6 +778,7 @@ void DynamicDataLoader::check_consistency( loading_ui &ui )
             { _( "Engine faults" ), &fault::check_consistency },
             { _( "Vehicle parts" ), &vpart_info::check },
             { _( "Vehicle palettes" ), &VehiclePalette::check },
+            { _( "Vehicle groups" ), &VehicleGroup::check },
             { _( "Mapgen definitions" ), &check_mapgen_definitions },
             { _( "Mapgen palettes" ), &mapgen_palette::check_definitions },
             {

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -81,6 +81,16 @@ void VehicleGroup::load( const JsonObject &jo )
     }
 }
 
+void VehicleGroup::check()
+{
+    for( const auto &vgroup : vgroups ) {
+        for( const auto &veh : vgroup.second.vehicles ) {
+            if( !veh.obj.is_valid() ) {
+                debugmsg( "Invalid vehicle %s in Vehicle Group %s", veh.obj, vgroup.first );
+            }
+        }
+    }
+}
 void VehicleGroup::reset()
 {
     vgroups.clear();

--- a/src/vehicle_group.h
+++ b/src/vehicle_group.h
@@ -41,6 +41,7 @@ class VehicleGroup
 
         static void load( const JsonObject &jo );
         static void reset();
+        static void check();
 
     private:
         weighted_int_list<vproto_id> vehicles;


### PR DESCRIPTION
## Purpose of change (The Why)
#8410 missed the beer and hydrogen peroxide vehicles
This went unnoticed because tests no screm

## Describe the solution (The How)
Tests now go screm
Add those vehicles

## Describe alternatives you've considered
Find all the other places tests should go screm

## Testing
Vehicle now exists
Remove vehicle, run tests
Tests go screm

## Additional context
Tests must screm more, let me be lazy on json PRs

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [96321e6](https://github.com/cataclysmbn/Cataclysm-BN/commit/96321e6ae55fe389a685f0ac2a2c180d6eb81026) (style(autofix.ci): automated formatting) on 2026-05-21 19:09:17

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26244387510/artifacts/7143879909)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26244387510/artifacts/7144658361)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26244387510/artifacts/7143772218)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26244387510/artifacts/7144107515)
<!-- END artifact comment -->