### PR TITLE
fix: hallu effect scales to actual duration, no longer clipped at 30 m

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1219,7 +1219,7 @@
   {
     "type": "effect_type",
     "id": "hallu",
-    "max_duration": "30 m",
+    "max_duration": "6 h",
     "blood_analysis_description": "Hallucinations"
   },
   {

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -222,14 +222,20 @@ static void eff_fun_bleed( player &u, effect &it )
 }
 static void eff_fun_hallu( player &u, effect &it )
 {
-    // TODO: Redo this to allow for variable durations
-    // Time intervals are drawn from the old ones based on 3600 (6-hour) duration.
-    constexpr int maxDuration = 21600;
-    constexpr int comeupTime = static_cast<int>( maxDuration * 0.9 );
-    constexpr int noticeTime = static_cast<int>( comeupTime + ( maxDuration - comeupTime ) / 2 );
-    constexpr int peakTime = static_cast<int>( maxDuration * 0.8 );
-    constexpr int comedownTime = static_cast<int>( maxDuration * 0.3 );
-    const int dur = to_turns<int>( it.get_duration() );
+    // Scale thresholds to the actual duration this instance was added with so
+    // that short doses (pink tablets) still go through the full lifecycle and
+    // longer ones (spells / monster attacks) aren't cut off early.
+    const time_duration remaining = it.get_duration();
+    const time_duration total = ( calendar::turn - it.get_start_time() ) + remaining;
+    if( total <= 0_turns ) {
+        return;
+    }
+    const int totalTurns = to_turns<int>( total );
+    const int comeupTime = static_cast<int>( totalTurns * 0.9 );
+    const int noticeTime = static_cast<int>( comeupTime + ( totalTurns - comeupTime ) / 2 );
+    const int peakTime = static_cast<int>( totalTurns * 0.8 );
+    const int comedownTime = static_cast<int>( totalTurns * 0.3 );
+    const int dur = to_turns<int>( remaining );
     // Baseline
     if( dur == noticeTime ) {
         u.add_msg_if_player( m_warning, _( "You feel a little strange." ) );


### PR DESCRIPTION
## Summary

Closes #9066.

Two interlocking bugs prevented the `hallu` effect (pink tablets, mushrooms, flaming-eye stare, spells, monster attacks) from doing anything observable:

1. [`data/json/effects.json`](data/json/effects.json) capped `hallu` at `"max_duration": "30 m"` (1800 turns), clamping every source — even those that try to apply it for hours — to half an hour.
2. [`eff_fun_hallu`](src/player_hardcoded_effects.cpp) hardcoded its trigger thresholds around `maxDuration = 21600` turns (6 h). At the JSON cap of 30 min, the effect never reached any of those thresholds; even without the cap, short doses (pink tablets at 1 h) still missed every check because the handler ignored the actual instance duration. The in-source TODO at the top of the function explicitly flagged this as needing fixing.

## Fix

- **JSON:** bump `max_duration` to `"6 h"`, matching the longest natural source (`add_effect(effect_hallu, 6_hours)` for the flaming-eye stare).
- **Code:** derive thresholds from the actual duration of this instance using `(calendar::turn - get_start_time()) + get_duration()`. The handler now scales the notice / coming-up / peak / full-symptoms / comedown phases proportionally to whatever duration the effect was added with — including the short 1 h dose from pink tablets.

## Test plan

- [x] Builds clean (`cataclysm-bn-tiles`, `RelWithDebInfo`, MSVC).
- [x] In-game: applied `hallu` via debug menu and verified the effect persists past 30 minutes (Blood Analysis CBM continues to show "Hallucinations" through a full hour of wait-advancing in 5-minute steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c439d4e](https://github.com/cataclysmbn/Cataclysm-BN/commit/c439d4e74021b0ac81bc75c29b799d91543cf748) (fix: hallu effect scales to actual duration, no longer clipped at 30 m) on 2026-05-25 20:59:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26417901212/artifacts/7204793273)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26417901212/artifacts/7204715692)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26417901212/artifacts/7204702661)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26417901212/artifacts/7204558984)
<!-- END artifact comment -->