### PR TITLE
fix: make dragging over ramps functional

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -122,6 +122,7 @@ static std::mutex g_debug_log_mutex;
 static bool capturing = false;
 /** сaptured debug messages */
 static std::string captured;
+static std::ostringstream captured_log;
 
 
 #if defined(_WIN32) && defined(LIBBACKTRACE)
@@ -204,12 +205,14 @@ capture_debugmsg::capture_debugmsg()
 {
     capturing = true;
     captured = "";
+    captured_log.str( "" );
+    captured_log.clear();
 }
 
 std::string capture_debugmsg::dmsg()
 {
     capturing = false;
-    return captured;
+    return captured + captured_log.str();
 }
 
 capture_debugmsg::~capture_debugmsg()
@@ -1560,6 +1563,10 @@ detail::DebugLogGuard detail::realDebugLog( DL lev, DC cl, const char *filename,
 {
     if( lev == DL::Error ) {
         error_observed = true;
+    }
+
+    if( capturing && cl == DC::DebugMsg ) {
+        return DebugLogGuard( captured_log );
     }
 
     if( checkDebugLevelClass( lev, cl ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11185,7 +11185,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     const auto grabbed_furn_pos = tripoint_bub_ms( u.bub_pos() + u.grab_point );
 
     bool grabbed = u.get_grab_type() != OBJECT_NONE;
-    auto grabbed_vehicle_target = std::optional<vehicle_grab_target>{};
+    auto grabbed_vehicle_target = std::optional<vehicle_grab_target> {};
     if( grabbed && u.get_grab_type() == OBJECT_VEHICLE ) {
         grabbed_vehicle_target = vehicle_grab_target_at( m, u.bub_pos() + u.grab_point );
         if( grabbed_vehicle_target ) {
@@ -12022,7 +12022,7 @@ struct furniture_move_effort_options {
 };
 
 static auto multiply_ratio_round_up( const int value, const int numerator, const int denominator )
--> int
+- > int
 {
     const auto safe_denominator = std::max( 1, denominator );
     return ( value * numerator + safe_denominator - 1 ) / safe_denominator;
@@ -12093,7 +12093,7 @@ static auto furniture_contents_strength_req( map &here, const tripoint_bub_ms &p
 }
 
 static auto furniture_move_effort_for( const furniture_move_effort_options &options )
--> furniture_move_effort
+- > furniture_move_effort
 {
     const auto vertical_direction = furniture_vertical_direction_for( options.from, options.to );
     const auto &furntype = options.here.furn( options.from ).obj();
@@ -12175,7 +12175,7 @@ auto game::grabbed_furn_move( const tripoint_rel_ms &dp ) -> bool
     const auto dst_items = m.i_at( fdest ).size();
 
     const auto only_liquid_items = std::all_of( m.i_at( fdest ).begin(), m.i_at( fdest ).end(),
-    [&]( const auto &liquid_item ) {
+    [&]( const auto & liquid_item ) {
         return liquid_item->made_of( LIQUID );
     } );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11181,8 +11181,8 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     bool pulling = false; // moving -away- from grabbed tile; check for move_cost > 0
     bool shifting_furniture = false; // moving furniture and staying still; skip check for move_cost > 0
 
-    const auto furn_pos = u.bub_pos() + u.grab_point;
-    const auto furn_dest = dest_loc + u.grab_point;
+    const auto dp = dest_loc - u.bub_pos();
+    const auto grabbed_furn_pos = tripoint_bub_ms( u.bub_pos() + u.grab_point );
 
     bool grabbed = u.get_grab_type() != OBJECT_NONE;
     auto grabbed_vehicle_target = std::optional<vehicle_grab_target>{};
@@ -11193,8 +11193,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
         }
     }
     if( grabbed ) {
-        const auto &dp = dest_loc - u.bub_pos();
-        if( u.get_grab_type() == OBJECT_VEHICLE ) {
+        if( u.get_grab_type() == OBJECT_VEHICLE || u.get_grab_type() == OBJECT_FURNITURE ) {
             const auto horizontal_dp = tripoint_rel_ms( dp.xy(), 0 );
             const auto horizontal_grab = tripoint_rel_ms( u.grab_point.xy(), 0 );
             pushing = horizontal_dp == horizontal_grab;
@@ -11204,7 +11203,13 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
             pulling = dp == -u.grab_point;
         }
     }
-    if( grabbed && u.get_grab_type() != OBJECT_VEHICLE && dest_loc.z() != u.bub_pos().z() ) {
+    const auto ramp_entry = tripoint_bub_ms( dest_loc.xy(), u.bub_pos().z() );
+    const auto allow_furniture_z_move = grabbed && u.get_grab_type() == OBJECT_FURNITURE &&
+                                        ( pushing || pulling ) && dp.z() != 0 && via_ramp &&
+                                        ( ( dp.z() > 0 && m.has_flag( TFLAG_RAMP_UP, ramp_entry ) ) ||
+                                          ( dp.z() < 0 && m.has_flag( TFLAG_RAMP_DOWN, ramp_entry ) ) );
+    if( grabbed && u.get_grab_type() != OBJECT_VEHICLE && dest_loc.z() != u.bub_pos().z() &&
+        !allow_furniture_z_move ) {
         add_msg( m_warning, _( "You let go of the grabbed object." ) );
         grabbed = false;
         u.grab( OBJECT_NONE );
@@ -11214,7 +11219,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     const vehicle *grabbed_vehicle = nullptr;
     if( grabbed && u.get_grab_type() == OBJECT_FURNITURE ) {
         // We only care about shifting, because it's the only one that can change our destination
-        if( m.has_furn( u.bub_pos() + u.grab_point ) ) {
+        if( m.has_furn( grabbed_furn_pos ) ) {
             shifting_furniture = !pushing && !pulling;
         } else {
             // We were grabbing a furniture that isn't there
@@ -11348,7 +11353,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
 
     const int mcost = m.combined_movecost( u.bub_pos(), dest_loc, grabbed_vehicle, modifier,
                                            via_ramp ) * multiplier;
-    if( grabbed_move( dest_loc - u.bub_pos() ) ) {
+    if( grabbed_move( dp, allow_furniture_z_move ) ) {
         return true;
     } else if( mcost == 0 && !character_funcs::can_noclip( u ) ) {
         return false;
@@ -11522,15 +11527,16 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     }
 
     auto oldpos = u.bub_pos();
-    auto submap_shift = place_player( dest_loc );
+    const auto keep_grab = u.get_grab_type() == OBJECT_VEHICLE || allow_furniture_z_move;
+    auto submap_shift = place_player( dest_loc, keep_grab );
     auto ms_shift = project_to<coords::ms>( submap_shift );
     oldpos = oldpos - ms_shift;
 
     if( pulling && u.get_grab_type() == OBJECT_FURNITURE ) {
-        const auto shifted_furn_pos = furn_pos - ms_shift;
-        const auto shifted_furn_dest = furn_dest - ms_shift;
-        const time_duration fire_age = m.get_field_age( shifted_furn_pos, fd_fire );
-        const int fire_intensity = m.get_field_intensity( shifted_furn_pos, fd_fire );
+        const auto shifted_furn_pos = grabbed_furn_pos - ms_shift;
+        const auto shifted_furn_dest = tripoint_bub_ms( u.bub_pos() + u.grab_point );
+        const auto fire_age = m.get_field_age( shifted_furn_pos, fd_fire );
+        const auto fire_intensity = m.get_field_intensity( shifted_furn_pos, fd_fire );
         m.remove_field( shifted_furn_pos, fd_fire );
         m.set_field_intensity( shifted_furn_dest, fd_fire, fire_intensity );
         m.set_field_age( shifted_furn_dest, fd_fire, fire_age );
@@ -11545,7 +11551,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     return true;
 }
 
-point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc )
+auto game::place_player( const tripoint_bub_ms &dest_loc, const bool keep_grab ) -> point_rel_sm
 {
     const optional_vpart_position vp1 = m.veh_at( dest_loc );
     if( const std::optional<std::string> label = vp1.get_label() ) {
@@ -11670,7 +11676,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc )
     // Move the player
     // Start with z-level, to make it less likely that old functions (2D ones) freak out
     if( m.has_zlevels() && dest_loc.z() != get_levz() ) {
-        vertical_shift( dest_loc.z() );
+        vertical_shift( dest_loc.z(), keep_grab );
     }
 
     if( u.is_hauling() && ( !m.can_put_items( dest_loc ) ||
@@ -11995,11 +12001,136 @@ bool game::phasing_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     return false;
 }
 
-bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
+enum class furniture_vertical_direction {
+    none,
+    up,
+    down,
+};
+
+struct furniture_move_effort {
+    int str_req = 0;
+    int adjusted_str = 0;
+    int move_cost = 0;
+    int stamina_cost = 0;
+};
+
+struct furniture_move_effort_options {
+    const avatar &you;
+    map &here;
+    tripoint_bub_ms from;
+    tripoint_bub_ms to;
+};
+
+static auto multiply_ratio_round_up( const int value, const int numerator, const int denominator )
+-> int
+{
+    const auto safe_denominator = std::max( 1, denominator );
+    return ( value * numerator + safe_denominator - 1 ) / safe_denominator;
+}
+
+static auto furniture_vertical_direction_for( const tripoint_bub_ms &from,
+        const tripoint_bub_ms &to ) -> furniture_vertical_direction
+{
+    if( to.z() > from.z() ) {
+        return furniture_vertical_direction::up;
+    }
+
+    if( to.z() < from.z() ) {
+        return furniture_vertical_direction::down;
+    }
+
+    return furniture_vertical_direction::none;
+}
+
+static auto ramp_adjusted_furniture_destination( map &here, const tripoint_bub_ms &from,
+        const tripoint_rel_ms &horizontal_dp ) -> tripoint_bub_ms
+{
+    auto dest = tripoint_bub_ms( from + horizontal_dp );
+
+    if( here.has_flag( TFLAG_RAMP_UP, dest ) && here.inbounds_z( dest.z() + 1 ) ) {
+        dest.z() += 1;
+    } else if( here.has_flag( TFLAG_RAMP_DOWN, dest ) && here.inbounds_z( dest.z() - 1 ) ) {
+        dest.z() -= 1;
+    }
+
+    return dest;
+}
+
+static auto is_ramp_tile_or_mate( const map &here, const tripoint_bub_ms &pos ) -> bool
+{
+    if( here.has_flag( TFLAG_RAMP, pos ) || here.has_flag( TFLAG_RAMP_UP, pos ) ||
+        here.has_flag( TFLAG_RAMP_DOWN, pos ) ) {
+        return true;
+    }
+
+    const auto above = pos + tripoint_above;
+    const auto below = pos + tripoint_below;
+    return ( here.inbounds_z( above.z() ) && here.has_flag( TFLAG_RAMP_DOWN, above ) ) ||
+           ( here.inbounds_z( below.z() ) && here.has_flag( TFLAG_RAMP_UP, below ) );
+}
+
+static auto furniture_drag_strength( const avatar &you ) -> int
+{
+    auto adjusted_str = you.get_str();
+    if( you.is_mounted() ) {
+        auto *mons = you.mounted_creature.get();
+        if( mons->has_flag( MF_RIDEABLE_MECH ) && mons->mech_str_addition() != 0 ) {
+            adjusted_str = mons->mech_str_addition();
+        }
+    }
+
+    return adjusted_str;
+}
+
+static auto furniture_contents_strength_req( map &here, const tripoint_bub_ms &pos ) -> int
+{
+    auto furniture_contents_weight = 0_gram;
+    for( const auto &contained_item : here.i_at( pos ) ) {
+        furniture_contents_weight += contained_item->weight();
+    }
+
+    return furniture_contents_weight / 4_kilogram;
+}
+
+static auto furniture_move_effort_for( const furniture_move_effort_options &options )
+-> furniture_move_effort
+{
+    const auto vertical_direction = furniture_vertical_direction_for( options.from, options.to );
+    const auto &furntype = options.here.furn( options.from ).obj();
+    auto str_req = std::max( 0, furntype.move_str_req +
+                             furniture_contents_strength_req( options.here, options.from ) );
+
+    if( vertical_direction == furniture_vertical_direction::up ) {
+        str_req = multiply_ratio_round_up( str_req, 3, 2 );
+    }
+
+    const auto adjusted_str = furniture_drag_strength( options.you );
+    auto move_cost = str_req * 10;
+    constexpr auto dresser_strength_anchor = 8;
+    auto stamina_cost = multiply_ratio_round_up(
+                            get_option<int>( "PLAYER_BASE_STAMINA_BURN_RATE" ) * 7,
+                            str_req, dresser_strength_anchor );
+    stamina_cost = multiply_ratio_round_up( stamina_cost, std::max( 1, str_req ),
+                                            std::max( std::max( 1, str_req ), adjusted_str ) );
+
+    if( vertical_direction != furniture_vertical_direction::none ) {
+        move_cost *= 2;
+        stamina_cost = multiply_ratio_round_up( stamina_cost, 3, 2 );
+    }
+
+    return furniture_move_effort{
+        .str_req = str_req,
+        .adjusted_str = adjusted_str,
+        .move_cost = move_cost,
+        .stamina_cost = stamina_cost,
+    };
+}
+
+auto game::grabbed_furn_move( const tripoint_rel_ms &dp ) -> bool
 {
     // Furniture: pull, push, or standing still and nudging object around.
     // Can push furniture out of reach.
-    auto fpos = u.bub_pos() + u.grab_point;
+    const auto fpos = tripoint_bub_ms( u.bub_pos() + u.grab_point );
     // supposed position of grabbed furniture
     if( !m.has_furn( fpos ) ) {
         // Where did it go? We're grabbing thin air so reset.
@@ -12008,68 +12139,71 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
         return false;
     }
 
-    const bool pushing_furniture = dp ==  u.grab_point;
-    const bool pulling_furniture = dp == -u.grab_point;
-    const bool shifting_furniture = !pushing_furniture && !pulling_furniture;
+    const auto horizontal_dp = tripoint_rel_ms( dp.xy(), 0 );
+    const auto horizontal_grab = tripoint_rel_ms( u.grab_point.xy(), 0 );
+    const auto pushing_furniture = horizontal_dp ==  horizontal_grab;
+    const auto pulling_furniture = horizontal_dp == -horizontal_grab;
+    const auto shifting_furniture = !pushing_furniture && !pulling_furniture;
 
-    auto fdest = fpos + dp; // intended destination of furniture.
+    const auto furniture_dp = pushing_furniture || pulling_furniture ? horizontal_dp : dp;
+    const auto fdest = ramp_adjusted_furniture_destination( m, fpos, furniture_dp );
+    const auto ramp_drag = fdest.z() != fpos.z() || dp.z() != 0 ||
+                           is_ramp_tile_or_mate( m, fdest );
     // Check floor: floorless tiles don't need to be flat and have no traps
-    const bool has_floor = m.has_floor( fdest );
+    const auto has_floor = m.has_floor( fdest );
     // Unfortunately, game::is_empty fails for tiles we're standing on,
     // which will forbid pulling, so:
-    const bool canmove = (
+    const auto canmove = (
                              m.passable( fdest ) &&
                              critter_at<npc>( fdest ) == nullptr &&
                              critter_at<monster>( fdest ) == nullptr &&
                              ( !pulling_furniture || is_empty( u.bub_pos() + dp ) ) &&
-                             ( !has_floor || m.has_flag( "FLAT", fdest ) ) &&
+                             ( !has_floor || m.has_flag( "FLAT", fdest ) || ramp_drag ) &&
                              !m.has_furn( fdest ) &&
                              !m.veh_at( fdest ) &&
                              ( !has_floor || m.tr_at( fdest ).is_null() )
                          );
 
-    const furn_t furntype = m.furn( fpos ).obj();
-    const int src_items = m.i_at( fpos ).size();
-    const int dst_items = m.i_at( fdest ).size();
+    const auto &furntype = m.furn( fpos ).obj();
+    if( furntype.move_str_req < 0 ) {
+        add_msg( _( "You can't move the %s." ), furntype.name() );
+        u.grab( OBJECT_NONE );
+        return false;
+    }
 
-    const bool only_liquid_items = std::all_of( m.i_at( fdest ).begin(), m.i_at( fdest ).end(),
-    [&]( item * const & liquid_item ) {
+    const auto src_items = m.i_at( fpos ).size();
+    const auto dst_items = m.i_at( fdest ).size();
+
+    const auto only_liquid_items = std::all_of( m.i_at( fdest ).begin(), m.i_at( fdest ).end(),
+    [&]( const auto &liquid_item ) {
         return liquid_item->made_of( LIQUID );
     } );
 
-    const bool dst_item_ok = !m.has_flag( "NOITEM", fdest ) &&
+    const auto dst_item_ok = !m.has_flag( "NOITEM", fdest ) &&
                              !m.has_flag( "SWIMMABLE", fdest ) &&
                              !m.has_flag( "DESTROY_ITEM", fdest );
 
-    const bool src_item_ok = m.furn( fpos ).obj().has_flag( "CONTAINER" ) ||
+    const auto src_item_ok = m.furn( fpos ).obj().has_flag( "CONTAINER" ) ||
                              m.furn( fpos ).obj().has_flag( "FIRE_CONTAINER" ) ||
                              m.furn( fpos ).obj().has_flag( "SEALED" );
 
-    const int fire_intensity = m.get_field_intensity( fpos, fd_fire );
-    time_duration fire_age = m.get_field_age( fpos, fd_fire );
+    const auto fire_intensity = m.get_field_intensity( fpos, fd_fire );
+    auto fire_age = m.get_field_age( fpos, fd_fire );
 
-    int str_req = furntype.move_str_req;
-    // Factor in weight of items contained in the furniture.
-    units::mass furniture_contents_weight = 0_gram;
-    for( auto &contained_item : m.i_at( fpos ) ) {
-        furniture_contents_weight += contained_item->weight();
-    }
-    str_req += furniture_contents_weight / 4_kilogram;
-    int adjusted_str = u.get_str();
-    if( u.is_mounted() ) {
-        auto mons = u.mounted_creature.get();
-        if( mons->has_flag( MF_RIDEABLE_MECH ) && mons->mech_str_addition() != 0 ) {
-            adjusted_str = mons->mech_str_addition();
-        }
-    }
+    const auto effort = furniture_move_effort_for( {
+        .you = u,
+        .here = m,
+        .from = fpos,
+        .to = fdest,
+    } );
     if( !canmove ) {
         // TODO: What is something?
         add_msg( _( "The %s collides with something." ), furntype.name() );
         u.moves -= 50;
         return true;
         ///\EFFECT_STR determines ability to drag furniture
-    } else if( str_req > adjusted_str &&
-               one_in( std::max( 20 - str_req - adjusted_str, 2 ) ) ) {
+    } else if( effort.str_req > effort.adjusted_str &&
+               one_in( std::max( 20 - effort.str_req - effort.adjusted_str, 2 ) ) ) {
         add_msg( m_bad, _( "You strain yourself trying to move the heavy %s!" ),
                  furntype.name() );
         u.moves -= 100;
@@ -12081,12 +12215,13 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
         return true;
     }
 
-    u.moves -= str_req * 10;
+    u.moves -= effort.move_cost;
+    u.mod_stamina( -effort.stamina_cost, false );
     // Additional penalty if we can't comfortably move it.
-    if( str_req > adjusted_str ) {
-        int move_penalty = std::pow( str_req, 2.0 ) + 100.0;
+    if( effort.str_req > effort.adjusted_str ) {
+        auto move_penalty = static_cast<int>( std::pow( effort.str_req, 2.0 ) + 100.0 );
         if( move_penalty <= 1000 ) {
-            if( adjusted_str >= str_req - 3 ) {
+            if( effort.adjusted_str >= effort.str_req - 3 ) {
                 u.moves -= std::max( 3000, move_penalty * 10 );
                 add_msg( m_bad, _( "The %s is really heavy!" ), furntype.name() );
                 if( one_in( 3 ) ) {
@@ -12110,11 +12245,11 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
             }
         }
     }
-    sounds::sound( fdest, furntype.move_str_req * 2, sounds::sound_t::movement,
+    sounds::sound( fdest, effort.str_req * 2, sounds::sound_t::movement,
                    _( "a scraping noise." ), true, "misc", "scraping" );
 
-    active_tile_data *atd = active_tiles::furn_at<active_tile_data>
-                            ( tripoint_abs_ms( m.bub_to_abs( fpos ) ) );
+    auto *atd = active_tiles::furn_at<active_tile_data>
+                ( tripoint_abs_ms( m.bub_to_abs( fpos ) ) );
 
     // Swap furniture vars between tiles beforehand
     // because the furn_set call will clear the vars
@@ -12143,12 +12278,12 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
     if( src_items > 0 ) { // Move the stuff inside.
         if( dst_item_ok && src_item_ok ) {
             // Assume contents of both cells are legal, so we can just swap contents.
-            std::vector<detached_ptr<item>> temp = m.i_clear( fpos );
-            std::vector<detached_ptr<item>> temp2 = m.i_clear( fdest );
-            for( detached_ptr<item> &it : temp ) {
+            auto temp = m.i_clear( fpos );
+            auto temp2 = m.i_clear( fdest );
+            for( auto &it : temp ) {
                 m.i_at( fdest ).insert( std::move( it ) );
             }
-            for( detached_ptr<item> &it : temp2 ) {
+            for( auto &it : temp2 ) {
                 m.i_at( fpos ).insert( std::move( it ) );
             }
         } else {
@@ -12158,7 +12293,7 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
 
     if( shifting_furniture ) {
         // We didn't move
-        auto d_sum = u.grab_point + dp;
+        auto d_sum = fdest - u.bub_pos();
         if( std::abs( d_sum.x() ) < 2 && std::abs( d_sum.y() ) < 2 ) {
             u.grab_point = d_sum; // furniture moved relative to us
         } else { // we pushed furniture out of reach
@@ -12167,6 +12302,9 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
         }
         return true; // We moved furniture but stayed still.
     }
+
+    const auto player_next_pos = tripoint_bub_ms( u.bub_pos() + dp );
+    u.grab_point = fdest - player_next_pos;
 
     if( pushing_furniture && m.impassable( fpos ) ) {
         // Not sure how that chair got into a wall, but don't let player follow.
@@ -12179,14 +12317,15 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
     return false;
 }
 
-bool game::grabbed_move( const tripoint_rel_ms &dp )
+auto game::grabbed_move( const tripoint_rel_ms &dp, const bool allow_furniture_z_move ) -> bool
 {
     if( u.get_grab_type() == OBJECT_NONE ) {
         return false;
     }
 
-    if( dp.z() != 0 && u.get_grab_type() != OBJECT_VEHICLE ) {
-        // No dragging furniture up/down stairs yet!
+    if( dp.z() != 0 && u.get_grab_type() != OBJECT_VEHICLE &&
+        !( u.get_grab_type() == OBJECT_FURNITURE && allow_furniture_z_move ) ) {
+        // Furniture can only follow z-level movement through explicit ramp dragging.
         return false;
     }
 
@@ -13742,7 +13881,7 @@ std::optional<tripoint_bub_ms> game::find_or_make_stairs( map &mp, const int z_a
     return stairs;
 }
 
-void game::vertical_shift( const int z_after )
+auto game::vertical_shift( const int z_after, const bool keep_grab ) -> void
 {
     if( z_after < -OVERMAP_DEPTH || z_after > OVERMAP_HEIGHT ) {
         debugmsg( "Tried to get z-level %d outside allowed range of %d-%d",
@@ -13750,9 +13889,7 @@ void game::vertical_shift( const int z_after )
         return;
     }
 
-    // Vehicle grabs can remain valid across ramp z-level shifts. Other grabs
-    // still lack vertical movement support.
-    if( u.get_grab_type() != OBJECT_VEHICLE ) {
+    if( !keep_grab ) {
         u.grab( OBJECT_NONE );
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12021,8 +12021,8 @@ struct furniture_move_effort_options {
     tripoint_bub_ms to;
 };
 
-static auto multiply_ratio_round_up( const int value, const int numerator, const int denominator )
-- > int
+static auto multiply_ratio_round_up( const int value, const int numerator,
+                                     const int denominator ) -> int
 {
     const auto safe_denominator = std::max( 1, denominator );
     return ( value * numerator + safe_denominator - 1 ) / safe_denominator;
@@ -12092,8 +12092,8 @@ static auto furniture_contents_strength_req( map &here, const tripoint_bub_ms &p
     return furniture_contents_weight / 4_kilogram;
 }
 
-static auto furniture_move_effort_for( const furniture_move_effort_options &options )
-- > furniture_move_effort
+static auto furniture_move_effort_for(
+    const furniture_move_effort_options &options ) -> furniture_move_effort
 {
     const auto vertical_direction = furniture_vertical_direction_for( options.from, options.to );
     const auto &furntype = options.here.furn( options.from ).obj();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -196,6 +196,7 @@
 #include "veh_interact.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_grab.h"
 #include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
@@ -11184,12 +11185,26 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     const auto furn_dest = dest_loc + u.grab_point;
 
     bool grabbed = u.get_grab_type() != OBJECT_NONE;
+    auto grabbed_vehicle_target = std::optional<vehicle_grab_target>{};
+    if( grabbed && u.get_grab_type() == OBJECT_VEHICLE ) {
+        grabbed_vehicle_target = vehicle_grab_target_at( m, u.bub_pos() + u.grab_point );
+        if( grabbed_vehicle_target ) {
+            u.grab_point = grabbed_vehicle_target->pos - u.bub_pos();
+        }
+    }
     if( grabbed ) {
         const auto &dp = dest_loc - u.bub_pos();
-        pushing = dp ==  u.grab_point;
-        pulling = dp == -u.grab_point;
+        if( u.get_grab_type() == OBJECT_VEHICLE ) {
+            const auto horizontal_dp = tripoint_rel_ms( dp.xy(), 0 );
+            const auto horizontal_grab = tripoint_rel_ms( u.grab_point.xy(), 0 );
+            pushing = horizontal_dp == horizontal_grab;
+            pulling = horizontal_dp == -horizontal_grab;
+        } else {
+            pushing = dp ==  u.grab_point;
+            pulling = dp == -u.grab_point;
+        }
     }
-    if( grabbed && dest_loc.z() != u.bub_pos().z() ) {
+    if( grabbed && u.get_grab_type() != OBJECT_VEHICLE && dest_loc.z() != u.bub_pos().z() ) {
         add_msg( m_warning, _( "You let go of the grabbed object." ) );
         grabbed = false;
         u.grab( OBJECT_NONE );
@@ -11206,8 +11221,9 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
             grabbed = false;
         }
     } else if( grabbed && u.get_grab_type() == OBJECT_VEHICLE ) {
-        grabbed_vehicle = veh_pointer_or_null( m.veh_at( u.bub_pos() + u.grab_point ) );
-        if( grabbed_vehicle == nullptr ) {
+        if( grabbed_vehicle_target ) {
+            grabbed_vehicle = &grabbed_vehicle_target->vp.vehicle();
+        } else {
             // We were grabbing a vehicle that isn't there anymore
             grabbed = false;
         }
@@ -11218,6 +11234,10 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     if( u.grab_point != tripoint_rel_ms::zero() && !grabbed ) {
         add_msg( m_warning, _( "Can't find grabbed object." ) );
         u.grab( OBJECT_NONE );
+        pushing = false;
+        pulling = false;
+        shifting_furniture = false;
+        grabbed_vehicle = nullptr;
     }
 
     if( ( m.impassable( dest_loc ) && !character_funcs::can_noclip( u ) ) && !pushing &&
@@ -11328,13 +11348,10 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
 
     const int mcost = m.combined_movecost( u.bub_pos(), dest_loc, grabbed_vehicle, modifier,
                                            via_ramp ) * multiplier;
-    // only do this check if we can't noclip
-    if( !character_funcs::can_noclip( u ) ) {
-        if( grabbed_move( dest_loc - u.bub_pos() ) ) {
-            return true;
-        } else if( mcost == 0 ) {
-            return false;
-        }
+    if( grabbed_move( dest_loc - u.bub_pos() ) ) {
+        return true;
+    } else if( mcost == 0 && !character_funcs::can_noclip( u ) ) {
+        return false;
     }
 
     bool diag = trigdist && u.bub_pos().x() != dest_loc.x() && u.bub_pos().y() != dest_loc.y();
@@ -11509,7 +11526,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     auto ms_shift = project_to<coords::ms>( submap_shift );
     oldpos = oldpos - ms_shift;
 
-    if( pulling ) {
+    if( pulling && u.get_grab_type() == OBJECT_FURNITURE ) {
         const auto shifted_furn_pos = furn_pos - ms_shift;
         const auto shifted_furn_dest = furn_dest - ms_shift;
         const time_duration fire_age = m.get_field_age( shifted_furn_pos, fd_fire );
@@ -12168,8 +12185,8 @@ bool game::grabbed_move( const tripoint_rel_ms &dp )
         return false;
     }
 
-    if( dp.z() != 0 ) {
-        // No dragging stuff up/down stairs yet!
+    if( dp.z() != 0 && u.get_grab_type() != OBJECT_VEHICLE ) {
+        // No dragging furniture up/down stairs yet!
         return false;
     }
 
@@ -13733,8 +13750,11 @@ void game::vertical_shift( const int z_after )
         return;
     }
 
-    // TODO: Implement dragging stuff up/down
-    u.grab( OBJECT_NONE );
+    // Vehicle grabs can remain valid across ramp z-level shifts. Other grabs
+    // still lack vertical movement support.
+    if( u.get_grab_type() != OBJECT_VEHICLE ) {
+        u.grab( OBJECT_NONE );
+    }
 
     scent.reset();
 

--- a/src/game.h
+++ b/src/game.h
@@ -313,7 +313,7 @@ class game : public submap_load_listener
         std::optional<tripoint_bub_ms> find_or_make_stairs( map &mp, int z_after, bool &rope_ladder,
                 bool peeking );
         /** Actual z-level movement part of vertical_move. Doesn't include stair finding, traps etc. */
-        void vertical_shift( int z_after );
+        auto vertical_shift( int z_after, bool keep_grab = false ) -> void;
         /** Add goes up/down auto_notes (if turned on) */
         void vertical_notes( int z_before, int z_after );
         /** Checks to see if a player can use a computer (not illiterate, etc.) and uses if able. */
@@ -917,9 +917,9 @@ class game : public submap_load_listener
         /** Check for dangerous stuff at dest_loc, return false if the player decides
         not to step there */
         // Handle pushing during move, returns true if it handled the move
-        bool grabbed_move( const tripoint_rel_ms &dp );
+        auto grabbed_move( const tripoint_rel_ms &dp, bool allow_furniture_z_move = false ) -> bool;
         bool grabbed_veh_move( const tripoint_rel_ms &dp );
-        bool grabbed_furn_move( const tripoint_rel_ms &dp );
+        auto grabbed_furn_move( const tripoint_rel_ms &dp ) -> bool;
 
         void control_vehicle(); // Use vehicle controls  '^'
         void examine( const tripoint_bub_ms &p ); // Examine nearby terrain  'e'
@@ -936,7 +936,7 @@ class game : public submap_load_listener
         void butcher(); // Butcher a corpse  'B'
     public:
         // Places the player at the specified point; hurts feet, lists items etc.
-        point_rel_sm place_player( const tripoint_bub_ms &dest );
+        auto place_player( const tripoint_bub_ms &dest, bool keep_grab = false ) -> point_rel_sm;
         void place_player_overmap( const tripoint_abs_omt &om_dest );
 
         unsigned int get_seed() const;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -16,8 +16,10 @@
 #include "point.h"
 #include "sounds.h"
 #include "vehicle.h"
+#include "vehicle_grab.h"
 #include "vehicle_part.h"
 #include "vpart_position.h"
+#include "vpart_range.h"
 #include "debug.h"
 #include "rng.h"
 #include "tileray.h"
@@ -51,16 +53,11 @@ auto get_grabbed_vehicle_movecost( vehicle *veh ) -> int
 {
     const int str_req = base_str_req( veh );
     const auto &map = get_map();
-    const tripoint_bub_ms &vehpos = veh->bub_ms_location();
-
-    const auto get_wheel_pos = [&]( const int p ) {
-        return vehpos + veh->part( p ).precalc[0];
-    };
 
     const auto &wheel_indices = veh->wheelcache;
     return std::accumulate( wheel_indices.begin(), wheel_indices.end(), 0,
     [&]( const int sum, const int p ) {
-        const tripoint_bub_ms wheel_pos = get_wheel_pos( p );
+        const auto wheel_pos = veh->bub_part_location( p );
         const int mapcost = map.move_cost( wheel_pos, veh );
         const int movecost = str_req / static_cast<int>( wheel_indices.size() ) * mapcost;
 
@@ -101,20 +98,22 @@ auto get_vehicle_str_requirement( vehicle *veh ) -> int
 
 bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 {
-    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.bub_pos() + u.grab_point );
-    if( !grabbed_vehicle_vp ) {
+    const auto grabbed_vehicle_target = vehicle_grab_target_at( m, u.bub_pos() + u.grab_point );
+    if( !grabbed_vehicle_target ) {
         add_msg( m_info, _( "No vehicle at grabbed point." ) );
         u.grab( OBJECT_NONE );
         return false;
     }
-    vehicle *grabbed_vehicle = &grabbed_vehicle_vp->vehicle();
+    const auto &grabbed_vehicle_vp = grabbed_vehicle_target->vp;
+    u.grab_point = grabbed_vehicle_target->pos - u.bub_pos();
+    auto *grabbed_vehicle = &grabbed_vehicle_vp.vehicle();
     if( !grabbed_vehicle ||
         !grabbed_vehicle->handle_potential_theft( u ) ) {
         return false;
     }
-    const int grabbed_part = grabbed_vehicle_vp->part_index();
-    for( int part_index = 0; part_index < grabbed_vehicle->part_count(); ++part_index ) {
-        monster *mon = grabbed_vehicle->get_pet( part_index );
+    const auto grabbed_part = static_cast<int>( grabbed_vehicle_vp.part_index() );
+    for( const vpart_reference &part : grabbed_vehicle->get_all_parts() ) {
+        auto *mon = grabbed_vehicle->get_pet( static_cast<int>( part.part_index() ) );
         if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
             add_msg( m_info, _( "You cannot move this vehicle whilst your %s is harnessed!" ),
                      mon->get_name() );
@@ -128,31 +127,35 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         return false;
     }
 
-    auto dp_veh = -u.grab_point;
+    const auto player_next_pos = tripoint_bub_ms( u.bub_pos() + dp );
+    const auto horizontal_dp = tripoint_rel_ms( dp.xy(), 0 );
+    const auto horizontal_grab = tripoint_rel_ms( u.grab_point.xy(), 0 );
+    auto dp_veh = -horizontal_grab;
     const auto prev_grab = u.grab_point;
     auto next_grab = u.grab_point;
 
     bool zigzag = false;
 
-    if( dp == prev_grab ) {
+    if( horizontal_dp == horizontal_grab ) {
         // We are pushing in the direction of vehicle
-        dp_veh = dp;
-    } else if( std::abs( dp.x() + dp_veh.x() ) != 2 && std::abs( dp.y() + dp_veh.y() ) != 2 ) {
+        dp_veh = horizontal_dp;
+    } else if( std::abs( horizontal_dp.x() + dp_veh.x() ) != 2 &&
+               std::abs( horizontal_dp.y() + dp_veh.y() ) != 2 ) {
         // Not actually moving the vehicle, don't do the checks
-        u.grab_point = -( dp + dp_veh );
+        u.grab_point = prev_grab - dp;
         return false;
-    } else if( ( dp.x() == prev_grab.x() || dp.y() == prev_grab.y() ) &&
+    } else if( ( horizontal_dp.x() == prev_grab.x() || horizontal_dp.y() == prev_grab.y() ) &&
                next_grab.x() != 0 && next_grab.y() != 0 ) {
         // Zig-zag (or semi-zig-zag) pull: player is diagonal to vehicle
         // and moves away from it, but not directly away
-        dp_veh.x() = dp.x() == -dp_veh.x() ? 0 : dp_veh.x();
-        dp_veh.y() = dp.y() == -dp_veh.y() ? 0 : dp_veh.y();
+        dp_veh.x() = horizontal_dp.x() == -dp_veh.x() ? 0 : dp_veh.x();
+        dp_veh.y() = horizontal_dp.y() == -dp_veh.y() ? 0 : dp_veh.y();
 
         next_grab = -dp_veh;
         zigzag = true;
     } else {
         // We are pulling the vehicle
-        next_grab = -dp;
+        next_grab = -horizontal_dp;
     }
 
     // Make sure the mass and pivot point are correct
@@ -208,10 +211,10 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         // and in roughly the same direction.
         const auto new_part_pos = grabbed_vehicle->bub_ms_location() +
                                   grabbed_vehicle->part( grabbed_part ).precalc[ 1 ];
-        const auto expected_pos = tripoint_bub_ms( u.bub_pos() ) + dp + from;
-        const tripoint_rel_ms actual_dir = expected_pos - new_part_pos;
+        const auto expected_pos = player_next_pos + from;
+        const auto actual_dir = tripoint_rel_ms( expected_pos.xy() - new_part_pos.xy(), 0 );
 
-        grabbed_vehicle->adjust_zlevel( 1, dp );
+        grabbed_vehicle->adjust_zlevel( 1, actual_dir );
 
         // Set player location to illegal value so it can't collide with vehicle.
         const auto player_prev = u.bub_pos();
@@ -230,8 +233,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     // Try to place the vehicle in the position player just left rather than "flattening" the zig-zag
     tripoint_rel_ms final_dp_veh = get_move_dir( dp_veh, next_grab );
     if( final_dp_veh == tripoint_rel_ms::zero() && zigzag ) {
-        final_dp_veh = get_move_dir( -prev_grab, -dp );
-        next_grab = -dp;
+        final_dp_veh = get_move_dir( -tripoint_rel_ms( prev_grab.xy(), 0 ), -horizontal_dp );
     }
 
     if( final_dp_veh == tripoint_rel_ms::zero() ) {
@@ -239,8 +241,6 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         u.grab_point = prev_grab;
         return true;
     }
-
-    u.grab_point = next_grab;
 
     m.displace_vehicle( *grabbed_vehicle, final_dp_veh );
 
@@ -252,9 +252,11 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         return false;
     }
 
+    u.grab_point = grabbed_vehicle->bub_part_location( grabbed_part ) - player_next_pos;
+
     for( int p : grabbed_vehicle->wheelcache ) {
         if( one_in( 2 ) ) {
-            tripoint_bub_ms wheel_p = grabbed_vehicle->bub_part_location( grabbed_part );
+            const auto wheel_p = grabbed_vehicle->bub_part_location( p );
             grabbed_vehicle->handle_trap( wheel_p, p );
         }
     }

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -254,7 +254,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 
     u.grab_point = grabbed_vehicle->bub_part_location( grabbed_part ) - player_next_pos;
 
-    for( int p : grabbed_vehicle->wheelcache ) {
+    for( const auto p : grabbed_vehicle->wheelcache ) {
         if( one_in( 2 ) ) {
             const auto wheel_p = grabbed_vehicle->bub_part_location( p );
             grabbed_vehicle->handle_trap( wheel_p, p );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -95,6 +95,7 @@
 #include "units.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_grab.h"
 #include "vehicle_part.h"
 #include "vehicle_wait.h"
 #include "vpart_position.h"
@@ -587,8 +588,8 @@ static void grab()
     map &here = get_map();
 
     if( you.get_grab_type() != OBJECT_NONE ) {
-        if( const optional_vpart_position vp = here.veh_at( you.bub_pos() + you.grab_point ) ) {
-            add_msg( _( "You release the %s." ), vp->vehicle().name );
+        if( const auto target = vehicle_grab_target_at( here, you.bub_pos() + you.grab_point ) ) {
+            add_msg( _( "You release the %s." ), target->vp.vehicle().name );
         } else if( here.has_furn( you.bub_pos() + you.grab_point ) ) {
             add_msg( _( "You release the %s." ), here.furnname( you.bub_pos() + you.grab_point ) );
         }
@@ -609,12 +610,12 @@ static void grab()
         you.grab( OBJECT_NONE );
         return;
     }
-    if( const optional_vpart_position vp = here.veh_at( grabp ) ) {
-        if( !vp->vehicle().handle_potential_theft( get_avatar() ) ) {
+    if( const auto target = vehicle_grab_target_at( here, grabp ) ) {
+        if( !target->vp.vehicle().handle_potential_theft( get_avatar() ) ) {
             return;
         }
-        you.grab( OBJECT_VEHICLE, grabp - you.bub_pos() );
-        add_msg( _( "You grab the %s." ), vp->vehicle().name );
+        you.grab( OBJECT_VEHICLE, target->pos - you.bub_pos() );
+        add_msg( _( "You grab the %s." ), target->vp.vehicle().name );
     } else if( here.has_furn( grabp ) ) { // If not, grab furniture if present
         if( !here.furn( grabp ).obj().is_movable() ) {
             add_msg( _( "You can not grab the %s" ), here.furnname( grabp ) );

--- a/src/vehicle_grab.cpp
+++ b/src/vehicle_grab.cpp
@@ -19,7 +19,7 @@ auto vehicle_grab_target_at_exact( const map &here, const tripoint_bub_ms &pos )
 } // namespace
 
 auto vehicle_grab_target_at( const map &here, const tripoint_bub_ms &pos )
--> std::optional<vehicle_grab_target>
+- > std::optional<vehicle_grab_target>
 {
     if( const auto target = vehicle_grab_target_at_exact( here, pos ) ) {
         return target;

--- a/src/vehicle_grab.cpp
+++ b/src/vehicle_grab.cpp
@@ -6,8 +6,8 @@
 namespace
 {
 
-auto vehicle_grab_target_at_exact( const map &here, const tripoint_bub_ms &pos )
--> std::optional<vehicle_grab_target>
+auto vehicle_grab_target_at_exact( const map &here,
+                                   const tripoint_bub_ms &pos ) -> std::optional<vehicle_grab_target>
 {
     if( const auto vp = here.veh_at( pos ) ) {
         return vehicle_grab_target{ .pos = vp->pos(), .vp = *vp };
@@ -18,8 +18,8 @@ auto vehicle_grab_target_at_exact( const map &here, const tripoint_bub_ms &pos )
 
 } // namespace
 
-auto vehicle_grab_target_at( const map &here, const tripoint_bub_ms &pos )
-- > std::optional<vehicle_grab_target>
+auto vehicle_grab_target_at( const map &here,
+                             const tripoint_bub_ms &pos ) -> std::optional<vehicle_grab_target>
 {
     if( const auto target = vehicle_grab_target_at_exact( here, pos ) ) {
         return target;

--- a/src/vehicle_grab.cpp
+++ b/src/vehicle_grab.cpp
@@ -1,0 +1,56 @@
+#include "vehicle_grab.h"
+
+#include "map.h"
+#include "mapdata.h"
+
+namespace
+{
+
+auto vehicle_grab_target_at_exact( const map &here, const tripoint_bub_ms &pos )
+-> std::optional<vehicle_grab_target>
+{
+    if( const auto vp = here.veh_at( pos ) ) {
+        return vehicle_grab_target{ .pos = vp->pos(), .vp = *vp };
+    }
+
+    return std::nullopt;
+}
+
+} // namespace
+
+auto vehicle_grab_target_at( const map &here, const tripoint_bub_ms &pos )
+-> std::optional<vehicle_grab_target>
+{
+    if( const auto target = vehicle_grab_target_at_exact( here, pos ) ) {
+        return target;
+    }
+
+    const auto above = pos + tripoint_above;
+    const auto below = pos + tripoint_below;
+
+    if( here.has_flag( TFLAG_RAMP_UP, pos ) ) {
+        if( const auto target = vehicle_grab_target_at_exact( here, above ) ) {
+            return target;
+        }
+    }
+
+    if( here.has_flag( TFLAG_RAMP_DOWN, pos ) ) {
+        if( const auto target = vehicle_grab_target_at_exact( here, below ) ) {
+            return target;
+        }
+    }
+
+    if( here.inbounds_z( above.z() ) && here.has_flag( TFLAG_RAMP_DOWN, above ) ) {
+        if( const auto target = vehicle_grab_target_at_exact( here, above ) ) {
+            return target;
+        }
+    }
+
+    if( here.inbounds_z( below.z() ) && here.has_flag( TFLAG_RAMP_UP, below ) ) {
+        if( const auto target = vehicle_grab_target_at_exact( here, below ) ) {
+            return target;
+        }
+    }
+
+    return std::nullopt;
+}

--- a/src/vehicle_grab.h
+++ b/src/vehicle_grab.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <optional>
+
+#include "coordinates.h"
+#include "vpart_position.h"
+
+class map;
+
+struct vehicle_grab_target {
+    tripoint_bub_ms pos;
+    vpart_position vp;
+};
+
+auto vehicle_grab_target_at( const map &here, const tripoint_bub_ms &pos )
+-> std::optional<vehicle_grab_target>;

--- a/src/vehicle_grab.h
+++ b/src/vehicle_grab.h
@@ -13,4 +13,4 @@ struct vehicle_grab_target {
 };
 
 auto vehicle_grab_target_at( const map &here, const tripoint_bub_ms &pos )
--> std::optional<vehicle_grab_target>;
+- > std::optional<vehicle_grab_target>;

--- a/src/vehicle_grab.h
+++ b/src/vehicle_grab.h
@@ -12,5 +12,5 @@ struct vehicle_grab_target {
     vpart_position vp;
 };
 
-auto vehicle_grab_target_at( const map &here, const tripoint_bub_ms &pos )
-- > std::optional<vehicle_grab_target>;
+auto vehicle_grab_target_at( const map &here,
+                             const tripoint_bub_ms &pos ) -> std::optional<vehicle_grab_target>;

--- a/tests/furniture_grab_test.cpp
+++ b/tests/furniture_grab_test.cpp
@@ -1,0 +1,242 @@
+#include "catch/catch.hpp"
+
+#include <array>
+
+#include "avatar.h"
+#include "avatar_action.h"
+#include "calendar.h"
+#include "coordinates.h"
+#include "enums.h"
+#include "game.h"
+#include "game_constants.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "mapdata.h"
+#include "state_helpers.h"
+#include "type_id.h"
+
+static auto grabbed_ramp_x() -> int
+{
+    return g_half_mapsize_x + SEEX / 2;
+}
+
+static auto set_ramp_for_furniture( const int transit_x, const bool use_ramp,
+                                    const bool up ) -> void
+{
+    calendar::turn = calendar::turn_zero;
+    auto &player_character = get_player_character();
+    REQUIRE_FALSE( player_character.in_vehicle );
+
+    auto &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+    if( use_ramp ) {
+        const auto upper_zlevel = up ? 1 : 0;
+        const auto lower_zlevel = up - 1;
+        const auto highx = transit_x + ( up ? 0 : 1 );
+        const auto lowx = transit_x + ( up ? 1 : 0 );
+        const auto max_x = SEEX * MAPSIZE - 1;
+        const auto max_y = SEEY * MAPSIZE - 1;
+
+        for( const auto &pos : here.points_in_rectangle( tripoint_bub_ms( 0, 0, -1 ),
+                tripoint_bub_ms( transit_x - 1, max_y, 1 ) ) ) {
+            if( ( up && pos.z() == upper_zlevel ) || ( !up && pos.z() == lower_zlevel ) ) {
+                here.ter_set( pos, ter_id( "t_pavement" ) );
+            } else if( up ) {
+                here.ter_set( pos, ter_id( "t_rock" ) );
+            } else {
+                here.ter_set( pos, ter_id( "t_open_air" ) );
+            }
+        }
+
+        for( const auto &pos : here.points_in_rectangle( tripoint_bub_ms( transit_x + 2, 0, -1 ),
+                tripoint_bub_ms( max_x, max_y, 1 ) ) ) {
+            if( pos.z() == 0 ) {
+                here.ter_set( pos, ter_id( "t_pavement" ) );
+            } else if( pos.z() > 0 ) {
+                here.ter_set( pos, ter_id( "t_open_air" ) );
+            } else {
+                here.ter_set( pos, ter_id( "t_rock" ) );
+            }
+        }
+
+        for( const auto &pos : here.points_in_rectangle( tripoint_bub_ms( lowx, 0, lower_zlevel ),
+                tripoint_bub_ms( lowx, max_y, lower_zlevel ) ) ) {
+            here.ter_set( pos, ter_id( "t_ramp_up_low" ) );
+        }
+        for( const auto &pos : here.points_in_rectangle( tripoint_bub_ms( highx, 0, lower_zlevel ),
+                tripoint_bub_ms( highx, max_y, lower_zlevel ) ) ) {
+            here.ter_set( pos, ter_id( "t_ramp_up_high" ) );
+        }
+        for( const auto &pos : here.points_in_rectangle( tripoint_bub_ms( lowx, 0, upper_zlevel ),
+                tripoint_bub_ms( lowx, max_y, upper_zlevel ) ) ) {
+            here.ter_set( pos, ter_id( "t_ramp_down_low" ) );
+        }
+        for( const auto &pos : here.points_in_rectangle( tripoint_bub_ms( highx, 0, upper_zlevel ),
+                tripoint_bub_ms( highx, max_y, upper_zlevel ) ) ) {
+            here.ter_set( pos, ter_id( "t_ramp_down_high" ) );
+        }
+    }
+
+    for( const auto z : std::array{ -1, 0, 1 } ) {
+        here.invalidate_map_cache( z );
+        here.build_map_cache( z, true );
+    }
+}
+
+static auto setup_grabbed_furniture( const tripoint_bub_ms &player_pos,
+                                     const tripoint_bub_ms &furniture_pos,
+                                     const furn_id &furniture_id ) -> void
+{
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    player_character.setpos( player_pos );
+    player_character.str_max = 100;
+    player_character.str_cur = 100;
+    player_character.set_stamina( player_character.get_stamina_max() );
+
+    here.furn_set( furniture_pos, furniture_id );
+    player_character.grab( OBJECT_FURNITURE, furniture_pos - player_pos );
+    REQUIRE( player_character.get_grab_type() == OBJECT_FURNITURE );
+    REQUIRE( player_character.grab_point == furniture_pos - player_pos );
+}
+
+static auto check_avatar_still_grabs_furniture( const tripoint_bub_ms &expected_pos,
+        const furn_id &expected_furniture ) -> void
+{
+    const auto &here = get_map();
+    auto &player_character = get_avatar();
+    CHECK( player_character.get_grab_type() == OBJECT_FURNITURE );
+    const auto grabbed_pos = tripoint_bub_ms( player_character.bub_pos() + player_character.grab_point );
+    CHECK( grabbed_pos == expected_pos );
+    CHECK( here.furn( grabbed_pos ) == expected_furniture );
+}
+
+TEST_CASE( "grabbed_furniture_can_be_pulled_up_ramp", "[furniture][ramp][grab]" )
+{
+    clear_all_state();
+    const auto ramp_x = grabbed_ramp_x();
+    set_ramp_for_furniture( ramp_x, true, true );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    const auto test_furniture = furn_id( "f_chair" );
+    setup_grabbed_furniture( tripoint_bub_ms( ramp_x + 1, 60, 0 ),
+                             tripoint_bub_ms( ramp_x + 2, 60, 0 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x, 60, 1 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x + 1, 60, 0 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x + 1, 60, 0 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x - 1, 60, 1 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x, 60, 1 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x, 60, 1 ), test_furniture );
+}
+
+TEST_CASE( "grabbed_furniture_can_be_pushed_up_ramp", "[furniture][ramp][grab]" )
+{
+    clear_all_state();
+    const auto ramp_x = grabbed_ramp_x();
+    set_ramp_for_furniture( ramp_x, true, true );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    const auto test_furniture = furn_id( "f_chair" );
+    setup_grabbed_furniture( tripoint_bub_ms( ramp_x + 3, 60, 0 ),
+                             tripoint_bub_ms( ramp_x + 2, 60, 0 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x + 2, 60, 0 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x + 1, 60, 0 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x + 1, 60, 0 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x + 1, 60, 0 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x, 60, 1 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x, 60, 1 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x, 60, 1 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x - 1, 60, 1 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x - 1, 60, 1 ), test_furniture );
+}
+
+TEST_CASE( "grabbed_furniture_can_be_pulled_down_ramp", "[furniture][ramp][grab]" )
+{
+    clear_all_state();
+    const auto ramp_x = grabbed_ramp_x();
+    set_ramp_for_furniture( ramp_x, true, false );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    const auto test_furniture = furn_id( "f_chair" );
+    setup_grabbed_furniture( tripoint_bub_ms( ramp_x + 1, 60, 0 ),
+                             tripoint_bub_ms( ramp_x + 2, 60, 0 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x, 60, -1 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x + 1, 60, 0 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x + 1, 60, 0 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x - 1, 60, -1 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x, 60, -1 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x, 60, -1 ), test_furniture );
+}
+
+TEST_CASE( "grabbed_furniture_can_be_pushed_down_ramp", "[furniture][ramp][grab]" )
+{
+    clear_all_state();
+    const auto ramp_x = grabbed_ramp_x();
+    set_ramp_for_furniture( ramp_x, true, false );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    const auto test_furniture = furn_id( "f_chair" );
+    setup_grabbed_furniture( tripoint_bub_ms( ramp_x + 3, 60, 0 ),
+                             tripoint_bub_ms( ramp_x + 2, 60, 0 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x + 2, 60, 0 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x + 1, 60, 0 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x + 1, 60, 0 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x + 1, 60, 0 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x, 60, -1 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x, 60, -1 ), test_furniture );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( ramp_x, 60, -1 ) );
+    CHECK( here.furn( tripoint_bub_ms( ramp_x - 1, 60, -1 ) ) == test_furniture );
+    check_avatar_still_grabs_furniture( tripoint_bub_ms( ramp_x - 1, 60, -1 ), test_furniture );
+}
+
+TEST_CASE( "dragging_furniture_burns_extra_stamina", "[furniture][grab][stamina]" )
+{
+    clear_all_state();
+    set_ramp_for_furniture( 60, false, true );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    player_character.setpos( tripoint_bub_ms( 61, 60, 0 ) );
+    player_character.set_stamina( player_character.get_stamina_max() );
+    const auto walking_stamina = player_character.get_stamina();
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    const auto walking_burn = walking_stamina - player_character.get_stamina();
+
+    clear_all_state();
+    set_ramp_for_furniture( 60, false, true );
+    auto &second_here = get_map();
+    auto &second_player_character = get_avatar();
+    setup_grabbed_furniture( tripoint_bub_ms( 61, 60, 0 ),
+                             tripoint_bub_ms( 62, 60, 0 ), furn_id( "f_dresser" ) );
+    second_player_character.str_max = 8;
+    second_player_character.str_cur = 8;
+    const auto furniture_stamina = second_player_character.get_stamina();
+    REQUIRE( avatar_action::move( second_player_character, second_here, tripoint_rel_ms::west() ) );
+    const auto furniture_burn = furniture_stamina - second_player_character.get_stamina();
+
+    CHECK( furniture_burn > walking_burn );
+}

--- a/tests/furniture_grab_test.cpp
+++ b/tests/furniture_grab_test.cpp
@@ -106,7 +106,8 @@ static auto check_avatar_still_grabs_furniture( const tripoint_bub_ms &expected_
     const auto &here = get_map();
     auto &player_character = get_avatar();
     CHECK( player_character.get_grab_type() == OBJECT_FURNITURE );
-    const auto grabbed_pos = tripoint_bub_ms( player_character.bub_pos() + player_character.grab_point );
+    const auto grabbed_pos = tripoint_bub_ms( player_character.bub_pos() +
+                             player_character.grab_point );
     CHECK( grabbed_pos == expected_pos );
     CHECK( here.furn( grabbed_pos ) == expected_furniture );
 }

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 
+#include <array>
 #include <cstdio>
 #include <cstdlib>
 #include <sstream>
@@ -13,6 +14,7 @@
 #include <vector>
 
 #include "avatar.h"
+#include "avatar_action.h"
 #include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -20,6 +22,7 @@
 #include "coordinates.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_grab.h"
 #include "vehicle_part.h"
 #include "vpart_range.h"
 #include "bodypart.h"
@@ -83,8 +86,43 @@ static void set_ramp( const int transit_x, bool use_ramp, bool up )
             }
         }
     }
-    here.invalidate_map_cache( 0 );
-    here.build_map_cache( 0, true );
+    for( const auto z : std::array{ -1, 0, 1 } ) {
+        here.invalidate_map_cache( z );
+        here.build_map_cache( z, true );
+    }
+}
+
+static auto setup_grabbed_shopping_cart( const tripoint_bub_ms &player_pos,
+        const tripoint_bub_ms &cart_pos ) -> vehicle &
+{
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    player_character.setpos( player_pos );
+    player_character.str_max = 100;
+    player_character.str_cur = 100;
+
+    auto *veh_ptr = here.add_vehicle( vproto_id( "shopping_cart" ), cart_pos, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    for( const auto vp : veh_ptr->get_all_parts() ) {
+        veh_ptr->get_items( vp.part_index() ).clear();
+    }
+
+    player_character.grab( OBJECT_VEHICLE, cart_pos - player_pos );
+    REQUIRE( player_character.get_grab_type() == OBJECT_VEHICLE );
+    REQUIRE( player_character.grab_point == cart_pos - player_pos );
+
+    return *veh_ptr;
+}
+
+static auto check_avatar_still_grabs( const vehicle &expected_vehicle ) -> void
+{
+    auto &player_character = get_avatar();
+    CHECK( player_character.get_grab_type() == OBJECT_VEHICLE );
+    const auto grabbed_target = vehicle_grab_target_at( get_map(),
+                                player_character.bub_pos() + player_character.grab_point );
+    REQUIRE( grabbed_target );
+    CHECK( &grabbed_target->vp.vehicle() == &expected_vehicle );
 }
 
 // Algorithm goes as follows:
@@ -227,6 +265,156 @@ static std::vector<std::string> ramp_vehs_to_test = {{
         "motorcycle",
     }
 };
+
+TEST_CASE( "grabbed_shopping_cart_can_be_pulled_up_ramp", "[vehicle][ramp][grab]" )
+{
+    clear_all_state();
+    set_ramp( 60, true, true );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 61, 60, 0 ),
+                    tripoint_bub_ms( 62, 60, 0 ) );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, 1 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 61, 60, 0 ) );
+    check_avatar_still_grabs( cart );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 59, 60, 1 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, 1 ) );
+    check_avatar_still_grabs( cart );
+}
+
+TEST_CASE( "grabbed_shopping_cart_can_be_pulled_on_flat_ground", "[vehicle][grab]" )
+{
+    clear_all_state();
+    set_ramp( 60, false, true );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 61, 60, 0 ),
+                    tripoint_bub_ms( 62, 60, 0 ) );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, 0 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 61, 60, 0 ) );
+    check_avatar_still_grabs( cart );
+}
+
+TEST_CASE( "grabbed_shopping_cart_can_be_pulled_with_debug_noclip", "[vehicle][grab]" )
+{
+    clear_all_state();
+    set_ramp( 60, false, true );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 61, 60, 0 ),
+                    tripoint_bub_ms( 62, 60, 0 ) );
+    player_character.set_mutation( trait_id( "DEBUG_NOCLIP" ) );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, 0 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 61, 60, 0 ) );
+    check_avatar_still_grabs( cart );
+}
+
+TEST_CASE( "grabbed_shopping_cart_can_be_pushed_on_flat_ground", "[vehicle][grab]" )
+{
+    clear_all_state();
+    set_ramp( 60, false, true );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 62, 60, 0 ),
+                    tripoint_bub_ms( 61, 60, 0 ) );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 61, 60, 0 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, 0 ) );
+    check_avatar_still_grabs( cart );
+}
+
+TEST_CASE( "grabbed_shopping_cart_can_be_pushed_with_debug_noclip", "[vehicle][grab]" )
+{
+    clear_all_state();
+    set_ramp( 60, false, true );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 62, 60, 0 ),
+                    tripoint_bub_ms( 61, 60, 0 ) );
+    player_character.set_mutation( trait_id( "DEBUG_NOCLIP" ) );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 61, 60, 0 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, 0 ) );
+    check_avatar_still_grabs( cart );
+}
+
+TEST_CASE( "grabbed_shopping_cart_can_be_pushed_up_ramp", "[vehicle][ramp][grab]" )
+{
+    clear_all_state();
+    set_ramp( 60, true, true );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 62, 60, 0 ),
+                    tripoint_bub_ms( 61, 60, 0 ) );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 61, 60, 0 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, 1 ) );
+    check_avatar_still_grabs( cart );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, 1 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 59, 60, 1 ) );
+    check_avatar_still_grabs( cart );
+}
+
+TEST_CASE( "grabbed_shopping_cart_can_be_pulled_down_ramp", "[vehicle][ramp][grab]" )
+{
+    clear_all_state();
+    set_ramp( 60, true, false );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 61, 60, 0 ),
+                    tripoint_bub_ms( 62, 60, 0 ) );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, -1 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 61, 60, 0 ) );
+    check_avatar_still_grabs( cart );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 59, 60, -1 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, -1 ) );
+    check_avatar_still_grabs( cart );
+}
+
+TEST_CASE( "grabbed_shopping_cart_can_be_pushed_down_ramp", "[vehicle][ramp][grab]" )
+{
+    clear_all_state();
+    set_ramp( 60, true, false );
+
+    auto &here = get_map();
+    auto &player_character = get_avatar();
+    auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 62, 60, 0 ),
+                    tripoint_bub_ms( 61, 60, 0 ) );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 61, 60, 0 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, -1 ) );
+    check_avatar_still_grabs( cart );
+
+    REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
+    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, -1 ) );
+    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 59, 60, -1 ) );
+    check_avatar_still_grabs( cart );
+}
 
 // I'd like to do this in a single loop, but that doesn't work for some reason
 TEST_CASE( "vehicle_ramp_test_59", "[vehicle][ramp]" )

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -297,7 +297,7 @@ TEST_CASE( "grabbed_shopping_cart_can_be_pulled_on_flat_ground", "[vehicle][grab
     auto &here = get_map();
     auto &player_character = get_avatar();
     auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 61, 60, 0 ),
-                    tripoint_bub_ms( 62, 60, 0 ) );
+                 tripoint_bub_ms( 62, 60, 0 ) );
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
     CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, 0 ) );
@@ -313,7 +313,7 @@ TEST_CASE( "grabbed_shopping_cart_can_be_pulled_with_debug_noclip", "[vehicle][g
     auto &here = get_map();
     auto &player_character = get_avatar();
     auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 61, 60, 0 ),
-                    tripoint_bub_ms( 62, 60, 0 ) );
+                 tripoint_bub_ms( 62, 60, 0 ) );
     player_character.set_mutation( trait_id( "DEBUG_NOCLIP" ) );
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
@@ -330,7 +330,7 @@ TEST_CASE( "grabbed_shopping_cart_can_be_pushed_on_flat_ground", "[vehicle][grab
     auto &here = get_map();
     auto &player_character = get_avatar();
     auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 62, 60, 0 ),
-                    tripoint_bub_ms( 61, 60, 0 ) );
+                 tripoint_bub_ms( 61, 60, 0 ) );
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
     CHECK( player_character.bub_pos() == tripoint_bub_ms( 61, 60, 0 ) );
@@ -346,7 +346,7 @@ TEST_CASE( "grabbed_shopping_cart_can_be_pushed_with_debug_noclip", "[vehicle][g
     auto &here = get_map();
     auto &player_character = get_avatar();
     auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 62, 60, 0 ),
-                    tripoint_bub_ms( 61, 60, 0 ) );
+                 tripoint_bub_ms( 61, 60, 0 ) );
     player_character.set_mutation( trait_id( "DEBUG_NOCLIP" ) );
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -274,16 +274,18 @@ TEST_CASE( "grabbed_shopping_cart_can_be_pulled_up_ramp", "[vehicle][ramp][grab]
     auto &here = get_map();
     auto &player_character = get_avatar();
     auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 61, 60, 0 ),
-                    tripoint_bub_ms( 62, 60, 0 ) );
+                 tripoint_bub_ms( 62, 60, 0 ) );
+    const auto player_start_abs = player_character.abs_pos();
+    const auto cart_start_abs = cart.abs_ms_location();
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
-    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, 1 ) );
-    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 61, 60, 0 ) );
+    CHECK( player_character.abs_pos() == player_start_abs + tripoint_rel_ms( -1, 0, 1 ) );
+    CHECK( cart.abs_ms_location() == cart_start_abs + tripoint_rel_ms( -1, 0, 0 ) );
     check_avatar_still_grabs( cart );
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
-    CHECK( player_character.bub_pos() == tripoint_bub_ms( 59, 60, 1 ) );
-    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, 1 ) );
+    CHECK( player_character.abs_pos() == player_start_abs + tripoint_rel_ms( -2, 0, 1 ) );
+    CHECK( cart.abs_ms_location() == cart_start_abs + tripoint_rel_ms( -2, 0, 1 ) );
     check_avatar_still_grabs( cart );
 }
 
