### PR TITLE
feat(UI): PgUp/PgDn page navigation in the auto pickup manager

### DIFF
--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -189,6 +189,8 @@ void user_interface::show()
     bStuffChanged = false;
     input_context ctxt( "AUTO_PICKUP" );
     ctxt.register_cardinal();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     if( tabs.size() > 1 ) {
@@ -249,6 +251,27 @@ void user_interface::show()
             iColumn = 1;
             if( iLine < 0 ) {
                 iLine = cur_rules.size() - 1;
+            }
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Advance the view by one full visible-list page. Because
+            // calcStartPos re-centres the cursor on each redraw when
+            // MENU_SCROLL is on, a naive `cursor += content_height` step
+            // overlaps with the previous view on the first press from a
+            // clamped edge. Aim the cursor at the centre of the *next*
+            // page so the view truly shifts by content_height.
+            if( !cur_rules.empty() ) {
+                const int last = static_cast<int>( cur_rules.size() ) - 1;
+                const int half = std::max( 0, ( iContentHeight - 1 ) / 2 );
+                iColumn = 1;
+                if( action == "PAGE_DOWN" ) {
+                    iLine = iLine == last
+                            ? 0
+                            : std::min( last, iStartPos + iContentHeight + half );
+                } else {
+                    iLine = iLine == 0
+                            ? last
+                            : std::max( 0, iStartPos - iContentHeight + half );
+                }
             }
         } else if( action == "REMOVE_RULE" && currentPageNonEmpty ) {
             bStuffChanged = true;
@@ -466,6 +489,8 @@ void rule::test_pattern() const
 
     input_context ctxt( "AUTO_PICKUP_TEST" );
     ctxt.register_updown();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
@@ -520,6 +545,24 @@ void rule::test_pattern() const
             iLine--;
             if( iLine < 0 ) {
                 iLine = vMatchingItems.size() - 1;
+            }
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Advance the view by one full visible-list page. Because
+            // calcStartPos re-centres the cursor on each redraw when
+            // MENU_SCROLL is on, anchor the target cursor at the centre
+            // of the next page so the view truly shifts by content_height.
+            if( !vMatchingItems.empty() ) {
+                const int last = static_cast<int>( vMatchingItems.size() ) - 1;
+                const int half = std::max( 0, ( iContentHeight - 1 ) / 2 );
+                if( action == "PAGE_DOWN" ) {
+                    iLine = iLine == last
+                            ? 0
+                            : std::min( last, iStartPos + iContentHeight + half );
+                } else {
+                    iLine = iLine == 0
+                            ? last
+                            : std::max( 0, iStartPos - iContentHeight + half );
+                }
             }
         } else if( action == "QUIT" ) {
             break;


### PR DESCRIPTION
## Summary of the Commit

Adds PageUp / PageDown to both list views of the auto pickup manager — the main rule list (global + character tabs) and the test-rule item preview. Direct mirror of the recent safe mode manager change (#9051); same DDA UI-scrolling series as bionics (#9032), mutation (#9048), mission (#9050) and safemode (#9051).

## Purpose of change

Part of the DDA UI-scrolling umbrella (DDA #44152). With long auto-pickup rule lists, or a broad wildcard like `*` in the test view that matches a large itype set, single-stepping with arrow keys is tedious. PgUp/PgDn jumps by one full visible page in either direction.

## Describe the solution

`src/auto_pickup.cpp`:

- Register `PAGE_UP` / `PAGE_DOWN` in the `AUTO_PICKUP` context (main view) and in the `AUTO_PICKUP_TEST` context.
- Add a unified handler in each loop that advances the *view* by one full `iContentHeight` page. Because `calcStartPos` re-centres the cursor on each redraw when `MENU_SCROLL` is on, a naive `cursor += iContentHeight` step would visually overlap with the previous page on the first press from a clamped edge. We anchor the new cursor at `iStartPos + iContentHeight + half` so the resulting view truly shifts by one whole page — no overlap, no half-page.
- Wraps to the opposite extreme only when already at the end.

Diff: +43 / -0 in a single file.

## Testing

- Local Windows MSVC build (`windows-tiles-sounds-x64-msvc`, RelWithDebInfo) — clean, 0 errors.
- In-game test: opened the auto-pickup manager, populated rules, hit PgUp/PgDn — view advances by one full page each press, cursor follows. Then opened the test-rule view with a broad wildcard — PgDn/PgUp behave identically across the long item list.
- Up/Down arrows still single-step as before.
- Note: the cursor remains centred in the view because `MENU_SCROLL` is the global default. Disabling `MENU_SCROLL` in *Options → Interface* gives traditional snap-style behaviour (cursor at top after PgDn). Both modes work cleanly.

## Additional context

No save-format, JSON, or behaviour changes outside the input handlers. Translation strings: two new (`Page up`, `Page down`) matching the prior PRs in this series.

Refs: DDA umbrella issue cataclysmbn/Cataclysm-DDA#44152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c5bceae](https://github.com/cataclysmbn/Cataclysm-BN/commit/c5bceaef1cd1b32ae568213fbe77f1efff5f483d) (feat(UI): add PgUp/PgDn page navigation to auto pickup manager) on 2026-05-24 18:27:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26368039799/artifacts/7187331310)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26368039799/artifacts/7187317266)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26368039799/artifacts/7187200940)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26368039799/artifacts/7187176803)
<!-- END artifact comment -->