### PR TITLE
feat(UI): allow fetching ingredients for a recipe or construction (wip)

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -489,6 +489,15 @@
     "verbose_tooltip": false
   },
   {
+    "id": "ACT_FETCH_RECIPE_INGREDIENTS",
+    "type": "activity_type",
+    "verb": "fetching ingredients",
+    "suspendable": false,
+    "special": true,
+    "no_resume": true,
+    "verbose_tooltip": false
+  },
+  {
     "id": "ACT_MULTIPLE_FARM",
     "type": "activity_type",
     "verb": "farming",

--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -670,6 +670,13 @@
   },
   {
     "type": "keybinding",
+    "id": "FETCH_RECIPE_INGREDIENTS",
+    "category": "CRAFTING",
+    "name": "Fetch ingredients from nearby containers",
+    "bindings": [ { "input_method": "keyboard", "key": "G" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "LEVEL_UP",
     "name": "Go Up",
     "bindings": [ { "input_method": "keyboard", "key": "PPAGE" }, { "input_method": "keyboard", "key": "<" } ]
@@ -1483,6 +1490,13 @@
     "category": "CONSTRUCTION",
     "name": "Toggle unavailable constructions",
     "bindings": [ { "input_method": "keyboard", "key": ";" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "FETCH_RECIPE_INGREDIENTS",
+    "category": "CONSTRUCTION",
+    "name": "Fetch ingredients from nearby containers",
+    "bindings": [ { "input_method": "keyboard", "key": "G" } ]
   },
   {
     "type": "keybinding",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1068,9 +1068,24 @@ std::unique_ptr<activity_actor> move_items_activity_actor::deserialize( JsonIn &
     return actor;
 }
 
+void fetch_recipe_ingredients_activity_actor::start( player_activity &, Character &who )
+{
+    origin = get_map().bub_to_abs( who.bub_pos() );
+}
+
 void fetch_recipe_ingredients_activity_actor::do_turn( player_activity &act, Character &who )
 {
     auto &here = get_map();
+
+    // Helper: add item to inventory; overflow drops at the player's origin tile
+    const auto add_or_drop_at_origin = [&]( detached_ptr<item> taken ) {
+        if( !who.can_pick_weight( *taken, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ||
+            !who.can_pick_volume( *taken ) ) {
+            here.add_item_or_charges( here.abs_to_bub( origin ), std::move( taken ) );
+        } else {
+            who.i_add( std::move( taken ) );
+        }
+    };
 
     while( idx < pending.size() ) {
         const map_ingredient &next = pending[idx];
@@ -1092,7 +1107,7 @@ void fetch_recipe_ingredients_activity_actor::do_turn( player_activity &act, Cha
             if( it->typeId() == next.type && !it->made_of( LIQUID ) ) {
                 detached_ptr<item> taken = it->detach();
                 who.mod_moves( -pickup::cost_to_move_item( who, *taken ) );
-                who.i_add_or_drop( std::move( taken ) );
+                add_or_drop_at_origin( std::move( taken ) );
                 break;
             }
         }
@@ -1103,13 +1118,25 @@ void fetch_recipe_ingredients_activity_actor::do_turn( player_activity &act, Cha
                 if( it->typeId() == next.type && !it->made_of( LIQUID ) ) {
                     detached_ptr<item> taken = it->detach();
                     who.mod_moves( -pickup::cost_to_move_item( who, *taken ) );
-                    who.i_add_or_drop( std::move( taken ) );
+                    add_or_drop_at_origin( std::move( taken ) );
                     break;
                 }
             }
         }
 
         ++idx;
+    }
+
+    // All items collected — walk back to origin if needed
+    const tripoint_bub_ms orig_bub = here.abs_to_bub( origin );
+    if( !returning && who.bub_pos() != orig_bub ) {
+        returning = true;
+        auto route = here.route( who.bub_pos(), orig_bub,
+                                 who.get_legacy_pathfinding_settings() );
+        if( !route.empty() ) {
+            who.set_destination( route, who.remove_activity() );
+            return;
+        }
     }
 
     act.set_to_null();
@@ -1119,6 +1146,8 @@ void fetch_recipe_ingredients_activity_actor::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();
     jsout.member( "idx", idx );
+    jsout.member( "origin", origin );
+    jsout.member( "returning", returning );
     jsout.member( "pending" );
     jsout.start_array();
     for( const auto &mi : pending ) {
@@ -1137,6 +1166,8 @@ std::unique_ptr<activity_actor> fetch_recipe_ingredients_activity_actor::deseria
                      std::vector<map_ingredient>{} );
     JsonObject data = jsin.get_object();
     data.read( "idx", actor->idx );
+    data.read( "origin", actor->origin );
+    data.read( "returning", actor->returning );
     for( JsonObject elem : data.get_array( "pending" ) ) {
         map_ingredient mi;
         elem.read( "loc", mi.loc );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1068,6 +1068,84 @@ std::unique_ptr<activity_actor> move_items_activity_actor::deserialize( JsonIn &
     return actor;
 }
 
+void fetch_recipe_ingredients_activity_actor::do_turn( player_activity &act, Character &who )
+{
+    auto &here = get_map();
+
+    while( idx < pending.size() ) {
+        const map_ingredient &next = pending[idx];
+        const tripoint_bub_ms src = here.abs_to_bub( next.loc );
+
+        if( rl_dist( who.bub_pos(), src ) > 1 ) {
+            auto route = route_adjacent( static_cast<const player &>( who ), src );
+            if( route.empty() ) {
+                ++idx;
+                continue;
+            }
+            // Walk to the item; activity (with current idx) resumes on arrival
+            who.set_destination( route, who.remove_activity() );
+            return;
+        }
+
+        // Adjacent — grab from ground
+        for( item *it : here.i_at( src ) ) {
+            if( it->typeId() == next.type && !it->made_of( LIQUID ) ) {
+                detached_ptr<item> taken = it->detach();
+                who.mod_moves( -pickup::cost_to_move_item( who, *taken ) );
+                who.i_add_or_drop( std::move( taken ) );
+                break;
+            }
+        }
+        // Also grab from vehicle cargo at same tile
+        if( const std::optional<vpart_reference> vp =
+                here.veh_at( src ).part_with_feature( "CARGO", true ) ) {
+            for( item *it : vp->vehicle().get_items( vp->part_index() ) ) {
+                if( it->typeId() == next.type && !it->made_of( LIQUID ) ) {
+                    detached_ptr<item> taken = it->detach();
+                    who.mod_moves( -pickup::cost_to_move_item( who, *taken ) );
+                    who.i_add_or_drop( std::move( taken ) );
+                    break;
+                }
+            }
+        }
+
+        ++idx;
+    }
+
+    act.set_to_null();
+}
+
+void fetch_recipe_ingredients_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "idx", idx );
+    jsout.member( "pending" );
+    jsout.start_array();
+    for( const auto &mi : pending ) {
+        jsout.start_object();
+        jsout.member( "loc", mi.loc );
+        jsout.member( "type", mi.type );
+        jsout.end_object();
+    }
+    jsout.end_array();
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> fetch_recipe_ingredients_activity_actor::deserialize( JsonIn &jsin )
+{
+    auto actor = std::make_unique<fetch_recipe_ingredients_activity_actor>(
+                     std::vector<map_ingredient>{} );
+    JsonObject data = jsin.get_object();
+    data.read( "idx", actor->idx );
+    for( JsonObject elem : data.get_array( "pending" ) ) {
+        map_ingredient mi;
+        elem.read( "loc", mi.loc );
+        elem.read( "type", mi.type );
+        actor->pending.push_back( mi );
+    }
+    return actor;
+}
+
 void pickup_activity_actor::do_turn( player_activity &act, Character &who )
 {
     // If we don't have target items bail out
@@ -2588,6 +2666,7 @@ deserialize_functions = {
     { activity_id( "ACT_DIG_CHANNEL" ), &dig_channel_activity_actor::deserialize },
     { activity_id( "ACT_DISASSEMBLE" ), &disassemble_activity_actor::deserialize },
     { activity_id( "ACT_DROP" ), &drop_activity_actor::deserialize },
+    { activity_id( "ACT_FETCH_RECIPE_INGREDIENTS" ), &fetch_recipe_ingredients_activity_actor::deserialize },
     { activity_id( "ACT_HACKING" ), &hacking_activity_actor::deserialize },
     { activity_id( "ACT_HACKSAW" ), &hacksaw_activity_actor::deserialize },
     { activity_id( "ACT_LOCKPICK" ), &lockpick_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -526,6 +526,28 @@ class move_items_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
 };
 
+class fetch_recipe_ingredients_activity_actor : public activity_actor
+{
+    private:
+        std::vector<map_ingredient> pending;
+        std::size_t idx = 0;
+
+    public:
+        explicit fetch_recipe_ingredients_activity_actor( std::vector<map_ingredient> items ) :
+            pending( std::move( items ) ) {}
+
+        activity_id get_type() const override {
+            return activity_id( "ACT_FETCH_RECIPE_INGREDIENTS" );
+        }
+
+        void start( player_activity &, Character & ) override {}
+        void do_turn( player_activity &act, Character &who ) override;
+        void finish( player_activity &, Character & ) override {}
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
+};
+
 class toggle_gate_activity_actor : public activity_actor
 {
     private:

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -531,6 +531,8 @@ class fetch_recipe_ingredients_activity_actor : public activity_actor
     private:
         std::vector<map_ingredient> pending;
         std::size_t idx = 0;
+        tripoint_abs_ms origin;
+        bool returning = false;
 
     public:
         explicit fetch_recipe_ingredients_activity_actor( std::vector<map_ingredient> items ) :
@@ -540,7 +542,7 @@ class fetch_recipe_ingredients_activity_actor : public activity_actor
             return activity_id( "ACT_FETCH_RECIPE_INGREDIENTS" );
         }
 
-        void start( player_activity &, Character & ) override {}
+        void start( player_activity &, Character &who ) override;
         void do_turn( player_activity &act, Character &who ) override;
         void finish( player_activity &, Character & ) override {}
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -9,10 +9,12 @@
 #include <memory>
 #include <numeric>
 #include <ranges>
+#include <unordered_set>
 #include <utility>
 
 #include "action.h"
 #include "activity_actor_definitions.h"
+#include "cached_options.h"
 #include "avatar.h"
 #include "calendar.h"
 #include "character.h"
@@ -22,6 +24,7 @@
 #include "construction_category.h"
 #include "construction_group.h"
 #include "coordinates.h"
+#include "crafting.h"
 #include "crafting_quality.h"
 #include "cursesdef.h"
 #include "debug.h"
@@ -483,6 +486,8 @@ std::optional<construction_id> construction_menu( const bool blueprint )
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "RESET_FILTER" );
+    ctxt.register_action( "FETCH_RECIPE_INGREDIENTS",
+                          to_translation( "Fetch ingredients from nearby containers" ) );
 
     const std::vector<construction_category> &construct_cat = construction_categories::get_all();
     std::vector<size_t> construct_cat_order;
@@ -1475,6 +1480,28 @@ std::optional<construction_id> construction_menu( const bool blueprint )
             hide_unconstructable = !hide_unconstructable;
             offset = 0;
             list_available_constructions( available, cat_available, hide_unconstructable );
+        } else if( action == "FETCH_RECIPE_INGREDIENTS" ) {
+            if( constructs.empty() || select >= static_cast<int>( constructs.size() ) ) {
+                continue;
+            }
+            std::unordered_set<itype_id> wanted;
+            for( const construction *con : constructions_by_group( constructs[select] ) ) {
+                for( const auto &comp_group : con->requirements->get_components() ) {
+                    for( const auto &comp : comp_group ) {
+                        wanted.insert( comp.type );
+                    }
+                }
+            }
+            auto pending = gather_map_ingredients( g->u, wanted, PICKUP_RANGE );
+            if( pending.empty() ) {
+                popup( _( "No matching ingredients found in nearby containers." ) );
+            } else {
+                g->u.assign_activity(
+                    std::make_unique<player_activity>(
+                        std::make_unique<fetch_recipe_ingredients_activity_actor>(
+                            std::move( pending ) ) ) );
+                exit = true;
+            }
         } else if( action == "CONFIRM" ) {
             if( constructs.empty() || select >= static_cast<int>( constructs.size() ) ) {
                 // Nothing to be done here

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -639,6 +639,36 @@ void Character::invalidate_crafting_inventory()
     cached_position = tripoint_bub_ms::min();
 }
 
+std::vector<map_ingredient> gather_map_ingredients(
+    const Character &who,
+    const std::unordered_set<itype_id> &wanted,
+    int radius )
+{
+    auto &here = get_map();
+    std::vector<map_ingredient> result;
+
+    for( const tripoint_bub_ms &loc : closest_points_first( who.bub_pos(), 1, radius ) ) {
+        if( !here.clear_path( who.bub_pos(), loc, radius, 1, 100 ) ) {
+            continue;
+        }
+        for( const auto *it : here.i_at( loc ) ) {
+            if( !it->made_of( LIQUID ) && wanted.count( it->typeId() ) ) {
+                result.push_back( { here.bub_to_abs( loc ), it->typeId() } );
+            }
+        }
+        if( const std::optional<vpart_reference> vp =
+                here.veh_at( loc ).part_with_feature( "CARGO", true ) ) {
+            for( const auto *it : vp->vehicle().get_items( vp->part_index() ) ) {
+                if( !it->made_of( LIQUID ) && wanted.count( it->typeId() ) ) {
+                    result.push_back( { here.bub_to_abs( loc ), it->typeId() } );
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
 void Character::make_craft( const recipe_id &id_to_make, int batch_size,
                             const tripoint_bub_ms &loc )
 {

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -3,6 +3,7 @@
 #include <list>
 #include <optional>
 #include <set>
+#include <unordered_set>
 #include <vector>
 
 #include "point.h"
@@ -120,3 +121,17 @@ void complete_disassemble( Character &who, const iuse_location &target,
                            const tripoint_bub_ms &pos );
 
 } // namespace crafting
+
+/// An item found on the map that the player should physically walk to and collect.
+struct map_ingredient {
+    tripoint_abs_ms loc;
+    itype_id type;
+};
+
+/// Returns items within @p radius of @p who that match any id in @p wanted.
+/// Skips the player's own tile, unreachable tiles, and liquid items.
+/// Results are sorted nearest-first.
+std::vector<map_ingredient> gather_map_ingredients(
+    const Character &who,
+    const std::unordered_set<itype_id> &wanted,
+    int radius );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "cached_options.h"
 #include "calendar.h"
@@ -622,6 +623,8 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
     ctxt.register_action( "COMPARE" );
     ctxt.register_action( "TOGGLE_UNAVAILABLE" );
     ctxt.register_action( "ASSIGN_NPC_CRAFT", to_translation( "Assign nearest NPC to craft" ) );
+    ctxt.register_action( "FETCH_RECIPE_INGREDIENTS",
+                          to_translation( "Fetch ingredients from nearby containers" ) );
     if( highlight_unread_recipes ) {
         ctxt.register_action( "TOGGLE_RECIPE_UNREAD" );
         ctxt.register_action( "MARK_ALL_RECIPES_READ" );
@@ -1454,6 +1457,31 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
                         chosen = nullptr;
                         done = true;
                     }
+                }
+            }
+        } else if( action == "FETCH_RECIPE_INGREDIENTS" ) {
+            if( current.empty() || available[line].is_nested_category || current[line]->is_nested() ) {
+                popup( _( "Select a craftable recipe first." ) );
+            } else {
+                const recipe *rec = current[line];
+                std::unordered_set<itype_id> wanted;
+                for( const auto &alt : rec->deduped_requirements().alternatives() ) {
+                    for( const auto &comp_group : alt.get_components() ) {
+                        for( const auto &comp : comp_group ) {
+                            wanted.insert( comp.type );
+                        }
+                    }
+                }
+                auto pending = gather_map_ingredients( crafter, wanted, PICKUP_RANGE );
+                if( pending.empty() ) {
+                    popup( _( "No matching ingredients found in nearby containers." ) );
+                } else {
+                    crafter.assign_activity(
+                        std::make_unique<player_activity>(
+                            std::make_unique<fetch_recipe_ingredients_activity_actor>(
+                                std::move( pending ) ) ) );
+                    chosen = nullptr;
+                    done = true;
                 }
             }
         } else if( action == "HELP_RECIPE" ) {


### PR DESCRIPTION
## Purpose of change (The Why)

Sometimes you want to craft a recipe somewhere different than where you store your ingredients,
especially when constructing. Example a solar panel on the roof.

## Describe the solution (The How)

Pressing shift+G with a recipe selected will make the character fetch the ingredients and store them either in inventory or at the tile where the action was initiated. The character retrieves the items similarly to zones.

## Describe alternatives you've considered

## Testing

WIP

## Additional context

WIP

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR used AI assistance.
  - [ ] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9c56988](https://github.com/cataclysmbn/Cataclysm-BN/commit/9c56988f8aed0ce881b36193e06b1b7df9a403eb) (fix: fetch ingredients drops overflow at origin and returns player to origin) on 2026-05-23 16:07:15

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26336230663/artifacts/7177862283)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26336230663/artifacts/7178006585)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26336230663)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26336230663/artifacts/7177884933)
<!-- END artifact comment -->