### PR TITLE
fix: prevent the player from being able to persaude infinite microcentrifuges from the scavenger

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_scavenger_docmission.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_scavenger_docmission.json
@@ -21,11 +21,9 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_SCIENCE_REP_1" },
-            {
-              "not": { "npc_has_var": "micro_got", "type": "mission", "context": "docmission_1", "value": "yes" }
-            }
+            { "not": { "npc_has_var": "micro_got", "type": "mission", "context": "docmission_1", "value": "yes" } }
           ]
-        },
+        }
       },
       {
         "text": "Care to trade?",
@@ -91,22 +89,14 @@
     "id": [ "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_SUCCESS" ],
     "type": "talk_topic",
     "dynamic_line": "Wow, could it really do that?  Ok, please take it, and make sure to mention me when you save the world!",
-    "speaker_effect": {
-      "effect": [
-        { "npc_add_var": "micro_got", "type": "mission", "context": "docmission_1", "value": "yes" }
-      ]
-    },
+    "speaker_effect": { "effect": [ { "npc_add_var": "micro_got", "type": "mission", "context": "docmission_1", "value": "yes" } ] },
     "responses": [ { "text": "Yeah, I'll make sure to do that.", "topic": "TALK_DONE" } ]
   },
   {
     "id": [ "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_SUCCESS" ],
     "type": "talk_topic",
     "dynamic_line": "O-ok no need to get violent, just take it!",
-    "speaker_effect": {
-      "effect": [
-        { "npc_add_var": "micro_got", "type": "mission", "context": "docmission_1", "value": "yes" }
-      ]
-    },
+    "speaker_effect": { "effect": [ { "npc_add_var": "micro_got", "type": "mission", "context": "docmission_1", "value": "yes" } ] },
     "responses": [ { "text": "Good.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/refugee_center/surface_staff/NPC_scavenger_docmission.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_scavenger_docmission.json
@@ -18,7 +18,14 @@
       {
         "text": "What are you doing?",
         "topic": "TALK_DESCRIBE_SUPPLYDROP",
-        "condition": { "u_has_mission": "MISSION_SCIENCE_REP_1" }
+        "condition": {
+          "and": [
+            { "u_has_mission": "MISSION_SCIENCE_REP_1" },
+            {
+              "not": { "npc_has_var": "micro_got", "type": "mission", "context": "docmission_1", "value": "yes" }
+            }
+          ]
+        },
       },
       {
         "text": "Care to trade?",
@@ -84,12 +91,22 @@
     "id": [ "TALK_DESCRIBE_SUPPLYDROP_PERSUADE_SUCCESS" ],
     "type": "talk_topic",
     "dynamic_line": "Wow, could it really do that?  Ok, please take it, and make sure to mention me when you save the world!",
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "micro_got", "type": "mission", "context": "docmission_1", "value": "yes" }
+      ]
+    },
     "responses": [ { "text": "Yeah, I'll make sure to do that.", "topic": "TALK_DONE" } ]
   },
   {
     "id": [ "TALK_DESCRIBE_SUPPLYDROP_INTIMIDATE_SUCCESS" ],
     "type": "talk_topic",
     "dynamic_line": "O-ok no need to get violent, just take it!",
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "micro_got", "type": "mission", "context": "docmission_1", "value": "yes" }
+      ]
+    },
     "responses": [ { "text": "Good.", "topic": "TALK_DONE" } ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
You could infinitely persuade or intimidate the scavenger from the doctor mission for microcentrifuges
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds a variable that gets added to the npc after you successfully persuade or intimidate him to prevent this.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Debug did the quest, everything seems good.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [98e5833](https://github.com/cataclysmbn/Cataclysm-BN/commit/98e5833ab229333f3a2aa60412dc3fe62b930869) (style(autofix.ci): automated formatting) on 2026-05-22 04:11:48

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26266361973/artifacts/7152183501)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26266361973/artifacts/7152520743)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26266361973/artifacts/7152128400)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26266361973/artifacts/7152291730)
<!-- END artifact comment -->