### PR TITLE
fix(i18n): localize JSON flag item tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,10 @@ Before writing **ANY** code, verify:
 | `void fn(a, b, c, d, e)`               | `void fn(options_struct)`                                                        |
 | `[](){\n return 1; \n }`               | `[](){ return 1; }`                                                              |
 
-**Prefer `std::ranges`/`std::views`/`std::ranges::to`/cata_algo.h for collection work. Avoid manual iterator increment loops unless required by mutation semantics. When a file uses multiple range/view calls, reduce repeated qualifications with local aliases such as `namespace views = std::views;` or `using std::ranges::to`; avoid broad `using namespace` directives in headers.**
+**Prefer `std::ranges`/`std::views`/`std::ranges::to`/cata_algo.h for collection work. Avoid manual iterator increment loops unless required by mutation semantics.**
+
+- prefer function-local `using namespace std::views;` and use `transform`/`filter` unqualified.
+- prefer function-local `namespace ranges = std::ranges;` and use `ranges::*` without `std::`
 
 ## Coding Convention
 
@@ -88,7 +91,7 @@ deno fmt
 deno task dprint fmt
 ```
 
-- **Verify**: Build and fix any issues.
+- **Verify**: Build and fix any issues. Do not skip the game binary target when validating code changes; build `cataclysm-bn-tiles` together with tests.
 
 ```sh
 # Build project and tests

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -10,7 +10,7 @@
   "craft_inherit": true, // Items made with it will keep this flag
   "requires_flag": true, // Used by vehicle part flags, requires another part with this ID on the tile
   "inherit": true, // Item mods will pass this flag down to the item
