### PR TITLE
refactor: fix build warnings

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -396,7 +396,7 @@ bool activity_handlers::resume_for_multi_activities( player &p )
     return false;
 }
 
-void activity_handlers::burrow_do_turn( player_activity *act, player *p )
+void activity_handlers::burrow_do_turn( player_activity *act, player * )
 {
     sfx::play_activity_sound( "activity", "burrow",
                               sfx::get_heard_volume( abs_to_bub( act->placement ) ) );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -215,7 +215,6 @@ static const itype_id itype_rope_makeshift_30( "rope_makeshift_30" );
 static const itype_id itype_splinter( "splinter" );
 static const itype_id itype_stick_long( "stick_long" );
 static const itype_id itype_vine_30( "vine_30" );
-static const itype_id itype_welder( "welder" );
 static const itype_id itype_wool_staple( "wool_staple" );
 
 static const zone_type_id zone_type_FARM_PLOT( "FARM_PLOT" );
@@ -241,7 +240,6 @@ static const bionic_id bio_painkiller( "bio_painkiller" );
 
 static const itype_id itype_UPS( "UPS" );
 
-static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 static const trait_id trait_NOPAIN( "NOPAIN" );
 static const trait_id trait_SPIRITUAL( "SPIRITUAL" );
 static const trait_id trait_STOCKY_TROGLO( "STOCKY_TROGLO" );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1170,6 +1170,7 @@ static bool try_start_hacking( player &p, const tripoint_bub_ms &examp )
                            ( std::make_unique<hacking_activity_actor>() ) );
     }
     p.activity->placement = bub_to_abs( examp );
+    return true;
 }
 
 /**

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -156,7 +156,6 @@ static const itype_id itype_corpse( "corpse" );
 static const itype_id itype_electrohack( "electrohack" );
 static const auto itype_plumber_toolkit = itype_id( "plumber_toolkit" );
 static const itype_id itype_fake_milling_item( "fake_milling_item" );
-static const itype_id itype_fake_cloning_vat( "fake_cloning_vat_item" );
 static const itype_id itype_fake_smoke_plume( "fake_smoke_plume" );
 static const itype_id itype_fertilizer( "fertilizer" );
 static const itype_id itype_fire( "fire" );
@@ -210,12 +209,10 @@ static const trait_id trait_M_DEFENDER( "M_DEFENDER" );
 static const trait_id trait_M_DEPENDENT( "M_DEPENDENT" );
 static const trait_id trait_M_FERTILE( "M_FERTILE" );
 static const trait_id trait_M_SPORES( "M_SPORES" );
-static const trait_id trait_NOPAIN( "NOPAIN" );
 static const trait_id trait_PROBOSCIS( "PROBOSCIS" );
 static const trait_id trait_THRESH_MARLOSS( "THRESH_MARLOSS" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
 static const trait_id trait_WEB_BRIDGE( "WEB_BRIDGE" );
-static const trait_id trait_DEBUG_NOCLIP( "DEBUG_NOCLIP" );
 
 static const quality_id qual_ANESTHESIA( "ANESTHESIA" );
 static const quality_id qual_DIG( "DIG" );
@@ -232,7 +229,6 @@ static const mtype_id mon_spider_widow_giant_s( "mon_spider_widow_giant_s" );
 static const bionic_id bio_fingerhack( "bio_fingerhack" );
 static const bionic_id bio_lighter( "bio_lighter" );
 static const bionic_id bio_lockpick( "bio_lockpick" );
-static const bionic_id bio_painkiller( "bio_painkiller" );
 static const bionic_id bio_tools( "bio_tools" );
 
 static const itype_id itype_toolset( "toolset" );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1688,9 +1688,9 @@ void map::board_vehicle( const tripoint_bub_ms &pos, Character *who )
     auto vp = veh_at( pos ).part_with_feature( VPFLAG_BOARDABLE, true );
     if( !vp ) {
         const auto abs_pos = bub_to_abs( pos );
-        std::ranges::find_if( loaded_vehicles, [&]( vehicle * veh ) {
+        for( auto *veh : loaded_vehicles ) {
             if( veh == nullptr ) {
-                return false;
+                continue;
             }
             auto boardable_parts = veh->get_avail_parts( VPFLAG_BOARDABLE );
             const auto part_it = std::ranges::find_if( boardable_parts,
@@ -1698,11 +1698,11 @@ void map::board_vehicle( const tripoint_bub_ms &pos, Character *who )
                 return veh->abs_part_location( part.part() ) == abs_pos;
             } );
             if( part_it == boardable_parts.end() ) {
-                return false;
+                continue;
             }
             vp = *part_it;
-            return true;
-        } );
+            break;
+        }
     }
     if( !vp ) {
         if( who->grab_point.x() == 0 && who->grab_point.y() == 0 ) {
@@ -10637,8 +10637,6 @@ auto map::get_pf_special( const tripoint_bub_ms &p ) const -> pf_special
         return PF_WALL;
     }
     if( sm->pf_dirty ) {
-        const int smx = divide_round_to_minus_infinity( p.x(), SEEX );
-        const int smy = divide_round_to_minus_infinity( p.y(), SEEY );
         sm->rebuild_pf_cache( *this, project_to<coords::sm>( p ) );
     }
     return sm->pf_special_cache[l.x()][l.y()];

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -288,20 +288,6 @@ void mapbuffer::save( bool delete_after_save, bool notify_tracker, bool show_pro
 {
     const int num_total_submaps = static_cast<int>( submaps.size() );
 
-    // Spatial eviction only makes sense for the dimension the player is
-    // currently in — it has a reality bubble whose origin defines which omts
-    // are "near" enough to keep resident.  Non-current dimensions have no
-    // bubble, so their submaps are kept in memory (the submap_load_manager
-    // handles eviction for those independently).
-    const bool is_current_dimension =
-        g != nullptr && dimension_id_ == get_map().get_bound_dimension();
-
-    map &here = get_map();
-    const tripoint_abs_omt map_origin = is_current_dimension
-                                        ? project_to<coords::omt>( here.get_abs_sub() )
-                                        : tripoint_abs_omt{};
-    const bool map_has_zlevels = g != nullptr && here.has_zlevels();
-
     // Serial collection of unique OMT addresses with per-omt delete flags.
     // The UI progress popup runs here on the main thread only (show_progress=true).
     // When save() is dispatched from a worker thread (show_progress=false), the popup
@@ -340,19 +326,7 @@ void mapbuffer::save( bool delete_after_save, bool notify_tracker, bool show_pro
                 continue;
             }
 
-            bool omt_delete = delete_after_save;
-            /* I don't think this is right
-            if( is_current_dimension ) {
-                // Submaps outside the current map bounds or on wrong z-level
-                // are deleted from memory after saving.
-                const bool zlev_del = !map_has_zlevels && omt_addr.z() != g->get_levz();
-                omt_delete = omt_delete || zlev_del ||
-                              omt_addr.x() < map_origin.x() ||
-                              omt_addr.y() < map_origin.y() ||
-                              omt_addr.x() > map_origin.x() + g_half_mapsize ||
-                              omt_addr.y() > map_origin.y() + g_half_mapsize;
-            }
-            */
+            const bool omt_delete = delete_after_save;
 
             omts_to_process.push_back( { omt_addr, omt_delete } );
         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -114,9 +114,6 @@ static const trait_id trait_NPC_STATIC_NPC( "NPC_STATIC_NPC" );
 
 static constexpr int MON_RADIUS = 3;
 
