### PR TITLE
fix: Butchery Rot Guard

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3298,8 +3298,13 @@ void activity_handlers::repair_item_do_turn( player_activity *act, player *p )
     }
 }
 
-void activity_handlers::butcher_do_turn( player_activity * /*act*/, player *p )
+void activity_handlers::butcher_do_turn( player_activity *act, player *p )
 {
+    if( !act->targets.empty() && act->targets.back().is_destroyed() ) {
+        p->add_msg_if_player( m_bad, _( "The corpse completely rotted away!" ) );
+        act->set_to_null();
+        return;
+    }
     p->mod_stamina( -20 );
 }
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -330,7 +330,7 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
                                                         speed.moves_per_turn() ) ) );
             }
         } else {
-            if( !targets.empty() && targets.front().is_accessible() ) {
+            if( !targets.empty() && targets.front().is_accessible() && !targets.front().is_destroyed() ) {
                 target = string_format( ": %s", targets.front()->tname( targets.front()->count() ) );
             }
             if( moves_total > 0 ) {


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves #8180

## Describe the solution (The How)

Check if the item is destroyed during the progress message function, and handle rotted corpse in the butchery activity, displaying a bespoke message instead of a generic message.

## Describe alternatives you've considered

Just doing the guard.

## Testing

I had trouble verifying, I need @chaosvolt to check. I think it's fixed.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1e903be](https://github.com/cataclysmbn/Cataclysm-BN/commit/1e903be42e9ddbc21aab4df2c272ef6470bc8b9c) (Basis) on 2026-05-25 19:19:01

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26414169671/artifacts/7203201244)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26414169671/artifacts/7203624623)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26414169671/artifacts/7203451918)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26414169671/artifacts/7203313964)
<!-- END artifact comment -->