### PR TITLE
fix: Defensive Aimed-Shooting Crash Guard

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -301,9 +301,9 @@ auto projectile_attack( const projectile &proj_arg, const tripoint_bub_ms &sourc
 
     Creature *target_critter = g->critter_at( target_arg );
     map &here = get_map();
-    const double target_size = target_critter != nullptr ?
-                               target_critter->ranged_target_size() :
-                               here.ranged_target_size( target_arg );
+    const auto target_size = target_critter != nullptr ?
+                             target_critter->ranged_target_size() :
+                             here.inbounds( target_arg ) ? here.ranged_target_size( target_arg ) : 0.0;
     projectile_attack_aim const aim = projectile_attack_roll( dispersion, range, target_size );
 
     // TODO: move to-hit roll back in here

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -59,6 +59,11 @@ static const efftype_id effect_onfire( "onfire" );
 // render as LOW (dim, visible) rather than BRIGHT (same as direct sunlight).
 static constexpr float SOLAR_SHADOW_SCATTER = 0.09f;
 
+static auto outside_player_3d_z_range( const tripoint_bub_ms &target ) -> bool
+{
+    return fov_3d && std::abs( target.z() - g->u.bub_pos().z() ) > fov_3d_z_range;
+}
+
 void map::add_light_from_items( const tripoint_bub_ms &p, const item_stack::iterator &begin,
                                 const item_stack::iterator &end )
 {
@@ -1093,6 +1098,10 @@ bool map::pl_sees( const tripoint_bub_ms &t, const int max_range ) const
         return false;
     }
 
+    if( outside_player_3d_z_range( t ) ) {
+        return false;
+    }
+
     if( max_range >= 0 && square_dist( t, g->u.bub_pos() ) > max_range ) {
         return false;    // Out of range!
     }
@@ -1109,6 +1118,10 @@ bool map::pl_sees( const tripoint_bub_ms &t, const int max_range ) const
 bool map::pl_line_of_sight( const tripoint_bub_ms &t, const int max_range ) const
 {
     if( !inbounds( t ) ) {
+        return false;
+    }
+
+    if( outside_player_3d_z_range( t ) ) {
         return false;
     }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2733,7 +2733,8 @@ std::vector<Creature *> targetable_creatures( const Character &c, const int rang
             return false;
         }
 
-        if( outside_visible_z_range( shooter_pos, critter_pos ) ) {
+        if( outside_visible_z_range( shooter_pos, critter_pos ) )
+        {
             return false;
         }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -27,6 +27,7 @@
 #include "catalua_hooks.h"
 #include "catalua_icallback_actor.h"
 #include "catalua_sol.h"
+#include "cached_options.h"
 #include "character.h"
 #include "character_functions.h"
 #include "color.h"
@@ -2118,9 +2119,19 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
 }
 
 // Whether player character knows creature's position and can roughly track it with the aim cursor
+static auto outside_visible_z_range( const tripoint_bub_ms &from,
+                                     const tripoint_bub_ms &to ) -> bool
+{
+    return get_map().has_zlevels() && fov_3d &&
+           std::abs( from.z() - to.z() ) > fov_3d_z_range;
+}
+
 static bool pl_sees( const Creature &cr )
 {
     Character &u = get_player_character();
+    if( outside_visible_z_range( u.bub_pos(), cr.bub_pos() ) ) {
+        return false;
+    }
     return u.sees( cr ) || u.sees_with_infrared( cr ) || u.sees_with_specials( cr );
 }
 
@@ -2715,14 +2726,20 @@ std::vector<Creature *> targetable_creatures( const Character &c, const int rang
 {
     const vehicle *veh_from_turret = turret ? turret.get_veh() : nullptr;
     return g->get_creatures_if( [&c, range, veh_from_turret]( const Creature & critter ) -> bool {
-        if( std::round( rl_dist_exact( c.bub_pos(), critter.bub_pos() ) ) > range )
+        const auto shooter_pos = c.bub_pos();
+        const auto critter_pos = critter.bub_pos();
+        if( std::round( rl_dist_exact( shooter_pos, critter_pos ) ) > range )
         {
+            return false;
+        }
+
+        if( outside_visible_z_range( shooter_pos, critter_pos ) ) {
             return false;
         }
 
         // Special case: if range is 1, it's a melee attack.
         // Melee attacks can only target on same z-level or directly up/down, not "z-diagonally".
-        if( range <= 1 && c.bub_pos().z() != critter.bub_pos().z() && c.bub_pos().xy() != critter.bub_pos().xy() )
+        if( range <= 1 && shooter_pos.z() != critter_pos.z() && shooter_pos.xy() != critter_pos.xy() )
         {
             return false;
         }
@@ -2741,8 +2758,8 @@ std::vector<Creature *> targetable_creatures( const Character &c, const int rang
         map &here = get_map();
 
         // TODO: It should use projectile passability checks when finding path, not vision checks.
-        std::vector<tripoint_bub_ms> path = here.find_clear_path( c.bub_pos(), critter.bub_pos() );
-        auto prev_point = c.bub_pos();
+        std::vector<tripoint_bub_ms> path = here.find_clear_path( shooter_pos, critter_pos );
+        auto prev_point = shooter_pos;
         for( const tripoint_bub_ms &point : path )
         {
             if( here.obstructed_by_vehicle_rotation( prev_point, point ) ) {
@@ -3396,7 +3413,7 @@ bool target_ui::try_reacquire_target( bool critter, tripoint_bub_ms &new_dst )
 
     // Try to re-acquire target tile or tile where the target creature used to be
     auto local_lt = get_map().abs_to_bub( *you->last_target_pos );
-    if( dist_fn( local_lt ) <= range ) {
+    if( !outside_visible_z_range( src, local_lt ) && dist_fn( local_lt ) <= range ) {
         new_dst = local_lt;
         // Abort aiming if a creature moved in
         return !critter && !g->critter_at( local_lt, true );

--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -10,6 +10,7 @@
 #include "damage.h"
 #include "dispersion.h"
 #include "game.h"
+#include "game_constants.h"
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -116,6 +117,38 @@ TEST_CASE( "projectiles_stop_at_reality_bubble_edge", "[projectile][ballistics]"
                             test_proj, shooter_pos, target_pos, dispersion_sources {}, &shooter, &gun );
 
     CHECK( here.inbounds( attack.end_point ) );
+}
+
+TEST_CASE( "projectiles_stop_at_z_bounds", "[projectile][ballistics]" )
+{
+    clear_all_state();
+
+    auto &here = get_map();
+    const auto shooter_pos = tripoint_bub_ms( 2, 2, OVERMAP_HEIGHT );
+    const auto target_pos = tripoint_bub_ms( 2, 2, OVERMAP_HEIGHT + 1 );
+
+    REQUIRE( here.inbounds( shooter_pos ) );
+    here.ter_set( shooter_pos, ter_id( "t_dirt" ) );
+    here.furn_set( shooter_pos, furn_id( "f_null" ) );
+
+    auto &shooter = get_avatar();
+    shooter.setpos( shooter_pos );
+    shooter.set_body();
+
+    auto gun_ptr = item::spawn( itype_id( "m1a" ) );
+    gun_ptr->ammo_set( itype_id( "308" ), 1 );
+    auto &gun = *gun_ptr;
+
+    auto test_proj = projectile {};
+    test_proj.speed = gun.gun_speed();
+    test_proj.range = 20;
+    test_proj.impact = gun.gun_damage();
+
+    const auto attack = projectile_attack(
+                            test_proj, shooter_pos, target_pos, dispersion_sources {}, &shooter, &gun );
+
+    CHECK( here.inbounds( attack.end_point ) );
+    CHECK( attack.end_point == shooter_pos );
 }
 
 TEST_CASE( "adjacent_friendly_fire_prevention", "[projectile][ballistics]" )

--- a/tests/ranged_aiming_test.cpp
+++ b/tests/ranged_aiming_test.cpp
@@ -11,6 +11,8 @@
 #include "avatar.h"
 #include "avatar_action.h"
 #include "calendar.h"
+#include "cached_options.h"
+#include "cata_utility.h"
 #include "coordinates.h"
 #include "game.h"
 #include "map.h"
@@ -95,6 +97,39 @@ TEST_CASE( "Aiming at a clearly visible target", "[ranged][aiming]" )
             CHECK( std::count( t.begin(), t.end(), &z2 ) == 0 );
         }
     }
+}
+
+TEST_CASE( "Aiming at a loaded target outside 3D z range", "[ranged][aiming][zlevel]" )
+{
+    clear_all_state();
+
+    const auto restore_fov_3d = restore_on_out_of_scope<bool>( fov_3d );
+    const auto restore_fov_3d_z_range = restore_on_out_of_scope<int>( fov_3d_z_range );
+    fov_3d = true;
+    fov_3d_z_range = 0;
+
+    g->place_player( shooter_pos );
+    auto &shooter = g->u;
+    clear_character( shooter, true );
+    shooter.add_effect( efftype_id( "debug_clairvoyance" ), 1_seconds );
+    shooter.recalc_sight_limits();
+    arm_character( shooter, "glock_19" );
+
+    auto &here = get_map();
+    const auto target_pos = shooter_pos + tripoint_above;
+    here.ter_set( shooter_pos, ter_id( "t_dirt" ) );
+    here.furn_set( shooter_pos, furn_id( "f_null" ) );
+    here.ter_set( target_pos, ter_id( "t_open_air" ) );
+    here.furn_set( target_pos, furn_id( "f_null" ) );
+
+    auto &z = spawn_test_monster( "debug_mon", target_pos );
+    REQUIRE( shooter.sees( z ) );
+
+    const auto max_range = shooter.primary_weapon().gun_range( &shooter );
+    REQUIRE( max_range >= 10 );
+
+    const auto targets = ranged::targetable_creatures( shooter, max_range );
+    CHECK( std::count( targets.begin(), targets.end(), &z ) == 0 );
 }
 
 TEST_CASE( "Aiming at a target behind wall", "[ranged][aiming]" )


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #8874

## Describe the solution (The How)

Guard against FOV_3D_Z_RANGE shooting, which could theoretically maintain aim on a creature that flies above or below it when the creature wouldn't be properly target-able.
Also added a couple of tests.

## Describe alternatives you've considered

Ignoring the issue until someone else reports it and we can verify it.

## Testing

Ran tests. Game didn't break either, as far as I can tell.

## Additional context

No dev can recreate it, and the reporting user never replied.

AI disclosure:
gpt-5.5 xhigh used as assistant
It also wrote the tests and I double checked they looked good. I'm bad at designing tests, but I can verify they look valid.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5b7d78b](https://github.com/cataclysmbn/Cataclysm-BN/commit/5b7d78b229da886feb8adcde276efeda17de677f) (style(autofix.ci): automated formatting) on 2026-05-25 22:03:04

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419773239/artifacts/7205016525)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419773239/artifacts/7205335640)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419773239/artifacts/7205291140)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419773239/artifacts/7205109115)
<!-- END artifact comment -->