### PR TITLE
fix: preserve vehicle freezer freshness on pickup

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6343,6 +6343,7 @@ time_duration item::get_shelf_life() const
 double item::get_relative_rot() const
 {
     if( goes_bad() ) {
+        const_cast<item *>( this )->update_rot_from_location( temperature_flag::TEMP_NORMAL );
         return rot / get_shelf_life();
     }
     return 0;
@@ -6447,7 +6448,7 @@ auto item::calc_rot( time_point time, const units::temperature temp ) const -> t
     // always rot away and food rots away at twice the shelf life.  If the food
     // is in a sealed container they won't rot away, this avoids needlessly
     // calculating their rot in that case.
-    if( !is_corpse() && get_relative_rot() > 2.0 ) {
+    if( !is_corpse() && get_shelf_life() != 0_turns && rot / get_shelf_life() > 2.0 ) {
         return 0_seconds;
     }
 
@@ -10080,21 +10081,31 @@ static units::temperature clip_by_temperature_flag( units::temperature temperatu
     return temperature;
 }
 
-detached_ptr<item>  item::process_rot( detached_ptr<item> &&self, const bool seals,
-                                       const tripoint_bub_ms &pos,
-                                       player *carrier, const temperature_flag flag,
-                                       const weather_manager &weather )
+void item::update_rot_from_location( const temperature_flag temperature )
 {
-    if( !self ) {
-        return std::move( self );
+    if( !goes_bad() || last_rot_check == calendar::turn ) {
+        return;
     }
+
+    auto pos = tripoint_bub_ms::zero();
+    auto flag = temperature;
+    if( has_position() ) {
+        pos = position();
+        flag = rot::temperature_flag_for_location( get_map(), *this );
+    }
+    update_rot( pos, flag, get_weather() );
+}
+
+void item::update_rot( const tripoint_bub_ms &pos, const temperature_flag flag,
+                       const weather_manager &weather )
+{
     const time_point now = calendar::turn;
 
     // if player debug menu'd the time backward it breaks stuff, just reset the
     // last_temp_check and last_rot_check in this case
-    if( now - self->last_rot_check < 0_turns ) {
-        self->last_rot_check = now;
-        return std::move( self );
+    if( now - last_rot_check < 0_turns ) {
+        last_rot_check = now;
+        return;
     }
 
     // process rot at most once every 100_turns (10 min)
@@ -10104,8 +10115,8 @@ detached_ptr<item>  item::process_rot( detached_ptr<item> &&self, const bool sea
     units::temperature temp = weather.get_temperature( bub_to_abs( pos ) );
     temp = clip_by_temperature_flag( temp, flag );
 
-    time_point time = self->last_rot_check;
-    item_internal::scoped_goes_bad_cache _cache( &*self );
+    time_point time = last_rot_check;
+    item_internal::scoped_goes_bad_cache _cache( this );
 
     if( now - time > 1_hours ) {
         // This code is for items that were left out of reality bubble for long time
@@ -10137,27 +10148,32 @@ detached_ptr<item>  item::process_rot( detached_ptr<item> &&self, const bool sea
             units::temperature env_temperature_clipped = clip_by_temperature_flag( env_temperature_raw, flag );
 
             // Calculate item rot
-            self->rot += self->calc_rot( time, env_temperature_clipped );
-            self->last_rot_check = time;
-
-            if( self->has_rotten_away() && carrier == nullptr && !seals ) {
-                // No need to track item that will be gone
-                return detached_ptr<item>();
-            }
+            rot += calc_rot( time, env_temperature_clipped );
+            last_rot_check = time;
         }
     }
 
     // Remaining <1 h from above
     // and items that are held near the player
     if( now - time > smallest_interval ) {
-        self->rot += self->calc_rot( now, temp );
-        self->last_rot_check = now;
+        rot += calc_rot( now, temp );
+        last_rot_check = now;
+    }
+}
 
-        if( self->has_rotten_away() && carrier == nullptr && !seals ) {
-            return detached_ptr<item>();
-        } else {
-            return std::move( self );
-        }
+detached_ptr<item>  item::process_rot( detached_ptr<item> &&self, const bool seals,
+                                       const tripoint_bub_ms &pos,
+                                       player *carrier, const temperature_flag flag,
+                                       const weather_manager &weather )
+{
+    if( !self ) {
+        return std::move( self );
+    }
+
+    self->update_rot( pos, flag, weather );
+
+    if( self->has_rotten_away() && carrier == nullptr && !seals ) {
+        return detached_ptr<item>();
     }
     return std::move( self );
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -871,8 +871,20 @@ bool item::attempt_detach( std::function < detached_ptr<item>( detached_ptr<item
 bool item::attempt_split( int qty,
                           const std::function < detached_ptr<item>( detached_ptr<item> && ) > & cb )
 {
+    const bool split_needs_rot_actualization = goes_bad() && has_position();
+    const auto split_pos = split_needs_rot_actualization ? position() : tripoint_bub_ms::zero();
+    const auto vehicle_loc = dynamic_cast<vehicle_item_location *>( loc );
+    const auto split_temperature = !split_needs_rot_actualization ? temperature_flag::TEMP_NORMAL :
+                                   vehicle_loc != nullptr ? vehicle_loc->storage_temperature() :
+                                   rot::temperature_flag_for_location( get_map(), *this );
     detached_ptr<item> det = unsafe_split( qty );
+    if( det && split_needs_rot_actualization ) {
+        det = actualize_rot( std::move( det ), split_pos, split_temperature, get_weather() );
+    }
     if( !det ) {
+        if( charges == 0 && has_position() ) {
+            detach().release();
+        }
         return false;
     }
     item &after_split = *det;

--- a/src/item.h
+++ b/src/item.h
@@ -971,6 +971,13 @@ class item : public location_visitable<item>, public game_object<item>
         /** Get the shelf life of the item*/
         time_duration get_shelf_life() const;
 
+        /** Update @ref rot from current location without removing rotten-away items. */
+        void update_rot_from_location( temperature_flag temperature );
+
+        /** Update @ref rot at the specified location without removing rotten-away items. */
+        void update_rot( const tripoint_bub_ms &pos, temperature_flag temperature,
+                         const weather_manager &weather_generator );
+
         /** Get @ref rot value relative to shelf life (or 0 if item does not spoil) */
         double get_relative_rot() const;
 
@@ -1013,6 +1020,7 @@ class item : public location_visitable<item>, public game_object<item>
         bool has_rotten_away() const;
 
         time_duration get_rot() const {
+            const_cast<item *>( this )->update_rot_from_location( temperature_flag::TEMP_NORMAL );
             return rot;
         }
         void mod_rot( const time_duration &val ) {

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -10,12 +10,14 @@
 #include "monster.h"
 #include "npc.h"
 #include "player.h"
+#include "rot.h"
 #include "submap.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 #include "veh_type.h"
+#include "weather.h"
 #include "game.h"
 namespace
 {
@@ -441,7 +443,13 @@ item_location_type vehicle_item_location::where() const
 
 detached_ptr<item> vehicle_item_location::detach( item *it )
 {
+    const auto part_index = veh->get_part_id_hack( hack_id );
+    const auto item_pos = veh->mount_to_bubble( veh->get_part_hack( hack_id ).mount );
+    const auto temperature = rot::temperature_flag_for_part( *veh, part_index );
     detached_ptr<item> ret = veh->get_part_hack( hack_id ).remove_item( *it );
+    if( ret && temperature != temperature_flag::TEMP_NORMAL ) {
+        ret = item::actualize_rot( std::move( ret ), item_pos, temperature, get_weather() );
+    }
     veh->invalidate_mass();
     return ret;
 }

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -445,8 +445,9 @@ detached_ptr<item> vehicle_item_location::detach( item *it )
 {
     const auto part_index = veh->get_part_id_hack( hack_id );
     const auto item_pos = veh->mount_to_bubble( veh->get_part_hack( hack_id ).mount );
-    const auto temperature = rot::temperature_flag_for_part( *veh, part_index );
-    detached_ptr<item> ret = veh->get_part_hack( hack_id ).remove_item( *it );
+    const auto temperature = storage_temperature();
+    detached_ptr<item> ret = part_index >= 0 ? veh->remove_item( part_index, it ) :
+                             veh->get_part_hack( hack_id ).remove_item( *it );
     if( ret && temperature != temperature_flag::TEMP_NORMAL ) {
         ret = item::actualize_rot( std::move( ret ), item_pos, temperature, get_weather() );
     }
@@ -458,6 +459,13 @@ void vehicle_item_location::attach( detached_ptr<item> &&obj )
 {
     veh->get_part_hack( hack_id ).add_item( std::move( obj ) );
     veh->invalidate_mass();
+}
+
+auto vehicle_item_location::storage_temperature() const -> temperature_flag
+{
+    const auto part_index = veh->get_part_id_hack( hack_id );
+    return part_index >= 0 ? rot::temperature_flag_for_part( *veh,
+            part_index ) : temperature_flag::TEMP_NORMAL;
 }
 
 int vehicle_item_location::obtain_cost( const Character &ch, int qty, const item *it ) const

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -448,7 +448,7 @@ detached_ptr<item> vehicle_item_location::detach( item *it )
     const auto temperature = storage_temperature();
     detached_ptr<item> ret = part_index >= 0 ? veh->remove_item( part_index, it ) :
                              veh->get_part_hack( hack_id ).remove_item( *it );
-    if( ret && temperature != temperature_flag::TEMP_NORMAL ) {
+    if( ret ) {
         ret = item::actualize_rot( std::move( ret ), item_pos, temperature, get_weather() );
     }
     veh->invalidate_mass();
@@ -457,8 +457,13 @@ detached_ptr<item> vehicle_item_location::detach( item *it )
 
 void vehicle_item_location::attach( detached_ptr<item> &&obj )
 {
-    veh->get_part_hack( hack_id ).add_item( std::move( obj ) );
-    veh->invalidate_mass();
+    const auto part_index = veh->get_part_id_hack( hack_id );
+    if( part_index >= 0 ) {
+        obj = veh->add_item( part_index, std::move( obj ) );
+    } else {
+        veh->get_part_hack( hack_id ).add_item( std::move( obj ) );
+        veh->invalidate_mass();
+    }
 }
 
 auto vehicle_item_location::storage_temperature() const -> temperature_flag

--- a/src/locations.h
+++ b/src/locations.h
@@ -6,6 +6,7 @@
 
 class item;
 enum class item_location_type : int;
+enum class temperature_flag : int;
 class Character;
 class Creature;
 class submap;
@@ -181,6 +182,7 @@ class vehicle_item_location : public item_location
         bool is_loaded( const item *it ) const override;
         tripoint_bub_ms position( const item *it ) const override;
         item_location_type where() const override;
+        auto storage_temperature() const -> temperature_flag;
         int obtain_cost( const Character &ch, int qty, const item *it ) const override;
         std::string describe( const Character *ch, const item *it ) const override;
 };

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -1,7 +1,9 @@
 #include "catch/catch.hpp"
 
 #include <memory>
+#include <ranges>
 
+#include "avatar.h"
 #include "calendar.h"
 #include "coordinates.h"
 #include "enums.h"
@@ -16,6 +18,8 @@
 #include "weather.h"
 
 static const furn_str_id f_atomic_freezer( "f_atomic_freezer" );
+static const furn_str_id f_test_fridge_on( "f_fridge_on" );
+static const furn_str_id f_test_minifreezer_on( "f_minifreezer_on" );
 
 static void set_map_temperature( weather_manager &weather, units::temperature new_temperature )
 {
@@ -28,6 +32,73 @@ static void ensure_no_temperature_mods( tripoint_bub_ms location )
     REQUIRE( get_heat_radiation( location, false ) == 0 );
     REQUIRE( get_convection_temperature( location ) == 0 );
     REQUIRE( get_map().get_temperature( location ) == 0 );
+}
+
+struct vehicle_storage_fixture {
+    vehicle *veh = nullptr;
+    int part_index = -1;
+    tripoint_bub_ms pos;
+};
+
+static auto make_storage( const vpart_id &storage_part,
+                          const bool enabled ) -> vehicle_storage_fixture
+{
+    clear_all_state();
+    calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+    set_map_temperature( get_weather(), 18_c );
+
+    auto &here = get_map();
+    const auto vehicle_pos = tripoint_bub_ms( 60, 60, 0 );
+    auto *veh = here.add_vehicle( vproto_id( "none" ), vehicle_pos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
+    const auto part_index = veh->install_part( tripoint_mnt_veh::zero(), storage_part, true );
+    REQUIRE( part_index >= 0 );
+    veh->part( part_index ).enabled = enabled;
+    here.build_map_cache( vehicle_pos.z(), true );
+
+    return { .veh = veh, .part_index = part_index, .pos = vehicle_pos };
+}
+
+static auto add_sashimi_to_vehicle_part( vehicle &veh, const int part_index ) -> void
+{
+    auto sashimi = item::spawn( "sashimi" );
+    REQUIRE( sashimi->goes_bad() );
+    REQUIRE_FALSE( veh.add_item( part_index, std::move( sashimi ) ) );
+}
+
+static auto move_to_inventory_with_attempt_detach( item &stored ) -> item * // *NOPAD*
+{
+    item *carried = nullptr;
+    stored.attempt_detach( [&carried]( detached_ptr<item> &&it ) {
+        carried = &get_avatar().i_add( std::move( it ) );
+        return detached_ptr<item>();
+    } );
+    return carried;
+}
+
+static auto process_storage_for( const time_duration duration ) -> void
+{
+    constexpr auto interval = 20_minutes;
+    const auto intervals = to_turns<int>( duration ) / to_turns<int>( interval );
+    for( const auto _ : std::views::iota( 0, intervals ) ) {
+        static_cast<void>( _ );
+        calendar::turn += interval;
+        get_map().process_items();
+    }
+}
+
+static auto prepare_map_storage_test() -> void
+{
+    clear_all_state();
+    calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+    set_map_temperature( get_weather(), 18_c );
+}
+
+static auto add_sashimi_to_map( const tripoint_bub_ms &pos ) -> void
+{
+    get_map().add_item( pos, item::spawn( "sashimi" ) );
+    REQUIRE( get_map().i_at( pos ).size() == 1 );
 }
 
 TEST_CASE( "Rate of rotting" )
@@ -209,38 +280,103 @@ TEST_CASE( "Items don't rot away on map load if in a freezer" )
     REQUIRE( normal_stack_after.empty() );
 }
 
-TEST_CASE( "Vehicle freezer catches up food rot before removal" )
+TEST_CASE( "Vehicle storage temperature controls food rot" )
 {
-    clear_all_state();
-    calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+    SECTION( "powered freezers preserve food when removed after missed processing" ) {
+        auto fixture = make_storage( vpart_id( "minifreezer" ), true );
+        add_sashimi_to_vehicle_part( *fixture.veh, fixture.part_index );
 
-    auto &here = get_map();
-    const auto vehicle_pos = tripoint_bub_ms( 60, 60, 0 );
-    auto *veh = here.add_vehicle( vproto_id( "none" ), vehicle_pos, 0_degrees, 0, 0 );
-    REQUIRE( veh != nullptr );
-    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
-    const auto freezer_index = veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "minifreezer" ),
-                               true );
-    REQUIRE( freezer_index >= 0 );
-    veh->part( freezer_index ).enabled = true;
+        auto freezer_items = fixture.veh->get_items( fixture.part_index );
+        REQUIRE( freezer_items.size() == 1 );
 
-    auto sashimi = item::spawn( "sashimi" );
-    REQUIRE( sashimi->goes_bad() );
-    REQUIRE_FALSE( veh->add_item( freezer_index, std::move( sashimi ) ) );
+        calendar::turn += 21_days;
+        auto *carried = move_to_inventory_with_attempt_detach( freezer_items.only_item() );
 
-    auto freezer_items = veh->get_items( freezer_index );
-    REQUIRE( freezer_items.size() == 1 );
+        REQUIRE( carried != nullptr );
+        CHECK( carried->get_rot() == 0_turns );
 
-    calendar::turn += 21_days;
-    auto carried = freezer_items.only_item().detach();
+        get_avatar().process_items();
 
-    REQUIRE( carried );
-    CHECK( carried->get_rot() == 0_turns );
+        CHECK( !carried->rotten() );
+        CHECK( carried->get_rot() == 0_turns );
+    }
 
-    carried = item::process( std::move( carried ), nullptr, vehicle_pos, false,
-                             temperature_flag::TEMP_NORMAL, get_weather() );
+    SECTION( "powered fridges catch up partial rot when removed after missed processing" ) {
+        auto fixture = make_storage( vpart_id( "minifridge" ), true );
+        add_sashimi_to_vehicle_part( *fixture.veh, fixture.part_index );
 
-    REQUIRE( carried );
-    CHECK( !carried->rotten() );
-    CHECK( carried->get_rot() == 0_turns );
+        auto fridge_items = fixture.veh->get_items( fixture.part_index );
+        REQUIRE( fridge_items.size() == 1 );
+
+        calendar::turn += 24_hours;
+        auto *carried = move_to_inventory_with_attempt_detach( fridge_items.only_item() );
+
+        REQUIRE( carried != nullptr );
+        CHECK( carried->get_relative_rot() > 0.0 );
+        CHECK( carried->get_relative_rot() < 1.0 );
+
+        const auto rot_after_detach = carried->get_rot();
+        get_avatar().process_items();
+
+        CHECK( carried->get_rot() == rot_after_detach );
+    }
+
+    SECTION( "unpowered freezers do not protect food while it remains stored" ) {
+        auto fixture = make_storage( vpart_id( "minifreezer" ), false );
+        add_sashimi_to_vehicle_part( *fixture.veh, fixture.part_index );
+
+        process_storage_for( 25_hours );
+
+        CHECK( fixture.veh->get_items( fixture.part_index ).empty() );
+    }
+
+    SECTION( "vehicle seat storage rots food while it remains stored" ) {
+        auto fixture = make_storage( vpart_id( "seat" ), true );
+        add_sashimi_to_vehicle_part( *fixture.veh, fixture.part_index );
+
+        process_storage_for( 25_hours );
+
+        CHECK( fixture.veh->get_items( fixture.part_index ).empty() );
+    }
+}
+
+TEST_CASE( "Map powered fridge and freezer furniture controls food rot" )
+{
+    SECTION( "powered freezer furniture preserves food" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().furn_set( pos, f_test_minifreezer_on );
+        add_sashimi_to_map( pos );
+
+        process_storage_for( 25_hours );
+
+        auto items = get_map().i_at( pos );
+        REQUIRE( items.size() == 1 );
+        CHECK( items.only_item().get_rot() == 0_turns );
+        CHECK( !items.only_item().rotten() );
+    }
+
+    SECTION( "powered fridge furniture partially protects food" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().furn_set( pos, f_test_fridge_on );
+        add_sashimi_to_map( pos );
+
+        process_storage_for( 24_hours );
+
+        auto items = get_map().i_at( pos );
+        REQUIRE( items.size() == 1 );
+        CHECK( items.only_item().get_relative_rot() > 0.0 );
+        CHECK( items.only_item().get_relative_rot() < 1.0 );
+    }
+
+    SECTION( "unprotected map storage rots food normally" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        add_sashimi_to_map( pos );
+
+        process_storage_for( 25_hours );
+
+        CHECK( get_map().i_at( pos ).empty() );
+    }
 }

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -44,11 +44,12 @@ static auto make_storage( const vpart_id &storage_part,
                           const bool enabled ) -> vehicle_storage_fixture
 {
     clear_all_state();
-    calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+    calendar::turn = calendar::start_of_cataclysm + 91_days;
     set_map_temperature( get_weather(), 18_c );
 
     auto &here = get_map();
     const auto vehicle_pos = tripoint_bub_ms( 60, 60, 0 );
+    here.set_temperature( vehicle_pos, 100 );
     auto *veh = here.add_vehicle( vproto_id( "none" ), vehicle_pos, 0_degrees, 0, 0 );
     REQUIRE( veh != nullptr );
     REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
@@ -91,7 +92,7 @@ static auto process_storage_for( const time_duration duration ) -> void
 static auto prepare_map_storage_test() -> void
 {
     clear_all_state();
-    calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+    calendar::turn = calendar::start_of_cataclysm + 91_days;
     set_map_temperature( get_weather(), 18_c );
 }
 
@@ -345,6 +346,7 @@ TEST_CASE( "Map powered fridge and freezer furniture controls food rot" )
     SECTION( "powered freezer furniture preserves food" ) {
         prepare_map_storage_test();
         const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
         get_map().furn_set( pos, f_test_minifreezer_on );
         add_sashimi_to_map( pos );
 
@@ -359,6 +361,7 @@ TEST_CASE( "Map powered fridge and freezer furniture controls food rot" )
     SECTION( "powered fridge furniture partially protects food" ) {
         prepare_map_storage_test();
         const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
         get_map().furn_set( pos, f_test_fridge_on );
         add_sashimi_to_map( pos );
 
@@ -370,9 +373,24 @@ TEST_CASE( "Map powered fridge and freezer furniture controls food rot" )
         CHECK( items.only_item().get_relative_rot() < 1.0 );
     }
 
+    SECTION( "unprotected map storage reports stale rot when inspected before processing" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
+        add_sashimi_to_map( pos );
+
+        calendar::turn += 20_days;
+
+        auto items = get_map().i_at( pos );
+        REQUIRE( items.size() == 1 );
+        CHECK( items.only_item().get_rot() > 0_turns );
+        CHECK_FALSE( items.only_item().is_fresh() );
+    }
+
     SECTION( "unprotected map storage rots food normally" ) {
         prepare_map_storage_test();
         const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
         add_sashimi_to_map( pos );
 
         process_storage_for( 25_hours );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -9,7 +9,10 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "game.h" // Just for get_convection_temperature(), TODO: Remove
+#include "state_helpers.h"
 #include "units_temperature.h"
+#include "vehicle.h"
+#include "vehicle_part.h"
 #include "weather.h"
 
 static const furn_str_id f_atomic_freezer( "f_atomic_freezer" );
@@ -204,4 +207,40 @@ TEST_CASE( "Items don't rot away on map load if in a freezer" )
     REQUIRE( sealed_stack_after.size() == 1 );
     auto normal_stack_after = m.i_at( normal_pnt );
     REQUIRE( normal_stack_after.empty() );
+}
+
+TEST_CASE( "Vehicle freezer catches up food rot before removal" )
+{
+    clear_all_state();
+    calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+
+    auto &here = get_map();
+    const auto vehicle_pos = tripoint_bub_ms( 60, 60, 0 );
+    auto *veh = here.add_vehicle( vproto_id( "none" ), vehicle_pos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
+    const auto freezer_index = veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "minifreezer" ),
+                               true );
+    REQUIRE( freezer_index >= 0 );
+    veh->part( freezer_index ).enabled = true;
+
+    auto sashimi = item::spawn( "sashimi" );
+    REQUIRE( sashimi->goes_bad() );
+    REQUIRE_FALSE( veh->add_item( freezer_index, std::move( sashimi ) ) );
+
+    auto freezer_items = veh->get_items( freezer_index );
+    REQUIRE( freezer_items.size() == 1 );
+
+    calendar::turn += 21_days;
+    auto carried = freezer_items.only_item().detach();
+
+    REQUIRE( carried );
+    CHECK( carried->get_rot() == 0_turns );
+
+    carried = item::process( std::move( carried ), nullptr, vehicle_pos, false,
+                             temperature_flag::TEMP_NORMAL, get_weather() );
+
+    REQUIRE( carried );
+    CHECK( !carried->rotten() );
+    CHECK( carried->get_rot() == 0_turns );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

close #6019
close #9008
Related: #2324, #2647, #2653

Vehicle freezer food could accrue missed rot at room temperature when removed after long frozen storage. Unprotected vehicle storage also needed coverage to ensure normal spoilage is not masked.

## Describe the solution (The How)

Catch up rot using the source storage temperature before detaching/splitting items from storage.

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/0fe4d632-3b74-4ae1-bb14-b4324d9cb307" />
<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/af766b48-5fe5-4baf-94e5-02795b84ed4c" />
1. spawned car and added minifreezer with sashimi
2. waited a day
3. removed it from freezer
4. it is still fresh

Automated/local:
- `./out/build/linux-full/tests/cata_test-tiles "Vehicle storage temperature controls food rot"`
- `./out/build/linux-full/tests/cata_test-tiles "Map powered fridge and freezer furniture controls food rot"`
- `./out/build/linux-full/tests/cata_test-tiles "Rate of rotting,Items rot away,Items don't rot away on map load if in a freezer,Vehicle storage temperature controls food rot,Map powered fridge and freezer furniture controls food rot"`
- stale ground-item rot query covered by `unprotected map storage reports stale rot when inspected before processing`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles`

## Additional context

Used AI assistance.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.

<!-- BEGIN artifact comment -->

## Build Artifacts

Stale PR build for commit [71cd965](https://github.com/cataclysmbn/Cataclysm-BN/commit/71cd96528298b5f9aad1c33665becb315713ac19) (fix: actualize vehicle cargo rot on removal) on 2026-05-23 05:05:50; waiting for a build from the latest commit.

- [⏳ Linux tiles — stale](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26323102522/artifacts/7174218984)
- [⏳ Windows tiles — stale](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26323102522/artifacts/7174343910)
- [⏳ macOS tiles — stale](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26323102522/artifacts/7174171566)
- [⏳ Android tiles — stale](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26323102522/artifacts/7174211342)
<!-- END artifact comment -->
