### PR TITLE
feat(UI): allow JSON flags to define their item tags in the display name of the item

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -611,13 +611,15 @@
     "id": "resized_large",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This gear has been modified to accommodate <info>abnormally large mutated anatomy</info> with some <bad>increase to encumbrance</bad>."
+    "info": "This gear has been modified to accommodate <info>abnormally large mutated anatomy</info> with some <bad>increase to encumbrance</bad>.",
+    "tag": "(XL)"
   },
   {
     "id": "resized_small",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "info": "This gear has been modified to accommodate <info>abnormally small mutants</info> with some <bad>increase to encumbrance</bad>."
+    "info": "This gear has been modified to accommodate <info>abnormally small mutants</info> with some <bad>increase to encumbrance</bad>.",
+    "tag": "(XS)"
   },
   {
     "id": "UNDERSIZE",
@@ -658,14 +660,16 @@
     "type": "json_flag",
     "context": [ "GENERIC" ],
     "//": "This item will spawn friendly. Used for pets and such.",
-    "info": "Any creature spawned from this item will <info>always</info> emerge <good>friendly to you</good>."
+    "info": "Any creature spawned from this item will <info>always</info> emerge <good>friendly to you</good>.",
+    "tag": "(friendly)"
   },
   {
     "id": "SPAWN_HOSTILE",
     "type": "json_flag",
     "context": [ "GENERIC" ],
     "//": "This item will spawn mean. Used for target dummies and such.",
-    "info": "Any creature spawned from this item will <info>always</info> emerge <bad>against you</good>."
+    "info": "Any creature spawned from this item will <info>always</info> emerge <bad>against you</good>.",
+    "tag": "(hostile)"
   },
   {
     "id": "STAB",
@@ -693,27 +697,30 @@
     "context": [ "GENERIC" ]
   },
   {
-    "id": "RADIOSIGNAL_1",
+    "id": "RADIO_MOD",
     "type": "json_flag",
     "context": [ "TOOL", "TOOL_ARMOR" ]
+  },
+  {
+    "id": "RADIOSIGNAL_1",
+    "type": "json_flag",
+    "context": [ "TOOL", "TOOL_ARMOR" ],
+    "tag": "(radio: R)"
   },
   {
     "id": "RADIOSIGNAL_2",
     "type": "json_flag",
-    "context": [ "TOOL", "TOOL_ARMOR" ]
+    "context": [ "TOOL", "TOOL_ARMOR" ],
+    "tag": "(radio: B)"
   },
   {
     "id": "RADIOSIGNAL_3",
     "type": "json_flag",
-    "context": [ "TOOL", "TOOL_ARMOR" ]
+    "context": [ "TOOL", "TOOL_ARMOR" ],
+    "tag": "(radio: G)"
   },
   {
     "id": "RADIO_ACTIVATION",
-    "type": "json_flag",
-    "context": [ "TOOL", "TOOL_ARMOR" ]
-  },
-  {
-    "id": "RADIO_MOD",
     "type": "json_flag",
     "context": [ "TOOL", "TOOL_ARMOR" ]
   },
@@ -1007,7 +1014,8 @@
   {
     "id": "WET",
     "type": "json_flag",
-    "context": [ "GENERIC", "ARMOR", "TOOL_ARMOR" ]
+    "context": [ "GENERIC", "ARMOR", "TOOL_ARMOR" ],
+    "tag": "(wet)"
   },
   {
     "id": "POWERARMOR_EXO",

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -6,7 +6,7 @@
 {
   "type": "json_flag", // Required type
   "id": "GENERIC_FLAG", // Flag ID
-  "context": [ ], // Fluff field that does nothing but is required to exist
+  "context": [], // Fluff field that does nothing but is required to exist
   "craft_inherit": true, // Items made with it will keep this flag
   "requires_flag": true, // Used by vehicle part flags, requires another part with this ID on the tile
   "inherit": true, // Item mods will pass this flag down to the item

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -1,5 +1,21 @@
 # JSON Flags
 
+## Example
+
+```json
+{
+  "type": "json_flag", // Required type
+  "id": "GENERIC_FLAG", // Flag ID
+  "context": [ ], // Fluff field that does nothing but is required to exist
+  "craft_inherit": true, // Items made with it will keep this flag
+  "requires_flag": true, // Used by vehicle part flags, requires another part with this ID on the tile
+  "inherit": true, // Item mods will pass this flag down to the item
+  "tag": "string" // This will be appended to the display name of the item in the UI, if the item has this flag
+}
+```
+
+-
+
 ## Notes
 
 - Some flags (items, effects, vehicle parts) have to be defined in `flags.json` or `vp_flags.json`

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -428,6 +428,7 @@ void json_flag::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "requires_flag", requires_flag_ );
     optional( jo, was_loaded, "taste_mod", taste_mod_ );
     optional( jo, was_loaded, "restriction", restriction_ );
+    optional( jo, was_loaded, "tag", tag_ );
 
     // FIXME: most flags have a "context" field that isn't used for anything
     // Test for it here to avoid errors about unvisited members

--- a/src/flag.h
+++ b/src/flag.h
@@ -439,6 +439,11 @@ class json_flag
             return requires_flag_;
         }
 
