### PR TITLE
fix: lightmap will now reset on all player movement

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11677,6 +11677,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc )
         u.stop_hauling();
     }
     u.setpos( dest_loc );
+    m.invalidate_lightmap_caches();
     if( u.is_mounted() ) {
         monster *mon = u.mounted_creature.get();
         mon->setpos( dest_loc );
@@ -11977,6 +11978,7 @@ bool game::phasing_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
         //tunneling costs 100 moves baseline, 50 per extra tile up to a cap of 500 moves
         u.moves -= ( 50 + ( tunneldist * 50 ) );
         u.setpos( dest );
+        m.invalidate_lightmap_caches();
 
         if( m.veh_at( u.bub_pos() ).part_with_feature( "BOARDABLE", true ) ) {
             m.board_vehicle( u.bub_pos(), &u );


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #9021 

## Describe the solution (The How)
In `game::place_player` always invalidate that cache
I dont care at this point if everyone is going to get 5 billion speed and then complain there aint anything else I can do then reset it on each move
Also reset it on whatever on earth `phasing_move` is

## Describe alternatives you've considered
None

## Testing
Gave myself speedydex and 200 dex
I didn't outrun my phonelight

## Additional context
This is related to like 50 PRs and I am too lazy to find them all

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d6ae3b9](https://github.com/cataclysmbn/Cataclysm-BN/commit/d6ae3b9652a9d83635ae6932c23c6ce8636ec971) (fix: lightmap will now reset on all player movement) on 2026-05-24 05:55:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26352464887/artifacts/7182667529)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26352464887/artifacts/7182580222)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26352464887/artifacts/7182418090)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26352464887/artifacts/7182464289)
<!-- END artifact comment -->