### PR TITLE
fix: armor_portion_data now overwrites on copy-from

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2016,35 +2016,8 @@ void Item_factory::load( islot_armor &slot, const JsonObject &jo, const std::str
     assign( jo, "valid_mods", slot.valid_mods, strict );
 
     if( jo.has_array( "armor_portion_data" ) ) {
-        bool dont_add_first = false;
-        if( !slot.data.empty() ) { // Uses copy-from
-            dont_add_first = true;
-            const JsonObject &obj = *jo.get_array( "armor_portion_data" ).begin();
-
-            if( obj.has_array( "encumbrance" ) ) {
-                slot.data[0].encumber = obj.get_array( "encumbrance" ).get_int( 0 );
-                slot.data[0].max_encumber = obj.get_array( "encumbrance" ).get_int( 1 );
-            } else if( obj.has_int( "encumbrance" ) ) {
-                slot.data[0].encumber = obj.get_int( "encumbrance" );
-                slot.data[0].max_encumber = slot.data[0].encumber;
-            }
-            if( obj.has_int( "coverage" ) ) {
-                slot.data[0].coverage = obj.get_int( "coverage" );
-            }
-            body_part_set temp_cover_data;
-            assign_coverage_from_json( obj, "covers", temp_cover_data, slot.sided );
-            if( temp_cover_data.any() ) {
-                slot.data[0].covers = temp_cover_data;
-            }
-        }
-
+        slot.data.clear();
         for( const JsonObject &obj : jo.get_array( "armor_portion_data" ) ) {
-            // If this item used copy-from, data[0] is already set, so skip adding first data
-            if( dont_add_first ) {
-                obj.allow_omitted_members();
-                dont_add_first = false;
-                continue;
-            }
             armor_portion_data tempData;
             body_part_set temp_cover_data;
             assign_coverage_from_json( obj, "covers", temp_cover_data, slot.sided );


### PR DESCRIPTION
## Purpose of change (The Why)
MY CRIT GLOVES WONT WORK

## Describe the solution (The How)
Make em work

## Describe alternatives you've considered
Screm
Screm
More screm

## Testing
[em_armor.json](https://github.com/user-attachments/files/28134459/em_armor.json)
It load now

## Additional context
NEED MORE FIXES

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [db7ea07](https://github.com/cataclysmbn/Cataclysm-BN/commit/db7ea07d6e955c8a4cf64ff44451066231c9f8af) (fix: armor_portion_data now overwrites on copy-from) on 2026-05-22 05:59:00

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26269409216/artifacts/7153236433)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26269409216/artifacts/7153628707)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26269409216/artifacts/7153455185)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26269409216/artifacts/7153337562)
<!-- END artifact comment -->