### PR TITLE
fix: prevent infinite turn passes & more

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1920,17 +1920,23 @@ void activity_handlers::pulp_do_turn( player_activity *act, player *p )
     const auto &pos = here.abs_to_bub( act->placement );
 
     // Stabbing weapons are a lot less effective at pulping
-    const int cut_power = std::max( p->primary_weapon().damage_melee( DT_CUT ),
-                                    p->primary_weapon().damage_melee( DT_STAB ) / 2 );
+    const auto cut_power = std::max( p->primary_weapon().damage_melee( DT_CUT ),
+                                     p->primary_weapon().damage_melee( DT_STAB ) / 2 );
 
     ///\EFFECT_STR increases pulping power, with diminishing returns
-    float pulp_power = std::sqrt( ( p->str_cur + p->primary_weapon().damage_melee( DT_BASH ) ) *
-                                  ( cut_power + 1.0f ) );
-    float pulp_effort = p->str_cur + p->primary_weapon().damage_melee( DT_BASH );
+    const auto pulp_effort = std::max( 0, p->str_cur + p->primary_weapon().damage_melee( DT_BASH ) );
+    auto pulp_power = std::sqrt( pulp_effort * std::max( 0.0f, cut_power + 1.0f ) );
     // Multiplier to get the chance right + some bonus for survival skill
     pulp_power *= 40 + p->get_skill_level( skill_survival ) * 5;
 
-    const int mess_radius = p->primary_weapon().has_flag( flag_MESSY ) ? 2 : 1;
+    if( pulp_power <= 0.0f || !std::isfinite( pulp_power ) ) {
+        p->add_msg_player_or_npc( m_bad, _( "You are unable to pulp the corpse." ),
+                                  _( "<npcname> is unable to pulp the corpse." ) );
+        act->moves_left = 0;
+        return;
+    }
+
+    const auto mess_radius = p->primary_weapon().has_flag( flag_MESSY ) ? 2 : 1;
 
     int moves = 0;
     // use this to collect how many corpse are pulped

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -1095,8 +1095,10 @@ void do_pause( Character &who )
                         who.mutation_spend_resources( tid );
                     }
                 }
-            } else {
+            } else if( who.is_avatar() ) {
                 g->vertical_move( 0, true );
+            } else {
+                here.creature_on_trap( who, false );
             }
         }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -266,6 +266,23 @@ static void init_bubble_config()
     init_bubble_config( get_option<int>( "REALITY_BUBBLE_SIZE" ) );
 }
 
+static auto discard_monster_map_for_loaded_bubble( map &here,
+        const std::string &dimension_id ) -> void
+{
+    const auto origin = here.get_abs_sub();
+    const auto zmin = here.has_zlevels() ? -OVERMAP_DEPTH : origin.z();
+    const auto zmax = here.has_zlevels() ? OVERMAP_HEIGHT : origin.z();
+    const auto z_range = std::views::iota( zmin, zmax + 1 );
+    const auto xy_range = std::views::iota( 0, g_mapsize );
+    std::ranges::for_each(
+        cata::views::cartesian_product( z_range, xy_range, xy_range ),
+    [&]( auto tup ) {
+        const auto [gz, gx, gy] = tup;
+        get_overmapbuffer( dimension_id ).discard_monster_map(
+            tripoint_abs_sm{ origin.x() + gx, origin.y() + gy, gz } );
+    } );
+}
+
 static constexpr int DANGEROUS_PROXIMITY = 5;
 
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
@@ -3282,24 +3299,18 @@ bool game::load( const save_t &name )
     // setup() already called init_bubble_config() + m.resize().
     init_bubble_config();
     reality_bubble_radius_ = g_half_mapsize;
