### PR TITLE
fix: resume in-progress deconstruction on examineable tiles

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7321,6 +7321,14 @@ void game::examine( const tripoint_bub_ms &examp )
         return;
     }
 
+    // Route to the in-progress (de)construction handler before the CONSOLE
+    // shortcut so a partially-deconstructed examineable (e.g. computer
+    // console) can still be resumed or cancelled.
+    if( m.partial_con_at( examp ) && !u.is_mounted() ) {
+        iexamine::trap( u, examp );
+        return;
+    }
+
     if( m.has_flag( "CONSOLE", examp ) && !u.is_mounted() ) {
         use_computer( examp );
         return;


### PR DESCRIPTION
## Summary

Closes #8920.

In [`game::examine`](src/game.cpp), the `CONSOLE` flag shortcut called `use_computer()` and returned *before* the partial-construction handler at the bottom of the function ran. That meant a partially-deconstructed examineable tile (e.g. a computer console) couldn't be resumed or cancelled — pressing `E` would only open the computer interaction menu. The only workaround was to smash the console with `s` so the interaction was removed, after which the deconstruction could be resumed normally.

Check for a partial construction first and route to `iexamine::trap` (which already handles resume/cancel) when one exists. A console without an in-progress deconstruction still opens the computer interaction menu normally.

## Test plan

- [x] Builds clean (`cataclysm-bn-tiles`, `RelWithDebInfo`, MSVC).
- [x] In-game: pressing `E` on a clean console opens the computer interaction menu (regression check). Starting Advanced Object Deconstruction on the console, interrupting it, then pressing `E` now shows the "Unfinished task: ..., N% complete here, continue construction?" prompt; either resuming or cancelling works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bfe785d](https://github.com/cataclysmbn/Cataclysm-BN/commit/bfe785df99fb1c2bdd32f9577b4d58a264fddb0a) (fix: resume in-progress deconstruction on examineable tiles) on 2026-05-25 21:47:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419156671/artifacts/7204863086)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419156671/artifacts/7205176431)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419156671/artifacts/7204977276)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419156671/artifacts/7204925758)
<!-- END artifact comment -->