### PR TITLE
fix(UI): prevent input from being repeated when holding a key down and slowed

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2127,6 +2127,10 @@ bool game::do_turn()
     // Finally, clear pathfinding cache
     Pathfinding::clear_d_maps();
 
+    // // Drain the OS input buffer so key-repeat events generated during world
+    // // processing don't accumulate and drive movement after key release.
+    inp_mngr.pump_events();
+
     return false;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2127,8 +2127,8 @@ bool game::do_turn()
     // Finally, clear pathfinding cache
     Pathfinding::clear_d_maps();
 
-    // // Drain the OS input buffer so key-repeat events generated during world
-    // // processing don't accumulate and drive movement after key release.
+    // Drain the OS input buffer so key-repeat events generated during world
+    // processing don't accumulate and drive movement after key release.
     inp_mngr.pump_events();
 
     return false;


### PR DESCRIPTION
## Purpose of change (The Why)

Had a couple of deaths related to this, holding a key down a long time and then releasing it would still repeat the action many times after having released it.

## Describe the solution (The How)

Remove extra input event after the turn is processed.

## Describe alternatives you've considered

## Testing

Break leg, set pain to 200, hold button down for 5 seconds, with fix char stops, without char keeps walking way longer.

## Additional context

This seems much more noticeable on Linux, probably not needed in windows but shouldn't hurt?
fyi claude helped

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5f24354](https://github.com/cataclysmbn/Cataclysm-BN/commit/5f243549c014cdcd0bc72fcad55fe114fc80e64d) (Cleanup) on 2026-05-22 19:08:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26304323374/artifacts/7167568867)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26304323374/artifacts/7168165714)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26304323374/artifacts/7168291876)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26304323374/artifacts/7167736029)
<!-- END artifact comment -->