### PR TITLE
fix: use opened large tin cans for plutonium cells

### DIFF
--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -820,7 +820,7 @@
       [
         [ "can_drink_unsealed", 5 ],
         [ "can_food_unsealed", 5 ],
-        [ "can_food_big", 5 ],
+        [ "can_food_big_unsealed", 5 ],
         [ "can_medium_unsealed", 5 ],
         [ "canister_empty", 5 ]
       ]


### PR DESCRIPTION
## Purpose of change (The Why)

close #9034

## Describe the solution (The How)

Use `can_food_big_unsealed` in the plutonium fuel cell recipe, matching the other opened tin can alternatives.

## Describe alternatives you've considered

N/A

## Testing

- [x] `cmake --build --preset linux-full --target style-json-parallel`
- [x] `./build-scripts/lint-json.sh`
- [x] `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- [x] `./out/build/linux-full/src/cataclysm-bn-tiles --userdir "$tmp" --jsonverify`
- [x] `./out/build/linux-full/src/cataclysm-bn-tiles --userdir "$tmp" --check-mods bn`

## Additional context

N/A

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>
