### PR TITLE
fix: fix vehicle export function coordinates

### DIFF
--- a/src/vehicle_export.cpp
+++ b/src/vehicle_export.cpp
@@ -97,7 +97,6 @@ auto json_export::vehicle( JsonOut &json, const class vehicle &v ) -> void
         json.start_object( true );
         json.member( "x",  pos.x() );
         json.member( "y", pos.y() );
-        json.member( "y", pos.z() );
         json_parts_write( json, parts );
         json.end_object();
     }


### PR DESCRIPTION
## Purpose of change (The Why)
Apparently at some point vehicle export was broken
Noticed when looking at #9075

## Describe the solution (The How)
Determine that indeed vehicle parts do not currently accept the z coordinate
And that z should not be a second "y" value

## Describe alternatives you've considered
Make this error somehow

## Testing
Bicycle no longer has two y coordinates when exported

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [93448de](https://github.com/cataclysmbn/Cataclysm-BN/commit/93448deba434f57602d7ce584753f51889999441) (fix: fix vehicle export function coordinates) on 2026-05-26 02:51:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26427801741/artifacts/7207573662)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26427801741/artifacts/7207851033)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26427801741/artifacts/7207501262)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26427801741/artifacts/7207651983)
<!-- END artifact comment -->