### PR TITLE
fix(UI): Made numpad 6 and right arrow keys work like enter in numeric selection

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -3707,7 +3707,7 @@
     "type": "keybinding",
     "id": "TEXT.CONFIRM",
     "name": "Confirm text input",
-    "bindings": [ { "input_method": "keyboard", "key": "RETURN" } ]
+    "bindings": [ { "input_method": "keyboard", "key": "RETURN" }, { "input_method": "keyboard", "key": "NUMPAD_6" } ]
   },
   {
     "type": "keybinding",

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -128,6 +128,7 @@ void string_input_popup::create_context()
     ctxt->register_action( "PAGE_DOWN" );
     ctxt->register_action( "SCROLL_UP" );
     ctxt->register_action( "SCROLL_DOWN" );
+    ctxt->register_action( "NUMPAD_6" );
     ctxt->register_action( "ANY_INPUT" );
 }
 
@@ -351,6 +352,7 @@ int64_t string_input_popup::query_int64_t( const bool loop, const bool draw_only
     return std::atoll( query_string( loop, draw_only ).c_str() );
 }
 
+[[clang::optnone]]
 const std::string &string_input_popup::query_string( const bool loop, const bool draw_only,
         const bool printable )
 {
@@ -454,7 +456,8 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
             _position = -1;
             _canceled = true;
             return _text;
-        } else if( action == "TEXT.CONFIRM" ) {
+        } else if( action == "TEXT.CONFIRM" || ( action == "TEXT.RIGHT" && !( edit.empty() &&
+                   _position + 1 <= static_cast<int>( ret.size() ) ) ) ) {
             add_to_history( ret.str() );
             _confirmed = true;
             _text = ret.str();
@@ -591,6 +594,8 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
     _text = ret.str();
     return _text;
 }
+
+
 
 string_input_popup &string_input_popup::window( const catacurses::window &w, point start,
         int endx )

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -352,7 +352,6 @@ int64_t string_input_popup::query_int64_t( const bool loop, const bool draw_only
     return std::atoll( query_string( loop, draw_only ).c_str() );
 }
 
-[[clang::optnone]]
 const std::string &string_input_popup::query_string( const bool loop, const bool draw_only,
         const bool printable )
 {
@@ -594,8 +593,6 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
     _text = ret.str();
     return _text;
 }
-
-
 
 string_input_popup &string_input_popup::window( const catacurses::window &w, point start,
         int endx )


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Many people liked being able to use right arrow key to instead of enter to confirm number of items, so this readds that feature.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
closes #8988
closes #8958  
## Describe the solution (The How)
In the string_input_popup if the cursor mark is at the very right, the right arrow key will confirm. NUMPAD 6 key also now confirms. 
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Loaded a world, filter and numeric input popups, moved left and right with arrows keys, works fine. When right arrow is pressed at the end of the word, selection occurs. NUMPAD 6 selects regardless of location of cursor.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4ab786b](https://github.com/cataclysmbn/Cataclysm-BN/commit/4ab786bcc6f58b5125e9bd3518c2b6ac11537886) (Fixed unnecessary changes) on 2026-05-23 18:01:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26338531598/artifacts/7178428318)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26338531598/artifacts/7178629706)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26338531598/artifacts/7178474625)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26338531598/artifacts/7178481892)
<!-- END artifact comment -->