### PR TITLE
feat(UI): rename freezer item tag to frozen

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5156,7 +5156,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         if( is_loaded() ) {
             const auto temp = rot::temperature_flag_for_location( get_map(), *this );
             if( temp == temperature_flag::TEMP_FREEZER ) {
-                tagtext += _( " (very cold)" );
+                tagtext += _( " (frozen)" );
             } else if( temp == temperature_flag::TEMP_FRIDGE || temp == temperature_flag::TEMP_ROOT_CELLAR ) {
                 tagtext += _( " (cold)" );
             }

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -9,6 +9,7 @@
 #include "flag.h"
 #include "item.h"
 #include "itype.h"
+#include "map.h"
 #include "options_helpers.h"
 #include "state_helpers.h"
 #include "type_id.h"
@@ -101,6 +102,19 @@ TEST_CASE( "wet item", "[item][tname][wet]" )
     CHECK( rag.tname() == "rag (wet)" );
 }
 
+TEST_CASE( "food in freezer", "[item][tname][freezer]" )
+{
+    clear_all_state();
+
+    auto &here = get_map();
+    const auto pos = get_avatar().bub_pos();
+    here.furn_set( pos, furn_str_id( "f_freezer_on" ) );
+    here.add_item( pos, item::spawn( "mushroom" ) );
+
+    auto &mushroom = here.i_at( pos ).only_item();
+
+    CHECK( mushroom.tname() == "mushroom (fresh) (frozen)" );
+}
 
 TEST_CASE( "diamond item", "[item][tname][diamond]" )
 {


### PR DESCRIPTION
## Purpose of change (The Why)

Frozen food in freezers currently shows `(very cold)`. It takes more space than "frozen".

Related: https://github.com/cataclysmbn/Cataclysm-BN/pull/2850

## Describe the solution (The How)

Rename the freezer item temperature tag to `(frozen)` and cover it in `item::tname` tests.

## Describe alternatives you've considered

Leave the tag as `(very cold)`.

## Testing

- `cmake --build out/build/linux-full --target format`
- `cmake --build out/build/linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[item][tname][freezer]"`

Reviewer steps: put food in a powered freezer and confirm its item name shows `(frozen)`; put food in a fridge or root cellar and confirm it still shows `(cold)`.

## Additional context

Requested because `frozen` is shorter and more intuitive for items in freezers.

AI assistance: pi.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e72ba8a](https://github.com/cataclysmbn/Cataclysm-BN/commit/e72ba8a1b83d27a70925501e95bf5bc4fe5727f8) (feat(UI): rename freezer item tag to frozen) on 2026-05-27 06:11:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26492895379/artifacts/7232851008)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26492895379/artifacts/7233071667)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26492895379/artifacts/7232750357)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26492895379/artifacts/7232970525)
<!-- END artifact comment -->