-  "tag": "string" // This will be appended to the display name of the item in the UI, if the item has this flag
+  "tag": "string" // Translatable string appended to the item's UI display name, if the item has this flag
 }
 ```
 

--- a/docs/ko/mod/json/reference/json_flags.md
+++ b/docs/ko/mod/json/reference/json_flags.md
@@ -1,5 +1,21 @@
 # JSON Flags
 
+## Example
+
+```json
+{
+  "type": "json_flag", // 필수 유형
+  "id": "GENERIC_FLAG", // 플래그 ID
+  "context": [], // 존재해야 하지만 아무 작업도 하지 않는 장식용 필드
+  "craft_inherit": true, // 이것으로 제작한 아이템이 이 플래그를 유지합니다
+  "requires_flag": true, // 차량 부품 플래그에서 사용하며, 해당 타일에 이 ID를 가진 다른 부품이 필요합니다
+  "inherit": true, // 아이템 모드가 이 플래그를 아이템에 전달합니다
+  "tag": "string" // 아이템에 이 플래그가 있으면 아이템의 UI 표시 이름에 추가되는 번역 가능한 문자열
+}
+```
+
+-
+
 ## Notes
 
 - 일부 플래그(아이템, 효과, 차량 부품)는 `flags.json` 또는 `vp_flags.json`에 정의되어야 합니다.

--- a/lang/bn_extract_json_strings.sh
+++ b/lang/bn_extract_json_strings.sh
@@ -17,7 +17,6 @@ lang/extract_json_strings.py \
     -e "data/raw/color_templates/no_bright_background.json" \
     -E "data/mods/TEST_DATA/" \
     \
-    -s "data/json/flags.json" \
     -s "data/json/overmap_terrain.json" \
     -s "data/json/scores.json" \
     -s "data/json/traps.json" \

--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -162,7 +162,6 @@ automatically_convertible = {
     "GENERIC",
     "item_action",
     "ITEM_CATEGORY",
-    "json_flag",
     "mutation_flag",
     "keybinding",
     "LOOT_ZONE",
@@ -819,6 +818,13 @@ def extract_fault(state, item):
             writestr(state, method["success_msg"], format_strings=True, comment=f"Success message for mending method '{method['name']}' of fault '{item['name']}'")
 
 
+def extract_json_flag(state, item):
+    flag_id = item.get("id")
+    for field in ["info", "restriction", "tag"]:
+        if field in item:
+            writestr(state, item[field], comment=f"{field} for JSON flag '{flag_id}'")
+
+
 def extract_snippet(state, item):
     text = item["text"];
     if type(text) is not list:
@@ -861,6 +867,7 @@ extract_specials = {
     "recipe": extract_recipe,
     "scenario": extract_scenario,
     "skill_display_type": extract_skill_display_type,
+    "json_flag": extract_json_flag,
     "snippet": extract_snippet,
     "talk_topic": extract_talk_topic,
     "technique": extract_technique,

--- a/src/flag.h
+++ b/src/flag.h
@@ -440,9 +440,7 @@ class json_flag
         }
 
         /** The tag to be displayed on the item's display name when it has this flag */
-        std::string tag() const {
-            return tag_;
-        }
+        auto tag() const -> const translation & { return tag_; } // *NOPAD*
 
         /** The flag's modifier on the fun value of comestibles */
         int taste_mod() const {
@@ -468,7 +466,7 @@ class json_flag
         bool inherit_ = true;
         bool craft_inherit_ = false;
         std::string requires_flag_;
-        std::string tag_;
+        translation tag_;
         int taste_mod_ = 0;
 
         /** Load flag definition from JSON */

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13,6 +13,7 @@
 #include <locale>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <sstream>
 #include <string>
@@ -5242,20 +5243,21 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         modtext += std::string( pgettext( "Adjective, as in diamond katana", "diamond" ) ) + " ";
     }
 
-    // Collects all flags from the item and its type, then iterates over them, checking if they have
-    // a tag and appending it to the tagtext if they do. This is used to display tags from both the
-    // item and its type, such as (wet), (XL), ect.
-
-    std::vector<flag_id> all_flags;
-
-    all_flags.insert( all_flags.end(), this->get_flags().begin(), this->get_flags().end() );
-
-    all_flags.insert( all_flags.end(), type->item_tags.begin(), type->item_tags.end() );
-
-    for( const flag_id &f : all_flags ) {
-        if( !f->tag().empty() ) {
-            tagtext += " " + f->tag();
-        }
+    // Collects all flags from the item and its type, then appends their display tags to the item
+    // name. This is used to display tags from both the item and its type, such as (wet) or (XL).
+    namespace ranges = std::ranges;
+    const auto display_tags = []( const auto & flags ) {
+        using namespace std::views;
+        const auto get_tag = transform( []( const flag_id & f ) -> const translation & { return f->tag(); } );
+        const auto has_tag = filter( []( const translation & tag ) { return !tag.empty(); } );
+        const auto translate_tag = transform( []( const translation & tag ) { return tag.translated(); } );
+        return flags | get_tag | has_tag | translate_tag;
+    };
+    std::vector<std::string> flag_tags;
+    ranges::copy( display_tags( get_flags() ), std::back_inserter( flag_tags ) );
+    ranges::copy( display_tags( type->item_tags ), std::back_inserter( flag_tags ) );
+    if( !flag_tags.empty() ) {
+        tagtext += " " + enumerate_as_string( flag_tags, enumeration_conjunction::space );
     }
 
     if( is_favorite ) {


### PR DESCRIPTION

## Purpose of change (The Why)

<img width="678" height="73" alt="image" src="https://github.com/user-attachments/assets/cd03d767-bfbd-4b67-b3a0-5811de9fa3df" />

aaaaaaaaaaaaaaaaaa
fix #9101 not supporting i18n

## Describe the solution (The How)

- refactor using #9103 
- change `tag` from `std::string` to `translation`

## Describe alternatives you've considered

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/b2b2c822-73ae-4a80-a600-6b3d70a4a25e" />

```sh
lang/bn_extract_json_strings.sh -o /tmp/cataclysm-bn-json-verify.pot && rg -n -A2 'tag for JSON flag|msgid"\((XL|XS|friendly|hostile|radio: [RBG]|wet)\)"' /tmp/cataclysm-bn-json-verify.pot
```

extraction and usage both works

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [x] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [x] If applicable, add checks on game load that would validate the loaded data.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2122e7f](https://github.com/cataclysmbn/Cataclysm-BN/commit/2122e7fba619e2adbef44163fc5f85dc805115ea) (fix(i18n): localize JSON flag item tags) on 2026-05-26 16:51:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26459439404/artifacts/7220444743)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26459439404/artifacts/7220542762)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26459439404/artifacts/7220016487)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26459439404/artifacts/7220045169)
<!-- END artifact comment -->