### PR TITLE
feat(UI): PgUp/PgDn page navigation in the auto notes manager

### DIFF
--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -215,6 +215,8 @@ void auto_note_manager_gui::show()
 
     if( !emptyMode ) {
         ctx.register_cardinal();
+        ctx.register_action( "PAGE_UP", to_translation( "Page up" ) );
+        ctx.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
         ctx.register_action( "CONFIRM" );
         ctx.register_action( "QUIT" );
         ctx.register_action( "ENABLE_MAPEXTRA_NOTE" );
@@ -356,6 +358,22 @@ void auto_note_manager_gui::show()
                 currentLine = 0;
             } else {
                 ++currentLine;
+            }
+        } else if( currentAction == "PAGE_DOWN" || currentAction == "PAGE_UP" ) {
+            // Advance the view by one full visible-list page. Because
+            // calcStartPos re-centres the cursor on each redraw when
+            // MENU_SCROLL is on, anchor the target cursor at the centre
+            // of the next page so the view truly shifts by iContentHeight.
+            const int last = static_cast<int>( cacheSize ) - 1;
+            const int half = std::max( 0, ( iContentHeight - 1 ) / 2 );
+            if( currentAction == "PAGE_DOWN" ) {
+                currentLine = currentLine == last
+                              ? 0
+                              : std::min( last, startPosition + iContentHeight + half );
+            } else {
+                currentLine = currentLine == 0
+                              ? last
+                              : std::max( 0, startPosition - iContentHeight + half );
             }
         }  else if( currentAction == "ENABLE_MAPEXTRA_NOTE" ) {
             entry.second = true;


### PR DESCRIPTION
## Summary of the Commit

Adds PageUp / PageDown to the auto notes manager (`Esc → Auto Notes Manager`). Direct mirror of the recent safe mode (#9051) and auto pickup (#9055) enhancements; same DDA UI-scrolling series as bionics (#9032), mutation (#9048), mission (#9050).

## Purpose of change

Part of the DDA UI-scrolling umbrella (DDA #44152). The map-extras list in the auto notes manager runs to dozens of entries — single-stepping with arrow keys is tedious. PgUp / PgDn jumps by one full visible page in either direction.

## Describe the solution

`src/auto_note.cpp`:

- Register `PAGE_UP` / `PAGE_DOWN` in the non-empty context.
- Add a unified handler that advances the *view* by one full `iContentHeight` page. Because `calcStartPos` re-centres the cursor on each redraw when `MENU_SCROLL` is on, a naive `cursor += iContentHeight` step would visually overlap with the previous page on the first press from a clamped edge. We anchor the new cursor at `startPosition + iContentHeight + half` so the resulting view truly shifts by one whole page — no overlap, no half-page.
- Wraps to the opposite extreme only when already at the end.

Diff: +18 / -0 in a single file.

## Testing

- Local Windows MSVC build (`windows-tiles-sounds-x64-msvc`, RelWithDebInfo) — clean, 0 errors.
- In-game test: opened the auto notes manager (long map-extras list), confirmed PgUp / PgDn advance the visible window by exactly one page per press; cursor wraps to extreme on edge.
- Up / Down arrows still single-step as before.
- Note: the cursor remains centred in the view because `MENU_SCROLL` is the global default. Disabling `MENU_SCROLL` in *Options → Interface* gives traditional snap-style behaviour. Both modes work cleanly with this fix.

## Additional context

No save-format, JSON, or behaviour changes outside the input handler. Translation strings: two new (`Page up`, `Page down`) matching the prior PRs in this series.

Refs: DDA umbrella issue cataclysmbn/Cataclysm-DDA#44152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a504738](https://github.com/cataclysmbn/Cataclysm-BN/commit/a504738de7a0aab4852a224766ff811289670980) (feat(UI): add PgUp/PgDn page navigation to auto notes manager) on 2026-05-24 18:41:58

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26368322958/artifacts/7187419297)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26368322958/artifacts/7187404660)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26368322958/artifacts/7187323905)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26368322958/artifacts/7187253543)
<!-- END artifact comment -->