### PR TITLE
feat: make vehicle plutonium generators always on

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Before writing **ANY** code, verify:
 
 - prefer function-local `using namespace std::views;` and use `transform`/`filter` unqualified.
 - prefer function-local `namespace ranges = std::ranges;` and use `ranges::*` without `std::`
+- prefer method/function references over lambdas whenever possible, e.g. `transform( &vpart_position::part_index )` instead of `transform( []( const auto &vp ) { return vp.part_index(); } )`.
 
 ## Coding Convention
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,6 @@ Before writing **ANY** code, verify:
 
 - prefer function-local `using namespace std::views;` and use `transform`/`filter` unqualified.
 - prefer function-local `namespace ranges = std::ranges;` and use `ranges::*` without `std::`
-- prefer method/function references over lambdas whenever possible, e.g. `transform( &vpart_position::part_index )` instead of `transform( []( const auto &vp ) { return vp.part_index(); } )`.
 
 ## Coding Convention
 

--- a/data/json/vehicleparts/power.json
+++ b/data/json/vehicleparts/power.json
@@ -332,7 +332,7 @@
         "using": [ [ "welding_standard", 5 ], [ "vehicle_repair_electronics", 2 ] ]
       }
     },
-    "flags": [ "REACTOR", "PERPETUAL", "OBSTACLE" ],
+    "flags": [ "PERPETUAL", "OBSTACLE" ],
     "breaks_into": [
       { "item": "scrap", "count": [ 4, 16 ] },
       { "item": "steel_chunk", "count": [ 1, 6 ] },

--- a/data/json/vehicles/test.json
+++ b/data/json/vehicles/test.json
@@ -162,6 +162,16 @@
     ]
   },
   {
+    "id": "reactor_plutonium_generator_test",
+    "type": "vehicle",
+    "name": "Reactor plutonium generator test",
+    "parts": [
+      { "x": 0, "y": 0, "part": "frame_vertical" },
+      { "x": 0, "y": 0, "parts": [ "minireactor", "vp_plut_generator" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "seat", "dashboard", "storage_battery" ] }
+    ]
+  },
+  {
     "id": "solar_panel_test",
     "type": "vehicle",
     "name": "Solar test",

--- a/data/json/vehicles/test.json
+++ b/data/json/vehicles/test.json
@@ -172,6 +172,16 @@
     ]
   },
   {
+    "id": "plutonium_generator_test",
+    "type": "vehicle",
+    "name": "Plutonium generator test",
+    "parts": [
+      { "x": 0, "y": 0, "part": "frame_vertical" },
+      { "x": 0, "y": 0, "parts": [ "vp_plut_generator" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "seat", "dashboard", "storage_battery" ] }
+    ]
+  },
+  {
     "id": "solar_panel_test",
     "type": "vehicle",
     "name": "Solar test",

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1507,8 +1507,35 @@ void veh_interact::calc_overview()
         trim_and_print( w, point( 1, y ), getmaxx( w ) - 2, c_light_gray, batt );
         right_print( w, y, 1, c_light_gray, _( "Capacity  Status" ) );
     };
