### PR TITLE
fix(port): insert meat into smoker with hammerspace enabled

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1632,17 +1632,25 @@ std::vector<detached_ptr<item>> Character::consume_items( map &m,
 {
     std::vector<detached_ptr<item>> ret;
 
-    if( has_trait( trait_DEBUG_HS ) ) {
-        return ret;
-    }
-
     item_comp selected_comp = is.comp;
 
-    const tripoint_bub_ms &loc = origin;
     const bool by_charges = item::count_by_charges( selected_comp.type ) && selected_comp.count > 0;
     // Count given to use_amount/use_charges, changed by those functions!
     int real_count = ( selected_comp.count > 0 ) ? selected_comp.count * batch : std::abs(
                          selected_comp.count );
+
+    if( has_trait( trait_DEBUG_HS ) ) {
+        if( by_charges ) {
+            ret.push_back( item::spawn( selected_comp.type, calendar::start_of_cataclysm, real_count ) );
+        } else {
+            for( auto i = 0; i < real_count; i++ ) {
+                ret.push_back( item::spawn( selected_comp.type ) );
+            }
+        }
+        return ret;
+    }
+
+    const tripoint_bub_ms &loc = origin;
     // First try to get everything from the map, than (remaining amount) from player
     if( is.use_from & usage_from::map ) {
         if( by_charges ) {


### PR DESCRIPTION
## Purpose of change (The Why)

close #7614

Port of https://github.com/swe-productivity/Cataclysm-BN/pull/13.
Related: https://github.com/cataclysmbn/Cataclysm-BN/issues/7614

## Describe the solution (The How)

Makes debug hammerspace return the selected item or charge component instead of an empty consumed-item list.

## Testing

- [x] `cmake --fresh --preset lint`
- [x] `cmake --build build --target format`
- [x] `git show --check --oneline HEAD`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [x] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [x] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [x] I have linked the URL of original PR(s) in the description.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7cc78f3](https://github.com/cataclysmbn/Cataclysm-BN/commit/7cc78f34d9975ea44d03ed53454811ca6b2882a9) (fix(port): insert meat into smoker with hammerspace enabled) on 2026-05-22 13:50:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26284894740/artifacts/7159511866)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26284894740/artifacts/7160104589)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26284894740/artifacts/7159408632)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26284894740/artifacts/7159692216)
<!-- END artifact comment -->