### PR TITLE
feat(UI): PgUp/PgDn page navigation in character-creation pickers

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1277,6 +1277,8 @@ tab_direction set_traits( avatar &u, points_left &points )
 
     input_context ctxt( "NEW_CHAR_TRAITS" );
     ctxt.register_cardinal();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "PREV_TAB" );
     ctxt.register_action( "NEXT_TAB" );
@@ -1453,6 +1455,28 @@ tab_direction set_traits( avatar &u, points_left &points )
             iCurrentLine[iCurWorkingPage]++;
             if( static_cast<size_t>( iCurrentLine[iCurWorkingPage] ) >= traits_size[iCurWorkingPage] ) {
                 iCurrentLine[iCurWorkingPage] = 0;
+            }
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Advance the visible trait list by one full page on the active
+            // column. Because calcStartPos re-centres the cursor on each
+            // redraw when MENU_SCROLL is on, anchor the target at the centre
+            // of the next page so the view truly shifts by iContentHeight.
+            const int col_size = static_cast<int>( traits_size[iCurWorkingPage] );
+            if( col_size > 0 ) {
+                const int last = col_size - 1;
+                const int start = iStartPos[iCurWorkingPage];
+                const int content_h = static_cast<int>( iContentHeight );
+                const int half = std::max( 0, ( content_h - 1 ) / 2 );
+                int &cur = iCurrentLine[iCurWorkingPage];
+                if( action == "PAGE_DOWN" ) {
+                    cur = cur == last
+                          ? 0
+                          : std::min( last, start + content_h + half );
+                } else {
+                    cur = cur == 0
+                          ? last
+                          : std::max( 0, start - content_h + half );
+                }
             }
         } else if( action == "RANDOMIZE" ) {
             iCurrentLine[iCurWorkingPage] = rng( 0, traits_size[iCurWorkingPage] - 1 );
@@ -1716,6 +1740,8 @@ tab_direction set_bionics( avatar &u, points_left &points )
 
     input_context ctxt( "NEW_CHAR_TRAITS" );
     ctxt.register_cardinal();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "PREV_TAB" );
     ctxt.register_action( "NEXT_TAB" );
