### PR TITLE
fix: furniture is no longer ungrabbed after every movement

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12120,8 +12120,9 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
     std::swap( *srcVars, *dstVars );
 
     // Actually move the furniture.
-    m.furn_set( fdest, m.furn( fpos ), atd ? atd->clone() : nullptr );
-    m.furn_set( fpos, f_null );
+    // Ignore grab destroy checks
+    m.furn_set( fdest, m.furn( fpos ), atd ? atd->clone() : nullptr, true );
+    m.furn_set( fpos, f_null, nullptr, true );
     u.clear_memorized_overlay( m.bub_to_abs( tripoint_bub_ms( fpos ) ) );
 
     if( fire_intensity == 1 && !pulling_furniture ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2086,7 +2086,7 @@ void map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture,
     const furn_t &new_t = new_furniture.obj();
 
     // If player has grabbed this furniture and it's no longer grabbable, release the grab.
-    if( g->u.get_grab_type() == OBJECT_FURNITURE && g->u.bub_pos() == p &&
+    if( g->u.get_grab_type() == OBJECT_FURNITURE && g->u.bub_pos() - g->u.grab_point == p &&
         !new_t.is_movable() ) {
         add_msg( _( "The %s you were grabbing is destroyed!" ), old_t.name() );
         g->u.grab( OBJECT_NONE );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2062,7 +2062,7 @@ furn_id map::furn( const tripoint_bub_ms &p ) const
 }
 
 void map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture,
-                    const cata::poly_serialized<active_tile_data> &new_active )
+                    const cata::poly_serialized<active_tile_data> &new_active, bool ignore_grab_check )
 {
     if( is_out_of_bounds( p ) ) {
         return;
@@ -2086,7 +2086,8 @@ void map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture,
     const furn_t &new_t = new_furniture.obj();
 
     // If player has grabbed this furniture and it's no longer grabbable, release the grab.
-    if( g->u.get_grab_type() == OBJECT_FURNITURE && g->u.bub_pos() - g->u.grab_point == p &&
+    if( !ignore_grab_check && g->u.get_grab_type() == OBJECT_FURNITURE &&
+        g->u.bub_pos() + g->u.grab_point == p &&
         !new_t.is_movable() ) {
         add_msg( _( "The %s you were grabbing is destroyed!" ), old_t.name() );
         g->u.grab( OBJECT_NONE );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2086,7 +2086,7 @@ void map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture,
     const furn_t &new_t = new_furniture.obj();
 
     // If player has grabbed this furniture and it's no longer grabbable, release the grab.
-    if( g->u.get_grab_type() == OBJECT_FURNITURE && g->u.grab_point + g->u.bub_pos() == p &&
+    if( g->u.get_grab_type() == OBJECT_FURNITURE && g->u.bub_pos() == p &&
         !new_t.is_movable() ) {
         add_msg( _( "The %s you were grabbing is destroyed!" ), old_t.name() );
         g->u.grab( OBJECT_NONE );

--- a/src/map.h
+++ b/src/map.h
@@ -947,9 +947,11 @@ class map : public submap_load_listener
         * @param p Position within the map
         * @param new_furniture Id of new furniture
         * @param new_active Override default active tile of new furniture
+        * @param ignore_grabbed Ignore destruction of grabbed tile, useful when player is moved afterwards
         */
         void furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture,
-                       const cata::poly_serialized<active_tile_data> &new_active = nullptr );
+                       const cata::poly_serialized<active_tile_data> &new_active = nullptr,
+                       const bool ignore_grabbed = false );
         void furn_set( const point_bub_ms &p, const furn_id &new_furniture ) {
             furn_set( tripoint_bub_ms( p, abs_sub.z() ), new_furniture );
         }


### PR DESCRIPTION
## Purpose of change (The Why)
resolves: #9022 

## Describe the solution (The How)
Make it notice the furniture which is on the same tile as the player

## Describe alternatives you've considered
RUN GIT BLAME AND BLAME WHOEVER THOUGHT IT WAS A GOOD IDEA TO WRITE A TEST FOR A FEATURE THAT DOESN'T EVEN WORK

## Testing
My furniture is now dragged

## Additional context
~~Seriously it was the fact that the feature that did that was broken was the reason that we never got this issue,  I dont think I can blame the tripoint PR even because it fixed things~~

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9290be9](https://github.com/cataclysmbn/Cataclysm-BN/commit/9290be9cb9fbc92a45a203770c4d34a6c8e9c330) (ah yes test the broken function for functionality perfectly sane) on 2026-05-23 20:40:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26341723407/artifacts/7179496577)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26341723407/artifacts/7179547803)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26341723407/artifacts/7179378799)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26341723407/artifacts/7179385145)
<!-- END artifact comment -->