### PR TITLE
fix: hammerspace returns spawned items so furniture loading works

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1632,11 +1632,27 @@ std::vector<detached_ptr<item>> Character::consume_items( map &m,
 {
     std::vector<detached_ptr<item>> ret;
 
+    item_comp selected_comp = is.comp;
+
     if( has_trait( trait_DEBUG_HS ) ) {
+        // Hammerspace: spawn the requested items so furniture-loading callers
+        // (smoker_load_food, mill_load_food) receive items to move instead of
+        // an empty vector.
+        const bool by_charges_hs = item::count_by_charges( selected_comp.type ) &&
+                                   selected_comp.count > 0;
+        const int real_count_hs = ( selected_comp.count > 0 ) ? selected_comp.count * batch :
+                                  std::abs( selected_comp.count );
+        if( by_charges_hs ) {
+            detached_ptr<item> spawned = item::spawn( selected_comp.type );
+            spawned->charges = real_count_hs;
+            ret.push_back( std::move( spawned ) );
+        } else {
+            for( int i = 0; i < real_count_hs; ++i ) {
+                ret.push_back( item::spawn( selected_comp.type ) );
+            }
+        }
         return ret;
     }
-
-    item_comp selected_comp = is.comp;
 
     const tripoint_bub_ms &loc = origin;
     const bool by_charges = item::count_by_charges( selected_comp.type ) && selected_comp.count > 0;


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #7614.

`Character::consume_items` short-circuits and returns an empty `std::vector<detached_ptr<item>>` whenever the player has the `DEBUG_HS` (Hammerspace) trait, at [crafting.cpp:1635-1637](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/src/crafting.cpp#L1635-L1637).

That works for crafting recipes that **ignore** the returned items (most callers), but breaks any caller that needs to **move** the consumed items somewhere else — most visibly `smoker_load_food` at [iexamine.cpp:6854-6862](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/src/iexamine.cpp#L6854-L6862) and the parallel `mill_load_food`:

```cpp
std::vector<detached_ptr<item>> moved = p.consume_items( selected, 1,
                                        is_non_rotten_crafting_component );

for( detached_ptr<item> &m : moved ) {
    p.mod_moves( -p.item_handling_cost( *m ) );
    add_msg( m_info, _( "You carefully place %s %s in the rack." ), amount,
             item::nname( m->typeId(), amount ) );
    here.add_item( examp, std::move( m ) );
}
```

With Hammerspace active, `moved` was always empty → the for-loop became a no-op → the smoking rack stayed empty even though the player had clicked through all the load prompts. Same for the milling rack.

(Credit to @usagirei for [pinpointing the root cause](https://github.com/cataclysmbn/Cataclysm-BN/issues/7614#issuecomment-...) — though the line references in their comment have shifted since the issue was filed.)

## Describe the solution (The How)

Spawn the requested items inside the `DEBUG_HS` branch and return them, instead of returning an empty vector. For charge-counted components (e.g. liquids), a single item carries the full charge total; otherwise `count * batch` individual items are spawned.

```diff
 std::vector<detached_ptr<item>> ret;

+item_comp selected_comp = is.comp;
+
 if( has_trait( trait_DEBUG_HS ) ) {
+    // Hammerspace: spawn the requested items so furniture-loading callers
+    // (smoker_load_food, mill_load_food) receive items to move instead of
+    // an empty vector.
+    const bool by_charges_hs = item::count_by_charges( selected_comp.type ) &&
+                               selected_comp.count > 0;
+    const int real_count_hs = ( selected_comp.count > 0 ) ? selected_comp.count * batch :
+                              std::abs( selected_comp.count );
+    if( by_charges_hs ) {
+        detached_ptr<item> spawned = item::spawn( selected_comp.type );
+        spawned->charges = real_count_hs;
+        ret.push_back( std::move( spawned ) );
+    } else {
+        for( int i = 0; i < real_count_hs; ++i ) {
+            ret.push_back( item::spawn( selected_comp.type ) );
+        }
+    }
     return ret;
 }

-item_comp selected_comp = is.comp;
-
 const tripoint_bub_ms &loc = origin;
```

The `item_comp selected_comp = is.comp;` line is hoisted above the early-return so the new spawn block can reference it; the rest of the function is unchanged.

The `taken->charges = quantity` pattern matches existing usage at [character.cpp:12506-12507](https://github.com/cataclysmbn/Cataclysm-BN/blob/main/src/character.cpp#L12506-L12507).

## Describe alternatives you've considered

- **Fix `smoker_load_food` / `mill_load_food` callers instead of the shared `consume_items`** — rejected; `consume_items`' contract is "return the items I just consumed". Returning empty when the items conceptually came from Hammerspace's infinite stock violates that contract. Fixing every caller individually would be band-aids; fixing the shared function once is the root-cause fix.
- **Skip the Hammerspace branch entirely and let the normal `use_from::player` / `use_from::map` paths spawn nothing and silently succeed** — rejected; those paths actually look in inventory/map and would also return empty for items the player doesn't physically have. Hammerspace needs its own spawn path.

## Scope notes

This PR fixes the **`real items in inventory + Hammerspace + furniture load`** workflow that the issue reporter described. It does **not** address the broader UX of "Hammerspace alone with an empty inventory should pretend you have everything" — `smoker_load_food` filters smokable items from `p.crafting_inventory()` *before* `consume_items` is even called, so without at least one matching item in the player's real inventory the menu still fires `"You don't have any food that can be smoked."` That's a separate design question about whether `crafting_inventory()` should enumerate Hammerspace's implicit infinite stock; out of scope here.

## Testing

### Static verification

- Local incremental build with `windows-tiles-sounds-x64-msvc` preset, `RelWithDebInfo` config: **exit code 0**, no new warnings beyond the existing `LIBCMTD` linker note.
- Diff is a single 18-line addition to one function in `src/crafting.cpp`; no header changes, no API surface changes.

### Runtime smoke test

1. Loaded a save with a character at an evac shelter, debug-spawned an `f_smoking_rack` adjacent.
2. Debug menu → Mutate → `Debug Hammerspace`. Game logged `You gain a mutation called Debug Hammerspace!` confirming the trait was active.
3. Debug-spawned 100 chunks of meat; picked them up into real inventory until full, wielded one to absorb the overflow. All 100 chunks were carried (inventory + wielded), none left on the floor.
4. Pressed `E` on the smoking rack → "Insert food" → selected `chunk of meat` → entered count `80`.
5. **Result with the fix applied (verbatim from in-game text):**
   - Message log: `You carefully place 80 chunks of meat in the rack.`
   - Examine the smoker tile after loading: `There's a smoking rack here. You inspect its contents and find: -> chunks of meat (80)`

Pre-fix behaviour (per the issue body): the same workflow — DEBUG_HS active + smoker load — silently completed all menu steps but left the rack empty, because `consume_items` returned an empty vector and `for( detached_ptr<item> &m : moved )` iterated over nothing. The `has_trait(trait_DEBUG_HS)` check short-circuits before the normal `use_from::player` / `use_from::map` paths are reached, so the carried-inventory count is irrelevant to triggering the bug or the fix.

(Screenshot showing both the success message and the post-load examine dialog is attached to this PR.)

## Additional context

This PR used AI assistance (`Assisted-by: Claude:claude-opus-4-7`). Diagnosis pathway built on @usagirei's earlier issue comment.

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter. *(C++ change; formatter ran as part of the build pipeline, no diff.)*
- [x] I linked the relevant issue using `Closes #7614` in the Purpose section.

### Optional

- [x] This PR used AI assistance.
  - [x] Disclosed in the PR description and `Assisted-by:` trailer is on the commit.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [10abdb6](https://github.com/cataclysmbn/Cataclysm-BN/commit/10abdb6aa91c8faebd68f4339fcf4af787073b10) (fix: hammerspace returns spawned items so furniture loading works) on 2026-05-22 15:17:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26293126795/artifacts/7162988904)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26293126795/artifacts/7163770030)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26293126795/artifacts/7162889191)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26293126795/artifacts/7163242291)
<!-- END artifact comment -->