### PR TITLE
feat(lua): add on_add_msg hook in messages.cpp

### DIFF
--- a/data/mods/Test_on_add_msg_hook/modinfo.json
+++ b/data/mods/Test_on_add_msg_hook/modinfo.json
@@ -8,6 +8,6 @@
     "category": "content",
     "lua_api_version": 2,
     "dependencies": [ "bn" ],
-    "obsolete": true
+    "obsolete": false
   }
 ]

--- a/data/mods/Test_on_add_msg_hook/modinfo.json
+++ b/data/mods/Test_on_add_msg_hook/modinfo.json
@@ -8,6 +8,6 @@
     "category": "content",
     "lua_api_version": 2,
     "dependencies": [ "bn" ],
-    "obsolete": false
+    "obsolete": true
   }
 ]

--- a/data/mods/Test_on_add_msg_hook/modinfo.json
+++ b/data/mods/Test_on_add_msg_hook/modinfo.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "test_on_add_msg_hook",
+    "name": "on_add_msg hook smoke test",
+    "authors": [ "mythosmod" ],
+    "description": "Logs every game message via the on_add_msg Lua hook. Smoke test for PR #8993. Should be obsolete after PR merge.",
+    "category": "content",
+    "lua_api_version": 2,
+    "dependencies": [ "bn" ],
+    "obsolete": true
+  }
+]

--- a/data/mods/Test_on_add_msg_hook/preload.lua
+++ b/data/mods/Test_on_add_msg_hook/preload.lua
@@ -5,6 +5,7 @@ mod.msg_count = 0
 
 game.add_hook("on_add_msg", function(params)
   mod.msg_count = mod.msg_count + 1
-  gdebug.log_info(string.format("on_add_msg #%d  type=%s  msg=%q",
-    mod.msg_count, tostring(params.type), tostring(params.msg)))
+  gdebug.log_info(
+    string.format("on_add_msg #%d  type=%s  msg=%q", mod.msg_count, tostring(params.type), tostring(params.msg))
+  )
 end)

--- a/data/mods/Test_on_add_msg_hook/preload.lua
+++ b/data/mods/Test_on_add_msg_hook/preload.lua
@@ -1,0 +1,10 @@
+gdebug.log_info("on_add_msg smoke test: PRELOAD ONLINE")
+
+local mod = game.mod_runtime[game.current_mod]
+mod.msg_count = 0
+
+game.add_hook("on_add_msg", function(params)
+  mod.msg_count = mod.msg_count + 1
+  gdebug.log_info(string.format("on_add_msg #%d  type=%s  msg=%q",
+    mod.msg_count, tostring(params.type), tostring(params.msg)))
+end)

