### PR TITLE
fix: Valid Move Guard

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2671,8 +2671,6 @@ bool map::valid_move( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
 {
     // Used to account for the fact that older versions of GCC can trip on the if statement here.
     assert( to.z() > std::numeric_limits<int>::min() );
-    // Note: no need to check inbounds here, because maptile_at will do that
-    // If oob tile is supplied, the maptile_at will be an unpassable "null" tile
     if( std::abs( from.x() - to.x() ) > 1 || std::abs( from.y() - to.y() ) > 1 ||
         std::abs( from.z() - to.z() ) > 1 ) {
         return false;
@@ -2737,6 +2735,11 @@ bool map::valid_move( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
 
     if( bash ) {
         return true;
+    }
+    // get_cache() has no bounds check on z, and maptile_at's mapbuffer fallback
+    // can return non-null terrain for positions outside the reality bubble.
+    if( !inbounds( down_p ) || !inbounds_z( up_p.z() ) ) {
+        return up.get_furn_t().movecost >= 0;
     }
 
     int part_up;


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves #8636

## Describe the solution (The How)

Guards against out of bounds where the code erroneously claimed it wasn't needed.

## Testing

Couldn't replicate, but the crash report made it clear.

## Additional context

This could in theory just push an unrelated bug back, but it seems unlikely.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5da5ea2](https://github.com/cataclysmbn/Cataclysm-BN/commit/5da5ea2677ee355fe28c6c59dcbe3a012f65c22f) (Update map.cpp) on 2026-05-25 18:49:01

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26413195094/artifacts/7202878892)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26413195094/artifacts/7203278837)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26413195094/artifacts/7202834549)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26413195094/artifacts/7202997453)
<!-- END artifact comment -->