### PR TITLE
feat(UI): PgUp/PgDn page navigation in the safe mode manager

### DIFF
--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -103,6 +103,8 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
     bool changes_made = false;
     input_context ctxt( "SAFEMODE" );
     ctxt.register_cardinal();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "NEXT_TAB" );
@@ -282,6 +284,24 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
             line--;
             if( line < 0 ) {
                 line = current_tab.size() - 1;
+            }
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Advance the view by one full visible-list page. Because
+            // calcStartPos re-centres the cursor on each redraw, we aim the
+            // cursor at the centre of the *next* page so the resulting view
+            // truly shifts by content_height (no overlap, no half-pages).
+            if( !current_tab.empty() ) {
+                const int last = static_cast<int>( current_tab.size() ) - 1;
+                const int half = std::max( 0, ( content_height - 1 ) / 2 );
+                if( action == "PAGE_DOWN" ) {
+                    line = line == last
+                           ? 0
+                           : std::min( last, start_pos + content_height + half );
+                } else {
+                    line = line == 0
+                           ? last
+                           : std::max( 0, start_pos - content_height + half );
+                }
             }
         } else if( action == "ADD_DEFAULT_RULESET" ) {
             changes_made = true;
@@ -541,6 +561,8 @@ void safemode::test_pattern( const int tab_in, const int row_in )
 
     input_context ctxt( "SAFEMODE_TEST" );
     ctxt.register_updown();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
@@ -592,6 +614,24 @@ void safemode::test_pattern( const int tab_in, const int row_in )
             line--;
             if( line < 0 ) {
                 line = creature_list.size() - 1;
+            }
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Advance the view by one full visible-list page. Because
+            // calcStartPos re-centres the cursor on each redraw, we aim the
+            // cursor at the centre of the *next* page so the resulting view
+            // truly shifts by content_height (no overlap, no half-pages).
+            if( !creature_list.empty() ) {
+                const int last = static_cast<int>( creature_list.size() ) - 1;
+                const int half = std::max( 0, ( content_height - 1 ) / 2 );
+                if( action == "PAGE_DOWN" ) {
+                    line = line == last
+                           ? 0
+                           : std::min( last, start_pos + content_height + half );
+                } else {
+                    line = line == 0
+                           ? last
+                           : std::max( 0, start_pos - content_height + half );
+                }
             }
         } else if( action == "QUIT" ) {
             break;


### PR DESCRIPTION
## Summary of the Commit

Adds PageUp / PageDown to both list views of the safe mode manager (the main rule list and the test-rule creature preview). Same DDA UI-scrolling series as the recent bionics (#9032), mutation (#9048) and mission (#9050) menus.

## Purpose of change

Part of the DDA UI-scrolling umbrella (DDA #44152). With a long safe-mode rule list — or a wide test-rule wildcard like `zom*` matching dozens of creatures — the player previously had to single-step the cursor with the arrow keys. PgUp/PgDn now jumps by one full visible page in either direction.

## Describe the solution

`src/safemode_ui.cpp`:

- Register `PAGE_UP` / `PAGE_DOWN` in the `SAFEMODE` input context (main view) and in the test-rule input context.
- Add a unified handler in each loop that advances the *view* by one full `content_height` page. Because `calcStartPos` re-centres the cursor on each redraw (when `MENU_SCROLL` is on), a naive `cursor += content_height` step would visually overlap with the previous page on the first press from a clamped edge. We anchor the new cursor at `start_pos + content_height + half` so the resulting view truly shifts by one whole page — no overlap, no half-page, no skipped-but-visible rows.
- Wraps to the opposite extreme only when already at the end.

Diff: +40 / -0 in a single file.

## Testing

- Local Windows MSVC build (`windows-tiles-sounds-x64-msvc`, RelWithDebInfo) — clean, 0 errors.
- In-game test: opened the safe mode manager, populated rules, hit PgUp / PgDn — view advances by one full page each press, cursor follows. Then opened the test-rule view with a `zom*` wildcard (long creature list) — PgDn/PgUp behave identically, view shifts one screen at a time with no overlap.
- Up / Down arrows still single-step as before.
- Note: the cursor remains centred in the view between pages because `MENU_SCROLL` is the global default. Disabling `MENU_SCROLL` in *Options → Interface* gives traditional snap-style behaviour (cursor at top after PgDn, bottom after PgUp). Both modes work cleanly with this fix.

## Additional context

No save-format, JSON, or behaviour changes outside the input handlers. Translation strings: two new (`Page up`, `Page down`) matching the prior PRs in this series.

Refs: DDA umbrella issue cataclysmbn/Cataclysm-DDA#44152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [efd11ce](https://github.com/cataclysmbn/Cataclysm-BN/commit/efd11cec8363006293485723172885a94dbd13e4) (feat(UI): add PgUp/PgDn page navigation to safe mode manager) on 2026-05-24 15:52:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26364445055/artifacts/7186120680)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26364445055/artifacts/7186355071)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26364445055/artifacts/7186079572)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26364445055/artifacts/7186194791)
<!-- END artifact comment -->