### PR TITLE
fix(UI): Fix selection disappearing in drop + other menus when you use filter

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -785,14 +785,14 @@ void inventory_column::prepare_paging( const std::string &filter )
     } );
     entries.erase( new_end, entries.end() );
     // Then sort them with respect to categories
-    auto sort_function = [this](const inventory_entry& lhs, const inventory_entry& rhs) {
-        if (*lhs.get_category_ptr() != *rhs.get_category_ptr()) {
+    auto sort_function = [this]( const inventory_entry & lhs, const inventory_entry & rhs ) {
+        if( *lhs.get_category_ptr() != *rhs.get_category_ptr() ) {
             return *lhs.get_category_ptr() < *rhs.get_category_ptr();
         } else {
             return preset.sort_compare( lhs, rhs );
         }
     };
-    std::sort( entries.begin(), entries.end(), sort_function);
+    std::sort( entries.begin(), entries.end(), sort_function );
 
     // Recover categories
     const item_category *current_category = nullptr;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -441,7 +441,6 @@ size_t inventory_column::get_cells_width() const
 
 void inventory_column::set_filter( const std::string &filter )
 {
-
     entries_cell_cache.clear();
     paging_is_valid = false;
     prepare_paging( filter );
@@ -786,23 +785,15 @@ void inventory_column::prepare_paging( const std::string &filter )
     } );
     entries.erase( new_end, entries.end() );
     // Then sort them with respect to categories
-    auto from = entries.begin();
-    while( from != entries.end() ) {
-        auto to = std::next( from );
-        while( to != entries.end() && from->get_category_ptr() == to->get_category_ptr() ) {
-            to->update_cache();
-            std::advance( to, 1 );
+    auto sort_function = [this](const inventory_entry& lhs, const inventory_entry& rhs) {
+        if (*lhs.get_category_ptr() != *rhs.get_category_ptr()) {
+            return *lhs.get_category_ptr() < *rhs.get_category_ptr();
+        } else {
+            return preset.sort_compare( lhs, rhs );
         }
-        if( !ordered_categories.contains( from->get_category_ptr()->get_id().c_str() ) ) {
-            std::sort( from, to, [ this ]( const inventory_entry & lhs, const inventory_entry & rhs ) {
-                if( lhs.is_selectable() != rhs.is_selectable() ) {
-                    return lhs.is_selectable(); // Disabled items always go last
-                }
-                return preset.sort_compare( lhs, rhs );
-            } );
-        }
-        from = to;
-    }
+    };
+    std::sort( entries.begin(), entries.end(), sort_function);
+
     // Recover categories
     const item_category *current_category = nullptr;
     for( auto iter = entries.begin(); iter != entries.end(); ++iter ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -441,7 +441,7 @@ size_t inventory_column::get_cells_width() const
 
 void inventory_column::set_filter( const std::string &filter )
 {
-    entries = entries_unfiltered;
+    
     entries_cell_cache.clear();
     paging_is_valid = false;
     prepare_paging( filter );
@@ -769,6 +769,17 @@ void inventory_column::prepare_paging( const std::string &filter )
 
     // FIXME: toggled status of multiselect menu resets when filtering the menu
     // First, remove all non-items
+    for (size_t i = 0; i < entries_hidden.size(); ++i) {
+        entries.push_back(entries_hidden[i]);
+    }
+
+    entries_hidden.clear();
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].is_item() && !filter_fn(entries[i])) {
+            entries_hidden.push_back(entries[i]);
+        }
+    }
+
     const auto new_end = std::remove_if( entries.begin(),
     entries.end(), [&filter_fn]( const inventory_entry & entry ) {
         return !entry.is_item() || !filter_fn( entry );
@@ -822,9 +833,6 @@ void inventory_column::prepare_paging( const std::string &filter )
     }
     entries_cell_cache.clear();
     paging_is_valid = true;
-    if( entries_unfiltered.empty() ) {
-        entries_unfiltered = entries;
-    }
     // Select the uppermost possible entry
     select( selected_index, selected_index ? scroll_direction::BACKWARD : scroll_direction::FORWARD );
 }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -441,7 +441,7 @@ size_t inventory_column::get_cells_width() const
 
 void inventory_column::set_filter( const std::string &filter )
 {
-    
+
     entries_cell_cache.clear();
     paging_is_valid = false;
     prepare_paging( filter );
@@ -769,14 +769,14 @@ void inventory_column::prepare_paging( const std::string &filter )
 
     // FIXME: toggled status of multiselect menu resets when filtering the menu
     // First, remove all non-items
-    for (size_t i = 0; i < entries_hidden.size(); ++i) {
-        entries.push_back(entries_hidden[i]);
+    for( size_t i = 0; i < entries_hidden.size(); ++i ) {
+        entries.push_back( entries_hidden[i] );
     }
 
     entries_hidden.clear();
-    for (size_t i = 0; i < entries.size(); ++i) {
-        if (entries[i].is_item() && !filter_fn(entries[i])) {
-            entries_hidden.push_back(entries[i]);
+    for( size_t i = 0; i < entries.size(); ++i ) {
+        if( entries[i].is_item() && !filter_fn( entries[i] ) ) {
+            entries_hidden.push_back( entries[i] );
         }
     }
 

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -371,7 +371,7 @@ class inventory_column
         const inventory_selector_preset &preset;
 
         std::vector<inventory_entry> entries;
-        std::vector<inventory_entry> entries_unfiltered;
+        std::vector<inventory_entry> entries_hidden;
         navigation_mode mode = navigation_mode::ITEM;
         bool active = false;
         bool multiselect = false;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
When you select items in the drop menu and potentially any other menu inheriting from inventory_multiselector the selection marks are removed when you search using the filter. 

closes #8928 
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
The problem is that the way filtering is implemented in inventory_ui.h is that there are two std::vector<inventory_entry> for the unfiltered and filtered entries, they are technically separate objects instead of pointers, modifying the selection count of one didn't modify the other objects, so when you have to use the filter the other vector didn't reflect the changes made. I used https://github.com/CleverRaven/Cataclysm-DDA/pull/53441 solution where they just created another vector to store hidden entries, and swap inventory_entry between them as you filter.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
I considered many other solutions, like changing the filltered entries to a std::vector<inventory_entry*> but other solutions would require a much larger rewrite, and I fear the inventory_ui code now after 2 days of trying to fix this bug.
## Testing
Loaded a world, opened drop menu, selected an item, used filter to search for item, saw the item was still selected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
https://github.com/user-attachments/assets/616161be-7ae6-4d26-aeda-a8432d9b9c67
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I think there shouldn't be that many changes because the code didn't rely on the old std::vector<inventory_entry>entries_unfiltered that much any way, but if there are any bugs with filters breaking something, please let me know. 
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [X] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [X] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e5a5b20](https://github.com/cataclysmbn/Cataclysm-BN/commit/e5a5b2058c95ab929ced30d0673631dfce357686) (Ran astyle) on 2026-05-24 03:08:11

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349339670/artifacts/7181526751)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349339670/artifacts/7181692805)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349339670/artifacts/7181495504)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349339670/artifacts/7181573382)
<!-- END artifact comment -->