### PR TITLE
feat(UI): diary PgUp/PgDn page navigation

### DIFF
--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -183,6 +183,8 @@ void diary::show_diary_ui( diary *c_diary )
 
     input_context ctxt( "DIARY" );
     ctxt.register_cardinal();
+    ctxt.register_action( "PAGE_UP", to_translation( "Page up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Page down" ) );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "NEW_PAGE" );
@@ -340,6 +342,42 @@ void diary::show_diary_ui( diary *c_diary )
                 selected[window_mode::PAGE_WIN] = c_diary->pages.empty() ? 0 : c_diary->pages.size() - 1;
             }
 
+        } else if( action == "PAGE_DOWN" || action == "PAGE_UP" ) {
+            int page_size = 1;
+            int list_size = 0;
+            switch( currwin ) {
+                case window_mode::PAGE_WIN:
+                    page_size = std::max( 1, getmaxy( w_pages ) - 2 );
+                    list_size = static_cast<int>( c_diary->get_pages_list().size() );
+                    break;
+                case window_mode::CHANGE_WIN:
+                    page_size = std::max( 1, getmaxy( w_changes ) );
+                    list_size = static_cast<int>( c_diary->get_head_text().size() +
+                                                  c_diary->get_change_list().size() );
+                    break;
+                case window_mode::TEXT_WIN:
+                    page_size = std::max( 1, getmaxy( w_text ) );
+                    list_size = static_cast<int>( foldstring( c_diary->get_page_text(),
+                                                  std::max( 1, getmaxx( w_text ) - 2 ) ).size() );
+                    break;
+                default:
+                    break;
+            }
+            if( list_size > 0 ) {
+                const int last = list_size - 1;
+                const int cur = selected[currwin];
+                int target;
+                if( action == "PAGE_DOWN" ) {
+                    target = cur == last
+                             ? 0
+                             : std::min( last, cur + page_size );
+                } else {
+                    target = cur == 0
+                             ? last
+                             : std::max( 0, cur - page_size );
+                }
+                selected[currwin] = target;
+            }
         } else if( action == "CONFIRM" ) {
             if( !c_diary->pages.empty() ) {
                 c_diary->edit_page_ui( [&]() {


### PR DESCRIPTION
## Summary

- Adds `PAGE_UP`/`PAGE_DOWN` to the `DIARY` input context in `diary::show_diary_ui` so all three diary panes (page list, changes, text) can be paged.
- Handler operates on whichever pane `currwin` currently focuses (the one LEFT/RIGHT switches between), so a single handler covers all three.
- Page size matches each pane's window: `getmaxy(w_pages) - 2` for the bordered page list, `getmaxy(w_changes)` / `getmaxy(w_text)` for the borderless content panes.
- Clamps to the extreme first; a second press from the extreme wraps to the opposite end (PgDn at last → top, PgUp at top → last).
- `print_list_scrollable` already uses page-aligned scrolling (`top_of_page = entries_per_page * (selection / entries_per_page)`), so stepping by exactly page_size advances the view by exactly one page — no view-shift fix needed.

Part of upstream DDA umbrella issue [cataclysm-dda#44152](https://github.com/CleverRaven/Cataclysm-DDA/issues/44152) (UI scrolling).

Follows the same pattern used in #9032 (bionics), #9048 (mutation), #9050 (mission), #9051 (safemode), #9055 (auto-pickup), #9056 (auto-notes), #9058 (options), #9060 (newcharacter), #9061 (color manager), #9063 (mod manager), and the PgUp/PgDn extension in #9018 (auto-foraging).

## Test plan

- [x] Builds clean (`cataclysm-bn-tiles`, `RelWithDebInfo`, MSVC).
- [x] In-game: open the diary; LEFT/RIGHT to switch focus between the page list, changes pane, and text pane. PgDn pages forward exactly one window and clamps to the last entry on overshoot; a second PgDn from the bottom wraps to the top. PgUp mirrors. Works on all three panes. NEW_PAGE / DELETE PAGE / CONFIRM / EXPORT_DIARY unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [71abe02](https://github.com/cataclysmbn/Cataclysm-BN/commit/71abe024431e2092c5077f7d148292fcc44766d0) (feat(UI): diary PgUp/PgDn page navigation) on 2026-05-24 22:41:02

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26373559112/artifacts/7188908134)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26373559112/artifacts/7188879727)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26373559112/artifacts/7188742054)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26373559112/artifacts/7188728790)
<!-- END artifact comment -->