### PR TITLE
fix: allow directory rename during save conversion

### DIFF
--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -600,7 +600,7 @@ void ofstream_wrapper::close()
         remove_file( temp_path );
         throw std::runtime_error( "writing to file failed" );
     }
-    if( !rename_file( temp_path, path ) ) {
+    if( !rename_path( temp_path, path ) ) {
         // Leave the temp path, so the user can move it if possible.
         throw std::runtime_error( "moving temporary file \"" + temp_path.generic_string() + "\" failed" );
     }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -735,7 +735,7 @@ void DebugFile::init( DebugOutput output_mode, const std::string &filename )
             if( stat( filename.c_str(), &buffer ) == 0 ) {
                 // Continue with the old log file if it's smaller than 1 MiB
                 if( buffer.st_size >= 1024 * 1024 ) {
-                    rename_failed = !rename_file( filename, oldfile );
+                    rename_failed = !rename_path( filename, oldfile );
                 }
             }
             file = std::make_shared<std::ofstream>(

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -158,18 +158,12 @@ auto remove_file( const fs::path &path ) -> bool
     return fs::remove( path, ec ) && !ec;
 }
 
-auto rename_file( const fs::path &old_path, const fs::path &new_path ) -> bool
+auto rename_path( const fs::path &old_path, const fs::path &new_path ) -> bool
 {
-    if( !file_exist( old_path ) || dir_exist( new_path ) ) {
+    if( dir_exist( new_path ) ) {
         return false;
     }
     auto ec = std::error_code{};
-    if( file_exist( new_path ) ) {
-        fs::remove( new_path, ec );
-        if( ec ) {
-            return false;
-        }
-    }
     fs::rename( old_path, new_path, ec );
     return !ec;
 }

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -38,10 +38,10 @@ auto remove_directory( const fs::path &path ) -> bool;
  */
 auto remove_tree( const fs::path &path ) -> bool;
 /**
- * Rename a file, overwriting the target. Does not overwrite directories.
+ * Rename a file or directory, overwriting existing files. Does not overwrite directories.
  * @return true on success, false on failure.
  */
-auto rename_file( const fs::path &old_path, const fs::path &new_path ) -> bool;
+auto rename_path( const fs::path &old_path, const fs::path &new_path ) -> bool;
 /**
  * Check if can write to the given directory (write permission, disk space).
  * @return false if cannot write or if unable to check.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3068,7 +3068,7 @@ void game::move_save_to_graveyard( const std::string &dirname )
     for( const auto &src_path : save_files ) {
         const auto dst_path = graveyard_save_dir / src_path.filename();
 
-        if( rename_file( src_path, dst_path ) ) {
+        if( rename_path( src_path, dst_path ) ) {
             continue;
         }
 

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -227,7 +227,7 @@ void worldfactory::init()
             const auto origin_path = old_world.folder_path();
             // move files from origin_path into new world path
             for( const auto &origin_file : get_files_from_path( ".", origin_path, false ) ) {
-                rename_file( origin_file, newworld->folder_path() / origin_file.filename() );
+                rename_path( origin_file, newworld->folder_path() / origin_file.filename() );
             }
             newworld->world_saves = old_world.world_saves;
             newworld->WORLD_OPTIONS = old_world.WORLD_OPTIONS;
@@ -1621,7 +1621,10 @@ void worldfactory::convert_to_v2( const std::string &worldname )
     old_world->world_saves = worldinfo->world_saves;
 
     // Rename the world folder perform the move
-    rename_file( worldinfo->folder_path(), old_world->folder_path() );
+    if( !rename_path( worldinfo->folder_path(), old_world->folder_path() ) ) {
+        popup( _( "Failed to create backup world '%s', aborting conversion" ), backup_name );
+        return;
+    }
     worldinfo->world_save_format = save_format::V2_COMPRESSED_SQLITE3;
     world new_world( worldinfo );
     new_world.convert_from_v1( old_world );

--- a/tests/filesystem_test.cpp
+++ b/tests/filesystem_test.cpp
@@ -43,12 +43,14 @@ static void filesystem_test_group( int serial, const std::string &s1, const std:
     const auto file1_1 = dir1 / ( s2 + ".json" );
     const auto file1_2 = dir1 / ( s3 + ".json" );
     const auto dir2 = dir1 / s3;
+    const auto dir3 = base / ( s3 + "_renamed" );
     const auto file2_1 = dir2 / ( s2 + ".json" );
 
     CAPTURE( dir1 );
     CAPTURE( file1_1 );
     CAPTURE( file1_2 );
     CAPTURE( dir2 );
+    CAPTURE( dir3 );
     CAPTURE( file2_1 );
 
     std::string writebuf = s3;
@@ -81,14 +83,22 @@ static void filesystem_test_group( int serial, const std::string &s1, const std:
     REQUIRE( file_exist( file1_1 ) );
     REQUIRE( read_from_file( file1_1, reader ) );
     CHECK( readbuf == writebuf );
-    REQUIRE( rename_file( file1_1, file1_2 ) );
-    REQUIRE( !rename_file( file1_1, file1_2 ) );
+    REQUIRE( rename_path( file1_1, file1_2 ) );
+    REQUIRE( !rename_path( file1_1, file1_2 ) );
     REQUIRE( file_exist( file1_2 ) );
-    REQUIRE( !rename_file( file1_2, dir1 ) );
+    REQUIRE( !rename_path( file1_2, dir1 ) );
     REQUIRE( file_exist( file1_2 ) );
     REQUIRE( !dir_exist( file1_2 ) );
     REQUIRE( remove_file( file1_2 ) );
     REQUIRE( !remove_file( file1_2 ) );
+
+    // Renaming directories
+    REQUIRE( rename_path( dir1, dir3 ) );
+    REQUIRE( !dir_exist( dir1 ) );
+    REQUIRE( dir_exist( dir3 ) );
+    REQUIRE( !rename_path( dir3, base ) );
+    REQUIRE( remove_directory( dir3 ) );
+    REQUIRE( assure_dir_exist( dir1 ) );
 
     // Copying file
     REQUIRE( write_to_file( file1_1, writer, nullptr ) );


### PR DESCRIPTION
## Purpose of change (The Why)

V1 to V2 save conversion renames the world directory to create a backup. The old filesystem helper only accepted regular files, so directory backup creation failed.

Related: #8951

## Describe the solution (The How)

Rename the helper to `rename_path`, delegate to `std::filesystem::rename`, and handle backup rename failure before conversion proceeds.

## Describe alternatives you've considered

Using `std::filesystem::rename` directly at each call site would work, but keeping a bool-returning helper preserves existing call-site behavior.

## Testing

- `/usr/bin/astyle --options=.astylerc -n src/cata_utility.cpp src/debug.cpp src/filesystem.cpp src/filesystem.h src/game.cpp src/worldfactory.cpp tests/filesystem_test.cpp`
- `cmake --build --preset linux-full --target cata_test-tiles cataclysm-bn-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[filesystem]"`

## Additional context

None.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f8d935e](https://github.com/cataclysmbn/Cataclysm-BN/commit/f8d935e83f3a95dd0a80bd07f1b48b7962de4fd4) (fix: allow directory rename during save conversion) on 2026-05-22 07:27:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26272212913/artifacts/7154976428)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26272212913/artifacts/7154879232)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26272212913/artifacts/7154515232)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26272212913/artifacts/7154487885)
<!-- END artifact comment -->