### PR TITLE
feat: enumerate_as_string space support

### DIFF
--- a/src/output.h
+++ b/src/output.h
@@ -650,7 +650,8 @@ enum class enumeration_conjunction {
     and_,
     or_,
     newline,
-    arrow
+    arrow,
+    space
 };
 
 /**
@@ -674,6 +675,8 @@ std::string enumerate_as_string( const _Container &values,
                 return "\n";
             case enumeration_conjunction::arrow:
                 return _( " > " );
+            case enumeration_conjunction::space:
+                return " ";
         }
         debugmsg( "Unexpected conjunction" );
         return _( ", " );


### PR DESCRIPTION
## Purpose of change (The Why)

@scarf005 lamented the lack of space support for enumerate_as_string

## Describe the solution (The How)

Add space support to enumerate_as_string

## Describe alternatives you've considered

Not supporting spaces in enumerate_as_string

## Testing

Verified that enumerate_as_string supports spaces

## Additional context

enumerate_as_string deserves support for spaces