### PR TITLE
feat(UI): mod manager PgUp/PgDn page navigation

### DIFF
--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -801,6 +801,8 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
     ctxt.register_updown();
     ctxt.register_action( "LEFT", to_translation( "Switch to other list" ) );
     ctxt.register_action( "RIGHT", to_translation( "Switch to other list" ) );
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "NEXT_CATEGORY_TAB" );
@@ -1146,6 +1148,29 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
             active_header = next_header;
         } else if( action == "LEFT" ) {
             active_header = prev_header;
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            const int content_h = std::max( 1,
+                                            getmaxy( active_header == 0 ? w_list : w_active ) );
+            const size_t list_size = active_header == 0
+                                     ? all_tabs[iCurrentTab].mods.size()
+                                     : active_mod_order.size();
+            if( list_size > 0 ) {
+                const int last = static_cast<int>( list_size ) - 1;
+                const int start = startsel[active_header];
+                const int cur = static_cast<int>( selection );
+                const int half = std::max( 0, ( content_h - 1 ) / 2 );
+                int target;
+                if( action == "PAGE_DOWN" ) {
+                    target = cur == last
+                             ? 0
+                             : std::min( last, start + content_h + half );
+                } else {
+                    target = cur == 0
+                             ? last
+                             : std::max( 0, start - content_h + half );
+                }
+                selection = static_cast<size_t>( target );
+            }
         } else if( action == "CONFIRM" ) {
             const std::vector<mod_id> &current_tab_mods = all_tabs[iCurrentTab].mods;
             if( active_header == 0 && !current_tab_mods.empty() ) {


### PR DESCRIPTION
## Summary

- Adds `PAGE_UP`/`PAGE_DOWN` to the `MODMANAGER_DIALOG` input context in `worldfactory::show_modselection_window` so both the "Mod List" and "Mod Load Order" lists can be paged.
- Handler operates on whichever list `active_header` currently focuses (the one LEFT/RIGHT switches between), so a single handler covers both panels.
- Wrap at extremes; PgDn at last → top, PgUp at top → last.
- Cursor anchored at `startsel[active_header] + content_h + half` on PgDn (mirrored for PgUp) so it counters `calcStartPos` centering and a single press advances by exactly one visible page.

Part of upstream DDA umbrella issue [cataclysm-dda#44152](https://github.com/CleverRaven/Cataclysm-DDA/issues/44152) (UI scrolling).

Follows the same pattern used in #9032 (bionics), #9048 (mutation), #9050 (mission), #9051 (safemode), #9055 (auto-pickup), #9056 (auto-notes), #9058 (options), #9060 (newcharacter), #9061 (color manager), and the PgUp/PgDn extension in #9018 (auto-foraging).

## Test plan

- [x] Builds clean (`cataclysm-bn-tiles`, `RelWithDebInfo`, MSVC).
- [x] In-game: from main menu → **New World** → tab to Mod Manager. PgDn pages forward one visible page and the cursor lands near the top of the new view; PgUp mirrors; wraps cleanly at both extremes; works on both the left "Mod List" and the right "Mod Load Order" (use LEFT/RIGHT to switch focus); LEFT/RIGHT, CONFIRM, ADD_MOD/REMOVE_MOD, FILTER, and category-tab keys all unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ede7841](https://github.com/cataclysmbn/Cataclysm-BN/commit/ede7841a1d1be685fb02e2850b28e3693831cf2a) (feat(UI): mod manager PgUp/PgDn page navigation) on 2026-05-24 22:30:47

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26373284926/artifacts/7188821620)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26373284926/artifacts/7188815080)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26373284926/artifacts/7188692968)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26373284926/artifacts/7188663507)
<!-- END artifact comment -->