### PR TITLE
fix: voltmeter & tripoint vector bindings

### DIFF
--- a/data/json/lua/iuse/voltmeter.lua
+++ b/data/json/lua/iuse/voltmeter.lua
@@ -120,7 +120,7 @@ voltmeter.modify_grid_connections = function(who, item, pos)
   if choice < 0 then return 0 end
 
   local idx = choice + 1
-  local delta = TripointRelOmt.new(six_dirs[idx].x, six_dirs[idx].y, six_dirs[idx].z)
+  local delta = six_dirs[idx]
   if not delta then return 0 end
   local destination_pos_abs_omt = pos_abs_omt + delta
 

--- a/data/json/lua/iuse/voltmeter.lua
+++ b/data/json/lua/iuse/voltmeter.lua
@@ -120,7 +120,7 @@ voltmeter.modify_grid_connections = function(who, item, pos)
   if choice < 0 then return 0 end
 
   local idx = choice + 1
-  local delta = TripointRelOmt.new(six_dirs[idx])
+  local delta = TripointRelOmt.new(six_dirs[idx].x, six_dirs[idx].y, six_dirs[idx].z)
   if not delta then return 0 end
   local destination_pos_abs_omt = pos_abs_omt + delta
 

--- a/src/catalua_coord.h
+++ b/src/catalua_coord.h
@@ -4,9 +4,12 @@
 #include "coordinates.h"
 #include "point.h"
 
+#include <algorithm>
+#include <iterator>
 #include <optional>
 #include <stdexcept>
 #include <type_traits>
+#include <vector>
 
 namespace cata::detail::lua_coords
 {
@@ -216,6 +219,19 @@ auto sol_lua_push( sol::types<coord_point<Point, Origin, Scale>>, lua_State *L,
                    const coord_point<Point, Origin, Scale> &coord ) -> int
 {
     return cata::detail::lua_coords::push_coord( L, coord );
+}
+
+template<typename Point, origin Origin, scale Scale>
+auto sol_lua_push( sol::types<std::vector<coord_point<Point, Origin, Scale>>>, lua_State *L,
+                   const std::vector<coord_point<Point, Origin, Scale>> &coords ) -> int
+{
+    using Coord = coord_point<Point, Origin, Scale>;
+    auto lua_values = std::vector<cata::detail::lua_coords::lua_coord_for_t<Coord>> {};
+    lua_values.reserve( coords.size() );
+    std::ranges::transform( coords, std::back_inserter( lua_values ), []( const Coord & coord ) {
+        return cata::detail::lua_coords::to_lua( coord );
+    } );
+    return sol::stack::push( L, std::move( lua_values ) );
 }
 
 } // namespace coords


### PR DESCRIPTION
## Purpose of change (The Why)
resolves: #9040
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Some sorcery from azmodius to make vectors of tripoints given to lua actually work
And minor fix to new definition not accepting normal points after a later part of the tripoint fix

## Describe alternatives you've considered
None

## Testing
Voltmeter works now

## Additional context
I screamscream

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [8fbeec8](https://github.com/cataclysmbn/Cataclysm-BN/commit/8fbeec894957003f6f0f68d41a427a64ab33c1fc) (fix(lua): use cardinal tripoint directly) on 2026-05-24 05:46:20

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26352236890/artifacts/7182580104)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26352236890/artifacts/7182552656)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26352236890/artifacts/7182392411)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26352236890/artifacts/7182415346)
<!-- END artifact comment -->