### PR TITLE
fix: Rendering Fixes

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -268,6 +268,7 @@ struct tile_render_info {
     tripoint_bub_ms pos;
     // accumulator for 3d tallness of sprites rendered here so far;
     int height_3d = 0;
+    int screen_row = 0;
     lit_level ll;
     bool invisible[5];
     tile_render_info( const tripoint_bub_ms &pos, const int height_3d, const lit_level ll,
@@ -3137,10 +3138,10 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
 
     std::vector<tile_render_info> &draw_points = *draw_points_cache;
     int min_z = OVERMAP_HEIGHT;
+    draw_points.clear();
 
     for( int row = min_row; row < max_row; row ++ ) {
 
-        draw_points.clear();
         for( int col = min_col; col < max_col; col ++ ) {
             int temp_x;
             int temp_y;
@@ -3322,6 +3323,25 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
             bool had_visible_open_air = false;
             const int &x = temp_x;
             const int &y = temp_y;
+            const auto queue_draw_point = [&]( tile_render_info info ) {
+                info.screen_row = row;
+                draw_points.push_back( info );
+            };
+            const auto seen_through_air_light = [&]( const tripoint_bub_ms &pos ) {
+                const auto &light_cache = here.access_cache( pos.z() );
+                if( light_cache.inbounds( pos.xy() ) &&
+                    light_cache.sm[light_cache.idx( pos.x(), pos.y() )] > 0.0f ) {
+                    return lit_level::BRIGHT;
+                }
+                const auto light = here.ambient_light_at( pos );
+                if( light > LIGHT_SOURCE_BRIGHT ) {
+                    return lit_level::BRIGHT;
+                }
+                if( light > LIGHT_AMBIENT_LIT ) {
+                    return lit_level::LIT;
+                }
+                return lit_level::LOW;
+            };
 
             const bool in_vis_bounds = ( y >= min_visible_y && y <= max_visible_y && x >= min_visible_x &&
                                          x <= max_visible_x );
@@ -3348,7 +3368,8 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                             had_visible_open_air = true;
                         }
                     } else if( !has_memory && z < center.z() &&
-                               visibility == visibility_type::VIS_HIDDEN ) {
+                               visibility == visibility_type::VIS_HIDDEN &&
+                               !( fov_3d && had_visible_open_air && z < center.z() - fov_3d_z_range ) ) {
                         if( !drew_occluded_overlay ) {
                             drew_occluded_overlay = true;
                             // Draw a depth-faded semi-transparent overlay for the topmost occluded tile.
@@ -3384,12 +3405,16 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
 
                     const auto height_3d = ( pos.z() - center.z() ) * tileset_ptr->get_zlevel_height();
 
+                    const auto render_seen_through_air = fov_3d && had_visible_open_air && in_map_bounds &&
+                                                         z < center.z() - fov_3d_z_range;
+
                     for( int i = 0; i < 4; i++ ) {
                         const tripoint np = pos.raw() + neighborhood[i];
                         invisible[1 + i] = np.y < min_visible_y || np.y > max_visible_y ||
                                            np.x < min_visible_x || np.x > max_visible_x ||
-                                           would_apply_vision_effects( here.get_visibility( ch.visibility_cache[ch.idx( np.x, np.y )],
-                                                   cache ) );
+                                           ( !render_seen_through_air &&
+                                             would_apply_vision_effects( here.get_visibility( ch.visibility_cache[ch.idx( np.x, np.y )],
+                                                     cache ) ) );
                     }
 
                     if( !invisible[0] && apply_vision_effects( pos, visibility ) ) {
@@ -3402,12 +3427,22 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                             const lit_level above_ll = ch_above.inbounds( { pos.x(), pos.y() } )
                                                        ? ch_above.visibility_cache[ch_above.idx( pos.x(), pos.y() )]
                                                        : lit_level::BLANK;
-                            invisible[0] = above_ll == lit_level::BLANK;
+                            invisible[0] = !render_seen_through_air && above_ll == lit_level::BLANK;
+                            const auto vehicle_ll = above_ll != lit_level::BLANK ? above_ll :
+                                                    render_seen_through_air ? seen_through_air_light( pos ) : ll;
+                            if( render_seen_through_air ) {
+                                here.set_memory_seen_cache_dirty( pos );
+                            }
                             min_z = std::min( pos.z(), min_z );
-                            draw_points.emplace_back( pos, height_3d,
-                                                      above_ll != lit_level::BLANK ? above_ll : ll,
-                                                      invisible );
+                            queue_draw_point( tile_render_info( pos, height_3d, vehicle_ll, invisible ) );
                         } else {
+                            if( render_seen_through_air ) {
+                                here.set_memory_seen_cache_dirty( pos );
+                                min_z = std::min( pos.z(), min_z );
+                                queue_draw_point( tile_render_info( pos, height_3d,
+                                                  seen_through_air_light( pos ), invisible ) );
+                                break;
+                            }
                             if( has_draw_override( pos ) || has_memory ) {
                                 invisible[0] = true;
                             }
@@ -3420,135 +3455,144 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                             }
                             if( invisible[0] ) {
                                 min_z = std::min( pos.z(), min_z );
-                                draw_points.emplace_back( pos, height_3d, ll, invisible );
+                                queue_draw_point( tile_render_info( pos, height_3d, ll, invisible ) );
                             } else if( last_vis != center.z() + 1 ) {
-                                if( in_map_bounds && z < center.z() - fov_3d_z_range ) {
-                                    // The floor is below the 3D FOV limit, but the loop only
-                                    // reaches here through a fully transparent column above.
-                                    // Treat it as seen-through-sky: render and memorize at the
-                                    // floor's actual position with surface lighting + depth tint.
+                                if( fov_3d && in_map_bounds && z < center.z() - fov_3d_z_range ) {
                                     here.set_memory_seen_cache_dirty( pos );
                                     min_z = std::min( pos.z(), min_z );
-                                    //invisible[0] = true;
-                                    draw_points.emplace_back( pos, height_3d, lit_level::MEMORIZED, invisible );
-                                    //const ter_id &t = here.ter( pos );
-                                    //const auto tile = tile_search_params{ t.id().str(), C_TERRAIN, empty_string, 0, 0 };
-                                    //draw_from_id_string( tile, pos, std::nullopt, std::nullopt, lit_level::MEMORIZED, false, center.z - z, false );
+                                    queue_draw_point( tile_render_info( pos, height_3d,
+                                                      seen_through_air_light( pos ),
+                                                      invisible ) );
                                 } else {
                                     min_z = std::min( last_vis, min_z );
-                                    draw_points.emplace_back( tripoint_bub_ms( pos.xy(), last_vis ), height_3d,
-                                                              last_vis_ll, invisible );
+                                    queue_draw_point( tile_render_info( tripoint_bub_ms( pos.xy(), last_vis ),
+                                                      height_3d, last_vis_ll, invisible ) );
                                 }
                             } else if( had_visible_open_air && in_map_bounds ) {
                                 // No vehicle and no solid last_vis — placeholder so cross-z
                                 // sprite draws (player character above) still execute.
                                 min_z = std::min( pos.z(), min_z );
                                 invisible[0] = true;
-                                draw_points.emplace_back( pos, height_3d, ll, invisible );
+                                queue_draw_point( tile_render_info( pos, height_3d, ll, invisible ) );
                             }
                         }
 
                     } else {
                         min_z = std::min( pos.z(), min_z );
-                        draw_points.emplace_back( pos, height_3d, ll, invisible );
+                        queue_draw_point( tile_render_info( pos, height_3d, ll, invisible ) );
                     }
                     break;
                 }
             }
         }
 
