### PR TITLE
feat(UI): PgUp/PgDn page navigation in the Options menu

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3707,6 +3707,8 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
 
     input_context ctxt( "OPTIONS" );
     ctxt.register_cardinal();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "PREV_TAB" );
@@ -4031,6 +4033,66 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                     iCurrentLine = page_items.size() - 1;
                 }
             } while( !is_selectable( iCurrentLine ) );
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Mirror the redraw's "visible items" set (headers + items in
+            // expanded groups + blank lines in expanded groups) and step
+            // the cursor by `iContentHeight` rows in *that* visible space.
+            // This makes the perceived jump match one page height even
+            // when some groups are collapsed. Wraps at the visible
+            // extremes; skips non-selectable rows on landing.
+            const int total = static_cast<int>( page_items.size() );
+            const auto is_vis = [&]( int i ) -> bool {
+                const PageItem &it = page_items[i];
+                switch( it.type )
+                {
+                    case ItemType::GroupHeader:
+                        return true;
+                    case ItemType::BlankLine:
+                    case ItemType::Option:
+                        return groups_state[it.group];
+                    default:
+                        abort();
+                }
+            };
+            std::vector<int> visible;
+            visible.reserve( total );
+            int cur_vis = 0;
+            for( int i = 0; i < total; i++ ) {
+                if( is_vis( i ) ) {
+                    if( i == iCurrentLine ) {
+                        cur_vis = static_cast<int>( visible.size() );
+                    }
+                    visible.push_back( i );
+                }
+            }
+            if( !visible.empty() ) {
+                const int n_vis = static_cast<int>( visible.size() );
+                const int step = std::max( 1, iContentHeight );
+                int target_vis;
+                if( action == "PAGE_DOWN" ) {
+                    target_vis = cur_vis == n_vis - 1
+                                 ? 0
+                                 : std::min( n_vis - 1, cur_vis + step );
+                } else {
+                    target_vis = cur_vis == 0
+                                 ? n_vis - 1
+                                 : std::max( 0, cur_vis - step );
+                }
+                // Land on a selectable row — if the page-step put us on a
+                // blank line, walk in the same direction to the next one.
+                const int dir = action == "PAGE_DOWN" ? 1 : -1;
+                int probe = target_vis;
+                for( int i = 0; i < n_vis; i++ ) {
+                    if( is_selectable( visible[probe] ) ) {
+                        target_vis = probe;
+                        break;
+                    }
+                    probe = ( probe + dir + n_vis ) % n_vis;
+                }
+                if( is_selectable( visible[target_vis] ) ) {
+                    iCurrentLine = visible[target_vis];
+                }
+            }
         } else if( action == "NEXT_TAB" ) {
             iCurrentLine = 0;
             iStartPos = 0;


### PR DESCRIPTION
## Summary of the Commit

Adds PageUp / PageDown to the Options menu (`Esc → Options`, main-menu *Settings → Options*, and the world-creation options stage). Same DDA UI-scrolling series as bionics (#9032), mutation (#9048), mission (#9050), safemode (#9051), auto pickup (#9055), auto notes (#9056).

## Purpose of change

Part of the DDA UI-scrolling umbrella (DDA #44152). The Options pages each carry dozens of entries; single-stepping through them with arrow keys is painful. PgUp/PgDn now jumps by one full visible page in either direction.

## Describe the solution

`src/options.cpp`:

- Register `PAGE_UP` / `PAGE_DOWN` in the `OPTIONS` input context.
- Add a unified handler that mirrors the redraw's `is_visible` logic (headers always visible; blank-lines and options only when their group is expanded), then steps the cursor by `iContentHeight` in *visible* space. This matches what the player sees as "one page" even when several groups are collapsed.
- After the page-step, walk in the same direction until landing on a selectable row, so the cursor never sits on a header / blank line.
- Wraps at the visible extremes (last visible row + PgDn → first visible; first + PgUp → last), matching the other menus in this series.

Diff: +62 / -0 in a single file.

## Testing

- Local Windows MSVC build (`windows-tiles-sounds-x64-msvc`, RelWithDebInfo) — clean, 0 errors.
- In-game test: navigated the *Interface*, *Performance*, and other tabs with mixed collapsed / expanded groups; PgUp / PgDn jumps by one visible page each press, lands on selectable rows, wraps cleanly at extremes. Confirmed working with expandable group headers.
- Up / Down arrows still single-step as before. Tab navigation (LEFT/RIGHT) unchanged.

## Additional context

No save-format, JSON, or behavior changes outside the input handler. Translation strings: two new (`Page up`, `Page down`) matching the prior PRs in this series.

Refs: DDA umbrella issue cataclysmbn/Cataclysm-DDA#44152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9cd7b53](https://github.com/cataclysmbn/Cataclysm-BN/commit/9cd7b5372a50712c5c8c96def131e6762cad0c08) (feat(UI): add PgUp/PgDn page navigation to the Options menu) on 2026-05-24 19:36:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26369507561/artifacts/7187750413)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26369507561/artifacts/7187751750)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26369507561/artifacts/7187617403)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26369507561/artifacts/7187600010)
<!-- END artifact comment -->