### PR TITLE
fix: debug menu displays items as fresh

### DIFF
--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -742,7 +742,7 @@ void debug_menu::wishitem( Character *who, const tripoint_bub_ms &pos )
     std::vector<std::pair<std::string, const itype *>> opts;
     for( const itype *i : item_controller->all() ) {
         //TODO!: push up
-        auto it = item::spawn_temporary( i, calendar::start_of_cataclysm );
+        auto it = item::spawn_temporary( i, calendar::turn );
         if( it->has_flag( flag_VARSIZE ) ) {
             it->set_flag( flag_FIT );
         }


### PR DESCRIPTION
## Purpose of change (The Why)
Solves the "problem" with #9053

## Describe the solution (The How)
Temp debug menu item no longer is based at start of cataclysm

## Describe alternatives you've considered
None

## Testing
Load into next summer
Open debug menu
It works

## Additional context
Now to fix the instacrash by approving that PR

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a9ebbd3](https://github.com/cataclysmbn/Cataclysm-BN/commit/a9ebbd3490d3df3e9ed230d8c99a2325d8c3e37d) (fix: debug menu displays items as fresh) on 2026-05-24 23:02:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372735946/artifacts/7188675076)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372735946/artifacts/7189025078)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372735946/artifacts/7188487605)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26372735946/artifacts/7188488728)
<!-- END artifact comment -->