-        auto compare_z = [&]( tile_render_info a, tile_render_info b ) -> bool {
-            return ( a.pos.z() < b.pos.z() );
-        };
+    }
 
-        const std::array<decltype( &cata_tiles::draw_furniture ), 3> base_drawing_layers = {{
-                &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap
-            }
-        };
-        struct zlevel_layer {
-            bool hide_unseen;
-            decltype( &cata_tiles::draw_furniture ) function;
-        };
-        const std::array<zlevel_layer, 3> zlevel_drawing_layers = {{
-                {true, &cata_tiles::draw_field_or_item}, {false, &cata_tiles::draw_vpart}, {true, &cata_tiles::draw_critter_at}
-            }
-        };
-        const std::array<decltype( &cata_tiles::draw_furniture ), 2> final_drawing_layers = {{
-                &cata_tiles::draw_zone_mark, &cata_tiles::draw_zombie_revival_indicators
-            }
-        };
+    struct zlevel_layer {
+        bool hide_unseen;
+        decltype( &cata_tiles::draw_furniture ) function;
+    };
+    const auto base_drawing_layers = std::array{
+        &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap
+    };
+    const auto zlevel_drawing_layers = std::array{
+        zlevel_layer{ true, &cata_tiles::draw_field_or_item },
+        zlevel_layer{ false, &cata_tiles::draw_vpart },
+        zlevel_layer{ true, &cata_tiles::draw_critter_at }
+    };
+    const auto final_drawing_layers = std::array{
+        &cata_tiles::draw_zone_mark, &cata_tiles::draw_zombie_revival_indicators
+    };
 
