### PR TITLE
fix: recoilless weapons no longer eats all remaining moves on aim

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1883,9 +1883,6 @@ static void do_aim( avatar &you, const item &relevant, const double min_recoil )
         // Increase aim at the cost of moves
         you.mod_moves( -1 );
         you.recoil = std::max( min_recoil, you.recoil - aim_amount );
-    } else {
-        // If aim is already maxed, we're just waiting, so pass the turn.
-        you.set_moves( 0 );
     }
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #9045 

## Describe the solution (The How)
Remove the set_moves(0) on aiming a completely aimed weapon

## Describe alternatives you've considered
Add a new field for minimum aim time / add recoil to all laser weapons

## Testing
Pre-PR: SpeedyDex, Dex 500, spawn zombie bit away, spawn debug monster close, every shot zombie gets closer ( even though really you should have minimum 10 turns at 1000 speed...)
Post-PR: Same conditions, as you have 1000 speed with fire time of 15... you kill the debug monster before the zed moves
Go down to normal speed -> You get ~1 shot with no skills and ~8 shots with skills, matching UI displayed time

## Additional context
I honestly dont know how to balance this
But I know the current conditions are a bug
And I know this was set 14 years ago, and thus most likely didn't expect no-recoil weapons and super fast firing/speed characters

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [61f8c4c](https://github.com/cataclysmbn/Cataclysm-BN/commit/61f8c4c4e28eb9b6f17db2f49397b21a11bdf172) (fix: recoilless weapons no longer eat all remaining moves on aim) on 2026-05-24 19:35:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26369536418/artifacts/7187769920)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26369536418/artifacts/7187749877)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26369536418/artifacts/7187675301)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26369536418/artifacts/7187606698)
<!-- END artifact comment -->