@@ -361,16 +363,18 @@ TEST_CASE( "grabbed_shopping_cart_can_be_pushed_up_ramp", "[vehicle][ramp][grab]
     auto &here = get_map();
     auto &player_character = get_avatar();
     auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 62, 60, 0 ),
-                    tripoint_bub_ms( 61, 60, 0 ) );
+                 tripoint_bub_ms( 61, 60, 0 ) );
+    const auto player_start_abs = player_character.abs_pos();
+    const auto cart_start_abs = cart.abs_ms_location();
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
-    CHECK( player_character.bub_pos() == tripoint_bub_ms( 61, 60, 0 ) );
-    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, 1 ) );
+    CHECK( player_character.abs_pos() == player_start_abs + tripoint_rel_ms( -1, 0, 0 ) );
+    CHECK( cart.abs_ms_location() == cart_start_abs + tripoint_rel_ms( -1, 0, 1 ) );
     check_avatar_still_grabs( cart );
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
-    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, 1 ) );
-    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 59, 60, 1 ) );
+    CHECK( player_character.abs_pos() == player_start_abs + tripoint_rel_ms( -2, 0, 1 ) );
+    CHECK( cart.abs_ms_location() == cart_start_abs + tripoint_rel_ms( -2, 0, 1 ) );
     check_avatar_still_grabs( cart );
 }
 