-        std::ranges::stable_sort( draw_points, compare_z );
-        for( tile_render_info &p : draw_points ) {
-            draw_terrain( p.pos, p.ll, p.height_3d, p.invisible, center.z() - p.pos.z() );
-            if( p.pos.z() == center.z() ) {
-                const point screen_tl = player_to_screen( p.pos.xy() );
-                const SDL_Rect tile_rect{ screen_tl.x, screen_tl.y, tile_width, tile_height };
-                const bool in_selected_zone = has_selected_zone && p.pos.z() == selected_z &&
-                                              ( has_custom_selected_zone
-                                                ? zone_point_lookup.contains( p.pos )
-                                                : ( p.pos.x() >= selected_min.x() && p.pos.x() <= selected_max.x() &&
-                                                    p.pos.y() >= selected_min.y() && p.pos.y() <= selected_max.y() ) );
-                bool selected_drawn = false;
-                if( show_zones_overlay ) {
-                    for( const zone_render_data &zone : zones_to_draw ) {
-                        if( !zone.tiles.contains( p.pos.xy() ) ) {
-                            continue;
+    const auto draw_zone_overlay_for = [&]( const tile_render_info &p ) {
+        if( p.pos.z() != center.z() ) {
+            return;
+        }
+        const auto screen_tl = player_to_screen( p.pos.xy() );
+        const auto tile_rect = SDL_Rect{ screen_tl.x, screen_tl.y, tile_width, tile_height };
+        const auto in_selected_zone = has_selected_zone && p.pos.z() == selected_z &&
+                                      ( has_custom_selected_zone
+                                        ? zone_point_lookup.contains( p.pos )
+                                        : ( p.pos.x() >= selected_min.x() && p.pos.x() <= selected_max.x() &&
+                                            p.pos.y() >= selected_min.y() && p.pos.y() <= selected_max.y() ) );
+        auto selected_drawn = false;
+        if( show_zones_overlay ) {
+            for( const zone_render_data &zone : zones_to_draw ) {
+                if( !zone.tiles.contains( p.pos.xy() ) ) {
+                    continue;
+                }
+                draw_zone_overlay( {
+                    .renderer = renderer,
+                    .rect = tile_rect,
+                    .color = zone.color,
+                    .overlay_strings = overlay_strings,
+                    .alpha = in_selected_zone ? 128 : 64,
+                    .draw_label = false
+                } );
+                selected_drawn = selected_drawn || in_selected_zone;
+            }
+        }
+        if( in_selected_zone && !selected_drawn ) {
+            draw_zone_overlay( {
+                .renderer = renderer,
+                .rect = tile_rect,
+                .color = curses_color_to_SDL( c_light_green ),
+                .overlay_strings = overlay_strings,
+                .alpha = 128,
+                .draw_label = false
+            } );
+        }
+    };
+
+    if( !draw_points.empty() ) {
+        for( const auto z : std::views::iota( min_z, center.z() + 1 ) ) {
+            auto row_begin = draw_points.begin();
+            while( row_begin != draw_points.end() ) {
+                const auto row = row_begin->screen_row;
+                const auto row_end = std::find_if_not( row_begin, draw_points.end(),
+                [row]( const tile_render_info & info ) {
+                    return info.screen_row == row;
+                } );
+                const auto row_points = std::ranges::subrange( row_begin, row_end );
+                for( tile_render_info &p : row_points ) {
+                    if( p.pos.z() == z ) {
+                        draw_terrain( p.pos, p.ll, p.height_3d, p.invisible, center.z() - p.pos.z() );
+                        draw_zone_overlay_for( p );
+                    }
+                }
+                for( tile_render_info &p : row_points ) {
+                    if( p.pos.z() == z ) {
+                        for( const auto f : base_drawing_layers ) {
+                            ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, center.z() - p.pos.z() );
                         }
-                        draw_zone_overlay( {
-                            .renderer = renderer,
-                            .rect = tile_rect,
-                            .color = zone.color,
-                            .overlay_strings = overlay_strings,
-                            .alpha = in_selected_zone ? 128 : 64,
-                            .draw_label = false
-                        } );
-                        selected_drawn = selected_drawn || in_selected_zone;
-                    }
-                }
-                if( in_selected_zone && !selected_drawn ) {
-                    draw_zone_overlay( {
-                        .renderer = renderer,
-                        .rect = tile_rect,
-                        .color = curses_color_to_SDL( c_light_green ),
-                        .overlay_strings = overlay_strings,
-                        .alpha = 128,
-                        .draw_label = false
-                    } );
-                }
-            }
-        }
-
-        for( int z = min_z; z <= center.z(); z++ ) {
-            for( tile_render_info &p : draw_points ) {
-                if( p.pos.z() > z ) {
-                    break;
-                }
-                if( p.pos.z() == z ) {
-                    for( decltype( &cata_tiles::draw_furniture ) f : base_drawing_layers ) {
-                        ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, center.z() - p.pos.z() );
                     }
                 }
                 const auto &ch = here.access_cache( z );
-                for( const zlevel_layer &f : zlevel_drawing_layers ) {
-                    if( here.inbounds( p.pos ) && z != p.pos.z() ) {
-                        const auto z_ll = ch.inbounds( { p.pos.x(), p.pos.y() } )
-                                          ? ch.visibility_cache[ch.idx( p.pos.x(), p.pos.y() )]
-                                          : lit_level::BLANK;
-                        if( !f.hide_unseen || z_ll != lit_level::BLANK ) {
-                            const bool ( invis )[5] = {false, false, false, false, false};
-                            ( this->*( f.function ) )( { p.pos.xy(), z}, z_ll, p.height_3d, invis, center.z() - z );
+                for( tile_render_info &p : row_points ) {
+                    if( p.pos.z() > z ) {
+                        continue;
+                    }
+                    for( const zlevel_layer &f : zlevel_drawing_layers ) {
+                        if( here.inbounds( p.pos ) && z != p.pos.z() ) {
+                            const auto z_ll = ch.inbounds( { p.pos.x(), p.pos.y() } )
+                                              ? ch.visibility_cache[ch.idx( p.pos.x(), p.pos.y() )]
+                                              : lit_level::BLANK;
+                            if( !f.hide_unseen || z_ll != lit_level::BLANK ) {
+                                const bool ( invis )[5] = {false, false, false, false, false};
+                                ( this->*( f.function ) )( { p.pos.xy(), z}, z_ll, p.height_3d, invis, center.z() - z );
+                            }
+                        } else {
+                            ( this->*( f.function ) )( { p.pos.xy(), z}, p.ll, p.height_3d, p.invisible, center.z() - z );
                         }
-                    } else {
-                        ( this->*( f.function ) )( { p.pos.xy(), z}, p.ll, p.height_3d, p.invisible, center.z() - z );
                     }
                 }
+                row_begin = row_end;
             }
         }
-        for( tile_render_info &p : draw_points ) {
-            for( decltype( &cata_tiles::draw_furniture ) f : final_drawing_layers ) {
-                ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, 0 );
-            }
+    }
+    for( tile_render_info &p : draw_points ) {
+        for( const auto f : final_drawing_layers ) {
+            ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, 0 );
         }
     }
 
@@ -5308,7 +5352,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
 bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                   const bool ( &invisible )[5], int z_drop )
 {
-    if( !fov_3d && z_drop > 0 ) {
+    if( ( !fov_3d && z_drop > 0 ) || fov_3d_z_range < z_drop ) {
         return false;
     }
     bool result;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -5336,8 +5336,10 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
                 veh_part ) ) ) );
         const std::string vpname = "vp_" + vp_id.str();
         avatar &you = get_avatar();
-        if( here.check_seen_cache( p ) ) {
-            you.memorize_tile( here.bub_to_abs( p ), vpname, subtile, rotation );
+        const auto abs_pos = here.bub_to_abs( p );
+        // Projected rope segments are live draws, not persistent vehicle parts.
+        if( you.get_memorized_tile( abs_pos ).tile == vpname ) {
+            you.clear_memorized_overlay( abs_pos );
         }
         const tile_search_params tile = {vpname, C_VEHICLE_PART, empty_string, subtile, rotation};
         const bool ret = draw_from_id_string(

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3327,7 +3327,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                 info.screen_row = row;
                 draw_points.push_back( info );
             };
-            const auto seen_through_air_light = [&]( const tripoint_bub_ms &pos ) {
+            const auto seen_through_air_light = [&]( const tripoint_bub_ms & pos ) {
                 const auto &light_cache = here.access_cache( pos.z() );
                 if( light_cache.inbounds( pos.xy() ) &&
                     light_cache.sm[light_cache.idx( pos.x(), pos.y() )] > 0.0f ) {
@@ -3440,7 +3440,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                                 here.set_memory_seen_cache_dirty( pos );
                                 min_z = std::min( pos.z(), min_z );
                                 queue_draw_point( tile_render_info( pos, height_3d,
-                                                  seen_through_air_light( pos ), invisible ) );
+                                                                    seen_through_air_light( pos ), invisible ) );
                                 break;
                             }
                             if( has_draw_override( pos ) || has_memory ) {
@@ -3461,12 +3461,12 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                                     here.set_memory_seen_cache_dirty( pos );
                                     min_z = std::min( pos.z(), min_z );
                                     queue_draw_point( tile_render_info( pos, height_3d,
-                                                      seen_through_air_light( pos ),
-                                                      invisible ) );
+                                                                        seen_through_air_light( pos ),
+                                                                        invisible ) );
                                 } else {
                                     min_z = std::min( last_vis, min_z );
                                     queue_draw_point( tile_render_info( tripoint_bub_ms( pos.xy(), last_vis ),
-                                                      height_3d, last_vis_ll, invisible ) );
+                                                                        height_3d, last_vis_ll, invisible ) );
                                 }
                             } else if( had_visible_open_air && in_map_bounds ) {
                                 // No vehicle and no solid last_vis — placeholder so cross-z
@@ -3504,7 +3504,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
         &cata_tiles::draw_zone_mark, &cata_tiles::draw_zombie_revival_indicators
     };
 
