### PR TITLE
feat(lua): bind monster::make_pet()

### DIFF
--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -360,6 +360,7 @@ void cata::detail::reg_monster( sol::state &lua )
 
         SET_FX_T( make_fungus, bool() );
         SET_FX_T( make_friendly, void() );
+        SET_FX_T( make_pet, void() );
 
         SET_FX_T( make_ally, void( const monster & ) );
 


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #7880.

`monster::make_pet()` already exists in C++ and is used by several existing systems (pet-food iuse at `iuse.cpp:1565`, deploy-pet iuse_actor at `iuse_actor.cpp:1329`, dimension/zlave handling at `game.cpp:6301`, monexamine at `monexamine.cpp:490`), but isn't exposed to Lua. The neighbouring `make_friendly` and `make_ally` are already bound — this just adds the third sibling.

Reporter (jeremy7986) wants this so Lua mods can convert a hostile monster into a player pet for follow-on interactions (riding, naming, examining, etc.) without going through item or NPC-dialogue plumbing.

## Describe the solution (The How)

One-line binding addition in `src/catalua_bindings_creature.cpp`, immediately after the existing `make_friendly` binding:

```diff
         SET_FX_T( make_fungus, bool() );
         SET_FX_T( make_friendly, void() );
+        SET_FX_T( make_pet, void() );

         SET_FX_T( make_ally, void( const monster & ) );
```

C++ side reference (no change here, just for context):

- `monster::make_pet()` at [monster.cpp:3523-3528](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/src/monster.cpp#L3523-L3528) sets `friendly = -1` and `add_effect( effect_pet, 1_turns )`.
- The `pet` effect_type at [data/json/effects.json:195-201](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/data/json/effects.json#L195-L201) is declared `"permanent": true`, so the `1_turns` duration is effectively permanent once applied.
- `monster::attitude()` at [monster.cpp:1528-1545](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/src/monster.cpp#L1528-L1545) returns `MATT_FRIEND` toward the player whenever `friendly != 0`.
- `monster::is_pet()` at [monster.cpp:3530-3533](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/src/monster.cpp#L3530-L3533) is `friendly == -1 && has_effect( effect_pet )`, both of which `make_pet()` establishes.

## Describe alternatives you've considered

- **Also exposing `is_pet()` / `make_ally` overloads** — rejected for now; the issue specifically asks for `make_pet`. Per the "minimal changes" principle, follow-up PRs can add neighbouring accessors as concrete need arises.

## Testing

### Static verification

- Local incremental build with `windows-tiles-sounds-x64-msvc` preset, `RelWithDebInfo` config: **exit code 0**, no new warnings beyond the existing `LIBCMTD` linker note.
- No header changes required; the bound method signature `void monster::make_pet()` matches the macro's `SET_FX_T( make_pet, void() )` form.

### Runtime smoke test

Built a throwaway mod (`Test_make_pet_smoke`, not committed) that hooks `on_monster_spawn` and `pcall`s `monster:make_pet()` on the first 5 monsters spawned, logging `friendly` before/after and the call status:

<details>
<summary>Smoke-test mod source</summary>

`modinfo.json`:

```json
[{
  "type": "MOD_INFO",
  "id": "test_make_pet_smoke",
  "name": "make_pet Lua-binding Smoke Test",
  "category": "content",
  "lua_api_version": 2,
  "dependencies": [ "bn" ]
}]
```

`preload.lua`:

```lua
gdebug.log_info("make_pet_smoke: PRELOAD ONLINE")
local mod = game.mod_runtime[game.current_mod]
mod.count = 0
mod.max_pets = 5
game.add_hook("on_monster_spawn", function(params)
  if mod.count >= mod.max_pets then return end
  local mon = params.monster
  if not mon then return end
  mod.count = mod.count + 1
  local mon_type = tostring(mon:get_type())
  local before = mon.friendly
  local ok, err = pcall(function() mon:make_pet() end)
  gdebug.log_info(string.format(
    "make_pet_smoke #%d  monster=%s  friendly_before=%d  friendly_after=%d  ok=%s  err=%s",
    mod.count, mon_type, before, mon.friendly, tostring(ok), tostring(err)
  ))
end)
```

</details>

Log capture from one session (5/5 successful):

```
make_pet_smoke: PRELOAD ONLINE
make_pet_smoke #1  monster=MonsterTypeId[mon_squirrel_red]  friendly_before=0  friendly_after=-1  ok=true  err=nil
make_pet_smoke #2  monster=MonsterTypeId[mon_squirrel_red]  friendly_before=0  friendly_after=-1  ok=true  err=nil
make_pet_smoke #3  monster=MonsterTypeId[mon_fox_red]      friendly_before=0  friendly_after=-1  ok=true  err=nil
make_pet_smoke #4  monster=MonsterTypeId[mon_squirrel]     friendly_before=0  friendly_after=-1  ok=true  err=nil
make_pet_smoke #5  monster=MonsterTypeId[mon_squirrel]     friendly_before=0  friendly_after=-1  ok=true  err=nil
```

Confirms:

- 5 of 5 `pcall(mon:make_pet)` calls returned `ok=true err=nil`
- `friendly` field correctly transitioned `0` → `-1` (the pet sentinel value) in every call
- No game crashes, no Lua errors, no save-load issues

## Additional context

This PR used AI assistance (`Assisted-by: Claude:claude-opus-4-7`).

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter. *(One-line addition; no formatter changes.)*
- [x] I linked the relevant issue using `Closes #7880` in the Purpose section.

### Optional

- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added the [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [x] Bound function has a clear signature inherited from the existing C++ declaration; no extra Lua-side type annotation file is needed for `void()` methods on already-bound usertypes.
- [x] This PR used AI assistance.
  - [x] Disclosed in the PR description and `Assisted-by:` trailer is on the commit.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [29c01cf](https://github.com/cataclysmbn/Cataclysm-BN/commit/29c01cf20123270d83acdb3b2e396cc35d640eec) (feat(lua): bind monster::make_pet()) on 2026-05-22 13:16:35

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26287251594/artifacts/7160491003)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26287251594/artifacts/7161210002)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26287251594/artifacts/7160393638)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26287251594/artifacts/7160605692)
<!-- END artifact comment -->