-    update_map( u );
-    // Discard stale monster_map entries for submaps inside the initial bubble.
-    // Old saves can have duplicates (same monster in critter_tracker and monster_map);
-    // discarding in-bubble entries prevents visible duplication on load.
-    {
-        const tripoint &origin = m.get_abs_sub().raw();
-        const auto zmin = m.has_zlevels() ? -OVERMAP_DEPTH : origin.z;
-        const auto zmax = m.has_zlevels() ? OVERMAP_HEIGHT : origin.z;
-        const auto z_range = std::views::iota( zmin, zmax + 1 );
-        const auto xy_range = std::views::iota( 0, g_mapsize );
-        std::ranges::for_each(
-            cata::views::cartesian_product( z_range, xy_range, xy_range ),
-        [&]( auto tup ) {
-            auto [gz, gx, gy] = tup;
-            get_overmapbuffer( current_dimension_id_ ).discard_monster_map(
-                tripoint_abs_sm{ origin.x + gx, origin.y + gy, gz } );
-        } );
+    // Old saves can have duplicate authority for in-bubble monsters: one copy in
+    // active_monsters and another in overmap monster_map.  Purge the stale overmap
+    // buckets before update_map() gets a chance to spawn newly-entered submaps.
+    discard_monster_map_for_loaded_bubble( m, current_dimension_id_ );
+    // Repair active monsters left outside every loaded submap by older broken saves.
+    for( auto &critter : all_monsters() ) {
+        if( m.get_submap_at( critter.bub_pos() ) == nullptr ) {
+            despawn_monster( critter );
+        }
     }
+    update_map( u );
+    discard_monster_map_for_loaded_bubble( m, current_dimension_id_ );
     m.build_floor_cache( get_levz() );
     for( auto &e : u.inv_dump() ) {
         e->set_owner( g->u );
@@ -11896,10 +11907,10 @@ void game::place_player_overmap( const tripoint_abs_omt &om_dest )
         project_to<coords::sm>( om_dest ).raw() + point( -g_half_mapsize, -g_half_mapsize ) );
     const tripoint_bub_ms player_pos( u.bub_pos().xy(), map_sm_pos.z() );
     load_map( map_sm_pos );
-    m.spawn_monsters( true ); // Static monsters
     // update weather now as it could be different on the new location
     get_weather().nextweather = calendar::turn;
     place_player( player_pos );
+    m.spawn_monsters( true ); // Static monsters
     update_overmap_seen();
     // load_npcs() scans around the player's absolute position, updated by place_player().
     load_npcs();

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1925,7 +1925,10 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p )
         const auto ms = this_monster.abs_pos();
         const map &here = get_map();
         const auto local = here.abs_to_bub( ms );
-        assert( here.inbounds( local ) );
+        if( !here.inbounds( local ) ) {
+            debugmsg( "Monster at bub( %s, %s, %s ), abs( %s, %s, %s ) was out of bounds. Skipping spawn",
+                      local.x(), local.y(), local.z(), ms.x(), ms.y(), ms.z() );
+        }
         monster *const placed = g->place_critter_at( make_shared_fast<monster>( this_monster ), local );
         if( placed ) {
             placed->on_load();

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1504,13 +1504,19 @@ void faction_manager::deserialize( JsonIn &jsin )
 
 void Creature_tracker::deserialize( JsonIn &jsin )
 {
-    monsters_list.clear();
-    monsters_by_location.clear();
+    clear();
     jsin.start_array();
     while( !jsin.end_array() ) {
         // TODO: would be nice if monster had a constructor using JsonIn or similar, so this could be one statement.
-        shared_ptr_fast<monster> mptr = make_shared_fast<monster>();
+        auto mptr = make_shared_fast<monster>();
         jsin.read( *mptr );
+        if( const auto existing_mon_ptr = find( mptr->bub_pos() ) ) {
+            if( !existing_mon_ptr->is_hallucination() && !mptr->is_hallucination() ) {
+                DebugLog( DL::Warn, DC::Game ) << "Skipping duplicate active monster "
+                                               << mptr->disp_name() << " at " << mptr->bub_pos();
+                continue;
+            }
+        }
         add( mptr );
     }
 }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1997,7 +1997,8 @@ auto monster::load( const JsonObject &data,
     auto stored_pos_abs = tripoint_abs_ms::zero();
     if( data.read( "pos_abs", stored_pos_abs ) ) {
         pos_abs = stored_pos_abs;
-    } else if( has_legacy_x && has_legacy_y ) {
+    }
+    if( has_legacy_x && has_legacy_y ) {
         if( legacy_context ) {
             const auto abs_sm_pos = project_combine( legacy_context->om_pos, legacy_context->submap_pos );
             const auto legacy_remainder = project_remain<coords::sm>( legacy_bub_pos );


### PR DESCRIPTION
## Purpose of change / solution 

resolves #8479
Fixes overlapping monster on load errors
Also guarded against a potential infinite pulp loop
Fixes monster loading position errors

## Testing

Utilized save provided in #8479 to trigger load bug + infinite turns, no longer occur.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e6b8fa2](https://github.com/cataclysmbn/Cataclysm-BN/commit/e6b8fa25154f5ff536287855e6d041d0f640503f) (fix monster legacy loads and change bounds assert into debugmsg) on 2026-05-23 00:51:48

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26317547423/artifacts/7172387317)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26317547423/artifacts/7172659589)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26317547423/artifacts/7172336683)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26317547423/artifacts/7172418054)
<!-- END artifact comment -->