### PR TITLE
perf: improve iteration methods for performance

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -83,7 +83,14 @@ std::vector<item *> active_item_cache::get()
 
 std::vector<item *> active_item_cache::get_for_processing()
 {
-    std::vector<item *> items_to_process;
+    auto items_to_process = std::vector<item *> {};
+    get_for_processing( items_to_process );
+    return items_to_process;
+}
+
+auto active_item_cache::get_for_processing( std::vector<item *> &items_to_process ) -> void
+{
+    items_to_process.clear();
     for( std::pair < const int, std::pair<int, std::vector<cache_reference<item>>>> &kv :
          active_items ) {
         //The algorithm here is a bit weird. We're going to process a fraction of the list at a time, keeping track of where we are in the list with a simple int.
@@ -121,7 +128,6 @@ std::vector<item *> active_item_cache::get_for_processing()
             }
         }
     }
-    return items_to_process;
 }
 
 std::vector<item *> active_item_cache::get_special( special_item_type type )

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -66,10 +66,14 @@ class active_item_cache
          * Relies on the fact that item::processing_speed() is a constant.
          */
         std::vector<item *> get_for_processing();
+        /**
+         * Clears and fills @p items_to_process with the same items as get_for_processing().
+         * Reuses caller-owned vector capacity across submaps.
+         */
+        auto get_for_processing( std::vector<item *> &items_to_process ) -> void;
 
         /**
          * Returns the currently tracked list of special active items.
          */
         std::vector<item *> get_special( special_item_type type );
 };
-

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -748,9 +748,11 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
                map_cache.seen_cache[map_cache.idx( target.x(), target.y() )],
                map_cache.camera_cache[map_cache.idx( target.x(), target.y() )]
              );
-    map::apparent_light_info al = map::apparent_light_helper( map_cache, target );
-    int apparent_light = static_cast<int>(
-                             here.apparent_light_at( target, here.get_visibility_variables_cache() ) );
+    const auto &visibility_cache = here.get_visibility_variables_cache();
+    const auto al = map::apparent_light_helper( map_cache, target,
+                    visibility_cache.visibility_scale_factor );
+    const auto apparent_light = static_cast<int>(
+                                    here.apparent_light_at( target, visibility_cache ) );
     mvwprintw( w_info, point( 1, off++ ), _( "outside: %d sheltered: %d floor: %d obstructed: %d" ),
                static_cast<int>( here.is_outside( target ) ),
                static_cast<int>( here.is_sheltered( target ) ),

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -330,7 +330,7 @@ nc_color faction::food_supply_color()
 }
 
 auto faction::relationship_flags_with( const faction_id &guy_id ) const
--> const std::bitset<npc_factions::rel_types> *
+- > const std::bitset<npc_factions::rel_types> *
 {
     const auto rel_data = relations.find( guy_id.c_str() );
     return rel_data != relations.end() ? &rel_data->second : nullptr;

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -329,8 +329,8 @@ nc_color faction::food_supply_color()
     }
 }
 
-auto faction::relationship_flags_with( const faction_id &guy_id ) const
-- > const std::bitset<npc_factions::rel_types> *
+auto faction::relationship_flags_with( const faction_id &guy_id ) const ->
+const std::bitset<npc_factions::rel_types> *
 {
     const auto rel_data = relations.find( guy_id.c_str() );
     return rel_data != relations.end() ? &rel_data->second : nullptr;

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -329,14 +329,17 @@ nc_color faction::food_supply_color()
     }
 }
 
+auto faction::relationship_flags_with( const faction_id &guy_id ) const
+-> const std::bitset<npc_factions::rel_types> *
+{
+    const auto rel_data = relations.find( guy_id.c_str() );
+    return rel_data != relations.end() ? &rel_data->second : nullptr;
+}
+
 bool faction::has_relationship( const faction_id &guy_id, npc_factions::relationship flag ) const
 {
-    for( const auto &rel_data : relations ) {
-        if( rel_data.first == guy_id.c_str() ) {
-            return rel_data.second.test( flag );
-        }
-    }
-    return false;
+    const auto rel_data = relationship_flags_with( guy_id );
+    return rel_data != nullptr && rel_data->test( flag );
 }
 
 std::string fac_combat_ability_text( int val )

--- a/src/faction.h
+++ b/src/faction.h
@@ -109,6 +109,8 @@ class faction : public faction_template
         std::string food_supply_text();
         nc_color food_supply_color();
 
+        auto relationship_flags_with( const faction_id &guy_id ) const
+        -> const std::bitset<npc_factions::rel_types> *;
         bool has_relationship( const faction_id &guy_id, npc_factions::relationship flag ) const;
         void add_to_membership( const character_id &guy_id, const std::string &guy_name, bool known );
         void remove_member( const character_id &guy_id );
@@ -138,5 +140,4 @@ class faction_manager
 
         faction *get( const faction_id &id, bool complain = true );
 };
