### PR TITLE
feat(UI): increase size of examine menu

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -705,8 +705,8 @@ void inventory_column::on_input( const inventory_input &input )
         item_info_data dummy( highlighed->display_name(), {}, this_item, {} );
         dummy.handle_scrolling = true;
         draw_item_info( []() -> catacurses::window {
-            const int width = std::min( TERMX, FULL_SCREEN_WIDTH ) + std::max(0, TERMX - FULL_SCREEN_WIDTH) * (1.0/4);
-            const int height = std::min(TERMY, FULL_SCREEN_HEIGHT) + std::max(0, TERMY - FULL_SCREEN_HEIGHT) * (2.0/3);
+            const int width = std::min( TERMX, FULL_SCREEN_WIDTH ) + std::max( 0, TERMX - FULL_SCREEN_WIDTH ) * ( 1.0 / 4 );
+            const int height = std::min( TERMY, FULL_SCREEN_HEIGHT ) + std::max( 0, TERMY - FULL_SCREEN_HEIGHT ) * ( 2.0 / 3 );
             return catacurses::newwin( height, width, point( ( TERMX - width ) / 2, ( TERMY - height ) / 2 ) );
         }, dummy );
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -705,8 +705,8 @@ void inventory_column::on_input( const inventory_input &input )
         item_info_data dummy( highlighed->display_name(), {}, this_item, {} );
         dummy.handle_scrolling = true;
         draw_item_info( []() -> catacurses::window {
-            const int width = std::min( TERMX, FULL_SCREEN_WIDTH );
-            const int height = FULL_SCREEN_HEIGHT;
+            const int width = std::min( TERMX, FULL_SCREEN_WIDTH ) + std::max(0, TERMX - FULL_SCREEN_WIDTH) * (1.0/4);
+            const int height = std::min(TERMY, FULL_SCREEN_HEIGHT) + std::max(0, TERMY - FULL_SCREEN_HEIGHT) * (2.0/3);
             return catacurses::newwin( height, width, point( ( TERMX - width ) / 2, ( TERMY - height ) / 2 ) );
         }, dummy );
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The examine menu that pops up when you try to examine items from a menu was quite small, as for some reason the FULL_SCREEN_WIDTH and FULL_SCREEN_HEIGHT aren't equal to TERMX and TERMY.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
I made the code try to use more of the available space TERMX - FULL_SCREEN_WIDTH and TERMY - FULL_SCREEN_HEIGHT to increase the size of the menu.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Loaded world and examined item. The menu was much larger.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Old examine menu:
<img width="1890" height="909" alt="image" src="https://github.com/user-attachments/assets/ae3352cd-a397-43e5-863c-de57427fc91e" />
New examine menu:
<img width="1902" height="968" alt="Screenshot 2026-05-24 210550" src="https://github.com/user-attachments/assets/c462bf93-75aa-4a4e-8bfb-556c1627fc28" />
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0bdd368](https://github.com/cataclysmbn/Cataclysm-BN/commit/0bdd36800307c3a1bd287de4d34b959d840cf384) (Ran astyle) on 2026-05-25 03:09:51

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26379701693/artifacts/7190605346)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26379701693/artifacts/7190848290)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26379701693/artifacts/7190563299)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26379701693/artifacts/7190682245)
<!-- END artifact comment -->