### PR TITLE
feat: change Survivalist Jr. to cost 1 point

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -5753,7 +5753,7 @@
     "id": "jr_survivalist",
     "name": "Survivalist Jr.",
     "description": "Your parents were crazy preppers who thought some \"Cataclysm\" was coming, and insisted on preparing you for it.  Turns out they were right.  You didn't get a chance to thank them.  The only thing you can do for them now is what they always hoped you would do in the dark days ahead: survive.",
-    "points": 3,
+    "points": 1,
     "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "fabrication" }, { "level": 1, "name": "firstaid" } ],
     "items": {
       "both": {

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -5753,7 +5753,7 @@
     "id": "jr_survivalist",
     "name": "Survivalist Jr.",
     "description": "Your parents were crazy preppers who thought some \"Cataclysm\" was coming, and insisted on preparing you for it.  Turns out they were right.  You didn't get a chance to thank them.  The only thing you can do for them now is what they always hoped you would do in the dark days ahead: survive.",
-    "points": 1,
+    "points": 3,
     "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "fabrication" }, { "level": 1, "name": "firstaid" } ],
     "items": {
       "both": {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Survivalist Jr. costs 3 points, the same as the normal Survivalist, despite losing out on many skills and a few good pieces of equipment. For over a decade I've thought that this makes it a bad profession that few people would willingly pick. 

## Describe the solution (The How)

Make Survivalist Jr. only cost 1 point. 

My rationale when comparing it to the normal Survivalist:

-Survivalist Jr. loses out on 11 skill levels, and entirely lacks Athletics, Traps, and Cooking. As far as I understand, the main reason for the Survivalist to cost 3 points is due to how good their skills are.
-Survivalist Jr. loses out on a decent melee weapon and tool for sawing, butchering, and fine cutting in the form of a survival knife, replacing them with scissors, which only provide Cutting 1 and are very bad as a weapon. They also lose out on a lighter, long rope, plastic canteen, and scabbard.
-Survivalist Jr. gains a magnifying glass (only useful outdoors during sunlight, and takes a while to use), a resealable plastic bag (which can't be worn, unlike a canteen), 4 units of granola and a half-liter bottle of clean water (won't last for even 12 hours), and a first-aid kit (useful, but not ridiculously so). 

In addition, when comparing Survivalist Jr. to professions that cost 0 or 1 point, we can see that their clothes are only slightly above average (mainly due to wearing cargo pants along with a light jacket), and that the mere presence of a backpack isn't worth too much (as the backpacker costs only 0 points).  

## Describe alternatives you've considered

Repricing them to 2 points instead and/or giving them a pocket knife instead of scissors. 

## Testing

Opened the character creation menu, saw that they cost 1 point now, and that selecting the profession doesn't break anything.

## Additional context

None required

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.