### PR TITLE
fix: load legacy vehicle pivot saves

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -171,6 +171,7 @@ bool load_world_lua_state( const world *world, const std::string &path )
     const auto ret = world->read_from_file( path, [&]( std::istream & stream ) {
         JsonIn jsin( stream );
         JsonObject jsobj = jsin.get_object();
+        jsobj.allow_omitted_members();
 
         for( const mod_id &mod : mods ) {
             if( !jsobj.has_object( mod.str() ) ) {

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -269,6 +269,12 @@ auto game::unserialize( std::istream &fin ) -> bool
                 dim_data.read( "world_type", wt_str );
                 info.world_type = world_type_id( wt_str );
                 dim_data.read( "display_name", info.display_name );
+                auto legacy_origin_pos_x = 0;
+                auto legacy_origin_pos_y = 0;
+                auto legacy_origin_pos_z = 0;
+                dim_data.read( "origin_pos_x", legacy_origin_pos_x );
+                dim_data.read( "origin_pos_y", legacy_origin_pos_y );
+                dim_data.read( "origin_pos_z", legacy_origin_pos_z );
                 if( dim_data.has_object( "pocket_info" ) ) {
                     dim_data.read( "pocket_info", info.pocket_info );
                 } else if( dim_data.has_object( "bounds" ) ) {
@@ -1209,7 +1215,7 @@ void overmap::serialize( std::ostream &fout ) const
     json.end_array();
 
     std::vector<std::pair<om_pos_dir, std::string>> flattened_joins_used(
-                joins_used.begin(), joins_used.end() );
+        joins_used.begin(), joins_used.end() );
     json.member( "joins_used", flattened_joins_used );
     json.member( "mapgen_arg_storage", mapgen_arg_storage );
     fout << '\n';

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1215,7 +1215,7 @@ void overmap::serialize( std::ostream &fout ) const
     json.end_array();
 
     std::vector<std::pair<om_pos_dir, std::string>> flattened_joins_used(
-        joins_used.begin(), joins_used.end() );
+                joins_used.begin(), joins_used.end() );
     json.member( "joins_used", flattened_joins_used );
     json.member( "mapgen_arg_storage", mapgen_arg_storage );
     fout << '\n';

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3138,6 +3138,25 @@ auto read_legacy_vehicle_pivot( const JsonObject &data, tripoint_mnt_veh &pivot 
     pivot = tripoint_mnt_veh( pivot_json.get_int( 0 ), pivot_json.get_int( 1 ), z );
 }
 
+auto read_saved_vehicle_parts( const JsonObject &data, std::vector<vehicle_part> &parts ) -> void
+{
+    if( !data.has_array( "parts" ) ) {
+        return;
+    }
+
+    parts.clear();
+    const auto part_array = data.get_array( "parts" );
+    for( auto part_index = size_t{ 0 }; part_index < part_array.size(); ++part_index ) {
+        auto part = vehicle_part();
+        try {
+            part_array.read( part_index, part, true );
+            parts.push_back( std::move( part ) );
+        } catch( const JsonError &err ) {
+            DebugLog( DL::Warn, DC::DebugMsg ) << "Skipping invalid saved vehicle part: " << err.c_str();
+        }
+    }
+}
+
 } // namespace
 
 /*
@@ -3213,8 +3232,6 @@ void vehicle::deserialize( JsonIn &jsin )
     data.read( "theft_time", theft_time );
     data.read( "dimension_id", dimension_id_ );
 
-    data.read( "parts", parts );
-
     // we persist the pivot anchor so that if the rules for finding
     // the pivot change, existing vehicles do not shift around.
     // Loading vehicles that predate the pivot logic is a special
@@ -3223,6 +3240,8 @@ void vehicle::deserialize( JsonIn &jsin )
     read_legacy_vehicle_pivot( data, pivot_anchor[0] );
     pivot_anchor[1] = pivot_anchor[0];
     pivot_rotation[1] = pivot_rotation[0] = fdir_angle;
+
+    read_saved_vehicle_parts( data, parts );
     data.read( "is_following", is_following );
     data.read( "follow_distance", follow_distance );
     data.read( "is_patrolling", is_patrolling );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3119,6 +3119,27 @@ void label::serialize( JsonOut &json ) const
     json.end_object();
 }
 
+namespace
+{
+
+/// Vehicle pivots used to be 2D mount-space points before tripoint migration.
+auto read_legacy_vehicle_pivot( const JsonObject &data, tripoint_mnt_veh &pivot ) -> void
+{
+    if( !data.has_member( "pivot" ) ) {
+        return;
+    }
+
+    const auto pivot_json = data.get_array( "pivot" );
+    if( pivot_json.size() != 2 && pivot_json.size() != 3 ) {
+        data.throw_error( "vehicle pivot must have 2 or 3 coordinates", "pivot" );
+    }
+
+    const auto z = pivot_json.size() == 3 ? pivot_json.get_int( 2 ) : 0;
+    pivot = tripoint_mnt_veh( pivot_json.get_int( 0 ), pivot_json.get_int( 1 ), z );
+}
+
+} // namespace
+
 /*
  * Load vehicle from a json blob that might just exceed player in size.
  */
@@ -3199,7 +3220,7 @@ void vehicle::deserialize( JsonIn &jsin )
     // Loading vehicles that predate the pivot logic is a special
     // case of this, they will load with an anchor of (0,0) which
     // is what they're expecting.
-    data.read( "pivot", pivot_anchor[0] );
+    read_legacy_vehicle_pivot( data, pivot_anchor[0] );
     pivot_anchor[1] = pivot_anchor[0];
     pivot_rotation[1] = pivot_rotation[0] = fdir_angle;
     data.read( "is_following", is_following );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -155,6 +155,68 @@ auto vehicle_with_legacy_pivot_json() -> std::string
            )json";
 }
 