@@ -382,16 +386,18 @@ TEST_CASE( "grabbed_shopping_cart_can_be_pulled_down_ramp", "[vehicle][ramp][gra
     auto &here = get_map();
     auto &player_character = get_avatar();
     auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 61, 60, 0 ),
-                    tripoint_bub_ms( 62, 60, 0 ) );
+                 tripoint_bub_ms( 62, 60, 0 ) );
+    const auto player_start_abs = player_character.abs_pos();
+    const auto cart_start_abs = cart.abs_ms_location();
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
-    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, -1 ) );
-    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 61, 60, 0 ) );
+    CHECK( player_character.abs_pos() == player_start_abs + tripoint_rel_ms( -1, 0, -1 ) );
+    CHECK( cart.abs_ms_location() == cart_start_abs + tripoint_rel_ms( -1, 0, 0 ) );
     check_avatar_still_grabs( cart );
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
-    CHECK( player_character.bub_pos() == tripoint_bub_ms( 59, 60, -1 ) );
-    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, -1 ) );
+    CHECK( player_character.abs_pos() == player_start_abs + tripoint_rel_ms( -2, 0, -1 ) );
+    CHECK( cart.abs_ms_location() == cart_start_abs + tripoint_rel_ms( -2, 0, -1 ) );
     check_avatar_still_grabs( cart );
 }
 