+        /** Tags */
+        std::string tag() const {
+            return tag_;
+        }
+
         /** The flag's modifier on the fun value of comestibles */
         int taste_mod() const {
             return taste_mod_;
@@ -463,6 +468,7 @@ class json_flag
         bool inherit_ = true;
         bool craft_inherit_ = false;
         std::string requires_flag_;
+        std::string tag_;
         int taste_mod_ = 0;
 
         /** Load flag definition from JSON */

--- a/src/flag.h
+++ b/src/flag.h
@@ -439,7 +439,7 @@ class json_flag
             return requires_flag_;
         }
 
-        /** Tags */
+        /** The tag to be displayed on the item's display name when it has this flag */
         std::string tag() const {
             return tag_;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4133,11 +4133,11 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
 
         std::string signame;
         if( has_flag( flag_RADIOSIGNAL_1 ) ) {
-            signame = "<color_c_red>red</color> radio signal.";
+            signame = "<color_c_red>red</color> radio signal";
         } else if( has_flag( flag_RADIOSIGNAL_2 ) ) {
-            signame = "<color_c_blue>blue</color> radio signal.";
+            signame = "<color_c_blue>blue</color> radio signal";
         } else if( has_flag( flag_RADIOSIGNAL_3 ) ) {
-            signame = "<color_c_green>green</color> radio signal.";
+            signame = "<color_c_green>green</color> radio signal";
         }
         if( parts->test( iteminfo_parts::DESCRIPTION_RADIO_ACTIVATION_CHANNEL ) ) {
             info.emplace_back( "DESCRIPTION",
@@ -5150,11 +5150,6 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         }
     }
 
-    if( has_flag( flag_resized_large ) ) {
-        tagtext += _( " (XL)" );
-    } else if( has_flag( flag_resized_small ) ) {
-        tagtext += _( " (XS)" );
-    }
     const sizing sizing_level = get_sizing( you );
 
     if( sizing_level == sizing::human_sized_small_char ) {
@@ -5217,38 +5212,11 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         tagtext += string_format( " (%s [%d])", nname( item ), std::max( 1, item->volume / 250_ml ) * 5 );
     }
 
-    if( has_flag( flag_RADIO_MOD ) ) {
-        tagtext += _( " (radio:" );
-        if( has_flag( flag_RADIOSIGNAL_1 ) ) {
-            tagtext += pgettext( "The radio mod is associated with the [R]ed button.", "R)" );
-        } else if( has_flag( flag_RADIOSIGNAL_2 ) ) {
-            tagtext += pgettext( "The radio mod is associated with the [B]lue button.", "B)" );
-        } else if( has_flag( flag_RADIOSIGNAL_3 ) ) {
-            tagtext += pgettext( "The radio mod is associated with the [G]reen button.", "G)" );
-        } else {
-            debugmsg( "Why is the radio neither red, blue, nor green?" );
-            tagtext += "?)";
-        }
-    }
-
-    if( has_flag( flag_WET ) ) {
-        tagtext += _( " (wet)" );
-    }
     if( already_used_by_player( you ) ) {
         tagtext += _( " (used)" );
     }
     if( has_flag( flag_IS_UPS ) && get_var( "cable" ) == "plugged_in" ) {
         tagtext += _( " (plugged in)" );
-    }
-    if( has_flag( flag_SPAWN_FRIENDLY ) ) {
-        tagtext += _( " (friendly)" );
-    }
-    if( has_flag( flag_SPAWN_HOSTILE ) ) {
-        tagtext += _( " (hostile)" );
-    }
-
-    if( is_favorite ) {
-        tagtext += _( " *" ); // Display asterisk for favorite items
     }
 
     std::string modtext;
@@ -5260,6 +5228,22 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     }
     if( has_flag( flag_DIAMOND ) ) {
         modtext += std::string( pgettext( "Adjective, as in diamond katana", "diamond" ) ) + " ";
+    }
+
+    // These two loops go over all flags, static and dynamic, and adds their json-defined "tag" display strings
+    // to the item name. Used for things like (wet) or (XL) that are implemented as flags, but
+    // also for mod-added json flags that might not be known in advance.
+
+    for( const flag_id &f : this->get_flags() ) {
+        tagtext += f->tag();
+    }
+
+    for( const flag_id &f : type->item_tags ) {
+        tagtext += f->tag();
+    }
+
+    if( is_favorite ) {
+        tagtext += _( " *" ); // Display asterisk for favorite items
     }
 
     //~ This is a string to construct the item name as it is displayed. This format string has been added for maximum flexibility. The strings are: %1$s: Damage text (e.g. "bruised"). %2$s: burn adjectives (e.g. "burnt"). %3$s: tool modifier text (e.g. "atomic"). %4$s: vehicle part text (e.g. "3.8-Liter"). $5$s: main item text (e.g. "apple"). %6s: tags (e.g. "(wet) (poor fit)").

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5234,12 +5234,16 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     // to the item name. Used for things like (wet) or (XL) that are implemented as flags, but
     // also for mod-added json flags that might not be known in advance.
 
