### PR TITLE
fix: bathtub volume and keg_capacity inconsistency

### DIFF
--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -12,7 +12,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MOUNTABLE", "LIQUIDCONT" ],
     "max_volume": "200 L",
     "examine_action": "keg",
-    "keg_capacity": 600,
+    "keg_capacity": 800,
     "bash": {
       "str_min": 12,
       "str_max": 50,


### PR DESCRIPTION
## Purpose of change (The Why)

fixes #8938

The bathtub furniture has a max inventory storage volume of 200 L, but a `keg_capacity` of 600.
`keg_capacity` refers to the exact number of units of liquid it can hold. Volume refers to the inventory space.

1 L can hold 4 units of liquid. Meaning that in terms of inventory, a bathtub holds 800 units of liquid while its `keg_capacity` holds 600 units.

## Describe the solution (The How)

Give the bathtub a `keg_capacity` of 800

## Testing

Made a new save, first unloaded and then poured 200L of water from a steel drum into the bathtub. Both result in the same configuration of the tub holding 800 units, or 200L, of water.

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [470b980](https://github.com/cataclysmbn/Cataclysm-BN/commit/470b98006c098b904a558d52368c0b328af86b83) (fix: bathtub volume and keg_capacity inconsistency) on 2026-05-23 21:14:20

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26342560424/artifacts/7179553978)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26342560424/artifacts/7179745922)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26342560424/artifacts/7179619123)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26342560424/artifacts/7179627116)
<!-- END artifact comment -->