-    const auto draw_zone_overlay_for = [&]( const tile_render_info &p ) {
+    const auto draw_zone_overlay_for = [&]( const tile_render_info & p ) {
         if( p.pos.z() != center.z() ) {
             return;
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1900,13 +1900,33 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp )
     // Terrain memory is preserved so the ground beneath doesn't go black.
     {
         avatar &you = get_avatar();
-        for( const vpart_reference &vpr : veh.get_all_parts() ) {
+        const auto clear_matching_overlay = [&]( const tripoint_abs_ms &pos,
+                const std::string &tile_id ) {
+            if( you.get_memorized_tile( pos ).tile == tile_id ) {
+                you.clear_memorized_overlay( pos );
+            }
+        };
+
+        for( const auto &vpr : veh.get_all_parts() ) {
             if( !vpr.part().removed ) {
                 const auto &part = vpr.part();
                 const auto part_offset = tripoint_rel_ms(
                                              part.precalc[0],
                                              part.mount.z() + part.z_terrain[0] );
                 you.clear_memorized_overlay( src + part_offset );
+
+                const auto &part_info = part.info();
+                if( part_info.has_flag( VPFLAG_LADDER ) ) {
+                    const auto ladder_pos = src + part_offset;
+                    const auto rope_tile = "vp_" + part_info.get_id().str();
+                    const auto min_rope_z = std::max( ladder_pos.z() - part_info.ladder_length(),
+                                                      -OVERMAP_DEPTH );
+                    for( const auto z : std::views::iota( min_rope_z, ladder_pos.z() ) ) {
+                        auto rope_pos = ladder_pos;
+                        rope_pos.z() = z;
+                        clear_matching_overlay( rope_pos, rope_tile );
+                    }
+                }
             }
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1900,8 +1900,8 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp )
     // Terrain memory is preserved so the ground beneath doesn't go black.
     {
         avatar &you = get_avatar();
-        const auto clear_matching_overlay = [&]( const tripoint_abs_ms &pos,
-                const std::string &tile_id ) {
+        const auto clear_matching_overlay = [&]( const tripoint_abs_ms & pos,
+        const std::string & tile_id ) {
             if( you.get_memorized_tile( pos ).tile == tile_id ) {
                 you.clear_memorized_overlay( pos );
             }


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves #8977
Resolves #8975
Fixes ghost ropes from airships saving to map memory

## Describe the solution (The How)

Lots of finicky reorganization and cleanup. There's no clean way to describe it. I want compute shaders already.

## Testing

Verified:
Large sprites don't overlap again.
Trees don't render over everything now
New areas render correctly when seen from above
Creatures respect LOD limit
Rope isn't haunted

## Additional Information

I decided that waiting for any long-term fix for rendering wouldn't be acceptable.
This work will likely be destroyed during those, but that's alright. We need a stable release.

AI disclosure:
Used gpt-5.5 xhigh as assistant

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [fdf5cd8](https://github.com/cataclysmbn/Cataclysm-BN/commit/fdf5cd889efb890eacf85b746a4c79fb42d1a34d) (style(autofix.ci): automated formatting) on 2026-05-25 20:29:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26417111865/artifacts/7204178043)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26417111865/artifacts/7204419372)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26417111865/artifacts/7204141208)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26417111865/artifacts/7204303253)
<!-- END artifact comment -->