### PR TITLE
docs(port): add requirements list documentation

### DIFF
--- a/docs/en/mod/json/reference/json_info.md
+++ b/docs/en/mod/json/reference/json_info.md
@@ -622,6 +622,95 @@ an `"anything"` constraint on it. For example:
 This is a simple "survive a day" but is triggered by waking up, so it will be completed when you
 wake up for the first time after 24 hours into the game.
 
+### `requirements`
+
+The requirements system in Cataclysm defines reusable sets of components, tools, and qualities needed for crafting, construction, and other game mechanics. Requirements are defined in JSON format and located in `data/json/requirements/`.
+
+## JSON Structure
+
+### Basic Format
+
+```json
+{
+  "id": "unique_id",
+  "type": "requirement",
+  "//": "Optional comment",
+  "components": [
+    [
+      ["gasoline", 1],
+      ["diesel", 1],
+      ["biodiesel", 1]
+    ]
+  ],
+  "tools": [
+    [
+      ["soldering_iron", 1],
+      ["soldering_ethanol", 10],
+      ["toolset", 1]
+    ]
+  ],
+  "qualities": [
+    { "id": "CUT", "level": 1 },
+    { "id": "HAMMER", "level": 2 }
+  ]
+}
+```
+
+#### Format
+
+Any of the three last arrays is optional, as long as one of them is present (a requirement must depend on _something_ after all!)
+
+**Components** are organized as nested arrays representing alternatives and requirements:
+
+```json
+"components": [
+  [ /* Group 1: ONE of these required */ ],
+  [ /* Group 2: ONE of these required */ ]
+]
+```
+
+- `[ "item_id", quantity ]` - Specific item
+- `[ "item_id", quantity, "LIST" ]` - References another requirement definition
+
+**Tools** specify items that are used but not consumed, along with charge costs:
+
+```json
+"tools": [
+  [
+    [ "tool_id", charges ],
+    [ "alternative", charges, "LIST" ]
+  ]
+]
+```
+
+`charges` can be a positive integer, in which case it references the number of charges consumed, or `-1` to signify that no charges are used.
+
+**Qualities** specify minimum tool quality levels needed:
+
+````json
+"qualities": [
+  { "id": "QUALITY_ID", "level": min_level }
+]
+
+#### Usage in Recipes
+
+Here is an example of a requirement in a recipe:
+
+```json
+"using": [ [ "requirement_id", multiplier ] ]
+````
+
+Multiple requirements:
+
+```json
+"using": [
+  [ "welding_standard", 1 ],
+  [ "forging_standard", 2 ]
+]
+```
+
+You can explore the files in the `/data/json/requirements` folder to see common examples of requirements for certain types of items or components. Make sure that your requirements do not form any circular dependencies.
+
 ### Skills
 
 ```json


### PR DESCRIPTION
## Purpose of change (The Why)

close #3785

Port of https://github.com/swe-productivity/Cataclysm-BN/pull/11.
Related: https://github.com/cataclysmbn/Cataclysm-BN/issues/3785

## Describe the solution (The How)

Adds requirement JSON documentation, including `"type": "requirement"` and `"LIST"` examples.

## Testing

- [x] `deno fmt --check docs/en/mod/json/reference/json_info.md`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [x] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [x] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [x] I have linked the URL of original PR(s) in the description.

<sub>PR opened by gpt-5.5 high on pi</sub>

