### PR TITLE
feat(lua): add on_add_msg hook in messages.cpp

### DIFF
--- a/docs/en/mod/lua/hooks.md
+++ b/docs/en/mod/lua/hooks.md
@@ -104,3 +104,24 @@ turn=1335126   time="  0 seconds" type=neutral  message="The floor is lava!"
 ```
 
 you can see when 'the floor is lava', 0 priority hook gets cancelled, due to `on_character_try_move` having `.exit_early` set to true at the call site.
+
+## `on_add_msg`
+
+Fires whenever a message is added to the message log via `add_msg` / `Messages::add_msg`. Lets mods react to in-game events without polling the message stream.
+
+Params:
+
+- `msg`: the message text (string)
+- `type`: the message type (`MsgType` enum — `good`, `bad`, `mixed`, `warning`, `info`, `neutral`, `debug`, etc.)
+
+The hook fires after the empty / inactive / non-debug-mode early exits, but before cooldown coalescing — so duplicate / coalesced messages still trigger the hook. This matches the use cases of accessibility, alarm, and statistics mods, which want every surfaced line.
+
+Do not call `gapi.add_msg` from inside this hook — it will recurse.
+
+```lua
+game.add_hook("on_add_msg", function(params)
+  if params.type == MsgType.bad then
+    -- react to bad-news messages
+  end
+end)
+```

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -50,6 +50,7 @@ constexpr auto hook_names = std::array
     "on_npc_do_turn",
     "on_monster_do_turn",
     "on_make_mapgen_factory_list",
+    "on_add_msg",
 };
 
 void define_hooks( lua_state &state )

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -2,6 +2,8 @@
 #include "message_types.h"
 #include "calendar.h"
 #include "catacharset.h"
+#include "catalua_hooks.h"
+#include "catalua_sol.h"
 #include "color.h"
 #include "cursesdef.h"
 #include "debug.h"
@@ -185,6 +187,11 @@ class messages_impl
             if( type == m_debug ) {
                 DebugLog( DL::Info, DC::DebugModeMsg ) << msg;
             }
+
+            cata::run_hooks( "on_add_msg", [&]( sol::table & params ) {
+                params["msg"] = msg;
+                params["type"] = type;
+            } );
 
             game_message m = game_message( std::move( msg ), type );
 


### PR DESCRIPTION
## Summary

Closes #8829.

Adds an `on_add_msg` Lua hook that fires whenever a message is added to the message log. Lets accessibility, alarm, statistics, and similar mods react to in-game events without polling the message stream from Lua.

- Registers `"on_add_msg"` in `cata::hook_names` (src/catalua_hooks.cpp).
- Fires `cata::run_hooks("on_add_msg", ...)` inside `messages_impl::add_msg_string(string&&, type, flags)` after the empty / inactive / non-debug-mode early-exit gates, before cooldown coalescing so duplicate / coalesced messages still trigger the hook (intentional, for accessibility use case).
- Hook params: `msg` (text) and `type` (`MsgType` enum).
- Documents the new hook in `docs/en/mod/lua/hooks.md`.

29 lines total across 3 files. Follows the existing `cata::run_hooks` convention used by ~14 other hook call sites (`on_character_death`, `on_character_effect_added`, `on_creature_dodged`, etc.).

## Test plan

- [x] Local build: `cataclysm-bn-tiles` and `cata_test-tiles` build clean (RelWithDebInfo, MSVC 14.44, vcpkg x64-windows-static).
- [x] `cata_test-tiles "[lua]"` — all 186 assertions / 26 test cases pass (existing hook plumbing tests `lua_hooks_order_and_chaining` and `lua_hooks_exit_early` still green).
- [ ] CI cross-platform builds.
- [ ] Runtime smoke test from a Lua mod registering `on_add_msg` and triggering messages.

## Notes

- No new C++ unit test for the hook itself — `tests/fake_messages.cpp` stubs out `Messages::add_msg` to a no-op, so the hook firing site can't be exercised via the existing test harness without restructuring. The hook plumbing it relies on is already covered.
- `MsgType` enum (sol-exposed `game_message_type` via `reg_enum`) — verified Lua callers use unprefixed names (`MsgType.bad`, not `MsgType.m_bad`) and the doc reflects that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)