### PR TITLE
feat(UI): PgUp/PgDn page navigation in the mutation menu

### DIFF
--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -238,6 +238,8 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
 
     input_context ctxt( "MUTATIONS" );
     ctxt.register_updown();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "ANY_INPUT" );
     ctxt.register_action( "TOGGLE_EXAMINE" );
     ctxt.register_action( "TOGGLE_SPRITE" );
@@ -517,6 +519,31 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
                                                  cursor - half_list_view_location ), 0 );
                 }
 
+                examine_id = GetTrait( active, passive, cursor, tab_mode );
+            } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+                // Jump the cursor by one visible-list page; wrap only when already
+                // at the extreme row so the cursor doesn't loop freely. Using
+                // list_height keeps the step proportional to the player's actual
+                // screen rather than a fixed constant.
+                int last;
+                if( tab_mode == mutation_tab_mode::passive ) {
+                    last = static_cast<int>( passive.size() ) - 1;
+                } else if( tab_mode == mutation_tab_mode::active ) {
+                    last = static_cast<int>( active.size() ) - 1;
+                } else {
+                    continue;
+                }
+                if( last < 0 ) {
+                    continue;
+                }
+                const int page_step = std::max( 1, list_height );
+                if( action == "PAGE_DOWN" ) {
+                    cursor = cursor == last ? 0 : std::min( last, cursor + page_step );
+                } else {
+                    cursor = cursor == 0 ? last : std::max( 0, cursor - page_step );
+                }
+                scroll_position = std::clamp( cursor - half_list_view_location,
+                                              0, std::max( 0, max_scroll_position ) );
                 examine_id = GetTrait( active, passive, cursor, tab_mode );
             } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
                 if( tab_mode == mutation_tab_mode::active && !passive.empty() ) {

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -521,10 +521,13 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
 
                 examine_id = GetTrait( active, passive, cursor, tab_mode );
             } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
-                // Jump the cursor by one visible-list page; wrap only when already
-                // at the extreme row so the cursor doesn't loop freely. Using
-                // list_height keeps the step proportional to the player's actual
-                // screen rather than a fixed constant.
+                // Advance the view by one full visible-list page. Because the
+                // cursor is re-centred on every redraw when MENU_SCROLL is on,
+                // a naive `cursor += list_height` step overlaps with the
+                // previous page on the first press from a clamped edge. Aim
+                // the cursor at `scroll_position + list_height +
+                // half_list_view_location` so the view truly shifts by one
+                // whole page (no overlap, no half-page).
                 int last;
                 if( tab_mode == mutation_tab_mode::passive ) {
                     last = static_cast<int>( passive.size() ) - 1;
@@ -536,11 +539,16 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
                 if( last < 0 ) {
                     continue;
                 }
-                const int page_step = std::max( 1, list_height );
                 if( action == "PAGE_DOWN" ) {
-                    cursor = cursor == last ? 0 : std::min( last, cursor + page_step );
+                    cursor = cursor == last
+                             ? 0
+                             : std::min( last,
+                                         scroll_position + list_height + half_list_view_location );
                 } else {
-                    cursor = cursor == 0 ? last : std::max( 0, cursor - page_step );
+                    cursor = cursor == 0
+                             ? last
+                             : std::max( 0,
+                                         scroll_position - list_height + half_list_view_location );
                 }
                 scroll_position = std::clamp( cursor - half_list_view_location,
                                               0, std::max( 0, max_scroll_position ) );


### PR DESCRIPTION
## Summary of the Commit

Adds PageUp / PageDown page-navigation handlers to the mutation menu so long trait lists are no longer up-arrow-only. Same pattern as the recent bionics enhancement (#9032): registers `PAGE_UP` / `PAGE_DOWN` in the `MUTATIONS` input context and jumps the cursor by one visible page (`std::max( 1, list_height )`) within the currently-active tab. Wraps to the opposite extreme only when already at the end so the cursor doesn't loop freely.

## Purpose of change

Part of the DDA UI-scrolling umbrella (DDA #44152) — bringing PgUp/PgDn to one more menu that previously required dozens of arrow taps. With a long mutated character (30+ traits) the list scrolled one row at a time; this change scales the step to the player's actual screen height.

## Describe the solution

`src/mutation_ui.cpp`:

- Register `PAGE_UP` / `PAGE_DOWN` next to `register_updown()` with `to_translation()` labels.
- Add a unified handler after the `UP` branch. It honors the active/passive tab split (uses whichever list the current `tab_mode` points at), computes `page_step = std::max( 1, list_height )` so the jump matches a real page, and updates `scroll_position` via `std::clamp` so the existing `half_list_view_location` cursor model stays consistent.
- Refreshes `examine_id` after the jump so the description panel matches the new selection — same as the existing UP/DOWN branches.

Diff: +27 / -0 in a single file.

## Testing

- Local Windows MSVC build (`windows-tiles-sounds-x64-msvc`, RelWithDebInfo) — clean, 0 errors.
- In-game test: new char in debug mode, stacked ~30 mutations via *Mutate → Pick from list*, opened the mutation menu (`p`).
  - PgDn from row 0 jumps the cursor one visible page down; description panel updates to the new highlighted trait.
  - PgUp does the inverse.
  - At the last row, PgDn wraps to row 0; at row 0, PgUp wraps to the last row.
  - Passive/active tab switch still preserves cursor=0 reset as before.
  - Up/Down arrows still single-step.

## Additional context

No save-format, JSON, or behavior changes outside the input handler. Translation strings: two new (`Page up`, `Page down`) matching the bionics PR.

Refs: DDA umbrella issue cataclysmbn/Cataclysm-DDA#44152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d215fc5](https://github.com/cataclysmbn/Cataclysm-BN/commit/d215fc556f707ccb3ae5d58b6928300d34df54c3) (fix(UI): mutation PgUp/PgDn advance view by exactly one page) on 2026-05-24 16:44:21

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26365646687/artifacts/7186703253)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26365646687/artifacts/7186684114)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26365646687/artifacts/7186585712)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26365646687/artifacts/7186514045)
<!-- END artifact comment -->