-
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4625,7 +4625,8 @@ void game::mon_info_update( )
     };
 
     const auto player_attitude_from = []( const monster_attitude matt ) -> Attitude {
-        switch( matt ) {
+        switch( matt )
+        {
             case MATT_FRIEND:
             case MATT_FPASSIVE:
             case MATT_ZLAVE:
@@ -4682,7 +4683,8 @@ void game::mon_info_update( )
         }
 
         //Safemode monster check
-        const auto safemode_state = get_safemode().check_monster( critter.name(), player_attitude, mon_dist );
+        const auto safemode_state = get_safemode().check_monster( critter.name(), player_attitude,
+                                    mon_dist );
 
         if( ( !safemode_empty && safemode_state == RULE_BLACKLISTED ) || ( safemode_empty &&
                 ( MATT_ATTACK == matt || MATT_FOLLOW == matt ) ) ) {
@@ -5111,7 +5113,7 @@ void game::monmove()
     // references keeps the pointer snapshots valid if the live lists change later
     // in the turn, while avoiding repeated weak_ptr_fast lock/copy passes.
     auto monster_refs = critter_tracker->get_monsters_list();
-    auto mon_snap = std::vector<monster *>{};
+    auto mon_snap = std::vector<monster *> {};
     mon_snap.reserve( monster_refs.size() );
     for( const shared_ptr_fast<monster> &mon_ptr : monster_refs ) {
         if( mon_ptr && !mon_ptr->is_dead() ) {
@@ -5119,10 +5121,10 @@ void game::monmove()
         }
     }
 
-    auto npc_refs = std::vector<shared_ptr_fast<npc>>{};
+    auto npc_refs = std::vector<shared_ptr_fast<npc>> {};
     npc_refs.reserve( active_npc.size() );
     std::ranges::copy( active_npc, std::back_inserter( npc_refs ) );
-    auto npc_snap = std::vector<npc *>{};
+    auto npc_snap = std::vector<npc *> {};
     npc_snap.reserve( npc_refs.size() );
     for( const shared_ptr_fast<npc> &guy : npc_refs ) {
         if( guy && !guy->is_dead() ) {
@@ -5155,7 +5157,7 @@ void game::monmove()
     // turn_sight_cache_ is filled serially afterward, avoiding cache write-lock
     // contention in compute_plan().  map::sees() still supplies symmetric LOS reuse
     // for the ray traces below Creature::sees().
-    auto sight_jobs = std::vector<std::pair<const Creature *, const Creature *>>{};
+    auto sight_jobs = std::vector<std::pair<const Creature *, const Creature *>> {};
     const auto initial_sight_job_capacity =
         plannable.size() * ( npc_snap.size() + std::min( mon_snap.size(), size_t{ 16 } ) + 1 );
     sight_jobs.reserve( initial_sight_job_capacity );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5171,17 +5171,20 @@ void game::monmove()
     // Without this, hostile-faction pairs call turn_cached_sees() during the parallel
     // phase on a cache miss, taking a unique_lock and serialising all workers that
     // happen to need a faction-hostile LOS result at the same time.
-    // turn_cached_sees is symmetric — one prewarm_sight call covers both directions.
-    for( int i = 0; i < static_cast<int>( plannable.size() ); ++i ) {
-        monster *mon_a = plannable[i];
-        const int max_range_a = std::max( mon_a->type->vision_day, mon_a->type->vision_night );
-        for( int j = i + 1; j < static_cast<int>( plannable.size() ); ++j ) {
-            monster *mon_b = plannable[j];
-            if( rl_dist( mon_a->bub_pos(), mon_b->bub_pos() ) > max_range_a ) {
-                continue;
-            }
-            if( mon_a->faction.obj().attitude( mon_b->faction ) == MFA_HATE ) {
-                mon_a->prewarm_sight( *mon_b );
+    // turn_sight_cache_ is directional; map::sees() supplies symmetric LOS reuse.
+    {
+        ZoneScopedN( "monmove_faction_sight_prewarm" );
+        for( const auto i : std::views::iota( size_t{ 0 }, plannable.size() ) ) {
+            monster *mon_a = plannable[i];
+            const auto max_range_a = std::max( mon_a->type->vision_day, mon_a->type->vision_night );
+            for( const auto j : std::views::iota( i + 1, plannable.size() ) ) {
+                monster *mon_b = plannable[j];
+                if( rl_dist( mon_a->bub_pos(), mon_b->bub_pos() ) > max_range_a ) {
+                    continue;
+                }
+                if( mon_a->faction.obj().attitude( mon_b->faction ) == MFA_HATE ) {
+                    mon_a->prewarm_sight( *mon_b );
+                }
             }
         }
     }
@@ -5196,20 +5199,26 @@ void game::monmove()
     // can do group-morale/swarm checks on worker threads without calling
     // weak_ptr_fast::lock() (non-atomic _S_single refcount — data race on Linux).
     monster::faction_snap_t faction_snap;
-    std::ranges::for_each( mon_snap, [&]( monster * mon_ptr ) {
-        faction_snap[mon_ptr->faction].push_back( mon_ptr );
-    } );
+    {
+        ZoneScopedN( "monmove_build_faction_snap" );
+        std::ranges::for_each( mon_snap, [&]( monster * mon_ptr ) {
+            faction_snap[mon_ptr->faction].push_back( mon_ptr );
+        } );
+    }
     // Pre-compute per-faction hostile-faction lists once per tick.  compute_plan()
     // iterates only the hostile entries rather than all factions on every call.
     monster::hostile_fac_map_t hostile_fac_map;
-    for( const auto &[fac_id, _m] : faction_snap ) {
-        for( const auto &[other_id, _o] : faction_snap ) {
-            if( fac_id == other_id ) {
-                continue;
-            }
-            const auto att = fac_id.obj().attitude( other_id );
-            if( att != MFA_NEUTRAL && att != MFA_FRIENDLY ) {
-                hostile_fac_map[fac_id].push_back( other_id );
+    {
+        ZoneScopedN( "monmove_build_hostile_fac_map" );
+        for( const auto &[fac_id, _m] : faction_snap ) {
+            for( const auto &[other_id, _o] : faction_snap ) {
+                if( fac_id == other_id ) {
+                    continue;
+                }
+                const auto att = fac_id.obj().attitude( other_id );
+                if( att != MFA_NEUTRAL && att != MFA_FRIENDLY ) {
+                    hostile_fac_map[fac_id].push_back( other_id );
+                }
             }
         }
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5085,6 +5085,29 @@ void game::monmove()
     const int effective_budget = std::max( action_budget, tier0_count );
     TracyPlot( "LOD Effective Budget", static_cast<int64_t>( effective_budget ) );
 
+    // Build phase-local actor snapshots once for planning setup. Holding shared
+    // references keeps the pointer snapshots valid if the live lists change later
+    // in the turn, while avoiding repeated weak_ptr_fast lock/copy passes.
+    auto monster_refs = critter_tracker->get_monsters_list();
+    auto mon_snap = std::vector<monster *>{};
+    mon_snap.reserve( monster_refs.size() );
+    for( const shared_ptr_fast<monster> &mon_ptr : monster_refs ) {
+        if( mon_ptr && !mon_ptr->is_dead() ) {
+            mon_snap.push_back( mon_ptr.get() );
+        }
+    }
+
+    auto npc_refs = std::vector<shared_ptr_fast<npc>>{};
+    npc_refs.reserve( active_npc.size() );
+    std::ranges::copy( active_npc, std::back_inserter( npc_refs ) );
+    auto npc_snap = std::vector<npc *>{};
+    npc_snap.reserve( npc_refs.size() );
+    for( const shared_ptr_fast<npc> &guy : npc_refs ) {
+        if( guy && !guy->is_dead() ) {
+            npc_snap.push_back( guy.get() );
+        }
+    }
+
     // OPP-7: Unified disposition map: a single hash lookup in the execution
     // loop suffices:
     //   value >= 0  → index into precomputed[] (monster has a parallel plan)
@@ -5092,15 +5115,16 @@ void game::monmove()
     std::unordered_map<monster *, int> plan_index;
 
     std::vector<monster *> plannable;
-    for( monster &critter : all_monsters() ) {
-        if( !critter.is_dead() &&
-            !critter.has_effect( effect_ai_controlled ) &&
-            critter.moves > 0 &&
-            !critter.has_effect( effect_ridden ) &&
-            critter.lod_tier < 2 &&
-            critter.is_simulated() ) {
+    plannable.reserve( mon_snap.size() );
+    for( monster *critter : mon_snap ) {
+        if( !critter->is_dead() &&
+            !critter->has_effect( effect_ai_controlled ) &&
+            critter->moves > 0 &&
+            !critter->has_effect( effect_ridden ) &&
+            critter->lod_tier < 2 &&
+            critter->is_simulated() ) {
             // Tier-2 monsters skip full planning; they use the macro step.
-            plannable.push_back( &critter );
+            plannable.push_back( critter );
         }
     }
 
@@ -5116,9 +5140,9 @@ void game::monmove()
     for( monster *mon : plannable ) {
         mon->prewarm_sight( u );
         const int mon_max_sight = std::max( mon->type->vision_day, mon->type->vision_night );
-        for( npc &n : all_npcs() ) {
-            if( rl_dist( mon->bub_pos(), n.bub_pos() ) <= mon_max_sight ) {
-                mon->prewarm_sight( n );
+        for( npc *n : npc_snap ) {
+            if( rl_dist( mon->bub_pos(), n->bub_pos() ) <= mon_max_sight ) {
+                mon->prewarm_sight( *n );
             }
         }
     }
@@ -5142,21 +5166,12 @@ void game::monmove()
         }
     }
 
-    // Build creature snapshots for thread-safe compute_plan() access.
+    // Use the actor snapshots for thread-safe compute_plan() access.
     // compute_plan() calls g->all_monsters() / g->all_npcs() to find targets.
     // Those functions iterate weak_ptr_fast<T> objects whose refcounting uses
     // _S_single (non-atomic).  Concurrent lock() calls from worker threads are
-    // a data race.  Building plain pointer snapshots here, serially, avoids
+    // a data race.  Building plain pointer snapshots serially avoids
     // touching any weak_ptr_fast from worker threads.
-    std::vector<monster *> mon_snap;
-    mon_snap.reserve( plannable.size() * 2 );
-    for( monster &mon : all_monsters() ) {
-        mon_snap.push_back( &mon );
-    }
-    std::vector<npc *> npc_snap;
-    for( npc &n : all_npcs() ) {
-        npc_snap.push_back( &n );
-    }
     // Build faction snapshot: group monster pointers by faction so compute_plan()
     // can do group-morale/swarm checks on worker threads without calling
     // weak_ptr_fast::lock() (non-atomic _S_single refcount — data race on Linux).
@@ -5208,7 +5223,8 @@ void game::monmove()
     // budget.  Effect durations, hunger, and field damage tick normally for
     // all monsters.  The budget/tier system gates only the move loop below.
     // -----------------------------------------------------------------------
-    for( monster &critter : all_monsters() ) {
+    for( monster *critter_ptr : mon_snap ) {
+        monster &critter = *critter_ptr;
         // Skip monsters in lazy-border or otherwise non-simulated submaps — their
         // submap has no active caches (transparency, lightmap, fields) and
         // processing them would read stale or missing data.  They will be
@@ -5913,6 +5929,13 @@ void game::use_computer( const tripoint_bub_ms &p )
 template<typename T>
 T *game::critter_at( const tripoint_bub_ms &p, bool allow_hallucination )
 {
+    using lookup_type = std::remove_cv_t<T>;
+    constexpr auto wants_monster = std::is_base_of_v<lookup_type, monster>;
+    constexpr auto wants_player = std::is_base_of_v<lookup_type, avatar>;
+    constexpr auto wants_npc = std::is_base_of_v<lookup_type, npc>;
+    constexpr auto return_ridden_monster = std::is_same_v<lookup_type, monster> ||
+                                           std::is_same_v<lookup_type, Creature>;
+
     if( const shared_ptr_fast<monster> mon_ptr = critter_tracker->find( p ) ) {
         if( !allow_hallucination && mon_ptr->is_hallucination() ) {
             return nullptr;
@@ -5924,20 +5947,24 @@ T *game::critter_at( const tripoint_bub_ms &p, bool allow_hallucination )
         // otherwise, keep looking for the rider.
         // critter_at<creature> or critter_at() with no template will still default to returning monster first,
         // which is ok for the occasions where that happens.
-        if( !mon_ptr->has_effect( effect_ridden ) || ( std::is_same<T, monster>::value ||
-                std::is_same<T, Creature>::value || std::is_same<T, const monster>::value ||
-                std::is_same<T, const Creature>::value ) ) {
-            return dynamic_cast<T *>( mon_ptr.get() );
+        if( !mon_ptr->has_effect( effect_ridden ) || return_ridden_monster ) {
+            if constexpr( wants_monster ) {
+                return dynamic_cast<T *>( mon_ptr.get() );
+            } else {
+                return nullptr;
+            }
         }
     }
-    if( !std::is_same<T, npc>::value && !std::is_same<T, const npc>::value ) {
+    if constexpr( wants_player ) {
         if( p == u.bub_pos() ) {
             return dynamic_cast<T *>( &u );
         }
     }
-    for( auto &cur_npc : active_npc ) {
-        if( cur_npc->bub_pos() == p && !cur_npc->is_dead() ) {
-            return dynamic_cast<T *>( cur_npc.get() );
+    if constexpr( wants_npc ) {
+        for( auto &cur_npc : active_npc ) {
+            if( cur_npc->bub_pos() == p && !cur_npc->is_dead() ) {
+                return dynamic_cast<T *>( cur_npc.get() );
+            }
         }
     }
     return nullptr;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -302,10 +302,12 @@ static const std::string flag_AUTODOC_COUCH( "AUTODOC_COUCH" );
 static const efftype_id effect_accumulated_mutagen( "accumulated_mutagen" );
 static const efftype_id effect_adrenaline_mycus( "adrenaline_mycus" );
 static const efftype_id effect_ai_controlled( "ai_controlled" );
+static const efftype_id effect_ai_waiting( "ai_waiting" );
 static const efftype_id effect_assisted( "assisted" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_contacts( "contacts" );
+static const efftype_id effect_docile( "docile" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_drunk( "drunk" );
 static const efftype_id effect_evil( "evil" );
@@ -5148,43 +5150,92 @@ void game::monmove()
         }
     }
 
-    // Pre-warm both turn_sight_cache_ and skew_vision_cache
-    // for (monster → player), (monster → NPC), and faction-hostile (monster → monster)
-    // pairs before the parallel phase.  prewarm_sight() calls turn_cached_sees(),
-    // which populates turn_sight_cache_ under a unique_lock here (serial, zero
-    // contention).  The parallel phase then hits turn_sight_cache_ under shared_lock
-    // only — zero write contention.
-    //
-    // NPC pairs use a distance pre-cull: monsters beyond max_sight_range of an NPC
-    // can never see them, so the ray trace and cache insert are both skipped entirely.
-    for( monster *mon : plannable ) {
-        mon->prewarm_sight( u );
-        const int mon_max_sight = std::max( mon->type->vision_day, mon->type->vision_night );
-        for( npc *n : npc_snap ) {
-            if( rl_dist( mon->bub_pos(), n->bub_pos() ) <= mon_max_sight ) {
-                mon->prewarm_sight( *n );
+    // Pre-warm directed Creature::sees() jobs before the parallel planning phase.
+    // Worker threads compute raw perception results only; the shared
+    // turn_sight_cache_ is filled serially afterward, avoiding cache write-lock
+    // contention in compute_plan().  map::sees() still supplies symmetric LOS reuse
+    // for the ray traces below Creature::sees().
+    auto sight_jobs = std::vector<std::pair<const Creature *, const Creature *>>{};
+    const auto initial_sight_job_capacity =
+        plannable.size() * ( npc_snap.size() + std::min( mon_snap.size(), size_t{ 16 } ) + 1 );
+    sight_jobs.reserve( initial_sight_job_capacity );
+    const auto add_sight_job = [&]( const Creature & seer, const Creature & target ) {
+        sight_jobs.emplace_back( &seer, &target );
+    };
+    {
+        ZoneScopedN( "monmove_build_sight_jobs" );
+        for( auto *mon : plannable ) {
+            const auto mon_max_sight = std::max( mon->type->vision_day, mon->type->vision_night );
+            const auto mon_pos = mon->bub_pos();
+            const auto waiting = mon->has_effect( effect_ai_waiting );
+            const auto docile = mon->friendly != 0 && mon->has_effect( effect_docile );
+            if( !waiting && mon->friendly <= 0 &&
+                rl_dist( mon_pos, u.bub_pos() ) <= mon_max_sight ) {
+                add_sight_job( *mon, u );
+            }
+            for( auto *n : npc_snap ) {
+                const auto faction_att = mon->faction.obj().attitude( n->get_monster_faction() );
+                if( faction_att == MFA_NEUTRAL || faction_att == MFA_FRIENDLY ) {
+                    continue;
+                }
+                if( rl_dist( mon_pos, n->bub_pos() ) <= mon_max_sight ) {
+                    add_sight_job( *mon, *n );
+                }
+            }
+
+            const auto needs_group_sight =
+                mon->lod_tier <= lod_group_morale_max_tier &&
+                ( ( mon->has_flag( MF_GROUP_MORALE ) && mon->morale < mon->type->morale ) ||
+                  mon->has_flag( MF_SWARMS ) );
+            for( auto *target_mon : mon_snap ) {
+                if( target_mon == mon ) {
+                    continue;
+                }
+                if( rl_dist( mon_pos, target_mon->bub_pos() ) > mon_max_sight ) {
+                    continue;
+                }
+                if( mon->friendly != 0 && !docile && !waiting && target_mon->friendly == 0 ) {
+                    add_sight_job( *mon, *target_mon );
+                    continue;
+                }
+                if( mon->friendly == 0 ) {
+                    const auto faction_att = mon->faction.obj().attitude( target_mon->faction );
+                    if( faction_att != MFA_NEUTRAL && faction_att != MFA_FRIENDLY ) {
+                        add_sight_job( *mon, *target_mon );
+                        continue;
+                    }
+                    if( needs_group_sight && mon->faction == target_mon->faction ) {
+                        add_sight_job( *mon, *target_mon );
+                    }
+                }
             }
         }
     }
-
-    // Pre-warm faction-hostile monster pairs within max_sight_range.
-    // Without this, hostile-faction pairs call turn_cached_sees() during the parallel
-    // phase on a cache miss, taking a unique_lock and serialising all workers that
-    // happen to need a faction-hostile LOS result at the same time.
-    // turn_sight_cache_ is directional; map::sees() supplies symmetric LOS reuse.
-    {
-        ZoneScopedN( "monmove_faction_sight_prewarm" );
-        for( const auto i : std::views::iota( size_t{ 0 }, plannable.size() ) ) {
-            monster *mon_a = plannable[i];
-            const auto max_range_a = std::max( mon_a->type->vision_day, mon_a->type->vision_night );
-            for( const auto j : std::views::iota( i + 1, plannable.size() ) ) {
-                monster *mon_b = plannable[j];
-                if( rl_dist( mon_a->bub_pos(), mon_b->bub_pos() ) > max_range_a ) {
-                    continue;
+    TracyPlot( "Monmove Sight Jobs", static_cast<int64_t>( sight_jobs.size() ) );
+    if( !sight_jobs.empty() ) {
+        auto sight_results = std::vector<char>( sight_jobs.size(), 0 );
+        {
+            ZoneScopedN( "monmove_parallel_sight_prewarm" );
+            if( parallel_enabled && parallel_monster_planning && sight_jobs.size() > 1 ) {
+                parallel_for_chunked( 0, static_cast<int>( sight_jobs.size() ),
+                monster_plan_chunk_size, [&]( int i ) {
+                    const auto index = static_cast<size_t>( i );
+                    const auto &[seer, target] = sight_jobs[index];
+                    sight_results[index] = seer->sees( *target ) ? 1 : 0;
+                } );
+            } else {
+                for( const auto index : std::views::iota( size_t{ 0 }, sight_jobs.size() ) ) {
+                    const auto &[seer, target] = sight_jobs[index];
+                    sight_results[index] = seer->sees( *target ) ? 1 : 0;
                 }
-                if( mon_a->faction.obj().attitude( mon_b->faction ) == MFA_HATE ) {
-                    mon_a->prewarm_sight( *mon_b );
-                }
+            }
+        }
+        {
+            ZoneScopedN( "monmove_insert_sight_prewarm" );
+            auto lock = std::unique_lock<std::shared_mutex>( turn_sight_cache_mutex_ );
+            turn_sight_cache_.reserve( sight_jobs.size() );
+            for( const auto index : std::views::iota( size_t{ 0 }, sight_jobs.size() ) ) {
+                turn_sight_cache_.emplace( sight_jobs[index], sight_results[index] != 0 );
             }
         }
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4584,160 +4584,180 @@ void game::mon_info_update( )
     const time_duration sm_ignored_time = time_duration::from_turns(
             get_option<int>( "SAFEMODEIGNORETURNS" ) );
 
-    for( Creature *c : u.get_visible_creatures( g_mapsize_x ) ) {
-        monster *m = dynamic_cast<monster *>( c );
-        npc *p = dynamic_cast<npc *>( c );
-        const direction dir_to_mon = direction_from( view.xy(), point_bub_ms( c->bub_pos().x(),
-                                     c->bub_pos().y() ) );
-        const int mx = POSX + ( c->bub_pos().x() - view.x() );
-        const int my = POSY + ( c->bub_pos().y() - view.y() );
-        int index = 8;
+    const auto direction_index = []( const direction dir ) -> int {
+        switch( dir )
+        {
+            // *INDENT-OFF*
+            case direction::ABOVENORTHWEST: case direction::NORTHWEST: case direction::BELOWNORTHWEST: return 7;
+            case direction::ABOVENORTH:     case direction::NORTH:     case direction::BELOWNORTH:     return 0;
+            case direction::ABOVENORTHEAST: case direction::NORTHEAST: case direction::BELOWNORTHEAST: return 1;
+            case direction::ABOVEWEST:      case direction::WEST:      case direction::BELOWWEST:      return 6;
+            case direction::ABOVEEAST:      case direction::EAST:      case direction::BELOWEAST:      return 2;
+            case direction::ABOVESOUTHWEST: case direction::SOUTHWEST: case direction::BELOWSOUTHWEST: return 5;
+            case direction::ABOVESOUTH:     case direction::SOUTH:     case direction::BELOWSOUTH:     return 4;
+            case direction::ABOVESOUTHEAST: case direction::SOUTHEAST: case direction::BELOWSOUTHEAST: return 3;
+            case direction::ABOVECENTER:    case direction::CENTER:    case direction::BELOWCENTER:    return 8;
+            case direction::last: break;
+            // *INDENT-ON*
+        }
+        debugmsg( "invalid direction" );
+        abort();
+        return 8;
+    };
+
+    const auto compass_direction_index = []( const direction dir ) -> int {
+        switch( dir )
+        {
+            // *INDENT-OFF*
+            case direction::ABOVENORTHWEST: case direction::NORTHWEST: case direction::BELOWNORTHWEST: return 7;
+            case direction::ABOVENORTH:     case direction::NORTH:     case direction::BELOWNORTH:     return 0;
+            case direction::ABOVENORTHEAST: case direction::NORTHEAST: case direction::BELOWNORTHEAST: return 1;
+            case direction::ABOVEWEST:      case direction::WEST:      case direction::BELOWWEST:      return 6;
+            case direction::ABOVEEAST:      case direction::EAST:      case direction::BELOWEAST:      return 2;
+            case direction::ABOVESOUTHWEST: case direction::SOUTHWEST: case direction::BELOWSOUTHWEST: return 5;
+            case direction::ABOVESOUTH:     case direction::SOUTH:     case direction::BELOWSOUTH:     return 4;
+            case direction::ABOVESOUTHEAST: case direction::SOUTHEAST: case direction::BELOWSOUTHEAST: return 3;
+            default: return 8;
+            // *INDENT-ON*
+        }
+    };
+
+    const auto player_attitude_from = []( const monster_attitude matt ) -> Attitude {
+        switch( matt ) {
+            case MATT_FRIEND:
+            case MATT_FPASSIVE:
+            case MATT_ZLAVE:
+                return Attitude::A_FRIENDLY;
+            case MATT_ATTACK:
+                return Attitude::A_HOSTILE;
+            case MATT_FLEE:
+            case MATT_FOLLOW:
+            case MATT_IGNORE:
+            case MATT_NULL:
+            case MATT_UNKNOWN:
+            case NUM_MONSTER_ATTITUDES:
+                return Attitude::A_NEUTRAL;
+        }
+        return Attitude::A_NEUTRAL;
+    };
+
+    const auto visible_info = [&]( const tripoint_bub_ms & pos ) {
+        const auto dir_to_mon = direction_from( view.xy(), point_bub_ms( pos.x(), pos.y() ) );
+        const auto mx = POSX + ( pos.x() - view.x() );
+        const auto my = POSY + ( pos.y() - view.y() );
+        auto index = 8;
         if( !is_valid_in_w_terrain( point( mx, my ) ) ) {
             // for compatibility with old code, see diagram below, it explains the values for index,
             // also might need revisiting one z-levels are in.
-            switch( dir_to_mon ) {
-                case direction::ABOVENORTHWEST:
-                case direction::NORTHWEST:
-                case direction::BELOWNORTHWEST:
-                    index = 7;
-                    break;
-                case direction::ABOVENORTH:
-                case direction::NORTH:
-                case direction::BELOWNORTH:
-                    index = 0;
-                    break;
-                case direction::ABOVENORTHEAST:
-                case direction::NORTHEAST:
-                case direction::BELOWNORTHEAST:
-                    index = 1;
-                    break;
-                case direction::ABOVEWEST:
-                case direction::WEST:
-                case direction::BELOWWEST:
-                    index = 6;
-                    break;
-                case direction::ABOVECENTER:
-                case direction::CENTER:
-                case direction::BELOWCENTER:
-                    index = 8;
-                    break;
-                case direction::ABOVEEAST:
-                case direction::EAST:
-                case direction::BELOWEAST:
-                    index = 2;
-                    break;
-                case direction::ABOVESOUTHWEST:
-                case direction::SOUTHWEST:
-                case direction::BELOWSOUTHWEST:
-                    index = 5;
-                    break;
-                case direction::ABOVESOUTH:
-                case direction::SOUTH:
-                case direction::BELOWSOUTH:
-                    index = 4;
-                    break;
-                case direction::ABOVESOUTHEAST:
-                case direction::SOUTHEAST:
-                case direction::BELOWSOUTHEAST:
-                    index = 3;
-                    break;
-                case direction::last:
-                    debugmsg( "invalid direction" );
-                    abort();
-            }
+            index = direction_index( dir_to_mon );
         }
+        const auto compass_dir = direction_from( u.bub_pos().xy(), point_bub_ms( pos.x(), pos.y() ) );
+        return std::pair{ index, compass_direction_index( compass_dir ) };
+    };
+
+    const auto safemode_empty = get_safemode().empty();
+    const auto process_monster = [&]( const shared_ptr_fast<monster> &mon_ptr ) {
+        if( !mon_ptr || mon_ptr->is_dead() ) {
+            return;
+        }
+        monster &critter = *mon_ptr;
+        const auto mon_dist = rl_dist( u.bub_pos(), critter.bub_pos() );
+        if( u.bub_pos() == critter.bub_pos() || mon_dist > g_mapsize_x || !u.sees( critter ) ) {
+            return;
+        }
+        const auto [index, compass_index] = visible_info( critter.bub_pos() );
+        mon_visible.visible_count_by_dir[compass_index]++;
+
+        const auto matt = critter.attitude( &u );
+        const auto player_attitude = player_attitude_from( matt );
 
         // Accumulate hostile counts for danger music and combat bubble.
-        if( u.attitude_to( *c ) == Attitude::A_HOSTILE ) {
+        if( player_attitude == Attitude::A_HOSTILE ) {
             mon_visible.nearby_hostile_count++;
-            if( rl_dist( u.bub_pos(), c->bub_pos() ) <= combat_bubble_range ) {
+            if( mon_dist <= combat_bubble_range ) {
                 mon_visible.combat_hostile_count++;
             }
         }
-        // Per-direction creature count for the compass panel, computed player-relative
-        // (not view-offset-relative) so the compass stays accurate in look-mode.
-        const int compass_index = [&]() -> int {
-            const direction compass_dir = direction_from( u.bub_pos().xy(),
-                    point_bub_ms( c->bub_pos().x(), c->bub_pos().y() ) );
-            switch( compass_dir )
-            {
-                // *INDENT-OFF*
-                case direction::ABOVENORTHWEST: case direction::NORTHWEST: case direction::BELOWNORTHWEST: return 7;
-                case direction::ABOVENORTH:     case direction::NORTH:     case direction::BELOWNORTH:     return 0;
-                case direction::ABOVENORTHEAST: case direction::NORTHEAST: case direction::BELOWNORTHEAST: return 1;
-                case direction::ABOVEWEST:      case direction::WEST:      case direction::BELOWWEST:      return 6;
-                case direction::ABOVEEAST:      case direction::EAST:      case direction::BELOWEAST:      return 2;
-                case direction::ABOVESOUTHWEST: case direction::SOUTHWEST: case direction::BELOWSOUTHWEST: return 5;
-                case direction::ABOVESOUTH:     case direction::SOUTH:     case direction::BELOWSOUTH:     return 4;
-                case direction::ABOVESOUTHEAST: case direction::SOUTHEAST: case direction::BELOWSOUTHEAST: return 3;
-                default: return 8;
-                // *INDENT-ON*
+
+        //Safemode monster check
+        const auto safemode_state = get_safemode().check_monster( critter.name(), player_attitude, mon_dist );
+
+        if( ( !safemode_empty && safemode_state == RULE_BLACKLISTED ) || ( safemode_empty &&
+                ( MATT_ATTACK == matt || MATT_FOLLOW == matt ) ) ) {
+            if( index < 8 && critter.sees( g->u ) ) {
+                dangerous[index] = true;
             }
-        }();
+
+            if( !safemode_empty || mon_dist <= iProxyDist ) {
+                auto passmon = false;
+                if( critter.ignoring > 0 ) {
+                    if( safe_mode != SAFE_MODE_ON ) {
+                        critter.ignoring = 0;
+                    } else if( ( sm_ignored_time == 0_seconds || ( critter.lastseen_turn &&
+                                 *critter.lastseen_turn > calendar::turn - sm_ignored_time ) ) &&
+                               ( mon_dist > critter.ignoring / 2 || mon_dist < 6 ) ) {
+                        passmon = true;
+                    }
+                    critter.lastseen_turn = calendar::turn;
+                }
+
+                if( !passmon ) {
+                    newseen++;
+                    new_seen_mon.push_back( mon_ptr );
+                }
+            }
+        }
+
+        auto &vec = unique_mons[index];
+        const auto mon_it = std::find_if( vec.begin(), vec.end(),
+        [&]( const std::pair<const mtype *, int> &elem ) {
+            return elem.first == critter.type;
+        } );
+        if( mon_it == vec.end() ) {
+            vec.emplace_back( critter.type, 1 );
+        } else {
+            mon_it->second++;
+        }
+    };
+
+    const auto process_npc = [&]( const shared_ptr_fast<npc> &npc_ptr ) {
+        if( !npc_ptr || npc_ptr->is_dead() ) {
+            return;
+        }
+        npc &guy = *npc_ptr;
+        const auto npc_dist = rl_dist( u.bub_pos(), guy.bub_pos() );
+        if( u.bub_pos() == guy.bub_pos() || npc_dist > g_mapsize_x || !u.sees( guy ) ) {
+            return;
+        }
+        const auto [index, compass_index] = visible_info( guy.bub_pos() );
         mon_visible.visible_count_by_dir[compass_index]++;
 
-        rule_state safemode_state = RULE_NONE;
-        const bool safemode_empty = get_safemode().empty();
-
-        if( m != nullptr ) {
-            //Safemode monster check
-            monster &critter = *m;
-
-            const monster_attitude matt = critter.attitude( &u );
-            const int mon_dist = rl_dist( u.bub_pos(), critter.bub_pos() );
-            safemode_state = get_safemode().check_monster( critter.name(), critter.attitude_to( u ), mon_dist );
-
-            if( ( !safemode_empty && safemode_state == RULE_BLACKLISTED ) || ( safemode_empty &&
-                    ( MATT_ATTACK == matt || MATT_FOLLOW == matt ) ) ) {
-                if( index < 8 && critter.sees( g->u ) ) {
-                    dangerous[index] = true;
-                }
-
-                if( !safemode_empty || mon_dist <= iProxyDist ) {
-                    bool passmon = false;
-                    if( critter.ignoring > 0 ) {
-                        if( safe_mode != SAFE_MODE_ON ) {
-                            critter.ignoring = 0;
-                        } else if( ( sm_ignored_time == 0_seconds || ( critter.lastseen_turn &&
-                                     *critter.lastseen_turn > calendar::turn - sm_ignored_time ) ) &&
-                                   ( mon_dist > critter.ignoring / 2 || mon_dist < 6 ) ) {
-                            passmon = true;
-                        }
-                        critter.lastseen_turn = calendar::turn;
-                    }
-
-                    if( !passmon ) {
-                        newseen++;
-                        new_seen_mon.push_back( shared_from( critter ) );
-                    }
-                }
+        // Accumulate hostile counts for danger music and combat bubble.
+        if( u.attitude_to( guy ) == Attitude::A_HOSTILE ) {
+            mon_visible.nearby_hostile_count++;
+            if( npc_dist <= combat_bubble_range ) {
+                mon_visible.combat_hostile_count++;
             }
-
-            std::vector<std::pair<const mtype *, int>> &vec = unique_mons[index];
-            const auto mon_it = std::find_if( vec.begin(), vec.end(),
-            [&]( const std::pair<const mtype *, int> &elem ) {
-                return elem.first == critter.type;
-            } );
-            if( mon_it == vec.end() ) {
-                vec.emplace_back( critter.type, 1 );
-            } else {
-                mon_it->second++;
-            }
-        } else if( p != nullptr ) {
-            //Safe mode NPC check
-
-            const int npc_dist = rl_dist( u.bub_pos(), p->bub_pos() );
-            safemode_state = get_safemode().check_monster( get_safemode().npc_type_name(), p->attitude_to( u ),
-                             npc_dist );
-
-            if( ( !safemode_empty && safemode_state == RULE_BLACKLISTED ) || ( safemode_empty &&
-                    p->get_attitude() == NPCATT_KILL ) ) {
-                if( !safemode_empty || npc_dist <= iProxyDist ) {
-                    newseen++;
-                }
-            }
-            unique_types[index].push_back( p );
         }
+
+        //Safe mode NPC check
+        const auto safemode_state = get_safemode().check_monster( get_safemode().npc_type_name(),
+                                    guy.attitude_to( u ), npc_dist );
+
+        if( ( !safemode_empty && safemode_state == RULE_BLACKLISTED ) || ( safemode_empty &&
+                guy.get_attitude() == NPCATT_KILL ) ) {
+            if( !safemode_empty || npc_dist <= iProxyDist ) {
+                newseen++;
+            }
+        }
+        unique_types[index].push_back( &guy );
+    };
+
+    for( const shared_ptr_fast<monster> &critter : critter_tracker->get_monsters_list() ) {
+        process_monster( critter );
+    }
+    for( const shared_ptr_fast<npc> &guy : active_npc ) {
+        process_npc( guy );
     }
 
     if( newseen > mostseen ) {

--- a/src/game.h
+++ b/src/game.h
@@ -1165,11 +1165,12 @@ class game : public submap_load_listener
 
         int mostseen = 0; // # of mons seen last turn; if this increases, set safe_mode to SAFE_MODE_STOP
 
-        // P-8: per-turn symmetric sight-result cache used during parallel monster
-        // planning (monmove()).  Keyed on the sorted (lo, hi) Creature pointer
-        // pair so A→B and B→A share one entry (LOS ray is symmetric).  Cleared
-        // at the start of monmove() before the parallel phase begins.  Workers
-        // hold a shared_lock for hits and upgrade to unique_lock on a miss.
+        // P-8: per-turn Creature::sees() result cache used during parallel monster
+        // planning (monmove()).  Keyed on directional (seer, target) Creature pointer
+        // pairs; Creature::sees() includes observer and target perception rules, while
+        // map::sees() remains the symmetric LOS cache.  Cleared at the start of
+        // monmove() before the parallel phase begins.  Workers hold a shared_lock for
+        // hits and upgrade to unique_lock on a miss.
         // Lives in the public section so turn_cached_sees() in monmove.cpp can
         // access it directly without an additional indirection layer.
         struct TurnSightPairHash {

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -203,5 +203,3 @@ constexpr float very_obese = 35.0f;
 constexpr float morbidly_obese = 40.0f;
 } // namespace character_weight_category
 
-
-

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10040,7 +10040,7 @@ bool item::needs_processing() const
     return is_active() || has_flag( flag_RADIO_ACTIVATION ) || has_flag( flag_ETHEREAL_ITEM ) ||
            ( !contents.empty() && is_container() && contents.front().needs_processing() ) ||
            ( magazine_current() && magazine_current()->needs_processing() ) ||
-           is_artifact() || is_relic() || is_food();
+           is_artifact() || is_relic() || goes_bad();
 }
 
 int item::processing_speed() const

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1037,8 +1037,12 @@ map::apparent_light_info map::apparent_light_helper( const level_cache &map_cach
 lit_level map::apparent_light_at( const tripoint_bub_ms &p,
                                   const visibility_variables &cache ) const
 {
-    const int dist = rl_dist( g->u.bub_pos(), p );
+    return apparent_light_at( p, cache, rl_dist( g->u.bub_pos(), p ) );
+}
 
+lit_level map::apparent_light_at( const tripoint_bub_ms &p,
+                                  const visibility_variables &cache, const int dist ) const
+{
     // Clairvoyance overrides everything.
     if( dist <= cache.u_clairvoyance ) {
         return lit_level::BRIGHT;
@@ -1061,7 +1065,7 @@ lit_level map::apparent_light_at( const tripoint_bub_ms &p,
 
     // Unimpaired range is an override to strictly limit vision range based on various conditions,
     // but the player can still see light sources.
-    if( dist > g->u.unimpaired_range() ) {
+    if( dist > cache.u_unimpaired_range ) {
         if( !a.obstructed && map_cache.sm[map_cache.idx( p.x(), p.y() )] > 0.0 ) {
             return lit_level::BRIGHT_ONLY;
         } else {

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -951,18 +951,31 @@ float map::light_transparency( const tripoint_bub_ms &p ) const
 
 // End of tile light/transparency
 
+static auto scaled_visibility_for_view_distance( const float vis,
+        const float visibility_scale_factor ) -> float
+{
+    if( vis <= LIGHT_TRANSPARENCY_SOLID ) {
+        return 0.0f;
+    }
+    if( vis >= VISIBILITY_FULL ) {
+        return VISIBILITY_FULL;
+    }
+    if( visibility_scale_factor == 1.0f ) {
+        return vis;
+    }
+    return std::pow( vis, visibility_scale_factor );
+}
+
 map::apparent_light_info map::apparent_light_helper( const level_cache &map_cache,
-        const tripoint_bub_ms &p )
+        const tripoint_bub_ms &p, const float visibility_scale_factor )
 {
     const float vis = std::max( map_cache.seen_cache[map_cache.idx( p.x(), p.y() )],
                                 map_cache.camera_cache[map_cache.idx( p.x(), p.y() )] );
     // Use g_visible_threshold which scales with g_max_view_distance.
     const bool obstructed = vis <= LIGHT_TRANSPARENCY_SOLID + g_visible_threshold;
 
-    // Scale vis so the LIT/LOW transition happens at g_max_view_distance instead of 60.
     // vis^(60/g_max) stretches the 1/exp(t*d) decay curve to match the current bubble size.
-    const float scale_factor = 60.0f / static_cast<float>( g_max_view_distance );
-    const float scaled_vis = ( vis > 0.0f ) ? std::pow( vis, scale_factor ) : 0.0f;
+    const auto scaled_vis = scaled_visibility_for_view_distance( vis, visibility_scale_factor );
 
     auto is_opaque = [&map_cache]( point_bub_ms  p ) {
         return map_cache.transparency_cache[map_cache.idx( p.x(), p.y() )] <= LIGHT_TRANSPARENCY_SOLID &&
@@ -1031,7 +1044,7 @@ lit_level map::apparent_light_at( const tripoint_bub_ms &p,
         return lit_level::BRIGHT;
     }
     const auto &map_cache = get_cache_ref( p.z() );
-    const apparent_light_info a = apparent_light_helper( map_cache, p );
+    const apparent_light_info a = apparent_light_helper( map_cache, p, cache.visibility_scale_factor );
 
     float apparent_light = a.apparent_light;
 
@@ -1098,9 +1111,10 @@ bool map::pl_sees( const tripoint_bub_ms &t, const int max_range ) const
     }
 
     const auto &map_cache = get_cache_ref( t.z() );
-    const apparent_light_info a = apparent_light_helper( map_cache, t );
-    const float light_at_player = map_cache.lm[map_cache.idx( g->u.bub_pos().x(),
-                                                 g->u.bub_pos().y() )].max();
+    const auto visibility_scale_factor = 60.0f / static_cast<float>( g_max_view_distance );
+    const auto a = apparent_light_helper( map_cache, t, visibility_scale_factor );
+    const auto light_at_player = map_cache.lm[map_cache.idx( g->u.bub_pos().x(),
+                                        g->u.bub_pos().y() )].max();
     return !a.obstructed &&
            ( a.apparent_light >= g->u.get_vision_threshold( light_at_player ) ||
              map_cache.sm[map_cache.idx( t.x(), t.y() )] > 0.0 );

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1118,7 +1118,7 @@ bool map::pl_sees( const tripoint_bub_ms &t, const int max_range ) const
     const auto visibility_scale_factor = 60.0f / static_cast<float>( g_max_view_distance );
     const auto a = apparent_light_helper( map_cache, t, visibility_scale_factor );
     const auto light_at_player = map_cache.lm[map_cache.idx( g->u.bub_pos().x(),
-                                        g->u.bub_pos().y() )].max();
+                                                g->u.bub_pos().y() )].max();
     return !a.obstructed &&
            ( a.apparent_light >= g->u.get_vision_threshold( light_at_player ) ||
              map_cache.sm[map_cache.idx( t.x(), t.y() )] > 0.0 );

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -36,7 +36,8 @@ static auto lookup_distance( const int dx, const int dy, const int dz,
                std::round( distance ) );
 }
 
-auto rl_dist_lookup_table::matches( const rl_dist_lookup_table_dimensions &dimensions ) const -> bool
+auto rl_dist_lookup_table::matches( const rl_dist_lookup_table_dimensions &dimensions ) const ->
+bool
 {
     return dimensions_.trigdist == dimensions.trigdist &&
            dimensions_.max_dx >= dimensions.max_dx &&
@@ -109,7 +110,7 @@ auto rl_dist_lookup_table::index_3d( const int dx, const int dy, const int dz ) 
 }
 
 auto get_rl_dist_lookup_table( const rl_dist_lookup_table_dimensions &dimensions )
--> const rl_dist_lookup_table &
+- > const rl_dist_lookup_table &
 {
     static std::mutex distance_table_mutex;
     static rl_dist_lookup_table table;

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -109,8 +109,8 @@ auto rl_dist_lookup_table::index_3d( const int dx, const int dy, const int dz ) 
            static_cast<size_t>( dx );
 }
 
-auto get_rl_dist_lookup_table( const rl_dist_lookup_table_dimensions &dimensions )
-- > const rl_dist_lookup_table &
+auto get_rl_dist_lookup_table( const rl_dist_lookup_table_dimensions &dimensions ) ->
+const rl_dist_lookup_table &
 {
     static std::mutex distance_table_mutex;
     static rl_dist_lookup_table table;

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -4,7 +4,9 @@
 #include <cassert>
 #include <algorithm>
 #include <array>
+#include <mutex>
 #include <memory>
+#include <ranges>
 #include <tuple>
 #include <utility>
 
@@ -20,6 +22,103 @@ double iso_tangent( double distance, units::angle vertex )
 {
     // we can use the cosine formula (a² = b² + c² - 2bc⋅cosθ) to calculate the tangent
     return std::sqrt( 2 * std::pow( distance, 2 ) * ( 1 - cos( vertex ) ) );
+}
+
+static auto lookup_distance( const int dx, const int dy, const int dz,
+                             const bool use_trigdist ) -> uint16_t
+{
+    if( !use_trigdist ) {
+        return static_cast<uint16_t>( std::max( { dx, dy, dz } ) );
+    }
+    const auto squared = dx * dx + dy * dy + dz * dz;
+    const auto distance = static_cast<float>( std::sqrt( static_cast<double>( squared ) ) );
+    return static_cast<uint16_t>(
+               std::round( distance ) );
+}
+
+auto rl_dist_lookup_table::matches( const rl_dist_lookup_table_dimensions &dimensions ) const -> bool
+{
+    return dimensions_.trigdist == dimensions.trigdist &&
+           dimensions_.max_dx >= dimensions.max_dx &&
+           dimensions_.max_dy >= dimensions.max_dy &&
+           dimensions_.max_dz >= dimensions.max_dz;
+}
+
+auto rl_dist_lookup_table::reset( const rl_dist_lookup_table_dimensions &dimensions ) -> void
+{
+    dimensions_ = dimensions;
+
+    distances_2d_.resize( static_cast<size_t>( dimensions_.max_dx + 1 ) *
+                          static_cast<size_t>( dimensions_.max_dy + 1 ) );
+    for( const auto dy : std::views::iota( 0, dimensions_.max_dy + 1 ) ) {
+        for( const auto dx : std::views::iota( 0, dimensions_.max_dx + 1 ) ) {
+            distances_2d_[index_2d( dx, dy )] =
+                lookup_distance( dx, dy, 0, dimensions_.trigdist );
+        }
+    }
+
+    distances_3d_.resize( static_cast<size_t>( dimensions_.max_dx + 1 ) *
+                          static_cast<size_t>( dimensions_.max_dy + 1 ) *
+                          static_cast<size_t>( dimensions_.max_dz + 1 ) );
+    for( const auto dz : std::views::iota( 0, dimensions_.max_dz + 1 ) ) {
+        for( const auto dy : std::views::iota( 0, dimensions_.max_dy + 1 ) ) {
+            for( const auto dx : std::views::iota( 0, dimensions_.max_dx + 1 ) ) {
+                distances_3d_[index_3d( dx, dy, dz )] =
+                    lookup_distance( dx, dy, dz, dimensions_.trigdist );
+            }
+        }
+    }
+}
+
+auto rl_dist_lookup_table::distance_2d( const int dx, const int dy ) const -> int
+{
+    return distances_2d_[index_2d( std::abs( dx ), std::abs( dy ) )];
+}
+
+auto rl_dist_lookup_table::distance_3d( const int dx, const int dy, const int dz ) const -> int
+{
+    return distances_3d_[index_3d( std::abs( dx ), std::abs( dy ), std::abs( dz ) )];
+}
+
+auto rl_dist_lookup_table::row_2d( const int dy ) const -> std::span<const uint16_t>
+{
+    const auto row_start = distances_2d_.data() + index_2d( 0, std::abs( dy ) );
+    return { row_start, static_cast<size_t>( dimensions_.max_dx + 1 ) };
+}
+
+auto rl_dist_lookup_table::row_3d( const int dy, const int dz ) const -> std::span<const uint16_t>
+{
+    const auto row_start = distances_3d_.data() +
+                           index_3d( 0, std::abs( dy ), std::abs( dz ) );
+    return { row_start, static_cast<size_t>( dimensions_.max_dx + 1 ) };
+}
+
+auto rl_dist_lookup_table::index_2d( const int dx, const int dy ) const -> size_t
+{
+    return static_cast<size_t>( dy ) * static_cast<size_t>( dimensions_.max_dx + 1 ) +
+           static_cast<size_t>( dx );
+}
+
+auto rl_dist_lookup_table::index_3d( const int dx, const int dy, const int dz ) const -> size_t
+{
+    const auto row_size = static_cast<size_t>( dimensions_.max_dx + 1 );
+    const auto plane_size = row_size * static_cast<size_t>( dimensions_.max_dy + 1 );
+    return static_cast<size_t>( dz ) * plane_size +
+           static_cast<size_t>( dy ) * row_size +
+           static_cast<size_t>( dx );
+}
+
+auto get_rl_dist_lookup_table( const rl_dist_lookup_table_dimensions &dimensions )
+-> const rl_dist_lookup_table &
+{
+    static std::mutex distance_table_mutex;
+    static rl_dist_lookup_table table;
+
+    const std::lock_guard<std::mutex> lock( distance_table_mutex );
+    if( !table.matches( dimensions ) ) {
+        table.reset( dimensions );
+    }
+    return table;
 }
 
 void bresenham( point p1, point p2, int t,

--- a/src/line.h
+++ b/src/line.h
@@ -223,8 +223,8 @@ class rl_dist_lookup_table
         std::vector<uint16_t> distances_3d_;
 };
 
-auto get_rl_dist_lookup_table( const rl_dist_lookup_table_dimensions &dimensions )
-- > const rl_dist_lookup_table &;
+auto get_rl_dist_lookup_table( const rl_dist_lookup_table_dimensions &dimensions ) ->
+const rl_dist_lookup_table &;
 
 /**
  * Helper type for the return value of dist_fast().

--- a/src/line.h
+++ b/src/line.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <functional>
+#include <span>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #include "math_defines.h"
 #include "point.h"
@@ -193,6 +195,36 @@ inline int rl_dist( point a, point b )
 {
     return rl_dist( tripoint( a, 0 ), tripoint( b, 0 ) );
 }
+
+struct rl_dist_lookup_table_dimensions {
+    int max_dx = 0;
+    int max_dy = 0;
+    int max_dz = 0;
+    bool trigdist = false;
+};
+
+class rl_dist_lookup_table
+{
+    public:
+        auto matches( const rl_dist_lookup_table_dimensions &dimensions ) const -> bool;
+        auto reset( const rl_dist_lookup_table_dimensions &dimensions ) -> void;
+
+        auto distance_2d( int dx, int dy ) const -> int;
+        auto distance_3d( int dx, int dy, int dz ) const -> int;
+        auto row_2d( int dy ) const -> std::span<const uint16_t>;
+        auto row_3d( int dy, int dz ) const -> std::span<const uint16_t>;
+
+    private:
+        auto index_2d( int dx, int dy ) const -> size_t;
+        auto index_3d( int dx, int dy, int dz ) const -> size_t;
+
+        rl_dist_lookup_table_dimensions dimensions_;
+        std::vector<uint16_t> distances_2d_;
+        std::vector<uint16_t> distances_3d_;
+};
+
+auto get_rl_dist_lookup_table( const rl_dist_lookup_table_dimensions &dimensions )
+-> const rl_dist_lookup_table &;
 
 /**
  * Helper type for the return value of dist_fast().

--- a/src/line.h
+++ b/src/line.h
@@ -224,7 +224,7 @@ class rl_dist_lookup_table
 };
 
 auto get_rl_dist_lookup_table( const rl_dist_lookup_table_dimensions &dimensions )
--> const rl_dist_lookup_table &;
+- > const rl_dist_lookup_table &;
 
 /**
  * Helper type for the return value of dist_fast().

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6829,6 +6829,8 @@ void map::update_visibility_cache( const int zlev )
     visibility_variables_cache.u_clairvoyance = g->u.clairvoyance();
     visibility_variables_cache.u_sight_impaired = g->u.sight_impaired();
     visibility_variables_cache.u_is_boomered = g->u.has_effect( effect_boomered );
+    visibility_variables_cache.visibility_scale_factor =
+        60.0f / static_cast<float>( g_max_view_distance );
 
     auto sm_squares_seen = std::vector<int>( static_cast<size_t>( my_MAPSIZE ) * my_MAPSIZE, 0 );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5871,9 +5871,11 @@ void map::process_items()
             process_items_in_vehicles( *sm );
         } );
     }
-    // Making a copy, in case the original variable gets modified during `process_items_in_submap`
+    // Snapshot because processing can add or remove active submaps.
     ZoneScopedN( "process_items_submaps" );
-    const std::set<tripoint_abs_sm> submaps_with_active_items_copy = submaps_with_active_items;
+    const auto submaps_with_active_items_copy = std::vector<tripoint_abs_sm>(
+                submaps_with_active_items.begin(), submaps_with_active_items.end() );
+    auto active_items = std::vector<item *> {};
     for( const tripoint_abs_sm &abs_pos : submaps_with_active_items_copy ) {
         if( !submap_loader.is_simulated( bound_dimension_, tripoint_abs_sm( abs_pos ) ) ) {
             continue;
@@ -5884,7 +5886,7 @@ void map::process_items()
             continue;
         }
         if( !current_submap->active_items.empty() ) {
-            process_items_in_submap( *current_submap, local_pos );
+            process_items_in_submap( *current_submap, local_pos, active_items );
         }
     }
 }
@@ -5904,12 +5906,13 @@ static temperature_flag temperature_flag_at_point( const map &m, const tripoint_
     return temperature_flag::TEMP_NORMAL;
 }
 
-void map::process_items_in_submap( submap &current_submap, const tripoint_bub_sm &gridp )
+auto map::process_items_in_submap( submap &current_submap, const tripoint_bub_sm &gridp,
+                                   std::vector<item *> &active_items ) -> void
 {
     // Get a COPY of the active item list for this submap.
     // If more are added as a side effect of processing, they are ignored this turn.
     // If they are destroyed before processing, they don't get processed.
-    std::vector<item *> active_items = current_submap.active_items.get_for_processing();
+    current_submap.active_items.get_for_processing( active_items );
     const point grid_offset( gridp.x() * SEEX, gridp.y() * SEEY );
     for( item *&active_item_ref : active_items ) {
         if( !active_item_ref || !active_item_ref->is_loaded() ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8132,14 +8132,11 @@ void map::shift( const point_rel_sm &sp )
                 // Shift per-submap dirty bitsets so retained submaps stay clean.
                 shift_bitset_cache( gc.transparency_cache_dirty, gc.cache_mapsize, 1, sp );
                 shift_bitset_cache( gc.floor_cache_dirty, gc.cache_mapsize, 1, sp );
-                shift_bitset_cache( gc.outside_cache_dirty, gc.cache_mapsize, 1, sp );
                 // Shift flat cache data so retained submaps' data stays in the
                 // correct tile position.  New edge submaps get stale values that
                 // will be overwritten by the next build_*_cache() call.
                 shift_flat_cache( gc.transparency_cache, gc.cache_x, gc.cache_y, sp );
                 shift_flat_cache( gc.floor_cache, gc.cache_x, gc.cache_y, sp );
-                shift_flat_cache( gc.outside_cache, gc.cache_x, gc.cache_y, sp );
-                shift_flat_cache( gc.sheltered_cache, gc.cache_x, gc.cache_y, sp );
                 if( fov_3d_occlusion ) {
                     shift_flat_cache( gc.angled_sunlight_cache, gc.cache_x, gc.cache_y, sp );
                 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6839,18 +6839,19 @@ void map::update_visibility_cache( const int zlev )
 
     auto sm_squares_seen = std::vector<int>( static_cast<size_t>( my_MAPSIZE ) * my_MAPSIZE, 0 );
 
-    const auto min_z = fov_3d ? -OVERMAP_DEPTH : ( zlevels ? std::max( zlev - 1, -OVERMAP_DEPTH ) : zlev );
+    const auto min_z = fov_3d ? -OVERMAP_DEPTH : ( zlevels ? std::max( zlev - 1,
+                       -OVERMAP_DEPTH ) : zlev );
     const auto max_z = fov_3d ? OVERMAP_HEIGHT : zlev;
     const auto max_delta_z = std::max( std::abs( min_z - player_pos.z() ),
                                        std::abs( max_z - player_pos.z() ) );
     const auto &reference_cache = get_cache_ref( zlev );
     const auto *const distance_table = trigdist ?
-        &get_rl_dist_lookup_table( rl_dist_lookup_table_dimensions{
-            .max_dx = reference_cache.cache_x - 1,
-            .max_dy = reference_cache.cache_y - 1,
-            .max_dz = max_delta_z,
-            .trigdist = trigdist,
-        } ) :
+    &get_rl_dist_lookup_table( rl_dist_lookup_table_dimensions{
+        .max_dx = reference_cache.cache_x - 1,
+        .max_dy = reference_cache.cache_y - 1,
+        .max_dz = max_delta_z,
+        .trigdist = trigdist,
+    } ) :
         nullptr;
 
     for( const auto z : std::views::iota( min_z, max_z + 1 ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6818,15 +6818,17 @@ void map::update_submap_active_item_status( const tripoint_bub_ms &p )
 void map::update_visibility_cache( const int zlev )
 {
     ZoneScopedN( "update_visibility_cache" );
+    const auto player_pos = g->u.bub_pos();
     visibility_variables_cache.variables_set = true; // Not used yet
     visibility_variables_cache.g_light_level = static_cast<int>( g->light_level( zlev ) );
     {
-        const level_cache &plr_ch = get_cache_ref( g->u.bub_pos().z() );
+        const level_cache &plr_ch = get_cache_ref( player_pos.z() );
         visibility_variables_cache.vision_threshold = g->u.get_vision_threshold(
-                    plr_ch.lm[plr_ch.idx( g->u.bub_pos().x(), g->u.bub_pos().y() )].max() );
+                    plr_ch.lm[plr_ch.idx( player_pos.x(), player_pos.y() )].max() );
     }
 
     visibility_variables_cache.u_clairvoyance = g->u.clairvoyance();
+    visibility_variables_cache.u_unimpaired_range = g->u.unimpaired_range();
     visibility_variables_cache.u_sight_impaired = g->u.sight_impaired();
     visibility_variables_cache.u_is_boomered = g->u.has_effect( effect_boomered );
     visibility_variables_cache.visibility_scale_factor =
@@ -6834,27 +6836,44 @@ void map::update_visibility_cache( const int zlev )
 
     auto sm_squares_seen = std::vector<int>( static_cast<size_t>( my_MAPSIZE ) * my_MAPSIZE, 0 );
 
-    int min_z = fov_3d ? -OVERMAP_DEPTH : ( zlevels ? std::max( zlev - 1, -OVERMAP_DEPTH ) : zlev );
-    int max_z = fov_3d ? OVERMAP_HEIGHT : zlev;
+    const auto min_z = fov_3d ? -OVERMAP_DEPTH : ( zlevels ? std::max( zlev - 1, -OVERMAP_DEPTH ) : zlev );
+    const auto max_z = fov_3d ? OVERMAP_HEIGHT : zlev;
+    const auto max_delta_z = std::max( std::abs( min_z - player_pos.z() ),
+                                       std::abs( max_z - player_pos.z() ) );
+    const auto &reference_cache = get_cache_ref( zlev );
+    const auto *const distance_table = trigdist ?
+        &get_rl_dist_lookup_table( rl_dist_lookup_table_dimensions{
+            .max_dx = reference_cache.cache_x - 1,
+            .max_dy = reference_cache.cache_y - 1,
+            .max_dz = max_delta_z,
+            .trigdist = trigdist,
+        } ) :
+        nullptr;
 
-    for( int z = min_z; z <= max_z; z++ ) {
+    for( const auto z : std::views::iota( min_z, max_z + 1 ) ) {
 
         level_cache &vc_cache = get_cache( z );
         auto &visibility_cache = vc_cache.visibility_cache;
+        const auto dz = std::abs( z - player_pos.z() );
 
         // Fill visibility_cache.  apparent_light_at is read-only per tile.
         if( parallel_enabled && parallel_map_cache ) {
             parallel_for( 0, vc_cache.cache_x, [&]( int x ) {
-                for( int y = 0; y < vc_cache.cache_y; y++ ) {
+                const auto dx = std::abs( x - player_pos.x() );
+                for( const auto y : std::views::iota( 0, vc_cache.cache_y ) ) {
+                    const auto dy = std::abs( y - player_pos.y() );
+                    const auto dist = distance_table != nullptr ?
+                                      distance_table->distance_3d( dx, dy, dz ) :
+                                      std::max( { dx, dy, dz } );
                     visibility_cache[vc_cache.idx( x, y )] =
-                        apparent_light_at( tripoint_bub_ms{ x, y, z }, visibility_variables_cache );
+                        apparent_light_at( tripoint_bub_ms{ x, y, z }, visibility_variables_cache, dist );
                 }
             } );
             // Overmap discovery accumulation: serial, reads from the parallel-filled cache.
             // Kept separate because sm_squares_seen is not thread-safe to write from workers.
             if( z == zlev ) {
-                for( int x = 0; x < vc_cache.cache_x; x++ ) {
-                    for( int y = 0; y < vc_cache.cache_y; y++ ) {
+                for( const auto x : std::views::iota( 0, vc_cache.cache_x ) ) {
+                    for( const auto y : std::views::iota( 0, vc_cache.cache_y ) ) {
                         const auto ll = visibility_cache[vc_cache.idx( x, y )];
                         sm_squares_seen[( x / SEEX ) * my_MAPSIZE + y / SEEY] +=
                             ( ll == lit_level::BRIGHT || ll == lit_level::LIT );
@@ -6865,10 +6884,15 @@ void map::update_visibility_cache( const int zlev )
             // Serial path: merge visibility fill and overmap discovery into one pass,
             // avoiding a second full scan of the cache at the player's z-level.
             const bool count_discovery = ( z == zlev );
-            for( int x = 0; x < vc_cache.cache_x; x++ ) {
-                for( int y = 0; y < vc_cache.cache_y; y++ ) {
+            for( const auto x : std::views::iota( 0, vc_cache.cache_x ) ) {
+                const auto dx = std::abs( x - player_pos.x() );
+                for( const auto y : std::views::iota( 0, vc_cache.cache_y ) ) {
+                    const auto dy = std::abs( y - player_pos.y() );
+                    const auto dist = distance_table != nullptr ?
+                                      distance_table->distance_3d( dx, dy, dz ) :
+                                      std::max( { dx, dy, dz } );
                     const auto ll =
-                        apparent_light_at( tripoint_bub_ms{ x, y, z }, visibility_variables_cache );
+                        apparent_light_at( tripoint_bub_ms{ x, y, z }, visibility_variables_cache, dist );
                     visibility_cache[vc_cache.idx( x, y )] = ll;
                     if( count_discovery ) {
                         sm_squares_seen[( x / SEEX ) * my_MAPSIZE + y / SEEY] +=

--- a/src/map.h
+++ b/src/map.h
@@ -130,6 +130,7 @@ struct visibility_variables {
     int g_light_level;
     int u_clairvoyance;
     float vision_threshold;
+    float visibility_scale_factor;
 };
 
 struct bash_params {
@@ -607,7 +608,7 @@ class map : public submap_load_listener
         /** Helper function for light claculation; exposed here for map editor
          */
         static apparent_light_info apparent_light_helper( const level_cache &map_cache,
-                const tripoint_bub_ms &p );
+                const tripoint_bub_ms &p, float visibility_scale_factor );
         /** Determine the visible light level for a tile, based on light_at
          * for the tile, vision distance, etc
          *

--- a/src/map.h
+++ b/src/map.h
@@ -2243,7 +2243,8 @@ class map : public submap_load_listener
         void process_items();
     private:
         // Iterates over every item on the map, passing each item to the provided function.
-        void process_items_in_submap( submap &current_submap, const tripoint_bub_sm &gridp );
+        auto process_items_in_submap( submap &current_submap, const tripoint_bub_sm &gridp,
+                                      std::vector<item *> &active_items ) -> void;
         void process_items_in_vehicles( submap &current_submap );
         void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap );
 

--- a/src/map.h
+++ b/src/map.h
@@ -129,6 +129,7 @@ struct visibility_variables {
     // Cached values for map visibility calculations
     int g_light_level;
     int u_clairvoyance;
+    int u_unimpaired_range;
     float vision_threshold;
     float visibility_scale_factor;
 };
@@ -616,6 +617,8 @@ class map : public submap_load_listener
          * @param cache Currently cached visibility parameters
          */
         lit_level apparent_light_at( const tripoint_bub_ms &p, const visibility_variables &cache ) const;
+        lit_level apparent_light_at( const tripoint_bub_ms &p, const visibility_variables &cache,
+                                     int dist ) const;
         visibility_type get_visibility( lit_level ll,
                                         const visibility_variables &cache ) const;
 

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -16,8 +16,8 @@
 
 std::unordered_map< mfaction_str_id, mfaction_id > faction_map;
 std::vector< monfaction > faction_list;
-static auto faction_attitude_table = std::vector<mf_attitude>{};
-static auto faction_attitude_table_width = size_t{ 0 };
+static auto faction_attitude_table = std::vector<mf_attitude> {};
+static auto faction_attitude_table_width = size_t { 0 };
 
 void add_to_attitude_map( const std::set< std::string > &keys, mfaction_att_map &map,
                           mf_attitude value );
@@ -25,7 +25,7 @@ void add_to_attitude_map( const std::set< std::string > &keys, mfaction_att_map 
 void apply_base_faction( const monfaction &base, monfaction &faction );
 
 static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other )
--> mf_attitude;
+- > mf_attitude;
 
 /** @relates int_id */
 template<>
@@ -127,15 +127,15 @@ mf_attitude monfaction::attitude( const mfaction_id &other ) const
         static_cast<size_t>( source_index ) < faction_attitude_table_width &&
         static_cast<size_t>( target_index ) < faction_attitude_table_width ) {
         return faction_attitude_table[static_cast<size_t>( source_index ) *
-                                      faction_attitude_table_width +
-                                      static_cast<size_t>( target_index )];
+                                                           faction_attitude_table_width +
+                                                           static_cast<size_t>( target_index )];
     }
 
     return resolve_attitude_map( *this, other );
 }
 
 static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other )
--> mf_attitude
+- > mf_attitude
 {
     const auto found = source.attitude_map.find( other );
     if( found != source.attitude_map.end() ) {

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -24,8 +24,7 @@ void add_to_attitude_map( const std::set< std::string > &keys, mfaction_att_map 
 
 void apply_base_faction( const monfaction &base, monfaction &faction );
 
-static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other )
-- > mf_attitude;
+static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other ) -> mf_attitude;
 
 /** @relates int_id */
 template<>
@@ -134,8 +133,7 @@ mf_attitude monfaction::attitude( const mfaction_id &other ) const
     return resolve_attitude_map( *this, other );
 }
 
-static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other )
-- > mf_attitude
+static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other ) -> mf_attitude
 {
     const auto found = source.attitude_map.find( other );
     if( found != source.attitude_map.end() ) {

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -24,7 +24,8 @@ void add_to_attitude_map( const std::set< std::string > &keys, mfaction_att_map 
 
 void apply_base_faction( const monfaction &base, monfaction &faction );
 
-static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other ) -> mf_attitude;
+static auto resolve_attitude_map( const monfaction &source,
+                                  const mfaction_id &other ) -> mf_attitude;
 
 /** @relates int_id */
 template<>
@@ -133,7 +134,8 @@ mf_attitude monfaction::attitude( const mfaction_id &other ) const
     return resolve_attitude_map( *this, other );
 }
 
-static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other ) -> mf_attitude
+static auto resolve_attitude_map( const monfaction &source,
+                                  const mfaction_id &other ) -> mf_attitude
 {
     const auto found = source.attitude_map.find( other );
     if( found != source.attitude_map.end() ) {

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -16,11 +16,16 @@
 
 std::unordered_map< mfaction_str_id, mfaction_id > faction_map;
 std::vector< monfaction > faction_list;
+static auto faction_attitude_table = std::vector<mf_attitude>{};
+static auto faction_attitude_table_width = size_t{ 0 };
 
 void add_to_attitude_map( const std::set< std::string > &keys, mfaction_att_map &map,
                           mf_attitude value );
 
 void apply_base_faction( const monfaction &base, monfaction &faction );
+
+static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other )
+-> mf_attitude;
 
 /** @relates int_id */
 template<>
@@ -85,6 +90,8 @@ mfaction_id monfactions::get_or_add_faction( const mfaction_str_id &id )
 {
     auto found = faction_map.find( id );
     if( found == faction_map.end() ) {
+        faction_attitude_table.clear();
+        faction_attitude_table_width = 0;
         monfaction mfact;
         mfact.id = id;
         mfact.loadid = mfaction_id( faction_map.size() );
@@ -113,19 +120,35 @@ static void apply_base_faction( mfaction_id base, mfaction_id faction_id )
 
 mf_attitude monfaction::attitude( const mfaction_id &other ) const
 {
-    const auto &found = attitude_map.find( other );
-    if( found != attitude_map.end() ) {
+    const auto source_index = loadid.to_i();
+    const auto target_index = other.to_i();
+    if( faction_attitude_table_width > 0 &&
+        source_index >= 0 && target_index >= 0 &&
+        static_cast<size_t>( source_index ) < faction_attitude_table_width &&
+        static_cast<size_t>( target_index ) < faction_attitude_table_width ) {
+        return faction_attitude_table[static_cast<size_t>( source_index ) *
+                                      faction_attitude_table_width +
+                                      static_cast<size_t>( target_index )];
+    }
+
+    return resolve_attitude_map( *this, other );
+}
+
+static auto resolve_attitude_map( const monfaction &source, const mfaction_id &other )
+-> mf_attitude
+{
+    const auto found = source.attitude_map.find( other );
+    if( found != source.attitude_map.end() ) {
         return found->second;
     }
 
     const auto base = other.obj().base_faction;
     if( other != base ) {
-        return attitude( base );
+        return resolve_attitude_map( source, base );
     }
-
     // Shouldn't happen
     debugmsg( "Invalid faction relations (no relation found): %s -> %s",
-              id.c_str(), other.obj().id.c_str() );
+              source.id.c_str(), other.obj().id.c_str() );
     return MFA_FRIENDLY;
 }
 
@@ -133,6 +156,8 @@ void monfactions::reset()
 {
     faction_list.clear();
     faction_map.clear();
+    faction_attitude_table.clear();
+    faction_attitude_table_width = 0;
 }
 
 void monfactions::finalize()
@@ -217,6 +242,15 @@ void monfactions::finalize()
     }
 
     faction_list.shrink_to_fit(); // Save a couple of bytes
+
+    faction_attitude_table_width = faction_list.size();
+    faction_attitude_table.clear();
+    faction_attitude_table.reserve( faction_attitude_table_width * faction_attitude_table_width );
+    for( const monfaction &source : faction_list ) {
+        for( const monfaction &target : faction_list ) {
+            faction_attitude_table.push_back( resolve_attitude_map( source, target.loadid ) );
+        }
+    }
 }
 
 // Ensures all those factions exist

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -305,10 +305,10 @@ void monster::wander_to( const tripoint_bub_ms &p, int f )
     wandf = f;
 }
 
-// P-8: per-turn symmetric sight-result cache wrapper.
+// P-8: per-turn Creature::sees() result cache wrapper.
 // Checks g->turn_sight_cache_ before invoking the full Creature::sees() chain.
-// Key is the sorted (lo-address, hi-address) pointer pair so A→B and B→A share
-// one cache entry (exploiting the symmetry of LOS ray traces).
+// Key is directional because Creature::sees() includes observer and target
+// perception rules.  The symmetric LOS part is handled by map::sees().
 //
 // LOGIC-2 / P-5 note: x_in_y aggro-chance rolls inside compute_plan() run on
 // worker-thread RNG (tl_worker_engine).  This is data-race-free (P-5), but it
@@ -318,9 +318,7 @@ void monster::wander_to( const tripoint_bub_ms &p, int f )
 // into apply_plan() so they execute on the main thread with the shared engine.
 static bool turn_cached_sees( const Creature &seer, const Creature &target )
 {
-    const Creature *lo = &seer < &target ? &seer : &target;
-    const Creature *hi = &seer < &target ? &target : &seer;
-    const auto key = std::make_pair( lo, hi );
+    const auto key = std::make_pair( &seer, &target );
     {
         std::shared_lock<std::shared_mutex> lock( g->turn_sight_cache_mutex_ );
         const auto it = g->turn_sight_cache_.find( key );
@@ -358,8 +356,8 @@ float monster::rate_target( Creature &c, float best, bool smart, int precalc_dis
         return FLT_MAX;
     }
 
-    // P-8: use the per-turn symmetric cache so symmetric pairs (A checks B,
-    // B checks A) pay for at most one ray trace per turn instead of two.
+    // P-8: use the per-turn cache for repeated Creature::sees() checks in this
+    // direction.  Symmetric LOS reuse happens inside map::sees().
     if( !turn_cached_sees( *this, c ) ) {
         return FLT_MAX;
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -334,13 +334,6 @@ static bool turn_cached_sees( const Creature &seer, const Creature &target )
     return result;
 }
 
-void monster::prewarm_sight( const Creature &target ) const
-{
-    // Populate turn_sight_cache_ for this (monster, target) pair serially so
-    // the parallel planning phase hits only the shared_lock read path.
-    turn_cached_sees( *this, target );
-}
-
 float monster::rate_target( Creature &c, float best, bool smart, int precalc_dist ) const
 {
     // Use caller-supplied distance when available to avoid

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1678,6 +1678,47 @@ auto monster::attitude( const Character *u ) const -> monster_attitude
     return MATT_ATTACK;
 }
 
+auto monster::generic_npc_attitude_to() const -> Attitude
+{
+    auto effective_anger = anger;
+    auto effective_morale = morale;
+
+    if( friendly != 0 ) {
+        if( has_effect( effect_docile ) ) {
+            return Attitude::A_FRIENDLY;
+        }
+        if( !type->in_species( ZOMBIE ) ) {
+            return Attitude::A_FRIENDLY;
+        }
+    }
+    if( effect_cache[FLEEING] ) {
+        return Attitude::A_NEUTRAL;
+    }
+    if( has_effect( effect_pacified ) ) {
+        return Attitude::A_FRIENDLY;
+    }
+
+    if( has_flag( MF_FACTION_MEMORY ) ) {
+        static const mfaction_id player_faction( "player" );
+        effective_anger = get_faction_anger( player_faction );
+    }
+
+    if( effective_morale < 0 ) {
+        return Attitude::A_NEUTRAL;
+    }
+    if( effective_anger <= 0 ) {
+        return Attitude::A_NEUTRAL;
+    }
+    if( effective_anger < 10 ) {
+        return Attitude::A_NEUTRAL;
+    }
+    if( !aggro_character ) {
+        return Attitude::A_NEUTRAL;
+    }
+
+    return Attitude::A_HOSTILE;
+}
+
 int monster::hp_percentage() const
 {
     return get_hp( bodypart_id( "torso" ) ) * 100 / get_hp_max();

--- a/src/monster.h
+++ b/src/monster.h
@@ -301,14 +301,6 @@ class monster : public Creature, public location_visitable<monster>
         monster_action_t decide_action() const;
 
         /**
-         * Pre-warm the per-turn sight cache for the (this, target) pair.
-         * Call serially before the parallel planning phase so that
-         * compute_plan() hits the shared_lock read path instead of taking
-         * a unique_lock insert for every monster-player/NPC pair.
-         */
-        void prewarm_sight( const Creature &target ) const;
-
-        /**
          * Execution pass: applies the action returned by decide_action().
          * Must run on the main thread (or a thread that has exclusive access to
          * this monster's position in the reservation map).

--- a/src/monster.h
+++ b/src/monster.h
@@ -405,6 +405,7 @@ class monster : public Creature, public location_visitable<monster>
         // Combat
         bool is_fleeing( Character &who ) const; // True if we're fleeing
         auto attitude( const Character *u = nullptr ) const -> monster_attitude; // See the enum above
+        auto generic_npc_attitude_to() const -> Attitude;
         Attitude attitude_to( const Creature &other ) const override;
         void process_triggers(); // Process things that anger/scare us
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2262,10 +2262,16 @@ Attitude npc::attitude_to( const Creature &other ) const
     if( other.is_npc() || other.is_player() ) {
         const player &guy = dynamic_cast<const player &>( other );
         // check faction relationships first
-        if( has_faction_relationship( guy, npc_factions::kill_on_sight ) ) {
-            return Attitude::A_HOSTILE;
-        } else if( has_faction_relationship( guy, npc_factions::watch_your_back ) ) {
-            return Attitude::A_FRIENDLY;
+        const auto *guy_fac = guy.get_faction();
+        if( my_fac != nullptr && guy_fac != nullptr ) {
+            const auto rel_data = my_fac->relationship_flags_with( guy_fac->id );
+            if( rel_data != nullptr ) {
+                if( rel_data->test( npc_factions::kill_on_sight ) ) {
+                    return Attitude::A_HOSTILE;
+                } else if( rel_data->test( npc_factions::watch_your_back ) ) {
+                    return Attitude::A_FRIENDLY;
+                }
+            }
         }
     }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -122,6 +122,10 @@ static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_attention( "attention" );
 static const efftype_id effect_feral_infighting_punishment( "feral_infighting_punishment" );
 
+static const trait_id trait_ANIMALDISCORD( "ANIMALDISCORD" );
+static const trait_id trait_ANIMALDISCORD2( "ANIMALDISCORD2" );
+static const trait_id trait_ANIMALEMPATH( "ANIMALEMPATH" );
+static const trait_id trait_ANIMALEMPATH2( "ANIMALEMPATH2" );
 static const trait_id trait_BEE( "BEE" );
 static const trait_id trait_FLOWERS( "FLOWERS" );
 static const trait_id trait_MYCUS_FRIEND( "MYCUS_FRIEND" );
@@ -393,10 +397,21 @@ static auto npc_turn_cached_sees( const Creature &seer, const Creature &target )
 void npc::assess_danger()
 {
     ZoneScoped;
+    auto has_mutation_attitude_rules = false;
+    for( const trait_id &mut : get_mutations() ) {
+        const auto &mutation = mut.obj();
+        if( !mutation.anger_relations.empty() || !mutation.ignored_by.empty() ) {
+            has_mutation_attitude_rules = true;
+            break;
+        }
+    }
     // True if this NPC has traits/effects that cause monster::attitude() to return a
     // result different from what a generic NPC would get.  When false, we can use each
     // monster's per-npcmove-pass cached attitude instead of recomputing it.
-    const bool has_special_attitude_traits = guaranteed_hostile() || is_hallucination() ||
+    const auto has_special_attitude_traits = guaranteed_hostile() || is_hallucination() ||
+            has_mutation_attitude_rules ||
+            has_trait( trait_ANIMALEMPATH ) || has_trait( trait_ANIMALEMPATH2 ) ||
+            has_trait( trait_ANIMALDISCORD ) || has_trait( trait_ANIMALDISCORD2 ) ||
             has_trait( trait_PROF_FERAL ) || has_trait( trait_BEE ) ||
             has_trait( trait_FLOWERS ) || has_trait( trait_THRESH_MYCUS ) ||
             has_trait( trait_MYCUS_FRIEND ) || has_trait( trait_PHEROMONE_MAMMAL ) ||
@@ -501,6 +516,7 @@ void npc::assess_danger()
         }
     };
     {
+        ZoneScopedN( "npc_friend_enemy_scan" );
         const uint32_t current_version = g_npc_friends_dirty_version.load( std::memory_order_relaxed );
         const bool friends_dirty = ( ai_cache.npc_friends_version != current_version );
         if( friends_dirty ) {
@@ -551,9 +567,12 @@ void npc::assess_danger()
             Attitude att;
             if( !has_special_attitude_traits &&
                 critter.cached_npc_attitude_epoch == g_npcmove_attitude_epoch ) {
+                ZoneScopedN( "npc_monster_attitude_cache_hit" );
                 att = critter.cached_npc_attitude;
             } else {
-                att = critter.attitude_to( *this );
+                ZoneScopedN( "npc_monster_attitude_cache_miss" );
+                att = has_special_attitude_traits ? critter.attitude_to( *this ) :
+                      critter.generic_npc_attitude_to();
                 if( !has_special_attitude_traits ) {
                     critter.cached_npc_attitude_epoch = g_npcmove_attitude_epoch;
                     critter.cached_npc_attitude = att;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -506,7 +506,7 @@ void npc::assess_danger()
     // NPC friends are cached across turns; only rebuild when faction membership or active NPC
     // list changes (tracked via g_npc_friends_dirty_version).
     std::vector<weak_ptr_fast<Creature>> hostile_guys;
-    auto friend_positions = std::vector<tripoint_bub_ms>{};
+    auto friend_positions = std::vector<tripoint_bub_ms> {};
     const auto remember_friend_position = [&]( const weak_ptr_fast<Creature> &guy ) {
         if( auto ally = guy.lock() ) {
             friend_positions.push_back( ally->bub_pos() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -494,6 +494,12 @@ void npc::assess_danger()
     // NPC friends are cached across turns; only rebuild when faction membership or active NPC
     // list changes (tracked via g_npc_friends_dirty_version).
     std::vector<weak_ptr_fast<Creature>> hostile_guys;
+    auto friend_positions = std::vector<tripoint_bub_ms>{};
+    const auto remember_friend_position = [&]( const weak_ptr_fast<Creature> &guy ) {
+        if( auto ally = guy.lock() ) {
+            friend_positions.push_back( ally->bub_pos() );
+        }
+    };
     {
         const uint32_t current_version = g_npc_friends_dirty_version.load( std::memory_order_relaxed );
         const bool friends_dirty = ( ai_cache.npc_friends_version != current_version );
@@ -516,13 +522,18 @@ void npc::assess_danger()
         if( friends_dirty ) {
             ai_cache.npc_friends_version = current_version;
         }
-        std::ranges::copy( ai_cache.cached_npc_friends, std::back_inserter( ai_cache.friends ) );
+        for( const weak_ptr_fast<Creature> &guy : ai_cache.cached_npc_friends ) {
+            ai_cache.friends.emplace_back( guy );
+            remember_friend_position( guy );
+        }
     }
     if( sees( player_character.bub_pos() ) ) {
         if( is_enemy() ) {
             hostile_guys.emplace_back( g->shared_from( player_character ) );
         } else if( is_friendly( player_character ) ) {
-            ai_cache.friends.emplace_back( g->shared_from( player_character ) );
+            auto player_ref = g->shared_from( player_character );
+            friend_positions.push_back( player_character.bub_pos() );
+            ai_cache.friends.emplace_back( player_ref );
         }
     }
 
@@ -550,6 +561,7 @@ void npc::assess_danger()
             }
             if( att == Attitude::A_FRIENDLY ) {
                 ai_cache.friends.emplace_back( g->shared_from( critter ) );
+                friend_positions.push_back( critter.bub_pos() );
                 continue;
             }
             // Skip non-hostile monsters entirely — includes MATT_IGNORE, MATT_FLEE, and
@@ -584,18 +596,11 @@ void npc::assess_danger()
 
             // don't ignore monsters that are too close or too close to an ally if we can move
             bool is_too_close = dist <= def_radius;
-            for( const weak_ptr_fast<Creature> &guy : ai_cache.friends ) {
+            for( const tripoint_bub_ms &ally_pos : friend_positions ) {
                 if( is_too_close || self_defense_only ) {
                     break;
                 }
-                // HACK: Bit of a dirty hack - sometimes shared_from, returns nullptr or bad weak_ptr for
-                // friendly NPC when the NPC is riding a creature - I don't know why.
-                // so this skips the bad weak_ptrs, but this doesn't functionally change the AI Priority
-                // because the horse the NPC is riding is still in the ai_cache.friends vector,
-                // so either one would count as a friendly for this purpose.
-                if( auto ally = guy.lock() ) {
-                    is_too_close |= too_close( critter.bub_pos(), ally->bub_pos(), def_radius );
-                }
+                is_too_close |= too_close( critter.bub_pos(), ally_pos, def_radius );
             }
             // ignore distant monsters that our rules prevent us from attacking
             if( !is_too_close && is_player_ally() && !ok_by_rules( critter, dist, scaled_distance ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -371,14 +371,11 @@ static bool too_close( const tripoint_bub_ms &critter_pos, const tripoint_bub_ms
     return rl_dist( critter_pos, ally_pos ) <= def_radius;
 }
 
-// Per-turn symmetric sight cache wrapper — mirrors turn_cached_sees() in monmove.cpp.
-// Exploits LOS symmetry: if a monster already checked visibility against this NPC during
-// compute_plan(), the result is already cached and this call is a cheap shared_lock read.
+// Per-turn Creature::sees() cache wrapper — mirrors turn_cached_sees() in monmove.cpp.
+// Key is directional; map::sees() handles symmetric LOS reuse below this layer.
 static auto npc_turn_cached_sees( const Creature &seer, const Creature &target ) -> bool
 {
-    const Creature *lo = &seer < &target ? &seer : &target;
-    const Creature *hi = &seer < &target ? &target : &seer;
-    const auto key = std::make_pair( lo, hi );
+    const auto key = std::make_pair( &seer, &target );
     {
         std::shared_lock<std::shared_mutex> lock( g->turn_sight_cache_mutex_ );
         const auto it = g->turn_sight_cache_.find( key );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -337,6 +337,14 @@ void sounds::process_sounds()
 
     std::vector<centroid> sound_clusters = cluster_sounds( recent_sounds );
     const int weather_vol = get_weather().weather_id->sound_attn;
+    auto monster_listeners = std::vector<monster *>{};
+    if( !sound_clusters.empty() ) {
+        auto monsters = g->all_monsters();
+        monster_listeners.reserve( monsters.items ? monsters.items->size() : 0 );
+        for( monster &critter : monsters ) {
+            monster_listeners.push_back( &critter );
+        }
+    }
     for( const auto &this_centroid : sound_clusters ) {
         // Since monsters don't go deaf ATM we can just use the weather modified volume
         // If they later get physical effects from loud noises we'll have to change this
@@ -355,12 +363,12 @@ void sounds::process_sounds()
             get_overmapbuffer( get_map().get_bound_dimension() ).signal_hordes( target, sig_power );
         }
         // Alert all monsters (that can hear) to the sound.
-        for( monster &critter : g->all_monsters() ) {
+        for( monster *critter : monster_listeners ) {
             // TODO: Generalize this to Creature::hear_sound
-            const int dist = sound_distance( source, critter.bub_pos() );
+            const int dist = sound_distance( source, critter->bub_pos() );
             if( vol * 2 > dist ) {
                 // Exclude monsters that certainly won't hear the sound
-                critter.hear_sound( source, vol, dist );
+                critter->hear_sound( source, vol, dist );
             }
         }
     }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -337,7 +337,7 @@ void sounds::process_sounds()
 
     std::vector<centroid> sound_clusters = cluster_sounds( recent_sounds );
     const int weather_vol = get_weather().weather_id->sound_attn;
-    auto monster_listeners = std::vector<monster *>{};
+    auto monster_listeners = std::vector<monster *> {};
     if( !sound_clusters.empty() ) {
         auto monsters = g->all_monsters();
         monster_listeners.reserve( monsters.items ? monsters.items->size() : 0 );

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -24,6 +24,30 @@ TEST_CASE( "active_item_cache_ignores_expired_references", "[item]" )
     CHECK( cache.empty() );
 }
 
+TEST_CASE( "nonperishable_food_does_not_enter_active_item_cache", "[item]" )
+{
+    clear_all_state();
+    const auto loc = tripoint_bub_ms{ 60, 60, 0 };
+    g->m.i_clear( loc );
+    const auto abs_loc = g->m.get_abs_sub() + tripoint_rel_sm( loc.x() / SEEX, loc.y() / SEEY,
+                         loc.z() );
+    const auto baseline_active_submaps = g->m.get_submaps_with_active_items();
+
+    auto sugar = item::spawn( "sugar" );
+    REQUIRE( sugar->is_food() );
+    REQUIRE_FALSE( sugar->goes_bad() );
+    REQUIRE_FALSE( sugar->needs_processing() );
+    g->m.add_item( loc, std::move( sugar ) );
+    CHECK( g->m.get_submaps_with_active_items() == baseline_active_submaps );
+
+    auto sashimi = item::spawn( "sashimi" );
+    REQUIRE( sashimi->is_food() );
+    REQUIRE( sashimi->goes_bad() );
+    REQUIRE( sashimi->needs_processing() );
+    g->m.add_item( loc, std::move( sashimi ) );
+    CHECK( g->m.get_submaps_with_active_items().contains( abs_loc ) );
+}
+
 TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
 {
     clear_all_state();

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -197,7 +197,8 @@ static void full_map_test( const std::vector<std::string> &setup,
     for( int y = 0; y < height; ++y ) {
         for( int x = 0; x < width; ++x ) {
             const auto p = origin + point_rel_ms( x, y );
-            const map::apparent_light_info al = map::apparent_light_helper( cache, p );
+            const auto &visibility_cache = here.get_visibility_variables_cache();
+            const map::apparent_light_info al = map::apparent_light_helper( cache, p, visibility_cache.visibility_scale_factor );
             for( auto &pr : here.field_at( p ) ) {
                 fields << pr.second.name() << ',';
             }

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -198,7 +198,8 @@ static void full_map_test( const std::vector<std::string> &setup,
         for( int x = 0; x < width; ++x ) {
             const auto p = origin + point_rel_ms( x, y );
             const auto &visibility_cache = here.get_visibility_variables_cache();
-            const map::apparent_light_info al = map::apparent_light_helper( cache, p, visibility_cache.visibility_scale_factor );
+            const map::apparent_light_info al = map::apparent_light_helper(
+                                                cache, p, visibility_cache.visibility_scale_factor );
             for( auto &pr : here.field_at( p ) ) {
                 fields << pr.second.name() << ',';
             }

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -199,7 +199,7 @@ static void full_map_test( const std::vector<std::string> &setup,
             const auto p = origin + point_rel_ms( x, y );
             const auto &visibility_cache = here.get_visibility_variables_cache();
             const map::apparent_light_info al = map::apparent_light_helper(
-                                                cache, p, visibility_cache.visibility_scale_factor );
+                                                    cache, p, visibility_cache.visibility_scale_factor );
             for( auto &pr : here.field_at( p ) ) {
                 fields << pr.second.name() << ',';
             }


### PR DESCRIPTION
## Purpose of change (The Why)

Perf Perf Perf

## Describe the solution (The How)

Mostly about doing iteration smarter.
Sometimes we avoid it, sometimes we reduce it by packing functions into the same loop, sometimes we precalc before mult-threaded code so we don't write-lock.
There's also some general cleanup and the sparse item cache

## Testing

Tests + manual stress test with loading new area and with necropolis
Necropolis takes only 69% of the time per turn no joke:
<img width="999" height="647" alt="Tracy_xVN9OdDxjp" src="https://github.com/user-attachments/assets/ebb527b4-ed6c-48c1-9c4f-ddb8966936b1" />


## Additional context

I had considered including item abstraction in furniture containers, but once I was mostly done with that I realized it should be a different PR. We'll see how well that goes but it passed tests.

AI disclosure: used gpt-5.5 xhigh as assistant

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3b31678](https://github.com/cataclysmbn/Cataclysm-BN/commit/3b31678f1684be0295016adca60b6a727b5be2fb) (style(autofix.ci): automated formatting) on 2026-05-25 17:18:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26410055802/artifacts/7202280355)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26410055802/artifacts/7202228387)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26410055802/artifacts/7201967246)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26410055802/artifacts/7201944143)
<!-- END artifact comment -->