### PR TITLE
fix: `V` menu item lookaround point

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8878,14 +8878,15 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
 
     for( int i = 1; i <= range; i++ ) {
         int z = i % 2 ? center_z - i / 2 : center_z + i / 2;
-        for( auto &points_p_it : closest_points_first<tripoint_bub_ms>( {u.bub_pos().xy(), z}, iRadius ) ) {
+        for( tripoint_bub_ms &points_p_it : closest_points_first<tripoint_bub_ms>( {u.bub_pos().xy(), z},
+                iRadius ) ) {
             if( points_p_it.y() >= u.bub_pos().y() - iRadius && points_p_it.y() <= u.bub_pos().y() + iRadius &&
                 u.sees( points_p_it ) &&
                 m.sees_some_items( points_p_it, u ) ) {
 
                 for( auto &elem : m.i_at( points_p_it ) ) {
                     const std::string name = elem->tname();
-                    const auto relative_pos = points_p_it - u.bub_pos().raw();
+                    const tripoint_rel_ms relative_pos = points_p_it - u.bub_pos();
 
                     if( std::find( item_order.begin(), item_order.end(), name ) == item_order.end() ) {
                         item_order.push_back( name );
@@ -9828,8 +9829,8 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
                 }
                 mvwprintz( w_items, point( width_nob - right_padding, iNum - iStartPos ),
                            iNum == iActive ? c_light_green : c_light_gray,
-                           "%2d %s", rl_dist( point_bub_ms::zero(), p ),
-                           direction_name_short( direction_from( point_bub_ms::zero(), p ) ) );
+                           "%2d %s", rl_dist( point_rel_ms::zero(), p ),
+                           direction_name_short( direction_from( point_rel_ms::zero(), p ) ) );
                 ++iter;
             }
             iNum = 0;
@@ -10082,7 +10083,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
                 }
             }
             if( iter != filtered_items.end() ) {
-                active_pos = iter->vIG[page_num].pos - u.bub_pos();
+                active_pos = iter->vIG[page_num].pos;
                 activeItem = &( *iter );
             }
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8878,8 +8878,7 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
 
     for( int i = 1; i <= range; i++ ) {
         int z = i % 2 ? center_z - i / 2 : center_z + i / 2;
-        for( tripoint_bub_ms &points_p_it : closest_points_first<tripoint_bub_ms>( {u.bub_pos().xy(), z},
-                iRadius ) ) {
+        for( auto &points_p_it : closest_points_first<tripoint_bub_ms>( {u.bub_pos().xy(), z}, iRadius ) ) {
             if( points_p_it.y() >= u.bub_pos().y() - iRadius && points_p_it.y() <= u.bub_pos().y() + iRadius &&
                 u.sees( points_p_it ) &&
                 m.sees_some_items( points_p_it, u ) ) {

--- a/src/map_item_stack.cpp
+++ b/src/map_item_stack.cpp
@@ -14,7 +14,7 @@ map_item_stack::item_group::item_group() : count( 0 )
 {
 }
 
-map_item_stack::item_group::item_group( const tripoint_rel_ms &p, const int arg_count ) : pos( p ),
+map_item_stack::item_group::item_group( const tripoint_rel_ms &p, int arg_count ) : pos( p ),
     count( arg_count )
 {
 }

--- a/src/map_item_stack.cpp
+++ b/src/map_item_stack.cpp
@@ -14,7 +14,7 @@ map_item_stack::item_group::item_group() : count( 0 )
 {
 }
 
-map_item_stack::item_group::item_group( const tripoint_bub_ms &p, const int arg_count ) : pos( p ),
+map_item_stack::item_group::item_group( const tripoint_rel_ms &p, const int arg_count ) : pos( p ),
     count( arg_count )
 {
 }
@@ -24,14 +24,14 @@ map_item_stack::map_item_stack() : example( nullptr ), totalcount( 0 )
     vIG.emplace_back( );
 }
 
-map_item_stack::map_item_stack( const item *const it, const tripoint_bub_ms &pos ) : example( it ),
+map_item_stack::map_item_stack( const item *const it, const tripoint_rel_ms &pos ) : example( it ),
     totalcount( it->count() )
 {
     vIG.emplace_back( pos, totalcount );
     example_item_pos = pos;
 }
 
-void map_item_stack::add_at_pos( const item *const it, const tripoint_bub_ms &pos )
+void map_item_stack::add_at_pos( const item *const it, const tripoint_rel_ms &pos )
 {
     const int amount = it->count();
 
@@ -47,8 +47,8 @@ void map_item_stack::add_at_pos( const item *const it, const tripoint_bub_ms &po
 bool map_item_stack::map_item_stack_sort( const map_item_stack &lhs, const map_item_stack &rhs )
 {
     if( lhs.example->get_category() == rhs.example->get_category() ) {
-        return square_dist( tripoint_bub_ms::zero(), lhs.vIG[0].pos ) <
-               square_dist( tripoint_bub_ms::zero(), rhs.vIG[0].pos );
+        return square_dist( tripoint_rel_ms::zero(), lhs.vIG[0].pos ) <
+               square_dist( tripoint_rel_ms::zero(), rhs.vIG[0].pos );
     }
 
     return lhs.example->get_category() < rhs.example->get_category();

--- a/src/map_item_stack.h
+++ b/src/map_item_stack.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "coordinates.h"
-#include "point.h"
 
 class item;
 

--- a/src/map_item_stack.h
+++ b/src/map_item_stack.h
@@ -14,29 +14,29 @@ class map_item_stack
         class item_group
         {
             public:
-                tripoint_bub_ms pos;
+                tripoint_rel_ms pos;
                 int count;
 
                 //only expected to be used for things like lists and vectors
                 item_group();
-                item_group( const tripoint_bub_ms &p, int arg_count );
+                item_group( const tripoint_rel_ms &p, int arg_count );
         };
     public:
         // This should be per-group!
         const item *example; //an example item for showing stats, etc.
-        tripoint_bub_ms example_item_pos;
+        tripoint_rel_ms example_item_pos;
         std::vector<item_group> vIG;
         int totalcount;
 
         //only expected to be used for things like lists and vectors
         map_item_stack();
-        map_item_stack( const item *it, const tripoint_bub_ms &pos );
+        map_item_stack( const item *it, const tripoint_rel_ms &pos );
 
         // This adds to an existing item group if the last current
         // item group is the same position and otherwise creates and
         // adds to a new item group. Note that it does not search
         // through all older item groups for a match.
-        void add_at_pos( const item *it, const tripoint_bub_ms &pos );
+        void add_at_pos( const item *it, const tripoint_rel_ms &pos );
 
         static bool map_item_stack_sort( const map_item_stack &lhs, const map_item_stack &rhs );
 };


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #9033 
related: #8686 
## Describe the solution (The How)
map_item_stack was using incorrect tripoints
Fixes that

## Describe alternatives you've considered
Audit over all remaining uses of .raw()

## Testing
V menu works
Nothing else uses map_item_stacks

## Additional context
Sorting being off is always a good hint
```cpp
        return square_dist( tripoint_bub_ms::zero(), lhs.vIG[0].pos ) <
               square_dist( tripoint_bub_ms::zero(), rhs.vIG[0].pos );
```

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f480457](https://github.com/cataclysmbn/Cataclysm-BN/commit/f4804573d4d2a23a42b2e0378e9b30d5c9e7c235) (Minor cleanup) on 2026-05-24 03:45:21

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349965530/artifacts/7181696175)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349965530/artifacts/7181914754)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349965530/artifacts/7181661264)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349965530/artifacts/7181747687)
<!-- END artifact comment -->