### PR TITLE
fix(mods/rpg_system): correct Natural Healer healing values

### DIFF
--- a/data/mods/rpg_system/traits.json
+++ b/data/mods/rpg_system/traits.json
@@ -258,8 +258,8 @@
     "valid": false,
     "purifiable": false,
     "player_display": true,
-    "healing_awake": 1.5,
-    "healing_resting": 2.0
+    "healing_awake": 0.5,
+    "healing_resting": 1.0
   },
   {
     "type": "mutation",


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #7506.

The RPG System's `[Natural Healer]` trait advertises *"+50% HP regen while awake, +100% HP regen while resting"*, but its JSON sets `healing_awake: 1.5` and `healing_resting: 2.0`.

Vanilla mutations use a fractional convention for these fields — the number is the bonus, not the absolute multiplier. For reference, in `data/json/mutations/mutations.json`:

| Trait | `healing_awake` | `healing_resting` | Description |
|---|---|---|---|
| `FASTHEALER` | `0.2` | `0.5` | "20% faster whilst awake, 50% faster whilst asleep" |
| `FASTHEALER2` | `0.66` | `0.5` | — |
| `REGEN` | `2.0` | `1.5` | "200% faster awake, 150% faster asleep" |

So `Natural Healer`'s current `1.5` / `2.0` actually deliver **+150% / +200%** — three to four times what the description promises.

## Describe the solution (The How)

Two-value JSON change:

```diff
-    "healing_awake": 1.5,
-    "healing_resting": 2.0
+    "healing_awake": 0.5,
+    "healing_resting": 1.0
```

This restores the trait to the magnitude its own description advertises.

### Why the original symptom is so dramatic

The reporter's *"single bar to full health overnight"* combo (Imperceptive Healer + Natural Healer) is the worst case. `Character::calc_mutation_value` ([character.cpp:7510-7522](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/src/character.cpp#L7510-L7522)) sums the lowest negative with the highest positive:

| Stack | Before fix | After fix |
|---|---|---|
| Imperceptive Healer alone (`-0.9`) | `1.0 + (-0.9)` = `0.1×` rate | unchanged |
| + Natural Healer (was `2.0`, now `1.0`) | `1.0 + (-0.9 + 2.0)` = `2.1×` rate | `1.0 + (-0.9 + 1.0)` = `1.1×` rate |

A `2.1×` rate while sleeping with the worst healing debuff in the game is the source of the bug report.

## Describe alternatives you've considered

- **Rewrite the trait description to match the existing values** — rejected; vanilla traits all use the fractional convention, so the JSON values are the outlier, not the description.
- **Change `Character::calc_mutation_value` to sum positives instead of max-of-positives** — out of scope; that's by-design engine behavior used by many other mutations. The reporter's secondary observation (*"with fast healer char + natural healer, be disappointed"*) is caused by this max-of-positives rule, not by `Natural Healer`'s values. Per-trait tuning is the cheaper fix.

## Testing

### Static verification

- Diff is exactly two value changes, no schema or structural changes.
- No game rebuild needed — JSON-only, loaded at world creation.
- `Character::calc_mutation_value` arithmetic verified by inspection at [character.cpp:7510-7522](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/src/character.cpp#L7510-L7522), and the healing formulas at [character.cpp:7611-7625](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/src/character.cpp#L7611-L7625).
- Compared against all `healing_awake` / `healing_resting` usages across `data/json/mutations/mutations.json` to confirm the fractional convention.

### Runtime smoke test

Built a tiny throwaway mod (`Test_natural_healer_smoke`, not committed) that hooks `on_character_reset_stats` and logs the avatar's `get_hp()`, `has_effect("sleep")`, and active healing traits whenever HP or sleep state changes:

<details>
<summary>Smoke-test mod source</summary>

`modinfo.json`:

```json
[{
  "type": "MOD_INFO",
  "id": "test_natural_healer_smoke",
  "name": "Natural Healer Smoke Test",
  "category": "content",
  "lua_api_version": 2,
  "dependencies": [ "bn", "rpg_system" ]
}]
```

`preload.lua`:

```lua
local mod = game.mod_runtime[game.current_mod]
mod.last_hp = nil ; mod.last_sleeping = nil ; mod.tick = 0
local sleep_id = EffectTypeId.new("sleep")
local nh_id   = MutationBranchId.new("RPG_TRAIT_NATURAL_HEALER")
local imp_id  = MutationBranchId.new("SLOWHEALER3")

game.add_hook("on_character_reset_stats", function(params)
  local ch = params.character
  if not ch:is_avatar() then return end
  mod.tick = mod.tick + 1
  local hp = ch:get_hp()
  local sleeping = ch:has_effect(sleep_id)
  if hp ~= mod.last_hp or sleeping ~= mod.last_sleeping then
    local traits = {}
    if ch:has_trait(nh_id) then table.insert(traits, "NaturalHealer") end
    if ch:has_trait(imp_id) then table.insert(traits, "ImperceptiveHealer") end
    gdebug.log_info(string.format("nh_smoke #%d  hp=%d  sleeping=%s  traits=[%s]",
      mod.tick, hp, tostring(sleeping), table.concat(traits, " ")))
    mod.last_hp = hp ; mod.last_sleeping = sleeping
  end
end)
```

</details>

#### Run 1 — Natural Healer alone

Damaged a 900-HP character down to 240 HP, then slept.

```
nh_smoke #1     hp=900  sleeping=false  traits=[]                  -- world spawn
nh_smoke #2     hp=240  sleeping=false  traits=[NaturalHealer]     -- damaged
nh_smoke #1503  hp=246  sleeping=false  traits=[NaturalHealer]     +6 awake
nh_smoke #4503  hp=252  sleeping=false  traits=[NaturalHealer]     +6 awake
... (8 awake +6 ticks)
nh_smoke #52203 hp=282  sleeping=false  traits=[NaturalHealer]     -- end awake
nh_smoke #52318 hp=282  sleeping=true   traits=[NaturalHealer]     -- sleep starts
nh_smoke #53703 hp=288  sleeping=true   traits=[NaturalHealer]     +6 sleep
... (13 sleep +6 ticks)
nh_smoke #73503 hp=366  sleeping=true   traits=[NaturalHealer]     -- end sleep
nh_smoke #74703 hp=366  sleeping=false  traits=[NaturalHealer]     -- woke up
```

- Awake: +42 HP over ~50k ticks → rate ≈ `0.00084 HP/tick`
- Sleep: +84 HP over ~21k ticks → rate ≈ `0.00400 HP/tick`
- Sleep/awake ratio: **~4.76×** (formula prediction: `(1+1.0)/0.5 = 4×`)

#### Run 2 — Imperceptive Healer + Natural Healer (worst-case bug report combo)

Damaged a 1116-HP character down to 240 HP with both traits active, then slept.

```
nh_smoke #1     hp=1116 sleeping=false  traits=[]                                            -- spawn
nh_smoke #22    hp=240  sleeping=false  traits=[NaturalHealer ImperceptiveHealer]            -- damaged
nh_smoke #7803  hp=246  sleeping=false  traits=[NaturalHealer ImperceptiveHealer]            +6 awake
nh_smoke #21003 hp=252  sleeping=false  traits=[NaturalHealer ImperceptiveHealer]            +6 awake
... (5 awake +6 ticks)
nh_smoke #52803 hp=270  sleeping=false  traits=[NaturalHealer ImperceptiveHealer]            -- end awake
nh_smoke #54024 hp=270  sleeping=true   traits=[NaturalHealer ImperceptiveHealer]            -- sleep starts
nh_smoke #57003 hp=276  sleeping=true   traits=[NaturalHealer ImperceptiveHealer]            +6 sleep
... (7 sleep +6 ticks)
nh_smoke #74403 hp=312  sleeping=true   traits=[NaturalHealer ImperceptiveHealer]            -- end sleep
nh_smoke #77403 hp=312  sleeping=false  traits=[NaturalHealer ImperceptiveHealer]            -- woke up
```

- **HP recovered during sleep: 42 HP out of 876 lost = 4.8% of damage** — definitively NOT "single bar to full overnight"
- Sleep rate ≈ `0.00206 HP/tick` (Run 1 NH-alone sleep rate: `0.00400 HP/tick`)
- **Run 2 / Run 1 sleep ratio: 0.51×** — within sample noise of the formula prediction `1.1/2.0 = 0.55×`

The empirical 0.51× ratio confirms `mutation_value("healing_resting")` for the combo evaluates to `(-0.9) + 1.0 = 0.1` (giving sleep multiplier `1.1×`), exactly as predicted by `calc_mutation_value`'s min-of-negatives + max-of-positives rule.

### Reviewer suggestions

- A reviewer with RPG System experience may want to tune the awake/resting split. The values chosen (`0.5` / `1.0`) match the description verbatim; if balance demands something different, both are easy single-number tweaks.

## Additional context

This PR used AI assistance (`Assisted-by: Claude Opus 4.7 (1M context)`).

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter. *(JSON unchanged by formatter — diff verified.)*
- [x] I linked the relevant issue using `Closes #7506` in the Purpose section.

### Optional

- [x] This PR used AI assistance.
  - [x] Disclosed in the PR description and `Assisted-by:` trailer is on the commit.
