### PR TITLE
feat: add shoulder magazine pouch

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -353,6 +353,7 @@
       [ "baldric_holster", 3 ],
       [ "holster", 8 ],
       [ "shoulder_holster", 4 ],
+      [ "shoulder_pouch", 4 ],
       [ "bootstrap", 2 ],
       [ "wristholster", 1 ],
       [ "bholster", 5 ],

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -650,5 +650,35 @@
       "draw_cost": 35
     },
     "flags": [ "WAIST", "COMPACT", "OVERSIZE", "WATER_FRIENDLY", "ALLOWS_TAIL_SNAKE" ]
+  },
+  {
+    "id": "shoulder_pouch",
+    "type": "ARMOR",
+    "name": { "str": "shoulder magazine pouch", "str_pl": "shoulder magazine pouches" },
+    "description": "A shoulder pouch designed to be worn under a jacket or coat that can hold two small magazines or speedloaders. Normally meant to be worn alongside a shoulder holster, but can be used on its own.",
+    "volume": "250 ml",
+    "weight": "120 g",
+    "price": "20 USD",
+    "price_postapoc": "750 cent",
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "looks_like": "legpouch_large",
+    "color": "dark_gray",
+    "covers": [ "arm_either" ],
+    "coverage": 5,
+    "encumbrance": 1,
+    "max_encumbrance": 3,
+    "material_thickness": 2,
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Stash ammo",
+      "holster_msg": "You stash your %s.",
+      "multi": 2,
+      "min_volume": "25 ml",
+      "max_volume": "250 ml",
+      "draw_cost": 40,
+      "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
+    },
+    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "COMPACT" ]
   }
 ]

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -727,6 +727,17 @@
     "extend": { "flags": [ "POWERARMOR_MOD" ] }
   },
   {
+     "id": "power_armor_shoulder_holster",
+    "copy-from": "shoulder_pouch",
+    "type": "ARMOR",
+    "name": { "str": "power armor shoulder magazine pouch" },
+    "description": "A shoulder magazine pouch that can hold two small magazines or speedloaders, converted to clip onto power armor.",
+    "material": [ "leather", "steel" ],
+    "proportional": { "encumbrance": 2 },
+    "relative": { "weight": "500 g" },
+    "extend": { "flags": [ "POWERARMOR_MOD" ] }
+  },
+  {
     "id": "exosuit_survivor",
     "type": "TOOL_ARMOR",
     "category": "armor",

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -727,7 +727,7 @@
     "extend": { "flags": [ "POWERARMOR_MOD" ] }
   },
   {
-   "id": "power_armor_shoulder_pouch",
+    "id": "power_armor_shoulder_pouch",
     "copy-from": "shoulder_pouch",
     "type": "ARMOR",
     "name": { "str": "power armor shoulder magazine pouch" },

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -731,7 +731,7 @@
     "copy-from": "shoulder_pouch",
     "type": "ARMOR",
     "name": { "str": "power armor shoulder magazine pouch" },
-    "description": "A shoulder magazine pouch that can hold two small magazines or speedloaders, converted to clip onto power armor.",
+    "description": "A shoulder pouch that can hold two small magazines or speedloaders, converted to clip onto power armor.",
     "material": [ "leather", "steel" ],
     "proportional": { "encumbrance": 2 },
     "relative": { "weight": "500 g" },

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -727,7 +727,7 @@
     "extend": { "flags": [ "POWERARMOR_MOD" ] }
   },
   {
-     "id": "power_armor_shoulder_holster",
+   "id": "power_armor_shoulder_pouch",
     "copy-from": "shoulder_pouch",
     "type": "ARMOR",
     "name": { "str": "power armor shoulder magazine pouch" },

--- a/data/json/monsterdrops/zombie_cop.json
+++ b/data/json/monsterdrops/zombie_cop.json
@@ -52,6 +52,7 @@
       [ "kevlar", 35 ],
       [ "bholster", 3 ],
       [ "legpouch_large", 5 ],
+      [ "shoulder_pouch", 10 ],
       [ "pocket_firstaid", 10 ],
       [ "police_belt", 20 ],
       [ "rope_30", 5 ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2769,7 +2769,7 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "item": "sw629", "ammo-item": "44fmj", "charges": 6, "container-item": "shoulder_holster" },
-          { "item": "legpouch_large", "contents-group": "speedloaders_44_detective" },
+          { "item": "shoulder_pouch", "contents-group": "speedloaders_44_detective" },
           { "item": "44fmj", "charges": 12 }
         ]
       },
@@ -6630,7 +6630,7 @@
         "items": [ "fancy_sunglasses", "platinum_watch", "money_bundle" ],
         "entries": [
           { "item": "shoulder_holster", "contents-group": "hitman_pistol" },
-          { "item": "legpouch_large", "contents-group": "hitman_mags_ppq" }
+          { "item": "shoulder_pouch", "contents-group": "hitman_mags_ppq" }
         ]
       },
       "male": [

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -1104,6 +1104,18 @@
     "components": [ [ [ "leather", 8 ] ] ]
   },
   {
+    "result": "shoulder_pouch",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "15 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 10 ] ],
+    "components": [ [ [ "legpouch", 2 ] ], [ [ "shoulder_strap", 1 ] ] ]
+  },
+  {
     "result": "power_armor_back_holster",
     "type": "recipe",
     "category": "CC_ARMOR",
@@ -1341,5 +1353,19 @@
     "qualities": [ { "id": "HAMMER_FINE", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
     "using": [ [ "welding_standard", 10 ], [ "steel_standard", 1 ] ],
     "components": [ [ [ "grenadebandolier", 1 ] ] ]
+  },
+  {
+    "result": "power_armor_shoulder_pouch",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "mechanics",
+    "difficulty": 6,
+    "skills_required": [ "fabrication", 3 ],
+    "time": "30 m",
+    "autolearn": true,
+    "qualities": [ { "id": "HAMMER_FINE", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
+    "using": [ [ "welding_standard", 10 ], [ "steel_standard", 1 ] ],
+    "components": [ [ [ "shoulder_pouch", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

We have shoulder holsters, but it's not possible to wear a magazine pouch on the opposite arm, despite being a common thing in real life.

## Describe the solution (The How)

Adds a shoulder magazine pouch, along with a power armor version. It holds two handgun magazines or speedloaders, can be crafted by connecting a shoulder strap to two ankle holsters, and is worn on one arm. It spawns on zombie cops and in pawn shops (as both of these places can also spawn shoulder holsters).

The Hitman and Police Detective professions also had their leg magazine pouches replaced with shoulder magazine pouches. It makes more sense, given the fact that they both wear shoulder holsters. 

## Describe alternatives you've considered

Adding the pouch to more itemgroups. 

## Testing

Started as a detective and a hitman, and noticed that I have my pouch on. Checked the recipes for the pouch and its power armor version. Wore both pouches. Drew ammo from the pouches, then put it back in. 

## Additional context

None required

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [263a3c9](https://github.com/cataclysmbn/Cataclysm-BN/commit/263a3c9f0385a5bdbe43a6726e96550751e54c65) (style(autofix.ci): automated formatting) on 2026-05-24 03:37:22

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349883713/artifacts/7181672135)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349883713/artifacts/7181873517)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349883713/artifacts/7181628749)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26349883713/artifacts/7181708165)
<!-- END artifact comment -->