### PR TITLE
fix: allow salvaging items with installed toolmods / gunmods

### DIFF
--- a/src/salvage.cpp
+++ b/src/salvage.cpp
@@ -99,7 +99,11 @@ ret_val<bool> try_salvage( const item &target, quality_cache &q_cache )
         }
         return ret_val<bool>::make_failure( ret );
     }
-    if( !target.contents.empty() ) {
+    const bool has_non_mod_contents = target.contents.has_any_with(
+    []( const item & it ) {
+        return !it.is_toolmod() && !it.is_gunmod();
+    } );
+    if( has_non_mod_contents ) {
         return ret_val<bool>::make_failure(
                    string_format( _( "Please empty the %s before salvaged it up." ), target.tname() ) );
     }


### PR DESCRIPTION
## Summary

Closes #8919.

`salvage::try_salvage` in [src/salvage.cpp](src/salvage.cpp) rejected any item with non-empty `contents` and asked the player to "empty" it first. But installed toolmods (e.g. the UPS conversion mod) and gunmods live in `contents` and carry `NO_UNLOAD` — there is no player-accessible way to take them off, so the modded item became permanently unsalvageable.

Filters the contents check so only non-mod entries block salvage. Installed mods are treated as part of the item and consumed alongside it during salvage.

## Test plan

- [x] Builds clean (`cataclysm-bn-tiles`, `RelWithDebInfo`, MSVC).
- [x] In-game: debug-spawned Advanced 3D Printer with the UPS conversion mod installed now salvages successfully (previously blocked with the "please empty" message).
- [x] Control: a container with real contents (backpack with items in it) is still correctly rejected with the "please empty" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d05f73a](https://github.com/cataclysmbn/Cataclysm-BN/commit/d05f73ad635f24f070b3a163f20cf146a6db419a) (fix: allow salvaging items with installed toolmods / gunmods) on 2026-05-25 14:22:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26403138299/artifacts/7199347704)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26403138299/artifacts/7199801984)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26403138299/artifacts/7199237483)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26403138299/artifacts/7199520116)
<!-- END artifact comment -->