@@ -403,16 +409,18 @@ TEST_CASE( "grabbed_shopping_cart_can_be_pushed_down_ramp", "[vehicle][ramp][gra
     auto &here = get_map();
     auto &player_character = get_avatar();
     auto &cart = setup_grabbed_shopping_cart( tripoint_bub_ms( 62, 60, 0 ),
-                    tripoint_bub_ms( 61, 60, 0 ) );
+                 tripoint_bub_ms( 61, 60, 0 ) );
+    const auto player_start_abs = player_character.abs_pos();
+    const auto cart_start_abs = cart.abs_ms_location();
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
-    CHECK( player_character.bub_pos() == tripoint_bub_ms( 61, 60, 0 ) );
-    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 60, 60, -1 ) );
+    CHECK( player_character.abs_pos() == player_start_abs + tripoint_rel_ms( -1, 0, 0 ) );
+    CHECK( cart.abs_ms_location() == cart_start_abs + tripoint_rel_ms( -1, 0, -1 ) );
     check_avatar_still_grabs( cart );
 
     REQUIRE( avatar_action::move( player_character, here, tripoint_rel_ms::west() ) );
-    CHECK( player_character.bub_pos() == tripoint_bub_ms( 60, 60, -1 ) );
-    CHECK( cart.bub_ms_location() == tripoint_bub_ms( 59, 60, -1 ) );
+    CHECK( player_character.abs_pos() == player_start_abs + tripoint_rel_ms( -2, 0, -1 ) );
+    CHECK( cart.abs_ms_location() == cart_start_abs + tripoint_rel_ms( -2, 0, -1 ) );
     check_avatar_still_grabs( cart );
 }
 

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -12,6 +12,7 @@
 #include "cata_utility.h"
 #include "coordinates.h"
 #include "damage.h"
