### PR TITLE
feat(UI): PgUp/PgDn page navigation in the mission menu

### DIFF
--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -36,6 +36,8 @@ void game::list_missions()
     int entries_per_page = 0;
     input_context ctxt( "MISSIONS" );
     ctxt.register_cardinal();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
@@ -206,6 +208,18 @@ void game::list_missions()
                 selection = umissions.empty() ? 0 : umissions.size() - 1;
             } else {
                 selection--;
+            }
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Jump the cursor by one visible-list page; wrap only when already
+            // at the extreme so the cursor doesn't loop freely.
+            if( !umissions.empty() ) {
+                const size_t last = umissions.size() - 1;
+                const size_t page_step = std::max( 1, entries_per_page );
+                if( action == "PAGE_DOWN" ) {
+                    selection = selection == last ? 0 : std::min( last, selection + page_step );
+                } else {
+                    selection = selection == 0 ? last : ( selection > page_step ? selection - page_step : 0 );
+                }
             }
         } else if( action == "CONFIRM" ) {
             if( tab == tab_mode::TAB_ACTIVE && selection < umissions.size() ) {


### PR DESCRIPTION
## Summary of the Commit

Adds PageUp / PageDown page-navigation handlers to the mission menu (`m`) so long mission lists are no longer single-step only. Same pattern as the recent bionics (#9032) and mutation (#9048) enhancements: registers `PAGE_UP` / `PAGE_DOWN` in the `MISSIONS` input context and jumps the cursor by one visible page (`entries_per_page`). Wraps to the opposite extreme only when already at the end so the cursor doesn't loop freely.

## Purpose of change

Part of the DDA UI-scrolling umbrella (DDA #44152) — bringing PgUp/PgDn parity to one more list-based menu. With a long mission backlog the player previously had to up-arrow tap dozens of times to find a specific entry; this change scales the step to the page already used by the layout.

## Describe the solution

`src/mission_ui.cpp`:

- Register `PAGE_UP` / `PAGE_DOWN` next to `register_cardinal()` with `to_translation()` labels.
- Add a unified handler after the `UP` branch. Uses `entries_per_page` (already computed on resize for the layout) as the page step, wrapping at extremes.

Diff: +14 / -0 in a single file.

## Testing

- Local Windows MSVC build (`windows-tiles-sounds-x64-msvc`, RelWithDebInfo) — clean, 0 errors.
- In-game test: opened the mission menu with 4 active missions; cursor moves to top, bottom, and wraps correctly on PgDn from last and PgUp from first.
- Up/Down arrows still single-step as before; tab Left/Right unchanged.

## Additional context

No save-format, JSON, or behavior changes outside the input handler. Translation strings: two new (`Page up`, `Page down`) matching the prior PRs in this series.

Refs: DDA umbrella issue cataclysmbn/Cataclysm-DDA#44152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [05aec71](https://github.com/cataclysmbn/Cataclysm-BN/commit/05aec71ba99f223f77a225f9659cf4c376d3f5e5) (feat(UI): add PgUp/PgDn page navigation to mission menu) on 2026-05-24 14:42:36

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26362702785/artifacts/7185643552)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26362702785/artifacts/7185905352)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26362702785/artifacts/7185610607)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26362702785/artifacts/7185708351)
<!-- END artifact comment -->