+    overview_headers["POWER_GENERATOR"] = [this]( const catacurses::window & w, int y ) {
+        auto generator_epower_w = 0;
+        for( const auto &vpr : veh->get_all_parts() ) {
+            if( vpr.part().is_available() && vpr.part().is_perpetual_power_source() &&
+                !vpr.part().is_reactor() ) {
+                generator_epower_w += static_cast<int>( vpr.part().info().epower * vpr.part().health_percent() );
+            }
+        }
+        std::string generator;
+        if( generator_epower_w == 0 ) {
+            generator = _( "Power generators" );
+        } else if( generator_epower_w < 10000 ) {
+            generator = string_format( _( "Power generators: %s%+4d W</color>" ),
+                                       health_color( generator_epower_w ), generator_epower_w );
+        } else {
+            generator = string_format( _( "Power generators: %s%+4.1f kW</color>" ),
+                                       health_color( generator_epower_w ), generator_epower_w / 1000.0 );
+        }
+        trim_and_print( w, point( 1, y ), getmaxx( w ) - 2, c_light_gray, generator );
+        right_print( w, y, 1, c_light_gray, _( "Output  Status" ) );
+    };
     overview_headers["REACTOR"] = [this, epower_w]( const catacurses::window & w, int y ) {
-        int reactor_epower_w = veh->max_reactor_epower_w();
+        auto reactor_epower_w = 0;
+        for( const auto &vpr : veh->get_all_parts() ) {
+            if( vpr.part().is_available() && vpr.part().is_reactor() &&
+                veh->is_part_on( vpr.part_index() ) ) {
+                reactor_epower_w += static_cast<int>( vpr.part().info().epower * vpr.part().health_percent() );
+            }
+        }
         if( reactor_epower_w > 0 && epower_w < 0 ) {
             reactor_epower_w += epower_w;
         }
@@ -1632,6 +1659,20 @@ void veh_interact::calc_overview()
                              string_format( fmtstring, pt.ammo_capacity(), pct ) );
             };
             overview_opts.emplace_back( "BATTERY", &vpr.part(), next_hotkey( vpr.part(), hotkey ), details );