--- a/docs/en/mod/lua/hooks.md
+++ b/docs/en/mod/lua/hooks.md
@@ -104,3 +104,24 @@ turn=1335126   time="  0 seconds" type=neutral  message="The floor is lava!"
 ```
 
 you can see when 'the floor is lava', 0 priority hook gets cancelled, due to `on_character_try_move` having `.exit_early` set to true at the call site.
+
+## `on_add_msg`
+
+Fires whenever a message is added to the message log via `add_msg` / `Messages::add_msg`. Lets mods react to in-game events without polling the message stream.
+
+Params:
+
+- `msg`: the message text (string)
+- `type`: the message type (`MsgType` enum — `good`, `bad`, `mixed`, `warning`, `info`, `neutral`, `debug`, etc.)
+
+The hook fires after the empty / inactive / non-debug-mode early exits, but before cooldown coalescing — so duplicate / coalesced messages still trigger the hook. This matches the use cases of accessibility, alarm, and statistics mods, which want every surfaced line.
+
+Do not call `gapi.add_msg` from inside this hook — it will recurse.
+
+```lua
+game.add_hook("on_add_msg", function(params)
+  if params.type == MsgType.bad then
+    -- react to bad-news messages
+  end
+end)
+```

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -50,6 +50,7 @@ constexpr auto hook_names = std::array
     "on_npc_do_turn",
     "on_monster_do_turn",
     "on_make_mapgen_factory_list",
+    "on_add_msg",
 };
 
 void define_hooks( lua_state &state )

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -2,6 +2,8 @@
 #include "message_types.h"
 #include "calendar.h"
 #include "catacharset.h"
+#include "catalua_hooks.h"
+#include "catalua_sol.h"
 #include "color.h"
 #include "cursesdef.h"
 #include "debug.h"
@@ -185,6 +187,11 @@ class messages_impl
             if( type == m_debug ) {
                 DebugLog( DL::Info, DC::DebugModeMsg ) << msg;
             }
+
+            cata::run_hooks( "on_add_msg", [&]( sol::table & params ) {
+                params["msg"] = msg;
+                params["type"] = type;
+            } );
 
             game_message m = game_message( std::move( msg ), type );
 


### PR DESCRIPTION
## Summary

Closes #8829.

Adds an `on_add_msg` Lua hook that fires whenever a message is added to the message log. Lets accessibility, alarm, statistics, and similar mods react to in-game events without polling the message stream from Lua.

- Registers `"on_add_msg"` in `cata::hook_names` (src/catalua_hooks.cpp).
- Fires `cata::run_hooks("on_add_msg", ...)` inside `messages_impl::add_msg_string(string&&, type, flags)` after the empty / inactive / non-debug-mode early-exit gates, before cooldown coalescing so duplicate / coalesced messages still trigger the hook (intentional, for accessibility use case).
- Hook params: `msg` (text) and `type` (`MsgType` enum).
- Documents the new hook in `docs/en/mod/lua/hooks.md`.
- Adds `data/mods/Test_on_add_msg_hook/` smoke-test mod (parallel to `Test_for_Lua_hooks`) that logs every message to debug.log.

29 lines for the core change + a small test mod. Follows the existing `cata::run_hooks` convention used by ~14 other hook call sites (`on_character_death`, `on_character_effect_added`, `on_creature_dodged`, etc.).

## Test plan

- [x] Local build: `cataclysm-bn-tiles` and `cata_test-tiles` build clean (RelWithDebInfo, MSVC 14.44, vcpkg x64-windows-static).
- [x] `cata_test-tiles "[lua]"` — all 186 assertions / 26 test cases pass (existing hook plumbing tests `lua_hooks_order_and_chaining` and `lua_hooks_exit_early` still green).
- [x] Runtime smoke test: enabled `Test_on_add_msg_hook` mod, started a new character, **47 `on_add_msg` fires captured** across `m_good`/`m_bad`/`m_warning`/`m_info`/`m_neutral` types.
- [x] CI cross-platform builds (in progress at time of write).

<details>
<summary>Smoke test debug.log output (47 fires)</summary>

```
22:20:33.354 INFO LUA : on_add_msg smoke test: PRELOAD ONLINE
22:20:34.448 INFO LUA : on_add_msg #1   type=1  msg=" gets angry!"
22:20:36.522 INFO LUA : on_add_msg #2   type=1  msg=" gets angry!"
22:20:51.754 INFO LUA : on_add_msg #3   type=4  msg="You have learned a new style: Brawling!"
22:20:51.875 INFO LUA : on_add_msg #4   type=5  msg="You have survived the initial wave of panic, and have achieved (relative) safety in one of the many government evac shelters."
22:21:01.945 INFO LUA : on_add_msg #5   type=5  msg="It takes you a couple seconds to wield your switchblade."
22:21:09.325 INFO LUA : on_add_msg #6   type=5  msg="Cassy Kirk blocks some of the damage with their katana!"
22:21:09.325 INFO LUA : on_add_msg #7   type=5  msg="You quickly strike Cassy Kirk but do no damage."
22:21:09.325 INFO LUA : on_add_msg #8   type=1  msg="Cassy Kirk gets angry!"
22:21:09.936 INFO LUA : on_add_msg #9   type=3  msg="Spotted a survivor--safe mode is on!  (Press ! to turn it off, press ' to ignore monster)"
22:21:13.136 INFO LUA : on_add_msg #10  type=4  msg="Safe mode OFF!"
22:21:14.195 INFO LUA : on_add_msg #11  type=5  msg="Your torso encumbrance throws you off-balance."
22:21:14.195 INFO LUA : on_add_msg #12  type=5  msg="You miss."
22:21:14.232 INFO LUA : on_add_msg #13  type=0  msg="Cassy Kirk quickly strikes you."
22:21:14.270 INFO LUA : on_add_msg #14  type=0  msg="Cassy Kirk quickly strikes you."
22:21:14.271 INFO LUA : on_add_msg #15  type=4  msg="You hear Cassy Kirk saying \"You're going to pay for that, stupidass!\""
22:21:14.271 INFO LUA : on_add_msg #16  type=3  msg="You hear whack!"
22:21:14.271 INFO LUA : on_add_msg #17  type=3  msg="You hear whack!"
22:21:14.997 INFO LUA : on_add_msg #18  type=5  msg="Your pain distracts you!"
22:21:14.997 INFO LUA : on_add_msg #19  type=5  msg="You miss."
...
22:21:20.073 INFO LUA : on_add_msg #37  type=5  msg="You miss."
22:21:20.106 INFO LUA : on_add_msg #38  type=0  msg="Cassy Kirk quickly strikes you."
22:21:20.106 INFO LUA : on_add_msg #39  type=5  msg="Cassy Kirk swings wildly and misses."
22:21:20.107 INFO LUA : on_add_msg #40  type=3  msg="You hear whack!"
22:21:20.888 INFO LUA : on_add_msg #41  type=5  msg="Cassy Kirk blocks some of the damage with their katana!"
22:21:20.888 INFO LUA : on_add_msg #42  type=5  msg="You quickly strike Cassy Kirk but do no damage."
22:21:22.298 INFO LUA : on_add_msg #43  type=0  msg="You quickly strike Cassy Kirk for 11 damage."
22:21:23.358 INFO LUA : on_add_msg #44  type=0  msg="You quickly strike Cassy Kirk for 1 damage."
22:21:23.390 INFO LUA : on_add_msg #45  type=0  msg="Cassy Kirk quickly strikes you."
22:21:23.390 INFO LUA : on_add_msg #46  type=1  msg="Your limb breaks!"
```

`type` integer maps to `game_message_type` enum: `0=m_good`, `1=m_bad`, `2=m_mixed`, `3=m_warning`, `4=m_info`, `5=m_neutral`. Both `msg` and `type` flow through correctly.

</details>

## Notes

- No new C++ unit test for the hook firing site — `tests/fake_messages.cpp` stubs out `Messages::add_msg` to a no-op, so the firing site can't be exercised via the existing test harness without restructuring. The hook plumbing it relies on is already covered, and the smoke-test mod covers end-to-end behavior at runtime.
- `MsgType` enum (sol-exposed `game_message_type` via `reg_enum`) — verified Lua callers use unprefixed names (`MsgType.bad`, not `MsgType.m_bad`) and the doc reflects that.
- Supersedes (closed) draft PR #8992, which had been opened from a different fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ce67d28](https://github.com/cataclysmbn/Cataclysm-BN/commit/ce67d28225a93905df87869bf0f78a68edba807a) (test(lua): re-hide on_add_msg smoke-test mod (post-validation)) on 2026-05-24 14:30:48

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26362701264/artifacts/7185617705)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26362701264/artifacts/7185835713)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26362701264/artifacts/7185598148)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26362701264/artifacts/7185686026)
<!-- END artifact comment -->