### PR TITLE
feat(UI): color manager PgUp/PgDn page navigation

### DIFF
--- a/src/color.cpp
+++ b/src/color.cpp
@@ -792,6 +792,8 @@ void color_manager::show_gui()
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "REMOVE_CUSTOM" );
     ctxt.register_action( "LOAD_TEMPLATE" );
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
     std::map<std::string, color_struct> name_color_map;
@@ -885,6 +887,20 @@ void color_manager::show_gui()
             iCurrentLine++;
             if( iCurrentLine >= static_cast<int>( iMaxColors ) ) {
                 iCurrentLine = 0;
+            }
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            if( iMaxColors > 0 ) {
+                const int last = static_cast<int>( iMaxColors ) - 1;
+                const int half = std::max( 0, ( iContentHeight - 1 ) / 2 );
+                if( action == "PAGE_DOWN" ) {
+                    iCurrentLine = iCurrentLine == last
+                                   ? 0
+                                   : std::min( last, iStartPos + iContentHeight + half );
+                } else {
+                    iCurrentLine = iCurrentLine == 0
+                                   ? last
+                                   : std::max( 0, iStartPos - iContentHeight + half );
+                }
             }
         } else if( action == "LEFT" ) {
             iCurrentCol--;


### PR DESCRIPTION
## Summary

- Adds `PAGE_UP`/`PAGE_DOWN` to the `COLORS` input context in `color_manager::show_gui` so the color list can be paged.
- Wrap at extremes; PgDn at last → top, PgUp at top → last.
- Cursor anchored at `iStartPos + iContentHeight + half` on PgDn (mirrored for PgUp) so it counters `calcStartPos` centering and a single press advances by exactly one visible page.

Part of upstream DDA umbrella issue [cataclysm-dda#44152](https://github.com/CleverRaven/Cataclysm-DDA/issues/44152) (UI scrolling).

Follows the same pattern used in #9032 (bionics), #9048 (mutation), #9050 (mission), #9051 (safemode), #9055 (auto-pickup), #9056 (auto-notes), #9058 (options), #9060 (newcharacter), and the PgUp/PgDn extension in #9018 (auto-foraging).

## Test plan

- [x] Builds clean (`cataclysm-bn-tiles`, `RelWithDebInfo`, MSVC).
- [x] In-game: open **Settings → Colors**, PgDn pages forward one visible page and the cursor lands near the top of the new view; PgUp mirrors; wraps cleanly at both extremes; `LEFT`/`RIGHT` column toggle and `CONFIRM`/`REMOVE_CUSTOM`/`LOAD_TEMPLATE` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [49928cb](https://github.com/cataclysmbn/Cataclysm-BN/commit/49928cb89565a1c3b5ace44174c8c27a449857f6) (feat(UI): color manager PgUp/PgDn page navigation) on 2026-05-24 21:47:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372473542/artifacts/7188585751)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372473542/artifacts/7188553509)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372473542/artifacts/7188516354)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372473542/artifacts/7188414890)
<!-- END artifact comment -->