+#include "debug.h"
 #include "enums.h"
 #include "game.h"
 #include "item.h"
@@ -235,8 +236,15 @@ TEST_CASE( "vehicle deserialize keeps valid saved parts after an invalid part", 
     auto json = std::istringstream( vehicle_with_invalid_part_and_legacy_pivot_json() );
     auto jsin = JsonIn( json );
     auto veh = vehicle();
+    auto loaded = false;
 
-    REQUIRE( jsin.read( veh, true ) );
+    const auto debug_msg = capture_debugmsg_during( [&]() {
+        loaded = jsin.read( veh, true );
+    } );
+
+    REQUIRE( loaded );
+    CHECK( debug_msg.find( "Skipping invalid saved vehicle part" ) != std::string::npos );
+    CHECK( debug_msg.find( "missing_saved_vehicle_part" ) != std::string::npos );
     CHECK( veh.part_count() == 1 );
     CHECK( veh.mount_to_abs( tripoint_mnt_veh( 0, 0, 0 ) ) == tripoint_abs_ms( 4, 6, 0 ) );
 }

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -57,8 +57,8 @@ auto vehicle_points_contain_monster( const std::set<tripoint_abs_ms> &vehicle_po
     return std::ranges::any_of( vehicle_points, point_has_monster );
 }
 
