### PR TITLE
fix: prevent rot crash for contained items

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11512,7 +11512,8 @@ std::string item::describe_location( const Character *ch ) const
 
 item *item::parent_item() const
 {
-    contents_item_location *cont = dynamic_cast<contents_item_location *>( &*loc );
+    const auto location = loc ? loc : saved_loc;
+    auto *cont = dynamic_cast<contents_item_location *>( location );
     if( !cont ) {
         return nullptr;
     }

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -47,8 +47,13 @@ auto temperature_flag_for_location( const map &m, const item &loc ) -> temperatu
             }
             return temperature_flag_for_part( veh->vehicle(), cargo_index );
         }
-        case item_location_type::container:
-            return temperature_flag_for_location( m, *loc.parent_item() );
+        case item_location_type::container: {
+            const auto parent = loc.parent_item();
+            if( parent == nullptr ) {
+                return temperature_flag::TEMP_NORMAL;
+            }
+            return temperature_flag_for_location( m, *parent );
+        }
         default:
             debugmsg( "Invalid item location %d", static_cast<int>( loc.where() ) );
             return temperature_flag::TEMP_NORMAL;

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -11,6 +11,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "game.h" // Just for get_convection_temperature(), TODO: Remove
+#include "rot.h"
 #include "state_helpers.h"
 #include "units_temperature.h"
 #include "vehicle.h"
@@ -339,6 +340,25 @@ TEST_CASE( "Vehicle storage temperature controls food rot" )
 
         CHECK( fixture.veh->get_items( fixture.part_index ).empty() );
     }
+}
+
+TEST_CASE( "Contained item keeps parent location while temporarily detached" )
+{
+    prepare_map_storage_test();
+
+    auto container = item::spawn( "bag_plastic" );
+    REQUIRE( container->is_container() );
+    REQUIRE( container->contents.insert_item( item::spawn( "sashimi" ) ).success() );
+
+    auto checked = false;
+    container->contents.remove_top_items_with( [&]( detached_ptr<item> &&it ) {
+        checked = true;
+        CHECK( it->parent_item() == &*container );
+        CHECK( rot::temperature_flag_for_location( get_map(), *it ) == temperature_flag::TEMP_NORMAL );
+        return std::move( it );
+    } );
+
+    CHECK( checked );
 }
 
 TEST_CASE( "Map powered fridge and freezer furniture controls food rot" )


### PR DESCRIPTION
## Purpose of change (The Why)

close #9052
Related: #9010

## Describe the solution (The How)

Use `saved_loc` when resolving a temporarily detached contained item's parent. This keeps rot temperature lookup from dereferencing a null parent while container contents are being processed.

## Testing

teleported and walked around without crashes

## Additional context

The regression path is the temporary-detach processing used for container contents before rot checks.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [483d21f](https://github.com/cataclysmbn/Cataclysm-BN/commit/483d21f618cd421c2c2b20b2509ded5490da46b9) (fix: prevent rot crash for contained items) on 2026-05-24 16:59:16

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26366028311/artifacts/7186801766)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26366028311/artifacts/7186779627)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26366028311/artifacts/7186666559)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26366028311/artifacts/7186627966)
<!-- END artifact comment -->