### PR TITLE
fix: guard scent blockers against out-of-cache vehicles

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10255,8 +10255,12 @@ void map::function_over( const tripoint_bub_ms &start, const tripoint_bub_ms &en
 void map::scent_blockers( std::vector<char> &scent_transfer, int st_sy,
                           const point_bub_ms &min, const point_bub_ms &max )
 {
-    auto reduce = TFLAG_REDUCE_SCENT;
-    auto block = TFLAG_NO_SCENT;
+    if( st_sy <= 0 ) {
+        return;
+    }
+    const auto scent_cache_x = static_cast<int>( scent_transfer.size() / static_cast<size_t>( st_sy ) );
+    const auto reduce = TFLAG_REDUCE_SCENT;
+    const auto block = TFLAG_NO_SCENT;
     auto fill_values = [&]( const tripoint_bub_sm & gp, const submap * sm, point_sm_ms lp ) {
         // We need to generate the x/y coordinates, because we can't get them "for free"
         const auto p = project_combine( gp, lp );
@@ -10276,6 +10280,16 @@ void map::scent_blockers( std::vector<char> &scent_transfer, int st_sy,
                    tripoint_bub_ms( max.x(), max.y(), abs_sub.z() ), fill_values );
 
     const inclusive_rectangle<point_bub_ms> local_bounds( min, max );
+    const auto mark_vehicle_obstruction = [&]( const tripoint_bub_ms &part_pos ) {
+        if( !local_bounds.contains( part_pos.xy() ) || part_pos.x() < 0 || part_pos.y() < 0 ||
+            part_pos.x() >= scent_cache_x || part_pos.y() >= st_sy ) {
+            return;
+        }
+        const auto index = static_cast<size_t>( part_pos.x() * st_sy + part_pos.y() );
+        if( scent_transfer[index] == 5 ) {
+            scent_transfer[index] = 1;
+        }
+    };
 
     // Now vehicles
 
@@ -10283,23 +10297,13 @@ void map::scent_blockers( std::vector<char> &scent_transfer, int st_sy,
     for( auto &wrapped_veh : vehs ) {
         vehicle &veh = *( wrapped_veh.v );
         for( const vpart_reference &vp : veh.get_any_parts( VPFLAG_OBSTACLE ) ) {
-            const tripoint_bub_ms part_pos = vp.pos();
-            if( local_bounds.contains( part_pos.xy() ) &&
-                scent_transfer[part_pos.x() * st_sy + part_pos.y()] == 5 ) {
-                scent_transfer[part_pos.x() * st_sy + part_pos.y()] = 1;
-            }
+            mark_vehicle_obstruction( vp.pos() );
         }
 
         // Doors, but only the closed ones
         for( const vpart_reference &vp : veh.get_any_parts( VPFLAG_OPENABLE ) ) {
-            if( vp.part().open ) {
-                continue;
-            }
-
-            const tripoint_bub_ms part_pos = vp.pos();
-            if( local_bounds.contains( part_pos.xy() ) &&
-                scent_transfer[part_pos.x() * st_sy + part_pos.y()] == 5 ) {
-                scent_transfer[part_pos.x() * st_sy + part_pos.y()] = 1;
+            if( !vp.part().open ) {
+                mark_vehicle_obstruction( vp.pos() );
             }
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10280,7 +10280,7 @@ void map::scent_blockers( std::vector<char> &scent_transfer, int st_sy,
                    tripoint_bub_ms( max.x(), max.y(), abs_sub.z() ), fill_values );
 
     const inclusive_rectangle<point_bub_ms> local_bounds( min, max );
-    const auto mark_vehicle_obstruction = [&]( const tripoint_bub_ms &part_pos ) {
+    const auto mark_vehicle_obstruction = [&]( const tripoint_bub_ms & part_pos ) {
         if( !local_bounds.contains( part_pos.xy() ) || part_pos.x() < 0 || part_pos.y() < 0 ||
             part_pos.x() >= scent_cache_x || part_pos.y() >= st_sy ) {
             return;

--- a/tests/scent_test.cpp
+++ b/tests/scent_test.cpp
@@ -5,6 +5,8 @@
 #include "map_helpers.h"
 #include "game.h"
 #include "state_helpers.h"
+#include "vehicle.h"
+#include "veh_type.h"
 
 void old_scent_map_update( const tripoint_bub_ms &center, map &m,
                            std::array<std::array<int, MAPSIZE_Y>, MAPSIZE_X> &grscent );
@@ -121,6 +123,23 @@ void old_scent_map_update( const tripoint_bub_ms &center, map &m,
             }
         }
     }
+}
+
+TEST_CASE( "scent_blockers_ignore_vehicle_parts_outside_cache", "[scent]" )
+{
+    clear_all_state();
+
+    auto &here = get_map();
+    auto *const veh = here.add_vehicle( vproto_id( "none" ), tripoint_bub_ms::zero(), 0_degrees, 0,
+                                        0 );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( tripoint_mnt_veh( -1, 0, 0 ), vpart_id( "windshield" ), true ) >= 0 );
+    REQUIRE( veh->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "windshield" ), true ) >= 0 );
+
+    auto scent_transfer = std::vector<char>( MAPSIZE_X * MAPSIZE_Y, 5 );
+    here.scent_blockers( scent_transfer, MAPSIZE_Y, point_bub_ms( -5, -5 ), point_bub_ms( 5, 5 ) );
+
+    CHECK( scent_transfer[MAPSIZE_Y] == 1 );
 }
 
 TEST_CASE( "scent_matches_old", "[.]" )


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #8991.
Related: #8252

## Describe the solution (The How)

Guard vehicle scent obstruction updates against positions outside the scent cache before indexing `scent_transfer`.

## Describe alternatives you've considered

Leaving the terrain scan clamp alone and only checking vehicle positions, because the crash was in vehicle part handling.

## Testing

- `cmake --preset linux-full`
- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "scent_blockers_ignore_vehicle_parts_outside_cache"`
- `./out/build/linux-full/tests/cata_test-tiles "[scent]"`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`

## Additional context

The crash dump points at `map::scent_blockers` while processing vehicle parts near the scent cache edge.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [09e9f5f](https://github.com/cataclysmbn/Cataclysm-BN/commit/09e9f5f93001b397e3ac094daa394cabba3b42e2) (style: format scent blocker lambda) on 2026-05-22 03:38:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26265306691/artifacts/7151783075)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26265306691/artifacts/7152190378)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26265306691/artifacts/7151765860)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26265306691/artifacts/7151893667)
<!-- END artifact comment -->