-static void science_room( map *m, const point_bub_ms &p1, const point_bub_ms &p2, int z,
-                          int rotate );
-
 // (x,y,z) are absolute coordinates of a submap
 // x%2 and y%2 must be 0!
 void map::generate( const tripoint_abs_sm &p, const time_point &when )

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -721,7 +721,6 @@ void game::chat()
             const auto &to = p.value();
             if( npcselect == follower_count ) {
                 for( npc *them : followers ) {
-                    tripoint_abs_ms( here.bub_to_abs( to ) );
                     them->goto_to_this_pos = here.bub_to_abs( to );
                 }
                 yell_msg = _( "Everyone move there!" );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -378,7 +378,6 @@ weather_type_id get_weather_at_point( const point_abs_omt &pos )
     if( iter == weather_cache.end() ) {
         // TODO: fix point types
         tripoint_abs_omt pos_z( pos, OVERMAP_HEIGHT );
-        const auto abs_ms_pos = project_to<coords::ms>( pos_z );
         const auto &wgen = ACTIVE_OVERMAP_BUFFER.get_settings( pos_z ).weather;
         auto weather = wgen.get_weather_conditions( project_to<coords::ms>( pos_z ), calendar::turn,
                        g->get_seed() );

--- a/src/salvage.cpp
+++ b/src/salvage.cpp
@@ -321,7 +321,6 @@ bool prompt_salvage_single( Character &who, item &target )
         return false;
     }
 
-    map &here = get_map();
     std::string msg;
     msg += string_format( _( "Salvaging the %s may yield:\n" ),
                           colorize( target.tname(), target.color_in_inventory() ) );
@@ -347,7 +346,6 @@ bool prompt_salvage_single( Character &who, item &target )
 
 bool salvage_single( Character &who, item &target )
 {
-    map &here = get_map();
     quality_cache cache = who.crafting_inventory().get_quality_cache();
 
     if( auto res = try_salvage( target, cache ); !res.success() ) {


### PR DESCRIPTION
yet another build warning nag kil

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ffab97d](https://github.com/cataclysmbn/Cataclysm-BN/commit/ffab97d432a08b5557b85d4a74970c8b39635bcc) (More removal of unused variables) on 2026-05-27 09:00:17

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26498726071/artifacts/7235360178)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26498726071/artifacts/7235979929)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26498726071/artifacts/7235196828)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26498726071/artifacts/7235474770)
<!-- END artifact comment -->