### PR TITLE
test: Add tests related to some lua hooks

### DIFF
--- a/data/mods/TEST_DATA/effects.json
+++ b/data/mods/TEST_DATA/effects.json
@@ -38,5 +38,10 @@
     "type": "effect_type",
     "id": "test_juggling_l2",
     "effects_on_remove": [ { "effect_type": "test_juggling_l1", "duration": "0 s" } ]
+  },
+  {
+    "type": "effect_type",
+    "id": "test_lua_effect",
+    "flags": [ "EFFECT_LUA_ON_ADDED", "EFFECT_LUA_ON_TICK", "EFFECT_LUA_ON_REMOVED" ]
   }
 ]

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -1106,7 +1106,8 @@ struct hook_cleanup {
 // Append an entry backed by a C++ callable to a global hook list.
 // Returns the table index so the caller can build a hook_cleanup.
 template<typename Fn>
-static auto push_hook( sol::state &lua, const std::string &name, Fn &&fn ) -> std::pair<sol::table, int>
+static auto push_hook( sol::state &lua, const std::string &name,
+                       Fn &&fn ) -> std::pair<sol::table, int>
 {
     sol::table list = lua["game"]["hooks"][name];
     auto *L = lua.lua_state();

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -1,6 +1,7 @@
 #include "catch/catch.hpp"
 
 #include "avatar.h"
+#include "calendar.h"
 #include "catacharset.h"
 #include "catalua_coord.h"
 #include "catalua_hooks.h"
@@ -12,10 +13,17 @@
 #include "debug.h"
 #include "faction.h"
 #include "fstream_utils.h"
+#include "game.h"
+#include "init.h"
 #include "json.h"
 #include "map.h"
+#include "map_helpers.h"
 #include "mapdata.h"
+#include "effect.h"
+#include "monster.h"
+#include "npc.h"
 #include "options.h"
+#include "player_helpers.h"
 #include "state_helpers.h"
 #include "string_formatter.h"
 #include "stringmaker.h"
@@ -28,6 +36,7 @@
 #include "vehicle.h"
 #include "vehicle_part.h"
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <stdexcept>
@@ -1071,4 +1080,351 @@ TEST_CASE( "lua_hooks_exit_early", "[lua]" )
     CHECK( log_tbl.get<std::string>( 1 ) == "p10" );
     CHECK( results_tbl.get<bool>( "allowed" ) == false );
     CHECK( log_tbl.get<sol::optional<std::string>>( 2 ) == sol::nullopt );
+}
+
+// ─── Hook wiring tests ───────────────────────────────────────────────────────
+// Each test registers a callback on the global Lua state, triggers the
+// corresponding C++ event, asserts the callback fired, then removes the entry.
+//
+// The cleanup struct guarantees removal even when a REQUIRE inside a helper
+// throws and unwinds the stack.
+
+namespace
+{
+
+static const efftype_id effect_test_lua_effect( "test_lua_effect" );
+
+struct hook_cleanup {
+    sol::table list;
+    int idx;
+    hook_cleanup( sol::table l, int i ) : list( l ), idx( i ) {}
+    ~hook_cleanup() {
+        list[idx] = sol::lua_nil;
+    }
+};
+
+// Append an entry backed by a C++ callable to a global hook list.
+// Returns the table index so the caller can build a hook_cleanup.
+template<typename Fn>
+static auto push_hook( sol::state &lua, const std::string &name, Fn &&fn ) -> std::pair<sol::table, int>
+{
+    sol::table list = lua["game"]["hooks"][name];
+    auto *L = lua.lua_state();
+    sol::stack::push( L, list );
+    const auto idx = static_cast<int>( lua_rawlen( L, -1 ) ) + 1;
+    lua_pop( L, 1 );
+
+    auto entry = lua.create_table();
+    entry["mod_id"] = "test";
+    entry["priority"] = 0;
+    entry["fn"] = std::forward<Fn>( fn );
+    list[idx] = entry;
+    return { list, idx };
+}
+
+} // namespace
+
+// ── Trivial ──────────────────────────────────────────────────────────────────
+
+TEST_CASE( "lua_hook_wiring_character_reset_stats", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    const auto char_ptr = std::make_shared<Character *>( nullptr );
+    const auto [list, idx] = push_hook( lua, "on_character_reset_stats",
+    [char_ptr]( sol::table params ) {
+        *char_ptr = params["character"].get<sol::optional<Character *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup{ list, idx };
+
+    get_avatar().reset_stats();
+
+    CHECK( *char_ptr == &get_avatar() );
+}
+
+TEST_CASE( "lua_hook_wiring_monster_loaded", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    const auto mon_ptr = std::make_shared<monster *>( nullptr );
+    const auto cre_ptr = std::make_shared<Creature *>( nullptr );
+
+    const auto [ml, mi] = push_hook( lua, "on_monster_loaded",
+    [mon_ptr]( sol::table params ) {
+        *mon_ptr = params["monster"].get<sol::optional<monster *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup_ml{ ml, mi };
+
+    const auto [cl, ci] = push_hook( lua, "on_creature_loaded",
+    [cre_ptr]( sol::table params ) {
+        auto *m = params["creature"].get<sol::optional<monster *>>().value_or( nullptr );
+        *cre_ptr = static_cast<Creature *>( m );
+    } );
+    hook_cleanup cleanup_cl{ cl, ci };
+
+    monster &mon = spawn_test_monster( "mon_zombie", tripoint_bub_ms{ 5, 5, 0 } );
+    mon.on_load();
+
+    CHECK( *mon_ptr == &mon );
+    CHECK( *cre_ptr == static_cast<Creature *>( &mon ) );
+}
+
+// ── Easy ─────────────────────────────────────────────────────────────────────
+
+TEST_CASE( "lua_hook_wiring_monster_spawn", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    const auto mon_ptr = std::make_shared<monster *>( nullptr );
+    const auto cre_ptr = std::make_shared<Creature *>( nullptr );
+
+    const auto [ms, msi] = push_hook( lua, "on_monster_spawn",
+    [mon_ptr]( sol::table params ) {
+        *mon_ptr = params["monster"].get<sol::optional<monster *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup_ms{ ms, msi };
+
+    const auto [cs, csi] = push_hook( lua, "on_creature_spawn",
+    [cre_ptr]( sol::table params ) {
+        auto *m = params["creature"].get<sol::optional<monster *>>().value_or( nullptr );
+        *cre_ptr = static_cast<Creature *>( m );
+    } );
+    hook_cleanup cleanup_cs{ cs, csi };
+
+    monster &mon = spawn_test_monster( "mon_zombie", tripoint_bub_ms{ 5, 5, 0 } );
+
+    CHECK( *mon_ptr == &mon );
+    CHECK( *cre_ptr == static_cast<Creature *>( &mon ) );
+}
+
+TEST_CASE( "lua_hook_wiring_mon_death", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    monster &mon = spawn_test_monster( "mon_zombie", tripoint_bub_ms{ 5, 5, 0 } );
+
+    const auto mon_ptr = std::make_shared<monster *>( nullptr );
+    const auto [list, idx] = push_hook( lua, "on_mon_death",
+    [mon_ptr]( sol::table params ) {
+        *mon_ptr = params["mon"].get<sol::optional<monster *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup{ list, idx };
+
+    mon.die( nullptr );
+
+    CHECK( *mon_ptr == &mon );
+}
+
+TEST_CASE( "lua_hook_wiring_creature_melee_attacked", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    // avatar is at {60,60,0} after clear_all_state; place target adjacent
+    monster &mon = spawn_test_monster( "mon_zombie", tripoint_bub_ms{ 61, 60, 0 } );
+
+    const auto char_ptr = std::make_shared<Character *>( nullptr );
+    const auto tgt_ptr  = std::make_shared<Creature *>( nullptr );
+    const auto success  = std::make_shared<sol::optional<bool>>( sol::nullopt );
+
+    const auto [list, idx] = push_hook( lua, "on_creature_melee_attacked",
+    [char_ptr, tgt_ptr, success]( sol::table params ) {
+        *char_ptr = params["char"].get<sol::optional<Character *>>().value_or( nullptr );
+        *tgt_ptr  = params["target"].get<sol::optional<Creature *>>().value_or( nullptr );
+        *success  = params["success"].get<sol::optional<bool>>();
+    } );
+    hook_cleanup cleanup{ list, idx };
+
+    get_avatar().melee_attack( mon, false );
+
+    CHECK( *char_ptr == &get_avatar() );
+    CHECK( *tgt_ptr == static_cast<Creature *>( &mon ) );
+    CHECK( success->has_value() );
+}
+
+TEST_CASE( "lua_hook_wiring_npc_loaded", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    const auto npc_ptr = std::make_shared<npc *>( nullptr );
+    const auto cre_ptr = std::make_shared<Creature *>( nullptr );
+
+    const auto [nl, ni] = push_hook( lua, "on_npc_loaded",
+    [npc_ptr]( sol::table params ) {
+        *npc_ptr = params["npc"].get<sol::optional<npc *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup_nl{ nl, ni };
+
+    const auto [cl, ci] = push_hook( lua, "on_creature_loaded",
+    [cre_ptr]( sol::table params ) {
+        *cre_ptr = params["creature"].get<sol::optional<Creature *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup_cl{ cl, ci };
+
+    // spawn_npc calls g->load_npcs() which calls npc::on_load() for the new NPC
+    npc &spawned = spawn_npc( point_bub_ms{ 50, 50 }, "test_talker" );
+
+    CHECK( *npc_ptr == &spawned );
+    CHECK( *cre_ptr == static_cast<Creature *>( &spawned ) );
+}
+
+// ── Easy with test data (requires test_lua_effect in TEST_DATA/effects.json) ─
+
+TEST_CASE( "lua_hook_wiring_character_effect_added", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    REQUIRE( effect_test_lua_effect.is_valid() );
+
+    const auto char_ptr = std::make_shared<Character *>( nullptr );
+    const auto eff_ptr  = std::make_shared<effect *>( nullptr );
+    const auto [list, idx] = push_hook( lua, "on_character_effect_added",
+    [char_ptr, eff_ptr]( sol::table params ) {
+        *char_ptr = params["char"].get<sol::optional<Character *>>().value_or( nullptr );
+        *eff_ptr  = params["effect"].get<sol::optional<effect *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup{ list, idx };
+
+    get_avatar().add_effect( effect_test_lua_effect, 1_turns );
+
+    CHECK( *char_ptr == &get_avatar() );
+    CHECK( *eff_ptr != nullptr );
+}
+
+TEST_CASE( "lua_hook_wiring_character_effect_tick", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    REQUIRE( effect_test_lua_effect.is_valid() );
+
+    const auto char_ptr = std::make_shared<Character *>( nullptr );
+    const auto eff_ptr  = std::make_shared<effect *>( nullptr );
+    const auto [list, idx] = push_hook( lua, "on_character_effect",
+    [char_ptr, eff_ptr]( sol::table params ) {
+        *char_ptr = params["char"].get<sol::optional<Character *>>().value_or( nullptr );
+        *eff_ptr  = params["effect"].get<sol::optional<effect *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup{ list, idx };
+
+    // add_effect triggers process_one_effect(is_new=true) which fires the tick hook
+    get_avatar().add_effect( effect_test_lua_effect, 1_turns );
+
+    CHECK( *char_ptr == &get_avatar() );
+    CHECK( *eff_ptr != nullptr );
+}
+
+TEST_CASE( "lua_hook_wiring_character_effect_removed", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    REQUIRE( effect_test_lua_effect.is_valid() );
+
+    get_avatar().add_effect( effect_test_lua_effect, 1_turns );
+
+    const auto char_ptr = std::make_shared<Character *>( nullptr );
+    const auto eff_ptr  = std::make_shared<effect *>( nullptr );
+    const auto [list, idx] = push_hook( lua, "on_character_effect_removed",
+    [char_ptr, eff_ptr]( sol::table params ) {
+        *char_ptr = params["character"].get<sol::optional<Character *>>().value_or( nullptr );
+        *eff_ptr  = params["effect"].get<sol::optional<effect *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup{ list, idx };
+
+    get_avatar().remove_effect( effect_test_lua_effect );
+
+    CHECK( *char_ptr == &get_avatar() );
+    CHECK( *eff_ptr != nullptr );
+}
+
+TEST_CASE( "lua_hook_wiring_mon_effect_added", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    REQUIRE( effect_test_lua_effect.is_valid() );
+
+    monster &mon = spawn_test_monster( "mon_zombie", tripoint_bub_ms{ 5, 5, 0 } );
+
+    const auto mon_ptr = std::make_shared<monster *>( nullptr );
+    const auto eff_ptr = std::make_shared<effect *>( nullptr );
+    const auto [list, idx] = push_hook( lua, "on_mon_effect_added",
+    [mon_ptr, eff_ptr]( sol::table params ) {
+        *mon_ptr = params["mon"].get<sol::optional<monster *>>().value_or( nullptr );
+        *eff_ptr = params["effect"].get<sol::optional<effect *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup{ list, idx };
+
+    mon.add_effect( effect_test_lua_effect, 1_turns );
+
+    CHECK( *mon_ptr == &mon );
+    CHECK( *eff_ptr != nullptr );
+}
+
+TEST_CASE( "lua_hook_wiring_mon_effect_tick", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    REQUIRE( effect_test_lua_effect.is_valid() );
+
+    monster &mon = spawn_test_monster( "mon_zombie", tripoint_bub_ms{ 5, 5, 0 } );
+
+    const auto mon_ptr = std::make_shared<monster *>( nullptr );
+    const auto eff_ptr = std::make_shared<effect *>( nullptr );
+    const auto [list, idx] = push_hook( lua, "on_mon_effect",
+    [mon_ptr, eff_ptr]( sol::table params ) {
+        *mon_ptr = params["mon"].get<sol::optional<monster *>>().value_or( nullptr );
+        *eff_ptr = params["effect"].get<sol::optional<effect *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup{ list, idx };
+
+    mon.add_effect( effect_test_lua_effect, 1_turns );
+
+    CHECK( *mon_ptr == &mon );
+    CHECK( *eff_ptr != nullptr );
+}
+
+TEST_CASE( "lua_hook_wiring_mon_effect_removed", "[lua]" )
+{
+    clear_all_state();
+    auto &state = *DynamicDataLoader::get_instance().lua;
+    sol::state &lua = state.lua;
+
+    REQUIRE( effect_test_lua_effect.is_valid() );
+
+    monster &mon = spawn_test_monster( "mon_zombie", tripoint_bub_ms{ 5, 5, 0 } );
+    mon.add_effect( effect_test_lua_effect, 1_turns );
+
+    const auto cre_ptr = std::make_shared<Creature *>( nullptr );
+    const auto eff_ptr = std::make_shared<effect *>( nullptr );
+    const auto [list, idx] = push_hook( lua, "on_mon_effect_removed",
+    [cre_ptr, eff_ptr]( sol::table params ) {
+        *cre_ptr = params["mon"].get<sol::optional<Creature *>>().value_or( nullptr );
+        *eff_ptr = params["effect"].get<sol::optional<effect *>>().value_or( nullptr );
+    } );
+    hook_cleanup cleanup{ list, idx };
+
+    mon.remove_effect( effect_test_lua_effect );
+
+    CHECK( *cre_ptr == static_cast<Creature *>( &mon ) );
+    CHECK( *eff_ptr != nullptr );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

Add more tests to help prevent unintended changes/bugs

## Describe the solution (The How)

Added tests

  - lua_hook_wiring_character_reset_stats
  - lua_hook_wiring_monster_loaded
  - lua_hook_wiring_monster_spawn
  - lua_hook_wiring_mon_death
  - lua_hook_wiring_creature_melee_attacked
  - lua_hook_wiring_npc_loaded
  - lua_hook_wiring_character_effect_added
  - lua_hook_wiring_character_effect_tick
  - lua_hook_wiring_character_effect_removed
  - lua_hook_wiring_mon_effect_added
  - lua_hook_wiring_mon_effect_tick
  - lua_hook_wiring_mon_effect_removed

They should catch the hook not being called, invalid args/params.


## Describe alternatives you've considered

## Testing

Ran them, they are tests.

## Additional context

fyi assisted by claude

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [09e044b](https://github.com/cataclysmbn/Cataclysm-BN/commit/09e044bb242e14ff3a2877e1adde22ce45bcc10f) (format) on 2026-05-26 15:01:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26453127602/artifacts/7217587245)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26453127602/artifacts/7217858706)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26453127602/artifacts/7217123640)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26453127602/artifacts/7217307077)
<!-- END artifact comment -->