### PR TITLE
fix(balance): make Insect Wings mutation only give movement speed when activated

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -69,5 +69,12 @@
     "description": "Fix'em all!",
     "copy-from": "hammer",
     "relic_data": { "passive_effects": [ { "id": "ENCH_WEAPON_DEBUGGY_ACIDIC" } ] }
+  },
+  {
+    "type": "enchantment",
+    "id": "ENCH_INSECT_WINGS_ACTIVE",
+    "has": "HELD",
+    "condition": "ACTIVE",
+    "values": [{ "value": "MOVE_COST", "multiply": -0.25 }]
   }
 ]

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -75,6 +75,6 @@
     "id": "ENCH_INSECT_WINGS_ACTIVE",
     "has": "HELD",
     "condition": "ACTIVE",
-    "values": [{ "value": "MOVE_COST", "multiply": -0.25 }]
+    "values": [ { "value": "MOVE_COST", "multiply": -0.25 } ]
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3599,7 +3599,7 @@
     "active": true,
     "cost": 100,
     "stamina": true,
-    "movecost_modifier": 0.75,
+    "enchantments": [ "ENCH_INSECT_WINGS_ACTIVE" ],
     "falling_damage_multiplier": 0.75
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

fixes #5717

## Describe the solution (The How)

Making use of the enchantments system to modify the movement cost when the mutation is active.

## Describe alternatives you've considered

Hardcoding it into the `run_cost()` function.

## Testing

Activated the Insect Wings mutation in game, movement cost is multiplied by 0.75.
When not activated, the movement cost is not affected.

## Additional context

The enchantment system doesn't multiply the movement cost directly, instead it multiplies by `(1 + bonus)`. Currently this is fine, but when multiple systems try to modify movement cost through this system, it might get wacky.

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [18f9e25](https://github.com/cataclysmbn/Cataclysm-BN/commit/18f9e25976dff88c41f8fa1f142f509da0050da5) (style(autofix.ci): automated formatting) on 2026-05-25 03:59:05

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26378179592/artifacts/7190097566)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26378179592/artifacts/7191284245)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26378179592/artifacts/7190034594)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26378179592/artifacts/7190178889)
<!-- END artifact comment -->