-auto make_horde_vehicle_spawn_fixture( const horde_vehicle_spawn_options &options )
--> horde_vehicle_spawn_fixture
+auto make_horde_vehicle_spawn_fixture(
+    const horde_vehicle_spawn_options &options ) -> horde_vehicle_spawn_fixture
 {
     clear_all_state();
     ACTIVE_OVERMAP_BUFFER.clear();


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #2001
Implements dragging furniture over ramps too

## Describe the solution (The How)

Grabbing would lose track of the position, and it also discarded the z coordinate entirely.
Additionally, there was explicit z shift gating that prevented either vehicle or furniture movement across z-levels, which I removed.
On top of that, I made moving furniture cost stamina, and scaled that + movement cost based on z-direction. Moving furniture up a ramp costs more and requires more strength than going down or moving flat.

## Describe alternatives you've considered

      

## Testing

Fixed up the test for vehicle + made new ones for furniture grabs and the stamina cost. Additionally, I literally verified it worked.
Here's a clip:
https://github.com/user-attachments/assets/2573613a-73dd-4ec6-a434-d6623bad06be

## Additional context

Cool that it got fixed after years of sticking around. Props to @chaosvolt for pointing it out. Many old issues get ignored because they've simply never been verified fixed or still existing.

AI assistance from gpt-5.5 xhigh
Most of what it did was help write the tests, but as always I use AI for assistance work more than actual codegen.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7cfafec](https://github.com/cataclysmbn/Cataclysm-BN/commit/7cfafec075f8733afcefe1159a2b2a539c1a02b1) (Astyle ;_;) on 2026-05-24 12:25:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26360219964/artifacts/7185030381)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26360219964/artifacts/7185047313)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26360219964/artifacts/7185084026)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26360219964/artifacts/7184947783)
<!-- END artifact comment -->