### PR TITLE
fix(UI): let pause keys interrupt activities

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2143,8 +2143,12 @@ bool game::do_turn()
     Pathfinding::clear_d_maps();
 
     // Drain the OS input buffer so key-repeat events generated during world
-    // processing don't accumulate and drive movement after key release.
-    inp_mngr.pump_events();
+    // processing don't accumulate and drive movement after key release.  Keep
+    // input while activity or auto-move interruption checks are active, so
+    // pause/menu keys can still stop long-running actions.
+    if( !u.activity && !u.has_destination() ) {
+        inp_mngr.pump_events();
+    }
 
     return false;
 }


### PR DESCRIPTION
## Purpose of change (The Why)

close #9044

`pause` input pressed during long activities or auto-move was drained before the voluntary interruption check could see it.

Caused by #9017.

Related: #9044, #9017

## Describe the solution (The How)

Only drain queued input after world processing when the player is not in an activity and not auto-moving.

## Describe alternatives you've considered
1. wait
2. press .
3. can stop
## Testing

- [x] `cmake --build out/build/linux-full --target format`
- [x] `cmake --build --preset linux-full --target cataclysm-bn-tiles`
- [x] `cmake --build --preset linux-full --target cata_test-tiles`
- [x] `./out/build/linux-full/tests/cata_test-tiles "[input]"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2e1769a](https://github.com/cataclysmbn/Cataclysm-BN/commit/2e1769a1c1acd4e7b45c769c346ceb543c74d847) (fix: preserve activity interrupt input) on 2026-05-24 13:58:13

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26361936703/artifacts/7185408133)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26361936703/artifacts/7185628665)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26361936703/artifacts/7185378461)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26361936703/artifacts/7185465155)
<!-- END artifact comment -->