### PR TITLE
feat(field): implement monster_spawn_* on field types

### DIFF
--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1160,6 +1160,49 @@ auto process_fields_in_submap( submap &sm,
                 cur.set_field_intensity( cur.get_field_intensity() + 1 );
             }
 
+            // Monster spawning. The JSON schema (monster_spawn_chance / _count
+            // / _radius / _group on a field intensity_level) was wired up at
+            // the JSON and field_entry layer but never had a processing-side
+            // implementation, so any field that asked for a spawn was silently
+            // doing nothing. Only spawns when the field is in the primary
+            // bubble; off-bubble submaps tick fields too but can't safely
+            // place critters.
+            if( !is_newborn && cur.monster_spawn_chance() > 0 &&
+                one_in( cur.monster_spawn_chance() ) ) {
+                const mongroup_id grp = cur.monster_spawn_group();
+                const int spawn_count = cur.monster_spawn_count();
+                const int spawn_radius = std::max( 0, cur.monster_spawn_radius() );
+                if( grp && spawn_count > 0 ) {
+                    const auto origin_ms = project_to<coords::ms>( pos );
+                    const tripoint_abs_ms field_abs_ms(
+                        origin_ms.x() + local.x(),
+                        origin_ms.y() + local.y(),
+                        pos.z() );
+                    map &here = get_map();
+                    if( here.inbounds( field_abs_ms ) ) {
+                        const tripoint_bub_ms field_bub_ms = here.abs_to_bub( field_abs_ms );
+                        for( int n = 0; n < spawn_count; n++ ) {
+                            const tripoint_range<tripoint_bub_ms> spawn_range =
+                                points_in_radius( field_bub_ms, spawn_radius );
+                            const std::optional<tripoint_bub_ms> spawn_at = random_point(
+                                        spawn_range,
+                            []( const tripoint_bub_ms & t ) {
+                                map &m = get_map();
+                                return m.inbounds( t ) && m.passable( t ) &&
+                                       !g->critter_at( t );
+                            } );
+                            if( spawn_at ) {
+                                const MonsterGroupResult res =
+                                    MonsterGroupManager::GetResultFromGroup( grp );
+                                if( res.name ) {
+                                    g->place_critter_at( res.name, *spawn_at );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             const auto &ter = sm.get_ter( local ).obj();
             const auto &frn = sm.get_furn( local ).obj();
 


### PR DESCRIPTION
## Summary

Closes #8909.

The JSON schema for `field_type` accepts `monster_spawn_chance`, `monster_spawn_count`, `monster_spawn_radius`, and `monster_spawn_group` on each intensity level (see [`field_type.cpp:173-180`](src/field_type.cpp#L173-L180)), and [`field_entry`](src/field.cpp#L49-L66) exposes them via getters — but a code-wide grep showed **zero callers** of those getters. The whole config was wired up at the JSON and entry layer but never had a processing-side implementation. Modded death-fields (most visibly the secronom shapeshifter zombie's rebirth field) therefore silently did nothing.

This PR wires the config to the per-tick field processing loop in [`process_fields_in_submap`](src/map_field.cpp#L1106).

## Behavior

- Per non-newborn field, per tick: roll `1 / monster_spawn_chance`.
- On success, attempt to spawn `monster_spawn_count` monsters from `monster_spawn_group` at passable, unoccupied tiles within `monster_spawn_radius` of the field.
- Uses the established `MonsterGroupManager::GetResultFromGroup(...)` + `g->place_critter_at(...)` pattern from [`explosion.cpp:1982`](src/explosion.cpp#L1982).
- Bounded to the primary bubble — off-bubble submaps tick fields too, but `place_critter_at` can't safely target an unloaded submap, so off-bubble fields just don't roll.

## Test plan

- [x] Builds clean (`cataclysm-bn-tiles`, `RelWithDebInfo`, MSVC).
- [x] In-game (via a local test mod, not shipped): a field with `monster_spawn_chance: 1`, `monster_spawn_count: 1`, `monster_spawn_radius: 1`, `monster_spawn_group: "GROUP_BLOB"` now spawns blobs adjacent to itself on each tick until the field expires. Previously the field appeared but nothing spawned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5ce08b2](https://github.com/cataclysmbn/Cataclysm-BN/commit/5ce08b239040d6f8fbaa2779e2602856fd8d44ad) (feat(field): implement monster_spawn_* on field types) on 2026-05-25 22:26:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26420512790/artifacts/7205256921)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26420512790/artifacts/7205485178)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26420512790/artifacts/7205659385)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26420512790/artifacts/7205366346)
<!-- END artifact comment -->