+        }
+    }
+
+    auto details_power_generator = []( const vehicle_part & pt, const catacurses::window & w, int y ) {
+        right_print( w, y, 1, c_light_gray,
+                     string_format( _( "%+d W     %s" ), static_cast<int>( pt.info().epower * pt.health_percent() ),
+                                    pgettext( "vehicle part enabled value", "Yes" ) ) );
+    };
+
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        if( vpr.part().is_perpetual_power_source() && !vpr.part().is_reactor() &&
+            vpr.part().is_available() ) {
+            overview_opts.emplace_back( "POWER_GENERATOR", &vpr.part(), next_hotkey( vpr.part(), hotkey ),
+                                        details_power_generator );
         }
     }
 

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -804,7 +804,7 @@ void vpart_info::check()
         static const std::vector<std::string> handled = {{
                 "ENABLED_DRAINS_EPOWER", "SECURITY", "ENGINE",
                 "ALTERNATOR", "SOLAR_PANEL", "POWER_TRANSFER",
-                "REACTOR", "WIND_TURBINE", "WATER_WHEEL"
+                "PERPETUAL", "REACTOR", "WIND_TURBINE", "WATER_WHEEL"
             }
         };
         if( part.epower != 0 &&

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -777,8 +777,9 @@ void vehicle::init_state( const int init_veh_fuel, const int init_veh_status,
         const size_t p = vp.part_index();
         vehicle_part &pt = vp.part();
 
-        if( vp.has_feature( VPFLAG_REACTOR ) && one_in( 4 ) ) {
-            // De-hardcoded reactors, may or may not start active
+        const auto reactor_is_perpetual = pt.info().has_flag( "PERPETUAL" );
+        if( vp.has_feature( VPFLAG_REACTOR ) && ( reactor_is_perpetual || one_in( 4 ) ) ) {
+            // De-hardcoded reactors may or may not start active, but perpetual reactors are always active.
             pt.enabled = true;
         }
 
@@ -1464,7 +1465,8 @@ bool vehicle::is_engine_on( const int e ) const
 
 bool vehicle::is_part_on( const int p ) const
 {
-    return parts[p].enabled;
+    const auto &pt = parts[p];
+    return pt.enabled || ( pt.is_available() && pt.is_reactor() && pt.info().has_flag( "PERPETUAL" ) );
 }
 
 bool vehicle::is_alternator_on( const int a ) const

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6616,7 +6616,7 @@ void vehicle::refresh()
         if( vpi.has_flag( VPFLAG_ENGINE ) ) {
             engines.push_back( p );
         }
-        if( vpi.has_flag( VPFLAG_REACTOR ) || ( vpi.has_flag( str_PERPETUAL ) && vpi.epower > 0 ) ) {
+        if( vp.part().is_reactor() || vp.part().is_perpetual_power_source() ) {
             reactors.push_back( p );
         }
         if( vpi.has_flag( VPFLAG_SOLAR_PANEL ) ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -118,6 +118,7 @@ static const flag_id f_VEHICLE_HOTWIRE( "VEHICLE_HOTWIRE" );
 
 static const std::string str_DOOR_LOCKING( "DOOR_LOCKING" );
 static const std::string str_OPENCLOSE_INSIDE( "OPENCLOSE_INSIDE" );
+static const std::string str_PERPETUAL( "PERPETUAL" );
 
 static const std::vector<std::string> vs_NO_HOTWIRING = {
     "MUSCLE_LEGS",
@@ -777,9 +778,10 @@ void vehicle::init_state( const int init_veh_fuel, const int init_veh_status,
         const size_t p = vp.part_index();
         vehicle_part &pt = vp.part();
 
-        const auto reactor_is_perpetual = pt.info().has_flag( "PERPETUAL" );
-        if( vp.has_feature( VPFLAG_REACTOR ) && ( reactor_is_perpetual || one_in( 4 ) ) ) {
-            // De-hardcoded reactors may or may not start active, but perpetual reactors are always active.
+        if( pt.info().has_flag( str_PERPETUAL ) ) {
+            pt.enabled = true;
+        } else if( vp.has_feature( VPFLAG_REACTOR ) && one_in( 4 ) ) {
+            // De-hardcoded reactors may or may not start active.
             pt.enabled = true;
         }
 
@@ -1466,7 +1468,7 @@ bool vehicle::is_engine_on( const int e ) const
 bool vehicle::is_part_on( const int p ) const
 {
     const auto &pt = parts[p];
-    return pt.enabled || ( pt.is_available() && pt.is_reactor() && pt.info().has_flag( "PERPETUAL" ) );
+    return pt.enabled || ( pt.is_available() && pt.info().has_flag( str_PERPETUAL ) );
 }
 
 bool vehicle::is_alternator_on( const int a ) const
@@ -5644,7 +5646,7 @@ void vehicle::power_parts()
             const int gen_energy_bat = power_to_energy_bat( part_epower_w( elem ), 1_turns );
             if( parts[ elem ].is_unavailable() ) {
                 continue;
-            } else if( parts[ elem ].info().has_flag( STATIC( std::string( "PERPETUAL" ) ) ) ) {
+            } else if( parts[ elem ].info().has_flag( str_PERPETUAL ) ) {
                 reactor_working = true;
                 delta_energy_bat += std::min( storage_deficit_bat, gen_energy_bat );
             } else if( parts[elem].ammo_remaining() > 0 ) {
@@ -6614,7 +6616,7 @@ void vehicle::refresh()
         if( vpi.has_flag( VPFLAG_ENGINE ) ) {
             engines.push_back( p );
         }
-        if( vpi.has_flag( VPFLAG_REACTOR ) ) {
+        if( vpi.has_flag( VPFLAG_REACTOR ) || ( vpi.has_flag( str_PERPETUAL ) && vpi.epower > 0 ) ) {
             reactors.push_back( p );
         }
         if( vpi.has_flag( VPFLAG_SOLAR_PANEL ) ) {

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -609,6 +609,11 @@ bool vehicle_part::is_reactor() const
     return info().has_flag( VPFLAG_REACTOR );
 }
 
+auto vehicle_part::is_perpetual_power_source() const -> bool
+{
+    return info().has_flag( "PERPETUAL" ) && info().epower > 0;
+}
+
 bool vehicle_part::is_leaking() const
 {
     return  health_percent() <= 0.5 && ( is_tank() || is_battery() || is_reactor() );

--- a/src/vehicle_part.h
+++ b/src/vehicle_part.h
@@ -196,6 +196,9 @@ struct vehicle_part {
         /** Is this part a reactor? */
         bool is_reactor() const;
 
+        /** Does this part provide always-on electrical power? */
+        auto is_perpetual_power_source() const -> bool;
+
         /** is this part currently unable to retain to fluid/charge?
          *  this doesn't take into account whether or not the part has any contents
          *  remaining to leak

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <numeric>
+#include <ranges>
 #include <array>
 #include <cmath>
 #include <cstdlib>
@@ -112,24 +113,32 @@ void vehicle::add_toggle_to_opts( std::vector<uilist_entry> &options,
                                   std::vector<std::function<void()>> &actions, const std::string &name, char key,
                                   const std::string &flag )
 {
-    // fetch matching parts and abort early if none found
-    const auto found = get_avail_parts( flag );
+    using namespace std::views;
+    namespace ranges = std::ranges;
+
+    const auto is_toggleable = [&flag]( const vpart_reference & vp ) {
+        return flag != "REACTOR" || !vp.part().info().has_flag( "PERPETUAL" );
+    };
+    auto found = get_avail_parts( flag )
+                 | filter( is_toggleable )
+                 | transform( &vpart_position::part_index )
+                 | ranges::to<std::vector>();
     if( found.empty() ) {
         return;
     }
 
     // can this menu option be selected by the user?
-    bool allow = true;
+    auto allow = true;
 
     // determine target state - currently parts of similar type are all switched concurrently
-    bool state = std::none_of( found.begin(), found.end(), []( const vpart_reference & vp ) {
-        return vp.part().enabled;
+    const auto state = ranges::none_of( found, [this]( const auto p ) {
+        return parts[p].enabled;
     } );
 
     // if toggled part potentially usable check if could be enabled now (sufficient fuel etc.)
     if( state ) {
-        allow = std::any_of( found.begin(), found.end(), []( const vpart_reference & vp ) {
-            return vp.vehicle().can_enable( vp.part() );
+        allow = ranges::any_of( found, [this]( const auto p ) {
+            return can_enable( parts[p] );
         } );
     }
 
@@ -140,9 +149,9 @@ void vehicle::add_toggle_to_opts( std::vector<uilist_entry> &options,
     options.emplace_back( -1, allow, key, msg );
 
     actions.emplace_back( [ =, this ] {
-        for( const vpart_reference &vp : found )
+        for( const auto p : found )
         {
-            vehicle_part &e = vp.part();
+            auto &e = parts[p];
             if( e.enabled != state ) {
                 add_msg( state ? _( "Turned on %s" ) : _( "Turned off %s." ), e.name() );
                 e.enabled = state;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -116,8 +116,8 @@ void vehicle::add_toggle_to_opts( std::vector<uilist_entry> &options,
     using namespace std::views;
     namespace ranges = std::ranges;
 
-    const auto is_toggleable = [&flag]( const vpart_reference & vp ) {
-        return flag != "REACTOR" || !vp.part().info().has_flag( "PERPETUAL" );
+    const auto is_toggleable = []( const vpart_reference & vp ) {
+        return !vp.part().info().has_flag( "PERPETUAL" );
     };
     auto found = get_avail_parts( flag )
                  | filter( is_toggleable )

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -1,8 +1,10 @@
 #include "catch/catch.hpp"
 
 #include <cstdlib>
+#include <functional>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <vector>
 
 #include "avatar.h"
@@ -16,13 +18,21 @@
 #include "map_helpers.h"
 #include "state_helpers.h"
 #include "type_id.h"
+#include "ui.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
 #include "vehicle_selector.h"
+#include "veh_type.h"
 #include "weather.h"
 
-static const itype_id fuel_type_battery( "battery" );
-static const itype_id fuel_type_plut_cell( "plut_cell" );
+namespace
+{
+const auto fuel_type_battery = itype_id( "battery" );
+const auto fuel_type_plut_cell = itype_id( "plut_cell" );
+const auto vpart_minireactor = vpart_id( "minireactor" );
+const auto vpart_plut_generator = vpart_id( "vp_plut_generator" );
+
+} // namespace
 
 TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
 {
@@ -55,6 +65,59 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
                         CHECK( veh_ptr->fuel_left( fuel_type_battery ) == 100 );
                     }
                 }
+            }
+        }
+    }
+
+    SECTION( "vehicle with minireactor and plutonium generator" ) {
+        const auto reactor_origin = tripoint_bub_ms( 15, 15, 0 );
+        auto *veh_ptr = here.add_vehicle( vproto_id( "reactor_plutonium_generator_test" ), reactor_origin,
+                                          0_degrees, 0, 0 );
+        REQUIRE( veh_ptr != nullptr );
+
+        namespace ranges = std::ranges;
+
+        const auto reactor_part_matches = [veh_ptr]( const auto & id ) {
+            return [veh_ptr, &id]( const auto part_index ) {
+                return veh_ptr->part_info( part_index ).get_id() == id;
+            };
+        };
+        const auto minireactor_iter = ranges::find_if( veh_ptr->reactors,
+                                      reactor_part_matches( vpart_minireactor ) );
+        const auto plut_generator_iter = ranges::find_if( veh_ptr->reactors,
+                                         reactor_part_matches( vpart_plut_generator ) );
+        REQUIRE( minireactor_iter != veh_ptr->reactors.end() );
+        REQUIRE( plut_generator_iter != veh_ptr->reactors.end() );
+
+        const auto minireactor_index = *minireactor_iter;
+        const auto plut_generator_index = *plut_generator_iter;
+
+        auto &minireactor = veh_ptr->part( minireactor_index );
+        auto &plut_generator = veh_ptr->part( plut_generator_index );
+        minireactor.enabled = true;
+        plut_generator.enabled = true;
+
+        WHEN( "the reactor electronics menu action is used" ) {
+            auto options = std::vector<uilist_entry> {};
+            auto actions = std::vector<std::function<void()>> {};
+            veh_ptr->add_toggle_to_opts( options, actions, "reactor", 'r', "REACTOR" );
+            REQUIRE( options.size() == 1 );
+            REQUIRE( actions.size() == 1 );
+            actions.front()();
+
+            THEN( "the minireactor is toggled but the plutonium generator stays enabled" ) {
+                CHECK_FALSE( minireactor.enabled );
+                CHECK( plut_generator.enabled );
+            }
+        }
+
+        WHEN( "the plutonium generator enabled flag is false" ) {
+            minireactor.enabled = false;
+            plut_generator.enabled = false;
+
+            THEN( "the plutonium generator still provides reactor power" ) {
+                CHECK( veh_ptr->is_part_on( plut_generator_index ) );
+                CHECK( veh_ptr->max_reactor_epower_w() == veh_ptr->part_info( plut_generator_index ).epower );
             }
         }
     }

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -69,7 +69,7 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
         }
     }
 
-    SECTION( "vehicle with minireactor and plutonium generator" ) {
+    SECTION( "vehicle with reactor and perpetual plutonium generator" ) {
         const auto reactor_origin = tripoint_bub_ms( 15, 15, 0 );
         auto *veh_ptr = here.add_vehicle( vproto_id( "reactor_plutonium_generator_test" ), reactor_origin,
                                           0_degrees, 0, 0 );
@@ -91,6 +91,9 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
 
         const auto minireactor_index = *minireactor_iter;
         const auto plut_generator_index = *plut_generator_iter;
+
+        CHECK( veh_ptr->part_info( plut_generator_index ).has_flag( "PERPETUAL" ) );
+        CHECK_FALSE( veh_ptr->part_info( plut_generator_index ).has_flag( VPFLAG_REACTOR ) );
 
         auto &minireactor = veh_ptr->part( minireactor_index );
         auto &plut_generator = veh_ptr->part( plut_generator_index );

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -97,6 +97,8 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
 
         auto &minireactor = veh_ptr->part( minireactor_index );
         auto &plut_generator = veh_ptr->part( plut_generator_index );
+        CHECK( plut_generator.is_perpetual_power_source() );
+        CHECK_FALSE( plut_generator.is_reactor() );
         minireactor.enabled = true;
         plut_generator.enabled = true;
 
@@ -121,6 +123,46 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
             THEN( "the plutonium generator still provides reactor power" ) {
                 CHECK( veh_ptr->is_part_on( plut_generator_index ) );
                 CHECK( veh_ptr->max_reactor_epower_w() == veh_ptr->part_info( plut_generator_index ).epower );
+            }
+        }
+    }
+
+    SECTION( "vehicle with perpetual plutonium generator" ) {
+        const auto plut_generator_origin = tripoint_bub_ms( 20, 20, 0 );
+        auto *veh_ptr = here.add_vehicle( vproto_id( "plutonium_generator_test" ), plut_generator_origin,
+                                          0_degrees, 0, 0 );
+        REQUIRE( veh_ptr != nullptr );
+
+        namespace ranges = std::ranges;
+
+        const auto is_plut_generator = [veh_ptr]( const auto part_index ) {
+            return veh_ptr->part_info( part_index ).get_id() == vpart_plut_generator;
+        };
+        const auto plut_generator_iter = ranges::find_if( veh_ptr->reactors, is_plut_generator );
+        REQUIRE( plut_generator_iter != veh_ptr->reactors.end() );
+
+        const auto plut_generator_index = *plut_generator_iter;
+        auto &plut_generator = veh_ptr->part( plut_generator_index );
+        plut_generator.enabled = false;
+
+        CHECK( plut_generator.is_perpetual_power_source() );
+        CHECK_FALSE( plut_generator.is_reactor() );
+        CHECK( veh_ptr->is_part_on( plut_generator_index ) );
+        CHECK( veh_ptr->max_reactor_epower_w() == veh_ptr->part_info( plut_generator_index ).epower );
+
+        veh_ptr->discharge_battery( veh_ptr->fuel_left( fuel_type_battery ) );
+        REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 0 );
+
+        WHEN( "the plutonium generator charges the battery without fuel or enabled state" ) {
+            for( const auto ignored : std::views::iota( 0, 100 ) ) {
+                ( void )ignored;
+                veh_ptr->power_parts();
+            }
+
+            THEN( "the battery gains charge while the generator remains untoggled" ) {
+                CHECK( veh_ptr->fuel_left( fuel_type_battery ) > 0 );
+                CHECK_FALSE( plut_generator.enabled );
+                CHECK( veh_ptr->is_part_on( plut_generator_index ) );
             }
         }
     }


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/2d5ff5b8-0879-4410-87b5-94d530a4b19f" />

close #9109
Related: #5020

because there's neither reason you'd want to turn of vehicle plutonium generator nor it's easy to turn RTG off IRL

## Describe the solution (The How)

- Treat perpetual vehicle power sources as active for vehicle power.
- Keep perpetual power sources out of the electronics reactor toggle.
- Show non-reactor perpetual power sources in the vehicle overview as power generators.
- Add vehicle power regression tests for mixed minireactor/plutonium generator and generator-only vehicles.

## Describe alternatives you've considered

Separate reactor menu controls could work but as mentioned in issue, no real benefit to turn it off

## Testing

1. spawned atomic sports car, installed plutonium generator
2. drived around to drain battery a bit

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/255b3023-5cbc-4d70-be02-3558a1070a2e" />

3. confirmed that plutonium generator refills battery

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/39a83b12-8c61-4299-8655-c99a743f8083" />

4. enabled reactor, confirmed battery refills quickly
5. turned off reactor again, confirmed plutonium generator was still on and refilling battery

Commands:

- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "vehicle power with reactor and solar panels"`
- `./build-scripts/lint-json.sh`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder, or noted why docs were not updated in the PR description.
  - [x] If applicable, add checks on game load that would validate the loaded data.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e85ff21](https://github.com/cataclysmbn/Cataclysm-BN/commit/e85ff211c335038c3075443d4f83b9f5b89b8def) (chore: restore agent range guidance) on 2026-05-29 03:34:11

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26614135309/artifacts/7282097382)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26614135309/artifacts/7282306286)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26614135309/artifacts/7282101304)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26614135309/artifacts/7282050061)
<!-- END artifact comment -->