@@ -1892,6 +1918,27 @@ tab_direction set_bionics( avatar &u, points_left &points )
             iCurrentLine[iCurWorkingPage]++;
             if( static_cast<size_t>( iCurrentLine[iCurWorkingPage] ) >= bionics_size[iCurWorkingPage] ) {
                 iCurrentLine[iCurWorkingPage] = 0;
+            }
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Advance the visible bionic list by one full page on the active
+            // column. Anchor at the centre of the next page so the view
+            // truly shifts by iContentHeight even with calcStartPos centring.
+            const int col_size = static_cast<int>( bionics_size[iCurWorkingPage] );
+            if( col_size > 0 ) {
+                const int last = col_size - 1;
+                const int start = iStartPos[iCurWorkingPage];
+                const int content_h = static_cast<int>( iContentHeight );
+                const int half = std::max( 0, ( content_h - 1 ) / 2 );
+                int &cur = iCurrentLine[iCurWorkingPage];
+                if( action == "PAGE_DOWN" ) {
+                    cur = cur == last
+                          ? 0
+                          : std::min( last, start + content_h + half );
+                } else {
+                    cur = cur == 0
+                          ? last
+                          : std::max( 0, start - content_h + half );
+                }
             }
         } else if( action == "RANDOMIZE" ) {
             iCurrentLine[iCurWorkingPage] = rng( 0, bionics_size[iCurWorkingPage] - 1 );
@@ -2140,6 +2187,8 @@ tab_direction set_profession( avatar &u, points_left &points,
 
     input_context ctxt( "NEW_CHAR_PROFESSIONS" );
     ctxt.register_cardinal();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "CHANGE_GENDER" );
     ctxt.register_action( "PREV_TAB" );
@@ -2490,6 +2539,29 @@ tab_direction set_profession( avatar &u, points_left &points,
                 ui_manager::redraw();
             }
 #endif
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Advance the visible profession list by one full page. Anchor
+            // at the centre of the next page so calcStartPos's recentring
+            // shifts the view by exactly iContentHeight.
+            if( profs_length > 0 ) {
+                const int last = profs_length - 1;
+                const int half = std::max( 0, ( iContentHeight - 1 ) / 2 );
+                if( action == "PAGE_DOWN" ) {
+                    cur_id = cur_id == last
+                             ? 0
+                             : std::min( last, iStartPos + iContentHeight + half );
+                } else {
+                    cur_id = cur_id == 0
+                             ? last
+                             : std::max( 0, iStartPos - iContentHeight + half );
+                }
+                desc_offset = 0;
+#if defined(TILES)
+                if( use_character_preview ) {
+                    ui_manager::redraw();
+                }
+#endif
+            }
         } else if( action == "LEFT" ) {
             if( desc_offset > 0 ) {
                 desc_offset--;
@@ -2858,6 +2930,8 @@ tab_direction set_scenario( avatar &u, points_left &points,
 
     input_context ctxt( "NEW_CHAR_SCENARIOS" );
     ctxt.register_cardinal();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "PREV_TAB" );
     ctxt.register_action( "NEXT_TAB" );
@@ -3132,6 +3206,23 @@ tab_direction set_scenario( avatar &u, points_left &points,
             cur_id--;
             if( cur_id < 0 ) {
                 cur_id = scens_length - 1;
+            }
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            // Advance the visible scenario list by one full page. Anchor
+            // at the centre of the next page so calcStartPos's recentring
+            // shifts the view by exactly iContentHeight.
+            if( scens_length > 0 ) {
+                const int last = scens_length - 1;
+                const int half = std::max( 0, ( iContentHeight - 1 ) / 2 );
+                if( action == "PAGE_DOWN" ) {
+                    cur_id = cur_id == last
+                             ? 0
+                             : std::min( last, iStartPos + iContentHeight + half );
+                } else {
+                    cur_id = cur_id == 0
+                             ? last
+                             : std::max( 0, iStartPos - iContentHeight + half );
+                }
             }
         } else if( action == "RANDOMIZE" ) {
             cur_id = rng( 0, scens_length - 1 );


### PR DESCRIPTION
## Summary of the Commit

Adds PageUp / PageDown to the four long-list pickers in the character-creation flow: **Traits**, **Bionics**, **Profession**, and **Scenarios**. Continues the DDA UI-scrolling series alongside bionics (#9032), mutation (#9048), mission (#9050), safemode (#9051), auto pickup (#9055), auto notes (#9056), Options (#9058), and the auto-foraging consistency commit on #9018.

## Purpose of change

Part of the DDA UI-scrolling umbrella (DDA #44152). Each character-creation picker carries dozens to hundreds of entries depending on installed mods. Single-stepping with arrow keys through 100+ traits or 50+ scenarios is painful. PgUp/PgDn now jumps by one full visible page in either direction.

## Describe the solution

`src/newcharacter.cpp`:

- Register `PAGE_UP` / `PAGE_DOWN` in each of the four contexts: `NEW_CHAR_TRAITS` (used twice — traits view and bionics view), `NEW_CHAR_PROFESSIONS`, `NEW_CHAR_SCENARIOS`.
- Add a unified handler after each context's `DOWN` block that advances the cursor by one `iContentHeight` page. For the multi-column traits/bionics screens the page-step operates on the *currently-active column* (the one LEFT/RIGHT focuses).
- Because `calcStartPos` re-centres the cursor on each redraw when `MENU_SCROLL` is on, anchor the target cursor at `iStartPos + iContentHeight + half` so the view truly shifts by one full visible page per press. Wraps to the opposite extreme only at the edge row.
- `iContentHeight` is `size_t` in the trait/bionic screens — cast to `int` locally for `std::max(0, ...)`.

Skills picker is **intentionally** left untouched — its category-aware scroll model (where rows include category headers spliced inline with display offsets) needs a different page-step treatment and will be a separate change.

Diff: +91 / -0 in a single file.

## Testing

- Local Windows MSVC build (`windows-tiles-sounds-x64-msvc`, RelWithDebInfo) — clean, 0 errors.
- In-game test: started New Game → Custom Character, navigated through each of the four tabs.
  - **Traits**: PgUp/PgDn advances the active column (good / bad / neutral) by one page; LEFT/RIGHT swaps column unchanged.
  - **Bionics**: same column-aware behavior.
  - **Profession**: scrolls the (long) profession list by one page; filter input unaffected.
  - **Scenarios**: scrolls by one page; filter input unaffected.
- Up / Down arrows still single-step as before.
- Wraps to the opposite extreme at edge rows.
- Note: cursor stays centred in the view because `MENU_SCROLL` is the global default. Disabling `MENU_SCROLL` in *Options → Interface* gives snap-style behaviour. Both modes work cleanly.

## Additional context

No save-format, JSON, or behaviour changes outside the input handlers. Translation strings: two new (`Page up`, `Page down`) matching the prior PRs in this series.

Refs: DDA umbrella issue cataclysmbn/Cataclysm-DDA#44152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7ea93b9](https://github.com/cataclysmbn/Cataclysm-BN/commit/7ea93b9f241daed1f6761eb4a8ec8877c8380d3e) (feat(UI): add PgUp/PgDn page navigation to character creation pickers) on 2026-05-24 21:33:17

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372087801/artifacts/7188473757)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372087801/artifacts/7188461787)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372087801/artifacts/7188301981)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372087801/artifacts/7188305799)
<!-- END artifact comment -->