-    for( const flag_id &f : this->get_flags() ) {
-        tagtext += f->tag();
-    }
+    std::vector<flag_id> all_flags;
 
-    for( const flag_id &f : type->item_tags ) {
-        tagtext += f->tag();
+    all_flags.insert( all_flags.end(), this->get_flags().begin(), this->get_flags().end() );
+
+    all_flags.insert( all_flags.end(), type->item_tags.begin(), type->item_tags.end() );
+
+    for( const flag_id &f : all_flags ) {
+        if( !f->tag().empty() ) {
+            tagtext += " " + f->tag();
+        }
     }
 
     if( is_favorite ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5230,9 +5230,9 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         modtext += std::string( pgettext( "Adjective, as in diamond katana", "diamond" ) ) + " ";
     }
 
-    // These two loops go over all flags, static and dynamic, and adds their json-defined "tag" display strings
-    // to the item name. Used for things like (wet) or (XL) that are implemented as flags, but
-    // also for mod-added json flags that might not be known in advance.
+    // Collects all flags from the item and its type, then iterates over them, checking if they have
+    // a tag and appending it to the tagtext if they do. This is used to display tags from both the
+    // item and its type, such as (wet), (XL), ect.
 
     std::vector<flag_id> all_flags;
 


### PR DESCRIPTION
## Purpose of change (The Why)

Modders and JSON in general have very little control over how attributes of an item are communicated to the player via the UI. I am talking about things appended to the item name, such as (wet), (XS), (poor fit), and so on.
Furthermore, the C++ logic that determines what to display has a lot of individual `if else` statements for a bunch of specific flags.

## Describe the solution (The How)

Make a new optional field for flags called `tag`, which is just a string appended to the display name of the item, if the item has this flag. This makes contributors and modders capable of clearly communicating to the player what flags are currently active (should one wish to do so).

Several  `if else` statements checking for individual flags have been removed, and the appropriate data has been appended in the flags.json

Oh yea I also removed a single `.` from the string descriptions related to the radio mod items, as they were being doubled, displaying `..` in the game.

## Describe alternatives you've considered

Some other logic is still specific to certain tags, like the (old)/(rotten) tags for food, or the (plugged in ) tag for UPS systems. Their logic could in theory be changed to work with the flag tag system, but only if code abstraction is considered to be worth the squeeze.

## Testing

Started a game, spawned friendly robot items (which correctly display "(friendly)"), used the radio mod to see if the tags apply corrctly (see screenshot), and also testing my new (filthy) tag for my WIP dirty clothing mod gives positive results.

<img width="408" height="117" alt="image" src="https://github.com/user-attachments/assets/d0df41a0-23af-42ca-9e53-2c85dd78666f" />

### Mandatory

Assisted-by: ChatGPT
I have used ChatGPT to help me understand basic C++ notation and conventions, but did not use it to make specific design choices.

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).

### Optional

- [X] This PR used AI assistance.
  - [X] I disclosed it in the PR description and added an [`Assisted-by:` trailer]
 
- [X] This is a C++ PR that modifies JSON loading or behavior.
  - [X] I have documented the changes in the appropriate location in the `docs/` folder.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2e4b3a1](https://github.com/cataclysmbn/Cataclysm-BN/commit/2e4b3a1aaaa8d9b3a3cc664e3e958ae7b061df74) (style(autofix.ci): automated formatting) on 2026-05-26 05:48:38

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26432949135/artifacts/7209420359)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26432949135/artifacts/7209639187)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26432949135)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26432949135/artifacts/7209376146)
<!-- END artifact comment -->