+auto vehicle_with_invalid_part_and_legacy_pivot_json() -> std::string
+{
+    return R"json(
+           {
+           "type": "none",
+           "posx": 5,
+           "posy": 6,
+           "om_id": 0,
+           "faceDir": 180,
+           "moveDir": 180,
+           "turn_dir": 180,
+           "velocity": 0,
+           "falling": false,
+           "floating": false,
+           "flying": false,
+           "cruise_velocity": 0,
+           "vertical_velocity": 0,
+           "name": "legacy pivot invalid part test vehicle",
+           "owner": "",
+           "old_owner": "",
+           "parts": [
+           {
+           "id": "missing_saved_vehicle_part",
+           "mount_dx": 99,
+           "mount_dy": 99,
+           "open": false,
+           "direction": 0,
+           "blood": 0,
+           "proxy_part_id": "null",
+           "proxy_sym": 0,
+           "enabled": false,
+           "flags": 0,
+           "passenger_id": -1,
+           "crew_id": -1,
+           "items": [],
+           "ammo_pref": "null",
+           "part_color": [ 0, 0, 0, 0 ]
+       },
+           {
+           "id": "frame_horizontal",
+           "mount_dx": 0,
+           "mount_dy": 0,
+           "open": false,
+           "direction": 0,
+           "blood": 0,
+           "proxy_part_id": "null",
+           "proxy_sym": 0,
+           "enabled": false,
+           "flags": 0,
+           "passenger_id": -1,
+           "crew_id": -1,
+           "items": [],
+           "ammo_pref": "null",
+           "part_color": [ 0, 0, 0, 0 ]
+       }
+           ],
+           "pivot": [ -1, 0 ],
+           "zones": []
+       }
+           )json";
+}
+
 } // namespace
 
 TEST_CASE( "vehicle deserialize accepts legacy two coordinate pivot", "[vehicle][save]" )
@@ -165,6 +227,17 @@ TEST_CASE( "vehicle deserialize accepts legacy two coordinate pivot", "[vehicle]
 
     REQUIRE( jsin.read( veh, true ) );
     CHECK( veh.mount_to_abs( tripoint_mnt_veh( -1, 0, 0 ) ) == tripoint_abs_ms( 5, 6, 0 ) );
+    CHECK( veh.mount_to_abs( tripoint_mnt_veh( 0, 0, 0 ) ) == tripoint_abs_ms( 4, 6, 0 ) );
+}
+
+TEST_CASE( "vehicle deserialize keeps valid saved parts after an invalid part", "[vehicle][save]" )
+{
+    auto json = std::istringstream( vehicle_with_invalid_part_and_legacy_pivot_json() );
+    auto jsin = JsonIn( json );
+    auto veh = vehicle();
+
+    REQUIRE( jsin.read( veh, true ) );
+    CHECK( veh.part_count() == 1 );
     CHECK( veh.mount_to_abs( tripoint_mnt_veh( 0, 0, 0 ) ) == tripoint_abs_ms( 4, 6, 0 ) );
 }
 

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -14,6 +15,7 @@
 #include "enums.h"
 #include "game.h"
 #include "item.h"
+#include "json.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "mongroup.h"
@@ -108,7 +110,63 @@ auto make_horde_vehicle_spawn_fixture( const horde_vehicle_spawn_options &option
     return horde_vehicle_spawn_fixture{ .vehicle_points = vehicle_points, .horde = horde };
 }
 
