### PR TITLE
fix: rot now checks for loaded before looking for a position

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10089,7 +10089,7 @@ void item::update_rot_from_location( const temperature_flag temperature )
 
     auto pos = tripoint_bub_ms::zero();
     auto flag = temperature;
-    if( has_position() ) {
+    if( is_loaded() && has_position() ) {
         pos = position();
         flag = rot::temperature_flag_for_location( get_map(), *this );
     }


### PR DESCRIPTION
## Purpose of change (The Why)
```
DEBUG    : position called on [can_medium] without a position

 FUNCTION : tripoint_bub_ms game_object<item>::position() const [T = item]
 FILE     : /home/runner/work/Cataclysm-BN/Cataclysm-BN/src/game_object.cpp
 LINE     : 166
 VERSION  : BN 2026-05-25 (2026-05-25)
 ```
NOT MORE GAME OBJECTS
SAVE THE PROFESSIONS WITH FOODS

## Describe the solution (The How)
Before checking position of item, check if it is loaded

## Describe alternatives you've considered
Revert #9010
I dunno what else could I do

## Testing
Hobo no longer screams on selection
Rot still happens
Hopefully tests think so too...

## Additional context
I scream

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.