### PR TITLE
fix: place_npc item action works with place_randomly and ACT_ON_RANGED_HIT

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1359,29 +1359,43 @@ void place_npc_iuse::load( const JsonObject &obj )
     obj.read( "place_randomly", place_randomly );
 }
 
-int place_npc_iuse::use( player &p, item &, bool, const tripoint_bub_ms & ) const
+int place_npc_iuse::use( player &p, item &it, bool, const tripoint_bub_ms &pos ) const
 {
     map &here = get_map();
+    // When triggered by a thrown projectile (ACT_ON_RANGED_HIT), the item is
+    // active and `pos` is the projectile's hit point. Use that as the origin
+    // and skip the interactive "place where?" prompt; otherwise spawn next
+    // to the player.
+    const bool remote = it.is_active();
+    const tripoint_bub_ms origin = remote ? pos : p.bub_pos();
     std::optional<tripoint_bub_ms> target_pos;
-    if( place_randomly ) {
-        const tripoint_range<tripoint_bub_ms> target_range = points_in_radius( p.bub_pos(), 1 );
+    if( place_randomly || remote ) {
+        const tripoint_range<tripoint_bub_ms> target_range = points_in_radius( origin, 1 );
         target_pos = random_point( target_range, []( const tripoint_bub_ms & t ) {
-            return !get_map().passable( t );
+            return get_map().passable( t );
         } );
     } else {
-        const std::string query = _( "Place npc where?" );
         target_pos = choose_adjacent( _( "Place npc where?" ) );
     }
     if( !target_pos ) {
+        if( remote ) {
+            // Avoid the item repeatedly trying to spawn if it remains active.
+            it.deactivate();
+        }
         return 0;
     }
     if( !here.passable( target_pos.value() ) ) {
         p.add_msg_if_player( m_info, _( "There is no square to spawn npc in!" ) );
+        if( remote ) {
+            it.deactivate();
+        }
         return 0;
     }
 
     here.place_npc( target_pos.value().xy(), npc_class_id );
-    p.mod_moves( -moves );
+    if( !remote ) {
+        p.mod_moves( -moves );
+    }
     p.add_msg_if_player( m_info, "%s", _( summon_msg ) );
     return 1;
 }


### PR DESCRIPTION
## Summary

Closes #8910.
Closes #8911.

[`place_npc_iuse::use`](src/iuse_actor.cpp) had two bugs that prevented NPC-spawning items from working outside the basic hand-placement path:

1. **`place_randomly: true` silently failed** — the predicate passed to `random_point` returned `!get_map().passable(t)`, i.e. it told `random_point` to pick *impassable* tiles. The actor then either landed on an impassable tile (and hit the "There is no square to spawn npc in!" branch) or found no candidate at all. Net result: nothing spawned.
2. **`ACT_ON_RANGED_HIT` was completely unhandled** — when an NPC-spawning item was thrown, the actor still tried to use the player's position and call `choose_adjacent()` interactively, which is wrong for a remote-triggered projectile. The sibling [`place_monster_iuse::use`](src/iuse_actor.cpp) already handles this case correctly; this PR mirrors that pattern.

## Fix

- Drop the `!` from the `random_point` predicate.
- When `it.is_active()` (i.e. triggered by `ACT_ON_RANGED_HIT`): use the projectile's hit position as the origin, skip the interactive prompt, deactivate the item on placement failure so it doesn't keep retrying every turn, and skip the move-cost deduction (the player is throwing, not activating in hand).

## Test plan

- [x] Builds clean (`cataclysm-bn-tiles`, `RelWithDebInfo`, MSVC).
- [x] In-game (via a one-file local test mod, not included): activating a `place_npc` item with `"place_randomly": true` now spawns an NPC in an adjacent passable tile. Throwing a `place_npc` item with the `ACT_ON_RANGED_HIT` flag now spawns an NPC at/next to the impact point. Both previously did nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4cfba44](https://github.com/cataclysmbn/Cataclysm-BN/commit/4cfba44f9f39a5d080682bfd2a9392f046eba6e4) (fix: place_npc item action works with place_randomly and ACT_ON_RANGED_HIT) on 2026-05-25 22:09:33

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419936697/artifacts/7205065164)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419936697/artifacts/7205402803)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419936697/artifacts/7205303370)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26419936697/artifacts/7205173650)
<!-- END artifact comment -->