+auto vehicle_with_legacy_pivot_json() -> std::string
+{
+    return R"json(
+           {
+           "type": "none",
+           "posx": 5,
+           "posy": 6,
+           "om_id": 0,
+           "faceDir": 180,
+           "moveDir": 180,
+           "turn_dir": 180,
+           "velocity": 0,
+           "falling": false,
+           "floating": false,
+           "flying": false,
+           "cruise_velocity": 0,
+           "vertical_velocity": 0,
+           "name": "legacy pivot test vehicle",
+           "owner": "",
+           "old_owner": "",
+           "parts": [
+           {
+           "id": "frame_horizontal",
+           "mount_dx": 0,
+           "mount_dy": 0,
+           "open": false,
+           "direction": 0,
+           "blood": 0,
+           "proxy_part_id": "null",
+           "proxy_sym": 0,
+           "enabled": false,
+           "flags": 0,
+           "passenger_id": -1,
+           "crew_id": -1,
+           "items": [],
+           "ammo_pref": "null",
+           "part_color": [ 0, 0, 0, 0 ]
+       }
+           ],
+           "pivot": [ -1, 0 ],
+           "zones": []
+       }
+           )json";
+}
+
 } // namespace
+
+TEST_CASE( "vehicle deserialize accepts legacy two coordinate pivot", "[vehicle][save]" )
+{
+    auto json = std::istringstream( vehicle_with_legacy_pivot_json() );
+    auto jsin = JsonIn( json );
+    auto veh = vehicle();
+
+    REQUIRE( jsin.read( veh, true ) );
+    CHECK( veh.mount_to_abs( tripoint_mnt_veh( -1, 0, 0 ) ) == tripoint_abs_ms( 5, 6, 0 ) );
+    CHECK( veh.mount_to_abs( tripoint_mnt_veh( 0, 0, 0 ) ) == tripoint_abs_ms( 4, 6, 0 ) );
+}
 
 TEST_CASE( "detaching_vehicle_unboards_passengers" )
 {


### PR DESCRIPTION
## Purpose of change (The Why)

close #9007 caused by https://github.com/cataclysmbn/Cataclysm-BN/pull/8686

The issue save can lose a vehicle during load because several legacy/save-compat cases combine:

- Legacy vehicle `pivot` can be saved as `[x, y]`; tripoint migration made the loader expect `[x, y, z]`.
- Saved vehicles can contain invalid part ids for the currently loaded data. Aborting `parts` deserialization left vehicle pivot/rotation/refresh incomplete, producing `Unexpected movement in rotated vehicle vector` and a broken/disappearing vehicle.
- `lua_state.json` can contain top-level state for inactive/missing mods such as `AZF`; those stale mod entries should be ignored instead of reported as invalid JSON fields.
- Legacy `loaded_dimensions` entries can include `origin_pos_x/y/z`; those fields should not trip strict unvisited-member reporting.

Related: #3988
Related: #6293
Related: #7697
Related: #7451
Related: #8283

## Describe the solution (The How)

- Read vehicle pivots with either 2 or 3 coordinates, defaulting legacy 2D mount-space `z` to `0`.
- Restore pivot/rotation before loading saved parts.
- Load saved vehicle parts individually, skipping invalid parts while preserving valid parts so the vehicle can finish loading and refresh normally.
- Allow omitted top-level `lua_state.json` mod entries during Lua state restore. Missing/inactive mod state is skipped; it is not lazy-loaded.
- Consume legacy `loaded_dimensions` `origin_pos_x/y/z` fields.
- Added regression tests for legacy 2-coordinate pivots and invalid saved parts preceding valid saved parts.

## Describe alternatives you've considered

A broad `tripoint` fallback could silently reinterpret unrelated malformed/global coordinates as `z = 0`, so this keeps the compatibility shim scoped to vehicle pivots.

Lazy-loading skipped Lua mod state was not added; inactive or missing mod state remains ignored during the current load.

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/e574cbb6-374a-480f-be06-aa45426df6e9" />
<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/207c4677-8eb0-4c59-840e-283d8ca131a4" />

was able to load vehicle in attached save in issue

- `cmake --build --preset linux-full --target cata_test-tiles cataclysm-bn-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[vehicle][save]"`
- `./out/build/linux-full/tests/cata_test-tiles "[save][load]"`
- Headless issue-save smoke test; verified the new log had no `AZF` unvisited JSON error, `origin_pos` unvisited JSON error, `map::unboard_vehicle`, or `Unexpected movement in rotated vehicle vector` entries before terminating the dummy-UI run.

## Additional context

The issue save contains a vehicle with `"pivot": [ -1, 0 ]`.

The issue save vehicle is `Not_Flying` in `maps/12.0.0/401.26.0.map`.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

Stale PR build for commit [dbc8e65](https://github.com/cataclysmbn/Cataclysm-BN/commit/dbc8e65992a41557b4d7e3ca5d87c9564d0bd986) (style: format savegame) on 2026-05-22 17:06:29; waiting for a build from the latest commit.

- [⏳ Linux tiles — stale](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26298734279/artifacts/7165354236)
- [⏳ Windows tiles — stale](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26298734279/artifacts/7165980276)
- [⏳ macOS tiles — stale](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26298734279/artifacts/7165241998)
- [⏳ Android tiles — stale](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26298734279/artifacts/7165553124)
<!-- END artifact comment -->