### PR TITLE
feat(mods): add no vehicle colors mod

### DIFF
--- a/data/mods/MoreVehicleColors/modinfo.json
+++ b/data/mods/MoreVehicleColors/modinfo.json
@@ -4,7 +4,7 @@
     "id": "vehicle_color_expansion",
     "name": "Vehicle Color Expansion",
     "authors": [ "Wishduck" ],
-    "description": "Greatly randomizes default vehicle colors. WARNING: May cause increased memory consumption",
+    "description": "Adds a greatly extended color list for painting, and expands vehicle palettes",
     "category": "graphical",
     "dependencies": [ "bn" ]
   }

--- a/data/mods/NoVehicleColors/modinfo.json
+++ b/data/mods/NoVehicleColors/modinfo.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "no_vehicle_colors",
+    "name": "No Vehicle Colors",
+    "authors": [ "Wishduck" ],
+    "description": "Limits vehicle colors to standard Cataclysm Red and Green",
+    "category": "graphical",
+    "dependencies": [ "bn" ],
+    "conflicts": [ "vehicle_color_expansion" ]
+  }
+]

--- a/data/mods/NoVehicleColors/vehicle_palette.json
+++ b/data/mods/NoVehicleColors/vehicle_palette.json
@@ -7,92 +7,92 @@
   {
     "type": "vehicle_color_palette",
     "id": "cargo_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "visibility_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "military_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "military_fighter",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "military_heli",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "military_boat",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "police_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "swat_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "construction_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "farm_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "firetruck_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "ems_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "bus_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "wienermobile_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "limo_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "sneaky_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "aircraft_standard",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",
     "id": "aircraft_commercial",
-    "clear": true,
+    "clear": true
   },
   {
     "type": "vehicle_color_palette",

--- a/data/mods/NoVehicleColors/vehicle_palette.json
+++ b/data/mods/NoVehicleColors/vehicle_palette.json
@@ -1,0 +1,102 @@
+[
+  {
+    "type": "vehicle_color_palette",
+    "id": "car_standard",
+    "clear": true
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "cargo_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "visibility_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_fighter",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_heli",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "military_boat",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "police_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "swat_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "construction_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "farm_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "firetruck_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "ems_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "bus_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "wienermobile_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "limo_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "sneaky_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "aircraft_standard",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "aircraft_commercial",
+    "clear": true,
+  },
+  {
+    "type": "vehicle_color_palette",
+    "id": "wooden_standard",
+    "clear": true
+  }
+]


### PR DESCRIPTION
## Purpose of change (The Why)
Apparently getting rid of colors is wanted

## Describe the solution (The How)
Add a mod which purges all palettes

## Describe alternatives you've considered
None

## Testing
Debug teleported to drive in theater
They all Cataclysm Red

## Additional context
Weh

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [700096a](https://github.com/cataclysmbn/Cataclysm-BN/commit/700096aac7dca94e389e332e3c361e22aea3eb45) (style(autofix.ci): automated formatting) on 2026-05-25 19:27:37

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26414456759/artifacts/7203301456)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26414456759/artifacts/7203727687)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26414456759/artifacts/7203430961)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26414456759/artifacts/7203452584)
<!-- END artifact comment -->