### PR TITLE
perf: Border Loading & Mapgen Improvements

### DIFF
--- a/src/catalua_mapgen.cpp
+++ b/src/catalua_mapgen.cpp
@@ -25,8 +25,7 @@ mapgen_function_lua::mapgen_function_lua( const std::string &func,
 void mapgen_function_lua::generate( mapgendata &dat )
 {
     ZoneScopedN( "mapgen_lua_generate" );
-    // generate_omt() must always be called on the main thread; this guard
-    // enforces that invariant for the Lua mapgen path.
+    // Lua mapgen must always run on the main thread.
     assert( !is_pool_worker_thread() );
     if( generate_func.valid() ) {
         sol::protected_function_result res = generate_func( &dat, &dat.m );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -775,6 +775,7 @@ void game::load_map( const tripoint_abs_sm &pos_sm, const bool pump_events )
     for( const auto &dim_id : submap_loader.active_dimensions() ) {
         ensure_distribution_grid_tracker_for( dim_id );
     }
+    submap_loader.update_lazy_border_focus( new_dim_id, u.abs_pos() );
     submap_loader.update();
     // Destroy trackers for non-primary dimensions that have no remaining tracked submaps.
     for( auto it = grid_trackers_.begin(); it != grid_trackers_.end(); ) {
@@ -2131,6 +2132,7 @@ bool game::do_turn()
     for( const auto &dim_id : submap_loader.active_dimensions() ) {
         ensure_distribution_grid_tracker_for( dim_id );
     }
+    submap_loader.update_lazy_border_focus( current_dimension_id_, u.abs_pos() );
     submap_loader.update();
     // Destroy trackers for non-primary dimensions with no remaining tracked submaps.
     for( auto it = grid_trackers_.begin(); it != grid_trackers_.end(); ) {
@@ -12585,6 +12587,7 @@ void game::resize_reality_bubble_to( int new_size )
     // on_submap_unloaded is safe here: map::on_submap_unloaded guards grid[]
     // writes behind contains_abs_sm(), so old out-of-bubble positions are
     // skipped and only vehicle/active-item tracking is cleaned up.
+    submap_loader.update_lazy_border_focus( current_dimension_id_, u.abs_pos() );
     submap_loader.update();
 
     // When the bubble grew, submaps outside the old (smaller) bubble just entered.
@@ -14151,6 +14154,7 @@ point_rel_sm game::update_map( int &x, int &y )
         for( const auto &dim_id : submap_loader.active_dimensions() ) {
             ensure_distribution_grid_tracker_for( dim_id );
         }
+        submap_loader.update_lazy_border_focus( m.get_bound_dimension(), u.abs_pos() );
         submap_loader.update();
         // Destroy trackers for non-primary dimensions with no remaining tracked submaps.
         for( auto it = grid_trackers_.begin(); it != grid_trackers_.end(); ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8255,27 +8255,6 @@ void map::shift( const point_rel_sm &sp )
     invalidate_lightmap_caches();
 }
 
-// Optimized mapgen function that only works properly for very simple overmap types
-// Does not create or require a temporary map and does its own saving
-static void generate_uniform( const tripoint_abs_sm &p, const ter_id &terrain_type,
-                              mapbuffer &dest )
-{
-    dbg( DL::Info ) << "generate_uniform p: " << p
-                    << "  terrain_type: " << terrain_type.id().str();
-
-    std::ranges::for_each(
-        cata::views::cartesian_product( std::views::iota( 0, 2 ), std::views::iota( 0, 2 ) ),
-    [&]( const auto & xy ) {
-        const auto [xd, yd] = xy;
-        auto pos = p + point( xd, yd );
-        auto sm = std::make_unique<submap>( pos );
-        sm->is_uniform = true;
-        sm->set_all_ter( terrain_type );
-        sm->last_touched = calendar::turn;
-        dest.add_submap( pos, sm );
-    } );
-}
-
 auto map::apply_boundary_overlay( submap &sm, const tripoint_abs_sm &pos ) -> void
 {
     if( !pocket_info_ ) {
@@ -8310,9 +8289,6 @@ void map::loadn( const tripoint_bub_sm &grid, const bool update_vehicles,
 {
     ZoneScopedN( "map_loadn" );
     ZoneValue( static_cast<uint64_t>( grid.z() + OVERMAP_DEPTH ) );
-    // Cache empty overmap types
-    static const oter_id rock( "empty_rock" );
-    static const oter_id air( "open_air" );
 
     const auto grid_abs_sub = bub_to_abs( tripoint_bub_sm( grid ) );
     const size_t gridn = get_nonant( tripoint_bub_sm( grid ) );
@@ -8365,36 +8341,8 @@ void map::loadn( const tripoint_bub_sm &grid, const bool update_vehicles,
         //  squares divisible by 2.
         // TODO: fix point types
         const auto grid_abs_omt = tripoint_abs_omt( project_to<coords::omt>( grid_abs_sub ) );
-        const auto grid_abs_sub_rounded = tripoint_abs_sm( project_to<coords::sm>( grid_abs_omt ) );
-
-        // Use the dimension-specific overmapbuffer so this path is safe to call from
-        // worker threads that have bound_dimension_ set via bind_dimension().
-        // Reads from the overmapbuffer (ter, get_settings, etc.) are treated as
-        // logically read-only; NPC write operations in generate() are serialised by
-        // overmapbuffer::npc_mutex_.
-        oter_id terrain_type;
-        {
-            ZoneScopedN( "loadn_generate_oter" );
-            terrain_type = get_overmapbuffer( bound_dimension_ ).ter( grid_abs_omt );
-        }
-
-        // Short-circuit if the map tile is uniform
-        // TODO: Replace with json mapgen functions.
         auto &dim_buf = MAPBUFFER_REGISTRY.get( bound_dimension_ );
-        if( terrain_type == air ) {
-            ZoneScopedN( "loadn_generate_uniform_air" );
-            generate_uniform( grid_abs_sub_rounded, t_open_air, dim_buf );
-        } else if( terrain_type == rock ) {
-            ZoneScopedN( "loadn_generate_uniform_rock" );
-            generate_uniform( grid_abs_sub_rounded, t_rock, dim_buf );
-        } else {
-            ZoneScopedN( "loadn_generate_tinymap" );
-            auto tmp_map = tinymap {};
-            // Bind the tinymap to this map's dimension so generated submaps
-            // land in the correct registry slot via loadn()'s dimension-aware lookup.
-            tmp_map.bind_dimension( bound_dimension_ );
-            tmp_map.generate( grid_abs_sub_rounded, calendar::turn );
-        }
+        dim_buf.generate_omt( grid_abs_omt );
 
         {
             ZoneScopedN( "loadn_generate_lookup" );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8429,19 +8429,23 @@ void map::loadn( const tripoint_bub_sm &grid, const bool update_vehicles,
         }
     }
 
-    // Batch-advance field decay, item timers, and vehicle power for any
-    // turns this submap missed while outside the reality bubble.
-    // Runs BEFORE actualize(); the two passes target disjoint effects.
-    if( tmpsub->last_touched < calendar::turn ) {
-        ZoneScopedN( "loadn_batch_turns" );
-        const int missed = to_turns<int>( calendar::turn - tmpsub->last_touched );
-        run_submap_batch_turns( *tmpsub, missed );
-        tmpsub->last_touched = calendar::turn;
-    }
+    if( tmpsub->last_touched == calendar::turn ) {
+        ZoneScopedN( "loadn_skip_current_turn_actualize" );
+    } else {
+        // Batch-advance field decay, item timers, and vehicle power for any
+        // turns this submap missed while outside the reality bubble.
+        // Runs BEFORE actualize(); the two passes target disjoint effects.
+        if( tmpsub->last_touched < calendar::turn ) {
+            ZoneScopedN( "loadn_batch_turns" );
+            const int missed = to_turns<int>( calendar::turn - tmpsub->last_touched );
+            run_submap_batch_turns( *tmpsub, missed );
+            tmpsub->last_touched = calendar::turn;
+        }
 
-    {
-        ZoneScopedN( "loadn_actualize" );
-        actualize( grid );
+        {
+            ZoneScopedN( "loadn_actualize" );
+            actualize( grid );
+        }
     }
 
     abs_sub.z() = old_abs_z;

--- a/src/map.h
+++ b/src/map.h
@@ -1798,7 +1798,7 @@ class map : public submap_load_listener
 
         // mapgen.cpp functions
         auto generate( const tripoint_abs_sm &p, const time_point &when,
-                       const map_generate_options &options = {} ) -> mapgen_result;
+        const map_generate_options &options = {} ) -> mapgen_result;
         void place_spawns( const mongroup_id &group, int chance,
                            const point_bub_ms &p1, const point_bub_ms &p2, float density,
                            bool individual = false, bool friendly = false, const std::string &name = "NONE",
@@ -2036,7 +2036,7 @@ class map : public submap_load_listener
 
         void copy_grid( const tripoint_bub_sm &to, const tripoint_bub_sm &from );
         auto draw_map( mapgendata &dat,
-                       const map_generate_options &options = {} ) -> mapgen_result;
+        const map_generate_options &options = {} ) -> mapgen_result;
 
         void draw_office_tower( const mapgendata &dat );
         void draw_lab( mapgendata &dat );

--- a/src/map.h
+++ b/src/map.h
@@ -33,6 +33,7 @@
 #include "line.h"
 #include "lru_cache.h"
 #include "mapdata.h"
+#include "mapgen_functions.h"
 #include "memory_fast.h"
 #include "shadowcasting.h"
 #include "submap_load_manager.h"
@@ -78,6 +79,13 @@ class vpart_reference;
 struct mongroup;
 struct projectile;
 struct veh_collision;
+
+struct map_generate_options {
+    bool defer_postprocess_hooks = false;
+    bool worker_safe = false;
+    bool use_selected_mapgen = false;
+    std::shared_ptr<mapgen_function> selected_mapgen;
+};
 template<typename T>
 class visitable;
 
@@ -1789,7 +1797,8 @@ class map : public submap_load_listener
         bool is_cornerfloor( const tripoint_bub_ms &p ) const;
 
         // mapgen.cpp functions
-        void generate( const tripoint_abs_sm &p, const time_point &when );
+        auto generate( const tripoint_abs_sm &p, const time_point &when,
+                       const map_generate_options &options = {} ) -> mapgen_result;
         void place_spawns( const mongroup_id &group, int chance,
                            const point_bub_ms &p1, const point_bub_ms &p2, float density,
                            bool individual = false, bool friendly = false, const std::string &name = "NONE",
@@ -2026,7 +2035,8 @@ class map : public submap_load_listener
         void monster_in_field( monster &z );
 
         void copy_grid( const tripoint_bub_sm &to, const tripoint_bub_sm &from );
-        void draw_map( mapgendata &dat );
+        auto draw_map( mapgendata &dat,
+                       const map_generate_options &options = {} ) -> mapgen_result;
 
         void draw_office_tower( const mapgendata &dat );
         void draw_lab( mapgendata &dat );

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <utility>
@@ -22,6 +23,8 @@
 #include "game_constants.h"
 #include "json.h"
 #include "map.h"
+#include "mapdata.h"
+#include "overmapbuffer.h"
 #include "output.h"
 #include "popup.h"
 #include "profile.h"
@@ -31,6 +34,49 @@
 #include "translations.h"
 #include "ui_manager.h"
 #include "world.h"
+
+namespace
+{
+
+auto uniform_terrain_for_omt( const std::string &dimension_id,
+                              const tripoint_abs_omt &omt_addr ) -> std::optional<ter_id>
+{
+    static const oter_id rock( "empty_rock" );
+    static const oter_id air( "open_air" );
+
+    const auto terrain_type = get_overmapbuffer( dimension_id ).ter( omt_addr );
+    if( terrain_type == air ) {
+        return t_open_air;
+    }
+    if( terrain_type == rock ) {
+        return t_rock;
+    }
+    return std::nullopt;
+}
+
+auto add_uniform_omt( mapbuffer &dest, const tripoint_abs_sm &base,
+                      const ter_id &terrain_type ) -> bool
+{
+    static constexpr auto offsets = std::array{
+        point_rel_sm::zero(),
+        point_rel_sm::east(),
+        point_rel_sm::south(),
+        point_rel_sm::south_east()
+    };
+
+    auto added_any = false;
+    std::ranges::for_each( offsets, [&]( const auto & offset ) {
+        const auto pos = base + offset;
+        auto sm = std::make_unique<submap>( pos );
+        sm->is_uniform = true;
+        sm->set_all_ter( terrain_type );
+        sm->last_touched = calendar::turn;
+        added_any |= dest.add_submap( pos, sm );
+    } );
+    return added_any;
+}
+
+} // namespace
 
 mapbuffer::mapbuffer() = default;
 mapbuffer::~mapbuffer() = default;
@@ -599,9 +645,9 @@ bool mapbuffer::preload_omt( const tripoint_abs_omt &omt_addr )
     return from_cache;
 }
 
-bool mapbuffer::generate_omt( const tripoint_abs_omt &omt_addr )
+auto mapbuffer::generate_omt( const tripoint_abs_omt &omt_addr ) -> bool
 {
-    ZoneScoped;
+    ZoneScopedN( "mapbuffer_generate_omt" );
     const auto base = project_to<coords::sm>( omt_addr );
     const bool all_loaded =
         lookup_submap_in_memory( base )
@@ -611,9 +657,18 @@ bool mapbuffer::generate_omt( const tripoint_abs_omt &omt_addr )
     if( all_loaded ) {
         return false;
     }
-    tinymap tmp_map;
-    tmp_map.bind_dimension( dimension_id_ );
-    tmp_map.generate( base, calendar::turn );
+
+    if( const auto uniform_terrain = uniform_terrain_for_omt( dimension_id_, omt_addr ) ) {
+        ZoneScopedN( "mapbuffer_generate_uniform_omt" );
+        return add_uniform_omt( *this, base, *uniform_terrain );
+    }
+
+    {
+        ZoneScopedN( "mapbuffer_generate_tinymap" );
+        tinymap tmp_map;
+        tmp_map.bind_dimension( dimension_id_ );
+        tmp_map.generate( base, calendar::turn );
+    }
     return true;
 }
 

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -663,8 +663,8 @@ auto mapbuffer::generate_omt( const tripoint_abs_omt &omt_addr,
         ZoneScopedN( "mapbuffer_generate_uniform_omt" );
         return {
             .status = add_uniform_omt( *this, base, *uniform_terrain )
-                      ? mapgen_result_status::generated
-                      : mapgen_result_status::not_generated,
+            ? mapgen_result_status::generated
+            : mapgen_result_status::not_generated,
         };
     }
 

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -645,7 +645,8 @@ bool mapbuffer::preload_omt( const tripoint_abs_omt &omt_addr )
     return from_cache;
 }
 
-auto mapbuffer::generate_omt( const tripoint_abs_omt &omt_addr ) -> bool
+auto mapbuffer::generate_omt( const tripoint_abs_omt &omt_addr,
+                              const mapbuffer_generate_omt_options &options ) -> mapgen_result
 {
     ZoneScopedN( "mapbuffer_generate_omt" );
     const auto base = project_to<coords::sm>( omt_addr );
@@ -655,21 +656,36 @@ auto mapbuffer::generate_omt( const tripoint_abs_omt &omt_addr ) -> bool
         && lookup_submap_in_memory( base + point_south )
         && lookup_submap_in_memory( base + point_south_east );
     if( all_loaded ) {
-        return false;
+        return {};
     }
 
     if( const auto uniform_terrain = uniform_terrain_for_omt( dimension_id_, omt_addr ) ) {
         ZoneScopedN( "mapbuffer_generate_uniform_omt" );
-        return add_uniform_omt( *this, base, *uniform_terrain );
+        return {
+            .status = add_uniform_omt( *this, base, *uniform_terrain )
+                      ? mapgen_result_status::generated
+                      : mapgen_result_status::not_generated,
+        };
     }
 
     {
         ZoneScopedN( "mapbuffer_generate_tinymap" );
         tinymap tmp_map;
         tmp_map.bind_dimension( dimension_id_ );
-        tmp_map.generate( base, calendar::turn );
+        const auto generate_result = tmp_map.generate( base, calendar::turn, {
+            .defer_postprocess_hooks = options.defer_postprocess_hooks,
+            .worker_safe = options.worker_safe,
+            .use_selected_mapgen = options.use_selected_mapgen,
+            .selected_mapgen = options.selected_mapgen,
+        } );
+        if( generate_result.needs_main_thread() ) {
+            return generate_result;
+        }
+        if( !generate_result.is_generated() ) {
+            return generate_result;
+        }
     }
-    return true;
+    return { .status = mapgen_result_status::generated };
 }
 
 auto mapbuffer::drain_pending_submap_destroy() -> void

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -435,7 +435,7 @@ void mapbuffer::save( bool delete_after_save, bool notify_tracker, bool show_pro
     }
 
     // Flush the pending-writes cache to disk.  These are omts that were
-    // serialised in memory (by presave_omt or unload_omt) but not yet written.
+    // serialised in memory by unload_omt() but not yet written.
     // Omts still resident in submaps were already handled by save_omt() above;
     // only evicted omts need to be written here.
     //
@@ -670,69 +670,6 @@ auto mapbuffer::generate_omt( const tripoint_abs_omt &omt_addr ) -> bool
         tmp_map.generate( base, calendar::turn );
     }
     return true;
-}
-
-void mapbuffer::presave_omt( const tripoint_abs_omt &omt_addr )
-{
-    ZoneScoped;
-    const auto base = project_to<coords::sm>( omt_addr );
-    const std::array<tripoint_abs_sm, 4> addrs = { {
-            base,
-            base + point_rel_sm::east(),
-            base + point_rel_sm::south(),
-            base + point_rel_sm::south_east()
-        }
-    };
-
-    // Collect raw submap pointers under the lock — brief hold only.
-    std::array<submap *, 4> ptrs = {};
-    bool all_uniform = true;
-    {
-        std::lock_guard<std::recursive_mutex> lk( submaps_mutex_ );
-        for( int i = 0; i < 4; ++i ) {
-            const auto it = submaps.find( addrs[i] );
-            if( it != submaps.end() && it->second ) {
-                ptrs[i] = it->second.get();
-                if( !it->second->is_uniform ) {
-                    all_uniform = false;
-                }
-            }
-        }
-    }
-
-    // Uniform omts regenerate faster than a disk round-trip.
-    if( all_uniform || disable_mapgen ) {
-        return;
-    }
-
-    // Serialise into the pending-writes cache outside the lock.  The submap
-    // objects stay alive until after this future resolves (submap_load_manager
-    // withholds eviction until the presave completes).  No disk I/O occurs here;
-    // the cache is flushed to disk only on an explicit save.
-    std::ostringstream buf;
-    {
-        JsonOut jsout( buf );
-        jsout.start_array();
-        for( int i = 0; i < 4; ++i ) {
-            submap *sm = ptrs[i];
-            if( !sm ) {
-                continue;
-            }
-            jsout.start_object();
-            jsout.member( "version", savegame_version );
-            jsout.member( "coordinates" );
-            jsout.start_array();
-            jsout.write( addrs[i].x() );
-            jsout.write( addrs[i].y() );
-            jsout.write( addrs[i].z() );
-            jsout.end_array();
-            sm->store( jsout );
-            jsout.end_object();
-        }
-        jsout.end_array();
-    }
-    std::lock_guard<std::mutex> pw_lk( pending_writes_mutex_ );
-    pending_writes_[omt_addr] = std::move( buf ).str();
 }
 
 auto mapbuffer::drain_pending_submap_destroy() -> void

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -11,10 +11,18 @@
 #include <vector>
 
 #include "coordinates.h"
+#include "mapgen_functions.h"
 #include "point.h"
 
 class submap;
 class JsonIn;
+
+struct mapbuffer_generate_omt_options {
+    bool defer_postprocess_hooks = false;
+    bool worker_safe = false;
+    bool use_selected_mapgen = false;
+    std::shared_ptr<mapgen_function> selected_mapgen;
+};
 
 /**
  * Store, buffer, save and load the entire world map.
@@ -115,14 +123,15 @@ class mapbuffer
          * Generate all submaps in the OMT at @p omt_addr if any are not yet
          * resident in memory.
          *
-         * May be called on a worker thread only when the OMT's mapgen pool is
-         * known not to contain Lua mapgen.  Lua postprocess hooks are deferred
-         * back to the main thread by map::generate().
+         * When @p options.worker_safe is true, Lua mapgen is reported via
+         * mapgen_result_status::needs_main_thread instead of running on the worker.
+         * Lua postprocess hooks can be deferred for batched main-thread dispatch.
          *
-         * Returns true if mapgen actually ran (omt was not fully resident),
-         * false if all submaps were already in memory and nothing was generated.
+         * Returns whether generation ran, was skipped, or must be retried on the
+         * main thread with the selected Lua generator.
          */
-        auto generate_omt( const tripoint_abs_omt &omt_addr ) -> bool;
+        auto generate_omt( const tripoint_abs_omt &omt_addr,
+                           const mapbuffer_generate_omt_options &options = {} ) -> mapgen_result;
 
         /**
          * Destroy submaps that were discarded by preload_omt() because the in-memory

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -125,26 +125,6 @@ class mapbuffer
         auto generate_omt( const tripoint_abs_omt &omt_addr ) -> bool;
 
         /**
-         * Serialise the OMT at @p omt_addr into the in-memory write-back cache
-         * (@c pending_writes_) without evicting submaps or touching disk.  Intended
-         * to be called from a background worker thread while the omt is in the border
-         * zone (not simulated), so that the subsequent eviction only needs to free the
-         * in-memory objects without an I/O stall.  The cached data is flushed to disk
-         * only on an explicit save; discarding it (via @c clear()) lets the player
-         * revert to the pre-session state.
-         *
-         * Thread-safety contract:
-         * - Briefly acquires @c submaps_mutex_ to collect raw submap pointers.
-         * - Releases the lock before serialization, so concurrent @c preload_omt()
-         *   or @c add_submap() calls on other omts are not blocked.
-         * - The caller (submap_load_manager) guarantees the submaps remain alive
-         *   in memory for the duration of this call by withholding eviction until
-         *   the returned future is resolved.
-         * - Writes to @c pending_writes_ under @c pending_writes_mutex_ (brief hold).
-         */
-        void presave_omt( const tripoint_abs_omt &omt_addr );
-
-        /**
          * Destroy submaps that were discarded by preload_omt() because the in-memory
          * version already existed.  Must be called on the main thread after all
          * preload_omt() futures have been joined.
@@ -193,8 +173,8 @@ class mapbuffer
         mutable std::mutex pending_destroy_mutex_;
         std::vector<std::unique_ptr<submap>> pending_destroy_submaps_;
 
-        /// Serialised omts awaiting disk flush.  Written by presave_omt() (worker
-        /// threads) and the save=true branch of unload_omt() (main thread); read back
+        /// Serialised omts awaiting disk flush.  Written by the save=true branch of
+        /// unload_omt() (main thread); read back
         /// by preload_omt() (worker threads) before falling through to disk.  Flushed
         /// to disk by save() and discarded by clear(), leaving disk files untouched so
         /// the player can revert to the pre-session state by quitting without saving.

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -131,7 +131,7 @@ class mapbuffer
          * main thread with the selected Lua generator.
          */
         auto generate_omt( const tripoint_abs_omt &omt_addr,
-                           const mapbuffer_generate_omt_options &options = {} ) -> mapgen_result;
+        const mapbuffer_generate_omt_options &options = {} ) -> mapgen_result;
 
         /**
          * Destroy submaps that were discarded by preload_omt() because the in-memory

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -121,7 +121,7 @@ class mapbuffer
          * Returns true if mapgen actually ran (omt was not fully resident),
          * false if all submaps were already in memory and nothing was generated.
          */
-        bool generate_omt( const tripoint_abs_omt &omt_addr );
+        auto generate_omt( const tripoint_abs_omt &omt_addr ) -> bool;
 
         /**
          * Serialise the OMT at @p omt_addr into the in-memory write-back cache

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -115,8 +115,9 @@ class mapbuffer
          * Generate all submaps in the OMT at @p omt_addr if any are not yet
          * resident in memory.
          *
-         * Must be called on the main thread — mapgen (including Lua mapgen) is
-         * not reentrant and cannot run safely on worker threads.
+         * May be called on a worker thread only when the OMT's mapgen pool is
+         * known not to contain Lua mapgen.  Lua postprocess hooks are deferred
+         * back to the main thread by map::generate().
          *
          * Returns true if mapgen actually ran (omt was not fully resident),
          * false if all submaps were already in memory and nothing was generated.

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -265,7 +265,7 @@ void map::generate( const tripoint_abs_sm &p, const time_point &when )
 
     // Run the Lua on_mapgen_postprocess hook.
     // Main thread: run immediately.  Worker thread: defer (Lua is not thread-safe).
-    // map::shift() drains deferred hooks after drain_completed().
+    // The main thread drains deferred hooks after worker mapgen completes.
     const auto omt_pos( project_to<coords::omt>( p ) );
     {
         ZoneScopedN( "generate_postprocess_hooks" );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3081,7 +3081,7 @@ class jmapgen_nested : public jmapgen_piece
                 return else_entries;
             }
         }
-        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list & {
+        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list& {
             if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_connections.test( dat ) ) {
                 ensure_resolved( entries, resolved_entries, resolved_entries_valid );
                 return resolved_entries;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3081,7 +3081,7 @@ class jmapgen_nested : public jmapgen_piece
                 return else_entries;
             }
         }
-        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list& {
+        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list & {
             if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_connections.test( dat ) ) {
                 ensure_resolved( entries, resolved_entries, resolved_entries_valid );
                 return resolved_entries;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3081,7 +3081,8 @@ class jmapgen_nested : public jmapgen_piece
                 return else_entries;
             }
         }
-        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list & { // *NOPAD*
+        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list
+        & { // *NOPAD*
             if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_connections.test( dat ) ) {
                 ensure_resolved( entries, resolved_entries, resolved_entries_valid );
                 return resolved_entries;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3081,7 +3081,7 @@ class jmapgen_nested : public jmapgen_piece
                 return else_entries;
             }
         }
-        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list& {
+        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list & { // *NOPAD*
             if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_connections.test( dat ) ) {
                 ensure_resolved( entries, resolved_entries, resolved_entries_valid );
                 return resolved_entries;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -144,7 +144,9 @@ auto map::generate( const tripoint_abs_sm &p, const time_point &when,
             debugmsg( "Submap already exists at (%d, %d, %d)", smp.x(), smp.y(), p.z() );
             continue;
         }
-        setsubmap( grid_pos, new submap( bub_to_abs( tripoint_bub_sm( smp, p.z() ) ) ) );
+        auto *new_submap = new submap( bub_to_abs( tripoint_bub_sm( smp, p.z() ) ) );
+        new_submap->last_touched = when;
+        setsubmap( grid_pos, new_submap );
         // TODO: memory leak if the code below throws before the submaps get stored/deleted!
     }
     const auto discard_unowned_generated_submaps = [&]() {
@@ -523,6 +525,20 @@ std::map<std::string, weighted_int_list<std::shared_ptr<mapgen_function_json_nes
         nested_mapgen;
 std::map<std::string, std::vector<std::unique_ptr<update_mapgen_function_json>> > update_mapgen;
 
+using nested_mapgen_function_list =
+    weighted_int_list<std::shared_ptr<mapgen_function_json_nested>>;
+
+struct nested_mapgen_ref {
+    const nested_mapgen_function_list *functions = nullptr;
+
+    friend auto operator==( const nested_mapgen_ref &lhs,
+                            const nested_mapgen_ref &rhs ) -> bool {
+        return lhs.functions == rhs.functions;
+    }
+};
+
+using nested_mapgen_ref_list = weighted_int_list<nested_mapgen_ref>;
+
 void call_mapgen_function( std::string name, mapgendata &dat, bool nested, const point_rel_ms &pos )
 {
     if( nested ) {
@@ -551,6 +567,7 @@ void calculate_mapgen_weights()   // TODO: rename as it runs jsonfunction setup 
     oter_mapgen.setup();
     // Not really calculate weights, but let's keep it here for now
     for( auto &pr : nested_mapgen ) {
+        pr.second.precalc();
         for( weighted_object<int, std::shared_ptr<mapgen_function_json_nested>> &ptr : pr.second ) {
             ptr.obj->setup();
             inp_mngr.pump_events();
@@ -3038,6 +3055,10 @@ class jmapgen_nested : public jmapgen_piece
     public:
         weighted_int_list<std::string> entries;
         weighted_int_list<std::string> else_entries;
+        mutable nested_mapgen_ref_list resolved_entries;
+        mutable nested_mapgen_ref_list resolved_else_entries;
+        mutable bool resolved_entries_valid = false;
+        mutable bool resolved_else_entries_valid = false;
         neighbor_oter_check neighbor_oters;
         neighbor_join_check neighbor_joins;
         neighbor_connection_check neighbor_connections;
@@ -3060,8 +3081,23 @@ class jmapgen_nested : public jmapgen_piece
                 return else_entries;
             }
         }
+        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list & {
+            if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_connections.test( dat ) ) {
+                ensure_resolved( entries, resolved_entries, resolved_entries_valid );
+                return resolved_entries;
+            } else {
+                ensure_resolved( else_entries, resolved_else_entries, resolved_else_entries_valid );
+                return resolved_else_entries;
+            }
+        }
         mapgen_phase phase() const override {
             return mapgen_phase::nested_mapgen;
+        }
+        auto finalize() const -> void override {
+            resolved_entries.clear();
+            resolved_else_entries.clear();
+            resolved_entries_valid = false;
+            resolved_else_entries_valid = false;
         }
         void merge_parameters_into( mapgen_parameters &params,
                                     const std::string &outer_context ) const override {
@@ -3090,25 +3126,27 @@ class jmapgen_nested : public jmapgen_piece
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y
                   ) const override {
-            const std::string *res = get_entries( dat ).pick();
-            if( res == nullptr || res->empty() || *res == "null" ) {
-                // This will be common when neighbors.test(...) is false, since else_entires is often empty.
+            ZoneScopedN( "jmapgen_nested_apply" );
+            const std::shared_ptr<mapgen_function_json_nested> *ptr = nullptr;
+            {
+                ZoneScopedN( "jmapgen_nested_pick" );
+                const nested_mapgen_ref *res = get_resolved_entries( dat ).pick();
+                if( res == nullptr || res->functions == nullptr ) {
+                    // This will be common when neighbors.test(...) is false, since else_entries is often empty.
+                    return;
+                }
+
+                // A second roll? Let's allow it for now
+                ptr = res->functions->pick();
+            }
+            if( ptr == nullptr || !*ptr ) {
                 return;
             }
 
-            const auto iter = nested_mapgen.find( *res );
-            if( iter == nested_mapgen.end() ) {
-                debugmsg( "Unknown nested mapgen function id %s", res->c_str() );
-                return;
+            {
+                ZoneScopedN( "jmapgen_nested_nest" );
+                ( *ptr )->nest( dat, point_rel_ms( x.get(), y.get() ) );
             }
-
-            // A second roll? Let's allow it for now
-            const auto &ptr = iter->second.pick();
-            if( ptr == nullptr ) {
-                return;
-            }
-
-            ( *ptr )->nest( dat, point_rel_ms( x.get(), y.get() ) );
         }
 
         void check( const std::string &oter_name, const mapgen_parameters & ) const override {
@@ -3117,21 +3155,17 @@ class jmapgen_nested : public jmapgen_piece
             neighbor_connections.check( oter_name );
         }
         bool has_vehicle_collision( const mapgendata &dat, const point_rel_ms &p ) const override {
-            const weighted_int_list<std::string> &selected_entries = get_entries( dat );
+            const nested_mapgen_ref_list &selected_entries = get_resolved_entries( dat );
 
             if( selected_entries.empty() ) {
                 return false;
             }
 
             for( auto &entry : selected_entries ) {
-                if( entry.obj == "null" ) {
+                if( entry.obj.functions == nullptr ) {
                     continue;
                 }
-                const auto iter = nested_mapgen.find( entry.obj );
-                if( iter == nested_mapgen.end() ) {
-                    return false;
-                }
-                for( const auto &nest : iter->second ) {
+                for( const auto &nest : *entry.obj.functions ) {
                     if( nest.obj->has_vehicle_collision( dat, p ) ) {
                         return true;
                     }
@@ -3139,6 +3173,36 @@ class jmapgen_nested : public jmapgen_piece
             }
 
             return false;
+        }
+    private:
+        static auto ensure_resolved( const weighted_int_list<std::string> &source,
+                                     nested_mapgen_ref_list &resolved,
+                                     bool &valid ) -> void {
+            if( valid ) {
+                return;
+            }
+            resolved = resolve_entries( source );
+            valid = true;
+        }
+
+        static auto resolve_entries( const weighted_int_list<std::string> &source )
+        -> nested_mapgen_ref_list {
+            auto resolved = nested_mapgen_ref_list {};
+            for( const auto &entry : source ) {
+                if( entry.obj.empty() || entry.obj == "null" ) {
+                    resolved.add( {}, entry.weight );
+                    continue;
+                }
+                const auto iter = nested_mapgen.find( entry.obj );
+                if( iter == nested_mapgen.end() ) {
+                    debugmsg( "Unknown nested mapgen function id %s", entry.obj.c_str() );
+                    resolved.add( {}, entry.weight );
+                    continue;
+                }
+                resolved.add( { &iter->second }, entry.weight );
+            }
+            resolved.precalc();
+            return resolved;
         }
 };
 
@@ -3889,6 +3953,9 @@ void mapgen_function_json_base::check_common( const std::string &oter_name ) con
 
 void jmapgen_objects::finalize()
 {
+    for( const auto &obj : objects ) {
+        obj.second->finalize();
+    }
     std::stable_sort( objects.begin(), objects.end(),
     []( const jmapgen_obj & l, const jmapgen_obj & r ) {
         return l.second->phase() < r.second->phase();
@@ -4130,23 +4197,35 @@ void mapgen_function_json::generate( mapgendata &md )
         ZoneScopedN( "mapgen_json_get_args" );
         args = get_args( md, mapgen_parameter_scope::omt );
     }
-    mapgendata md_with_params( md, args );
 
-    {
-        ZoneScopedN( "mapgen_json_setmap" );
-        for( auto &elem : setmap_points ) {
-            elem.apply( md_with_params, point_rel_ms::zero() );
+    const auto apply_contents = [&]( const mapgendata & active_md ) -> void {
+        {
+            ZoneScopedN( "mapgen_json_setmap" );
+            for( auto &elem : setmap_points ) {
+                elem.apply( active_md, point_rel_ms::zero() );
+            }
         }
-    }
 
-    {
-        ZoneScopedN( "mapgen_json_objects" );
-        objects.apply( md_with_params, point_rel_ms::zero() );
-    }
+        {
+            ZoneScopedN( "mapgen_json_objects" );
+            objects.apply( active_md, point_rel_ms::zero() );
+        }
 
-    {
-        ZoneScopedN( "mapgen_json_resolve_regional" );
-        resolve_regional_terrain_and_furniture( md_with_params );
+        {
+            ZoneScopedN( "mapgen_json_resolve_regional" );
+            resolve_regional_terrain_and_furniture( active_md );
+        }
+    };
+
+    if( args.map.empty() ) {
+        apply_contents( md );
+    } else {
+        auto md_with_params = std::optional<mapgendata> {};
+        {
+            ZoneScopedN( "mapgen_json_make_param_data" );
+            md_with_params.emplace( md, args );
+        }
+        apply_contents( *md_with_params );
     }
 
     {
@@ -4175,23 +4254,35 @@ void mapgen_function_json_nested::nest( const mapgendata &md, const point_rel_ms
         ZoneScopedN( "mapgen_json_nested_get_args" );
         args = get_args( md, mapgen_parameter_scope::nest );
     }
-    mapgendata md_with_params( md, args );
 
-    {
-        ZoneScopedN( "mapgen_json_nested_setmap" );
-        for( const jmapgen_setmap &elem : setmap_points ) {
-            elem.apply( md_with_params, offset );
+    const auto apply_contents = [&]( const mapgendata & active_md ) -> void {
+        {
+            ZoneScopedN( "mapgen_json_nested_setmap" );
+            for( const auto &elem : setmap_points ) {
+                elem.apply( active_md, offset );
+            }
         }
-    }
 
-    {
-        ZoneScopedN( "mapgen_json_nested_objects" );
-        objects.apply( md_with_params, offset );
-    }
+        {
+            ZoneScopedN( "mapgen_json_nested_objects" );
+            objects.apply( active_md, offset );
+        }
 
-    {
-        ZoneScopedN( "mapgen_json_nested_resolve_regional" );
-        resolve_regional_terrain_and_furniture( md_with_params );
+        {
+            ZoneScopedN( "mapgen_json_nested_resolve_regional" );
+            resolve_regional_terrain_and_furniture( active_md );
+        }
+    };
+
+    if( args.map.empty() ) {
+        apply_contents( md );
+    } else {
+        auto md_with_params = std::optional<mapgendata> {};
+        {
+            ZoneScopedN( "mapgen_json_nested_make_param_data" );
+            md_with_params.emplace( md, args );
+        }
+        apply_contents( *md_with_params );
     }
 }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -119,7 +119,8 @@ static void science_room( map *m, const point_bub_ms &p1, const point_bub_ms &p2
 
 // (x,y,z) are absolute coordinates of a submap
 // x%2 and y%2 must be 0!
-void map::generate( const tripoint_abs_sm &p, const time_point &when )
+auto map::generate( const tripoint_abs_sm &p, const time_point &when,
+                    const map_generate_options &options ) -> mapgen_result
 {
     ZoneScopedN( "map_generate" );
     ZoneValue( static_cast<uint64_t>( p.z() + OVERMAP_DEPTH ) );
@@ -146,6 +147,13 @@ void map::generate( const tripoint_abs_sm &p, const time_point &when )
         setsubmap( grid_pos, new submap( bub_to_abs( tripoint_bub_sm( smp, p.z() ) ) ) );
         // TODO: memory leak if the code below throws before the submaps get stored/deleted!
     }
+    const auto discard_unowned_generated_submaps = [&]() {
+        for( const auto smp : bubble_submaps() ) {
+            const auto grid_pos = get_nonant( tripoint_bub_sm( smp, p.z() ) );
+            delete getsubmap( grid_pos );
+            setsubmap( grid_pos, nullptr );
+        }
+    };
     // x, and y are submap coordinates, convert to overmap terrain coordinates
     // TODO: fix point types
     tripoint_abs_omt abs_omt( project_to<coords::omt>( p ) );
@@ -174,7 +182,11 @@ void map::generate( const tripoint_abs_sm &p, const time_point &when )
     mapgendata dat( abs_omt, *this, density, when, nullptr, omap );
     {
         ZoneScopedN( "generate_draw_map" );
-        draw_map( dat );
+        const auto draw_result = draw_map( dat, options );
+        if( draw_result.needs_main_thread() ) {
+            discard_unowned_generated_submaps();
+            return draw_result;
+        }
     }
 
     {
@@ -248,7 +260,7 @@ void map::generate( const tripoint_abs_sm &p, const time_point &when )
             const int gridn = get_nonant( pos );
             submap *const sm = getsubmap( gridn );
             if( sm == nullptr || sm->get_ter( point_sm_ms::zero() ) == t_null ) {
-                return;
+                return {};
             }
             // Transfer ownership of the freshly generated submap to the mapbuffer.
             // grid[] holds a borrowed reference to the mapbuffer-owned submap after this.
@@ -269,7 +281,7 @@ void map::generate( const tripoint_abs_sm &p, const time_point &when )
     const auto omt_pos( project_to<coords::omt>( p ) );
     {
         ZoneScopedN( "generate_postprocess_hooks" );
-        if( is_pool_worker_thread() ) {
+        if( is_pool_worker_thread() || options.defer_postprocess_hooks ) {
             push_deferred_mapgen_hook( { bound_dimension_, omt_pos, when } );
         } else {
             cata::run_on_mapgen_postprocess_hooks(
@@ -280,6 +292,7 @@ void map::generate( const tripoint_abs_sm &p, const time_point &when )
             );
         }
     }
+    return { .status = mapgen_result_status::generated };
 }
 
 void mapgen_function_builtin::generate( mapgendata &mgd )
@@ -319,9 +332,20 @@ class mapgen_basic_container
          */
         bool generate( mapgendata &dat, const int hardcoded_weight ) const {
             ZoneScopedN( "mapgen_container_generate" );
+            const auto ptr = pick( hardcoded_weight );
+            if( !ptr ) {
+                return false;
+            }
+            {
+                ZoneScopedN( "mapgen_container_dispatch" );
+                ptr->generate( dat );
+            }
+            return true;
+        }
+        auto pick( const int hardcoded_weight ) const -> std::shared_ptr<mapgen_function> {
             if( hardcoded_weight > 0 &&
                 rng( 1, weights_.get_weight() + hardcoded_weight ) > weights_.get_weight() ) {
-                return false;
+                return nullptr;
             }
             const std::shared_ptr<mapgen_function> *ptr = nullptr;
             {
@@ -329,18 +353,13 @@ class mapgen_basic_container
                 ptr = weights_.pick();
             }
             if( !ptr ) {
-                return false;
+                return nullptr;
             }
             assert( *ptr );
-            {
-                ZoneScopedN( "mapgen_container_dispatch" );
-                ( *ptr )->generate( dat );
-            }
-            return true;
+            return *ptr;
         }
-        /** Returns true if any generator in the weighted pool is Lua-based. */
-        auto any_lua() const -> bool {
-            bool found = false;
+        auto has_direct_lua_generator() const -> bool {
+            auto found = false;
             weights_.apply( [&]( const std::shared_ptr<mapgen_function> &ptr ) {
                 if( ptr && ptr->is_lua_generator() ) {
                     found = true;
@@ -390,6 +409,7 @@ class mapgen_factory
 {
     private:
         std::map<std::string, mapgen_basic_container> mapgens_;
+        bool any_direct_lua_generator_ = false;
 
         /// Collect all the possible and expected keys that may get used with @ref pick.
         static std::set<std::string> get_usages() {
@@ -415,6 +435,7 @@ class mapgen_factory
     public:
         void reset() {
             mapgens_.clear();
+            any_direct_lua_generator_ = false;
         }
         /// @see mapgen_basic_container::setup
         void setup() {
@@ -425,6 +446,9 @@ class mapgen_factory
             // Dummy entry, overmap terrain null should never appear and is
             // therefore never generated.
             mapgens_.erase( "null" );
+            any_direct_lua_generator_ = std::ranges::any_of( mapgens_, []( const auto & omw ) {
+                return omw.second.has_direct_lua_generator();
+            } );
         }
         void finalize_parameters() {
             for( std::pair<const std::string, mapgen_basic_container> &omw : mapgens_ ) {
@@ -462,15 +486,24 @@ class mapgen_factory
             }
             return iter->second.generate( dat, hardcoded_weight );
         }
-        /// Returns true if any generator registered under @p key is Lua-based.
-        auto has_lua_generator( const std::string &key ) const -> bool {
-            const auto iter = mapgens_.find( key );
+        auto pick( const std::string &key, const int hardcoded_weight = 0 ) const
+        -> std::shared_ptr<mapgen_function> {
+            const auto iter = mapgens_.find( disable_mapgen ? "test" : key );
+            if( iter == mapgens_.end() ) {
+                return nullptr;
+            }
+            return iter->second.pick( hardcoded_weight );
+        }
+        auto has_direct_lua_generator( const std::string &key ) const -> bool {
+            const auto iter = mapgens_.find( disable_mapgen ? "test" : key );
             if( iter == mapgens_.end() ) {
                 return false;
             }
-            return iter->second.any_lua();
+            return iter->second.has_direct_lua_generator();
         }
-
+        auto has_any_direct_lua_generator() const -> bool {
+            return any_direct_lua_generator_;
+        }
         mapgen_parameters get_map_special_params( const std::string &key ) const {
             const auto iter = mapgens_.find( key );
             if( iter == mapgens_.end() ) {
@@ -4218,7 +4251,7 @@ bool jmapgen_objects::has_vehicle_collision( const mapgendata &dat,
 }
 
 /////////////
-void map::draw_map( mapgendata &dat )
+auto map::draw_map( mapgendata &dat, const map_generate_options &options ) -> mapgen_result
 {
     ZoneScopedN( "map_draw_map" );
     const oter_id &terrain_type = dat.terrain_type();
@@ -4228,7 +4261,32 @@ void map::draw_map( mapgendata &dat )
     bool generated = false;
     {
         ZoneScopedN( "draw_map_run_mapgen_func" );
-        generated = run_mapgen_func( function_key, dat );
+        if( options.use_selected_mapgen ) {
+            if( options.selected_mapgen ) {
+                if( options.worker_safe && mapgen_function_needs_main_thread( options.selected_mapgen ) ) {
+                    return {
+                        .status = mapgen_result_status::needs_main_thread,
+                        .selected_mapgen = options.selected_mapgen,
+                    };
+                }
+                options.selected_mapgen->generate( dat );
+                generated = true;
+            }
+        } else if( options.worker_safe ) {
+            const auto selected_mapgen = oter_mapgen.pick( function_key );
+            if( selected_mapgen ) {
+                if( mapgen_function_needs_main_thread( selected_mapgen ) ) {
+                    return {
+                        .status = mapgen_result_status::needs_main_thread,
+                        .selected_mapgen = selected_mapgen,
+                    };
+                }
+                selected_mapgen->generate( dat );
+                generated = true;
+            }
+        } else {
+            generated = run_mapgen_func( function_key, dat );
+        }
     }
 
     if( !generated ) {
@@ -4256,6 +4314,7 @@ void map::draw_map( mapgendata &dat )
         ZoneScopedN( "draw_map_connections" );
         draw_connections( dat );
     }
+    return { .status = mapgen_result_status::generated };
 }
 
 const int SOUTH_EDGE = 2 * SEEY - 1;
@@ -6558,11 +6617,33 @@ bool run_mapgen_func( const std::string &mapgen_id, mapgendata &dat )
     return oter_mapgen.generate( dat, mapgen_id );
 }
 
-auto omt_mapgen_uses_lua( const std::string &dim_id, const tripoint_abs_omt &omt_addr ) -> bool
+auto pick_mapgen_func( const std::string &mapgen_id ) -> std::shared_ptr<mapgen_function>
 {
-    overmapbuffer &omap = get_overmapbuffer( dim_id );
-    const oter_id terrain_type = omap.ter( omt_addr );
-    return oter_mapgen.has_lua_generator( terrain_type->get_mapgen_id() );
+    ZoneScopedN( "pick_mapgen_func" );
+    return oter_mapgen.pick( mapgen_id );
+}
+
+auto mapgen_function_needs_main_thread( const std::shared_ptr<mapgen_function> &func ) -> bool
+{
+    if( !func ) {
+        return false;
+    }
+    if( func->is_lua_generator() ) {
+        return true;
+    }
+    const auto json_func = std::dynamic_pointer_cast<mapgen_function_json>( func );
+    return json_func && json_func->predecessor_mapgen != oter_str_id::NULL_ID() &&
+           oter_mapgen.has_direct_lua_generator( json_func->predecessor_mapgen.id().str() );
+}
+
+auto mapgen_has_any_direct_lua_generator() -> bool
+{
+    return oter_mapgen.has_any_direct_lua_generator();
+}
+
+auto mapgen_id_has_direct_lua_generator( const std::string &mapgen_id ) -> bool
+{
+    return oter_mapgen.has_direct_lua_generator( mapgen_id );
 }
 
 mapgen_parameters get_map_special_params( const std::string &mapgen_id )

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3081,7 +3081,7 @@ class jmapgen_nested : public jmapgen_piece
                 return else_entries;
             }
         }
-        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list & {
+        auto get_resolved_entries( const mapgendata &dat ) const -> const nested_mapgen_ref_list& {
             if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_connections.test( dat ) ) {
                 ensure_resolved( entries, resolved_entries, resolved_entries_valid );
                 return resolved_entries;
@@ -4201,7 +4201,8 @@ void mapgen_function_json::generate( mapgendata &md )
     const auto apply_contents = [&]( const mapgendata & active_md ) -> void {
         {
             ZoneScopedN( "mapgen_json_setmap" );
-            for( auto &elem : setmap_points ) {
+            for( auto &elem : setmap_points )
+            {
                 elem.apply( active_md, point_rel_ms::zero() );
             }
         }
@@ -4258,7 +4259,8 @@ void mapgen_function_json_nested::nest( const mapgendata &md, const point_rel_ms
     const auto apply_contents = [&]( const mapgendata & active_md ) -> void {
         {
             ZoneScopedN( "mapgen_json_nested_setmap" );
-            for( const auto &elem : setmap_points ) {
+            for( const auto &elem : setmap_points )
+            {
                 elem.apply( active_md, offset );
             }
         }

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -197,6 +197,8 @@ class jmapgen_piece
         virtual void merge_parameters_into( mapgen_parameters &,
                                             const std::string &/*outer_context*/ ) const {}
 
+        virtual auto finalize() const -> void {}
+
         /** Place something on the map from mapgendata &dat, at (x,y). */
         virtual void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y
                           ) const = 0;
@@ -566,5 +568,3 @@ void circle( map *m, const ter_id &type, double x, double y, double rad );
 void circle( map *m, const ter_id &type, const point_bub_ms &, int rad );
 void circle_furn( map *m, const furn_id &type, const point_bub_ms &, int rad );
 void add_corpse( map *m, const point_bub_ms & );
-
-

--- a/src/mapgen_async.h
+++ b/src/mapgen_async.h
@@ -16,7 +16,7 @@ struct lua_state;
  * When map::generate() runs on a worker thread, the Lua
  * on_mapgen_postprocess hook cannot execute in place (Lua is not
  * thread-safe).  Instead, the hook parameters are pushed here and
- * drained on the main thread by map::shift() after drain_completed().
+ * drained on the main thread after worker mapgen completes.
  *
  * The submaps are already in the mapbuffer when the hook runs (saven()
  * is called before the hook), so the main thread reconstructs a
@@ -67,7 +67,7 @@ void refresh_mapgen_postprocess_hook_presence( cata::lua_state &state );
  * from the hook land directly on the mapbuffer-owned submap objects.
  *
  * Must be called on the main thread only (Lua is not thread-safe).
- * Called by map::shift() after drain_completed().
+ * Called by map::shift() and the submap load manager after worker mapgen completes.
  */
 void run_deferred_mapgen_hooks();
 

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -9,6 +10,7 @@
 #include "type_id.h"
 
 class map;
+class mapgen_function;
 class mapgendata;
 class mission;
 struct mapgen_parameters;
@@ -18,6 +20,25 @@ struct tripoint;
 using mapgen_id = std::string;
 using mapgen_update_func = std::function<void( const tripoint_abs_omt &map_pos3, mission *miss )>;
 class JsonObject;
+
+enum class mapgen_result_status : int {
+    not_generated,
+    generated,
+    needs_main_thread,
+};
+
+struct mapgen_result {
+    mapgen_result_status status = mapgen_result_status::not_generated;
+    std::shared_ptr<mapgen_function> selected_mapgen;
+
+    auto is_generated() const -> bool {
+        return status == mapgen_result_status::generated;
+    }
+
+    auto needs_main_thread() const -> bool {
+        return status == mapgen_result_status::needs_main_thread;
+    }
+};
 
 /**
  * Calculates the coordinates of a rotated point.
@@ -79,14 +100,10 @@ bool run_mapgen_update_func( const std::string &update_mapgen_id, const tripoint
 bool run_mapgen_update_func( const std::string &update_mapgen_id, mapgendata &dat,
                              bool cancel_on_collision = true );
 bool run_mapgen_func( const std::string &mapgen_id, mapgendata &dat );
-/**
- * Returns true if the overmap terrain at @p om_addr in dimension @p dim_id
- * has at least one Lua-based mapgen function in its weighted pool.
- *
- * Used by mapbuffer::generate_omt() to detect whether a omt must be
- * deferred to the main thread (Lua is not reentrant on worker threads).
- */
-auto omt_mapgen_uses_lua( const std::string &dim_id, const tripoint_abs_omt &om_addr ) -> bool;
+auto pick_mapgen_func( const std::string &mapgen_id ) -> std::shared_ptr<mapgen_function>;
+auto mapgen_function_needs_main_thread( const std::shared_ptr<mapgen_function> &func ) -> bool;
+auto mapgen_has_any_direct_lua_generator() -> bool;
+auto mapgen_id_has_direct_lua_generator( const std::string &mapgen_id ) -> bool;
 std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_update(
             const std::string &update_mapgen_id );
 mapgen_parameters get_map_special_params( const std::string &mapgen_id );
@@ -99,5 +116,3 @@ namespace mapgen
 bool has_update_id( const mapgen_id &id );
 
 } // namespace mapgen
-
-

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -19,6 +19,7 @@
 #include "mapbuffer.h"
 #include "clzones.h"
 #include "mapgen_async.h"
+#include "mapgen_functions.h"
 #include "mapbuffer_registry.h"
 #include "point.h"
 #include "profile.h"
@@ -95,6 +96,15 @@ auto is_omt_zlevel_loaded( mapbuffer &mb, const tripoint_abs_omt &omt_addr ) -> 
            && mb.lookup_submap_in_memory( sm_base + point_south )
            && mb.lookup_submap_in_memory( sm_base + point_south_east );
 }
+
+auto is_any_omt_zlevel_loaded( mapbuffer &mb, const tripoint_abs_omt &omt_addr ) -> bool
+{
+    const auto sm_base = project_to<coords::sm>( omt_addr );
+    return mb.lookup_submap_in_memory( sm_base )
+           || mb.lookup_submap_in_memory( sm_base + point_east )
+           || mb.lookup_submap_in_memory( sm_base + point_south )
+           || mb.lookup_submap_in_memory( sm_base + point_south_east );
+}
 } // namespace
 
 submap_load_manager submap_loader;
@@ -153,7 +163,8 @@ void submap_load_manager::release_load( load_request_handle handle )
 {
     if( const auto it = requests_.find( handle );
         it != requests_.end() && it->second.source == load_request_source::lazy_border ) {
-        lazy_omt_queue_.clear();
+        lazy_omt_jobs_.clear();
+        lazy_omt_job_index_.clear();
         lazy_omt_budget_credit_ = 0.0;
         lazy_omt_last_credit_turn_ = -1;
     }
@@ -323,6 +334,7 @@ auto submap_load_manager::evict_omt_column( const retained_omt_key &key ) -> voi
     [&]( const auto z ) {
         const auto omt_addr = tripoint_abs_omt{ omt_xy, z };
         const auto qk = omt_key{ dim_id, omt_addr };
+        finish_lazy_omt_job( qk );
         const auto was_dirty = dirty_omts_.contains( qk );
         if( was_dirty ) {
             if( auto it = presave_futures_.find( qk ); it != presave_futures_.end() ) {
@@ -378,62 +390,83 @@ auto submap_load_manager::process_retained_omt_eviction() -> void
     evict_oldest_retained_omts( budget );
 }
 
-auto submap_load_manager::is_omt_column_loaded( const retained_omt_key &key ) -> bool
+auto submap_load_manager::load_lazy_omt_zlevel_data( mapbuffer &mb,
+        const tripoint_abs_omt &omt_addr ) -> lazy_omt_load_result
 {
-    const auto &[dim_id, omt_xy] = key;
-    auto &mb = MAPBUFFER_REGISTRY.get( dim_id );
-    return std::ranges::all_of( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ),
-    [&]( const auto z ) {
-        return is_omt_zlevel_loaded( mb, tripoint_abs_omt{ omt_xy, z } );
-    } );
+    ZoneScopedN( "slm_lazy_load_omt_zlevel_data" );
+    auto result = lazy_omt_load_result {};
+    if( is_omt_zlevel_loaded( mb, omt_addr ) ) {
+        return result;
+    }
+
+    result.dirty = mb.preload_omt( omt_addr );
+    if( !is_omt_zlevel_loaded( mb, omt_addr ) ) {
+        // Partial z-levels are rare, but resolving them can discard duplicate
+        // generated submaps; keep that on the main thread.
+        if( is_pool_worker_thread() && is_any_omt_zlevel_loaded( mb, omt_addr ) ) {
+            return result;
+        }
+        result.generated = mb.generate_omt( omt_addr );
+    }
+    return result;
 }
 
-auto submap_load_manager::mark_omt_column_dirty( const retained_omt_key &key ) -> void
+auto submap_load_manager::erase_lazy_omt_job( const omt_key &key ) -> void
 {
-    const auto &[dim_id, omt_xy] = key;
-    std::ranges::for_each( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ),
-    [&]( const auto z ) {
-        dirty_omts_.insert( { dim_id, tripoint_abs_omt{ omt_xy, z } } );
-    } );
+    const auto it = lazy_omt_job_index_.find( key );
+    if( it == lazy_omt_job_index_.end() ) {
+        return;
+    }
+    lazy_omt_jobs_.erase( it->second );
+    lazy_omt_job_index_.erase( it );
 }
 
-auto submap_load_manager::load_lazy_omt_column( const retained_omt_key &key ) -> void
+auto submap_load_manager::apply_lazy_omt_result( const omt_key &key,
+        const lazy_omt_load_result &result ) -> bool
 {
-    ZoneScopedN( "slm_lazy_load_omt_column" );
-    const auto &[dim_id, omt_xy] = key;
-    auto &mb = MAPBUFFER_REGISTRY.get( dim_id );
-    auto column_is_dirty = false;
+    MAPBUFFER_REGISTRY.get( key.first ).drain_pending_submap_destroy();
+    if( result.dirty || result.generated ) {
+        dirty_omts_.insert( key );
+    }
+    return result.generated;
+}
 
-    auto preload_futures = std::vector<std::future<bool>> {};
-    std::ranges::for_each( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ),
-    [&]( const auto z ) {
-        const auto omt_addr = tripoint_abs_omt{ omt_xy, z };
-        const auto qk = omt_key{ dim_id, omt_addr };
-        if( auto it = presave_futures_.find( qk ); it != presave_futures_.end() ) {
-            it->second.get();
-            presave_futures_.erase( it );
-            column_is_dirty = true;
-        }
-        if( is_omt_zlevel_loaded( mb, omt_addr ) ) {
-            return;
-        }
-        preload_futures.push_back( get_thread_pool().submit_returning( [&mb, omt_addr]() {
-            return mb.preload_omt( omt_addr );
-        } ) );
-    } );
+auto submap_load_manager::finish_lazy_omt_job( const omt_key &key ) -> bool
+{
+    erase_lazy_omt_job( key );
+    const auto it = lazy_omt_futures_.find( key );
+    if( it == lazy_omt_futures_.end() ) {
+        return false;
+    }
 
-    std::ranges::for_each( preload_futures, [&]( auto & future ) {
-        column_is_dirty |= future.get();
-    } );
-    mb.drain_pending_submap_destroy();
+    auto result = lazy_omt_load_result {};
+    {
+        ZoneScopedN( "slm_lazy_z_wait" );
+        result = it->second.get();
+    }
+    const auto generated = apply_lazy_omt_result( key, result );
+    lazy_omt_futures_.erase( it );
+    if( generated ) {
+        run_deferred_mapgen_hooks();
+        flush_deferred_zones();
+        run_deferred_autonotes();
+    }
+    return generated;
+}
 
+auto submap_load_manager::reap_lazy_omt_jobs() -> void
+{
+    ZoneScopedN( "slm_lazy_z_reap" );
     auto generated = false;
-    std::ranges::for_each( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ),
-    [&]( const auto z ) {
-        const auto omt_addr = tripoint_abs_omt{ omt_xy, z };
-        if( !is_omt_zlevel_loaded( mb, omt_addr ) ) {
-            generated |= mb.generate_omt( omt_addr );
+    auto completed = std::size_t{ 0 };
+    std::erase_if( lazy_omt_futures_, [&]( auto & entry ) {
+        auto &[key, future] = entry;
+        if( future.wait_for( std::chrono::seconds( 0 ) ) != std::future_status::ready ) {
+            return false;
         }
+        generated |= apply_lazy_omt_result( key, future.get() );
+        ++completed;
+        return true;
     } );
 
     if( generated ) {
@@ -441,10 +474,51 @@ auto submap_load_manager::load_lazy_omt_column( const retained_omt_key &key ) ->
         flush_deferred_zones();
         run_deferred_autonotes();
     }
+    TracyPlot( "Lazy Border Z Jobs Completed", static_cast<int64_t>( completed ) );
+    TracyPlot( "Lazy Border Z Jobs In-Flight", static_cast<int64_t>( lazy_omt_futures_.size() ) );
+}
 
-    if( column_is_dirty || generated ) {
-        mark_omt_column_dirty( key );
+auto submap_load_manager::start_lazy_omt_job( const omt_key &key ) -> bool
+{
+    if( lazy_omt_futures_.contains( key ) ) {
+        return false;
     }
+
+    auto &mb = MAPBUFFER_REGISTRY.get( key.first );
+    auto dirty = false;
+    if( auto it = presave_futures_.find( key ); it != presave_futures_.end() ) {
+        it->second.get();
+        presave_futures_.erase( it );
+        dirty = true;
+    }
+
+    if( is_omt_zlevel_loaded( mb, key.second ) ) {
+        if( dirty ) {
+            dirty_omts_.insert( key );
+        }
+        return false;
+    }
+
+    if( get_thread_pool().num_workers() == 0 || is_any_omt_zlevel_loaded( mb, key.second ) ||
+        omt_mapgen_uses_lua( key.first, key.second ) ) {
+        auto result = load_lazy_omt_zlevel_data( mb, key.second );
+        result.dirty |= dirty;
+        const auto generated = apply_lazy_omt_result( key, result );
+        if( generated ) {
+            run_deferred_mapgen_hooks();
+            flush_deferred_zones();
+            run_deferred_autonotes();
+        }
+        return true;
+    }
+
+    lazy_omt_futures_.emplace( key,
+    get_thread_pool().submit_returning( [&mb, omt_addr = key.second, dirty]() {
+        auto result = load_lazy_omt_zlevel_data( mb, omt_addr );
+        result.dirty |= dirty;
+        return result;
+    } ) );
+    return true;
 }
 
 auto submap_load_manager::lazy_omt_priority( const retained_omt_key &key ) const -> int
@@ -492,15 +566,18 @@ auto submap_load_manager::lazy_omt_priority( const retained_omt_key &key ) const
     return best;
 }
 
+auto submap_load_manager::lazy_omt_priority( const omt_key &key ) const -> int
+{
+    return lazy_omt_priority( retained_omt_key{ key.first, key.second.xy() } );
+}
+
 auto submap_load_manager::queue_lazy_border_omts( const horizontal_omt_set &border_omts ) -> void
 {
     ZoneScopedN( "slm_queue_lazy_border_omts" );
 
     auto candidates = std::vector<retained_omt_key> {};
     std::ranges::for_each( border_omts, [&]( const retained_omt_key & key ) {
-        if( !is_omt_column_loaded( key ) ) {
-            candidates.push_back( key );
-        }
+        candidates.push_back( key );
     } );
     std::ranges::sort( candidates, [&]( const retained_omt_key & lhs,
     const retained_omt_key & rhs ) {
@@ -518,41 +595,62 @@ auto submap_load_manager::queue_lazy_border_omts( const horizontal_omt_set &bord
         return lhs.second.y() < rhs.second.y();
     } );
 
-    lazy_omt_queue_.clear();
+    lazy_omt_jobs_.clear();
+    lazy_omt_job_index_.clear();
     std::ranges::for_each( candidates, [&]( const retained_omt_key & key ) {
-        lazy_omt_queue_.push_back( key );
+        const auto &[dim_id, omt_xy] = key;
+        auto &mb = MAPBUFFER_REGISTRY.get( dim_id );
+        std::ranges::for_each( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ),
+        [&]( const auto z ) {
+            const auto omt_addr = tripoint_abs_omt{ omt_xy, z };
+            const auto job_key = omt_key{ dim_id, omt_addr };
+            if( lazy_omt_futures_.contains( job_key ) || is_omt_zlevel_loaded( mb, omt_addr ) ) {
+                return;
+            }
+            auto it = lazy_omt_jobs_.insert( lazy_omt_jobs_.end(), job_key );
+            lazy_omt_job_index_.emplace( job_key, it );
+        } );
     } );
 }
 
 auto submap_load_manager::process_lazy_border_preload() -> void
 {
     ZoneScopedN( "slm_lazy_border_preload" );
-    const auto queued = lazy_omt_queue_.size();
+    const auto queued = lazy_omt_jobs_.size();
     TracyPlot( "Lazy Border OMT Queue", static_cast<int64_t>( queued ) );
+    TracyPlot( "Lazy Border Z Jobs Queue", static_cast<int64_t>( queued ) );
+    TracyPlot( "Lazy Border Z Jobs In-Flight", static_cast<int64_t>( lazy_omt_futures_.size() ) );
     if( queued == 0 ) {
         TracyPlot( "Lazy Border OMT Budget", int64_t{ 0 } );
+        TracyPlot( "Lazy Border Z Jobs Started", int64_t{ 0 } );
         return;
     }
 
     const auto urgent = static_cast<std::size_t>( std::ranges::count_if(
-    lazy_omt_queue_, [&]( const retained_omt_key & key ) {
+    lazy_omt_jobs_, [&]( const omt_key & key ) {
         return lazy_omt_priority( key ) > 0;
     } ) );
     TracyPlot( "Lazy Border Leading OMTs", static_cast<int64_t>( urgent ) );
+    TracyPlot( "Lazy Border Leading Z Jobs", static_cast<int64_t>( urgent ) );
 
-    const auto load_budget_matching = [&]( std::size_t budget, const auto &can_load ) {
-        while( budget > 0 && !lazy_omt_queue_.empty() ) {
-            const auto key = lazy_omt_queue_.front();
+    const auto load_budget_matching = [&]( std::size_t budget, const auto &can_load ) -> std::size_t {
+        auto started = std::size_t{ 0 };
+        while( budget > 0 && !lazy_omt_jobs_.empty() ) {
+            const auto key = lazy_omt_jobs_.front();
             if( !can_load( key ) ) {
-                return;
+                return started;
             }
-            lazy_omt_queue_.pop_front();
-            if( is_omt_column_loaded( key ) ) {
+            erase_lazy_omt_job( key );
+            auto &mb = MAPBUFFER_REGISTRY.get( key.first );
+            if( is_omt_zlevel_loaded( mb, key.second ) ) {
                 continue;
             }
-            load_lazy_omt_column( key );
-            --budget;
+            if( start_lazy_omt_job( key ) ) {
+                --budget;
+                ++started;
+            }
         }
+        return started;
     };
 
     if( lazy_omt_preload_direction_ == point_zero ) {
@@ -562,15 +660,17 @@ auto submap_load_manager::process_lazy_border_preload() -> void
                    static_cast<int64_t>( lazy_border_steps_to_cross_omt ) );
         TracyPlot( "Lazy Border Credit x1000", int64_t{ 0 } );
         TracyPlot( "Lazy Border OMT Budget", static_cast<int64_t>( budget ) );
-        load_budget_matching( budget, []( const retained_omt_key & ) {
+        const auto started = load_budget_matching( budget, []( const omt_key & ) {
             return true;
         } );
+        TracyPlot( "Lazy Border Z Jobs Started", static_cast<int64_t>( started ) );
         return;
     }
 
     const auto current_turn = to_turn<int>( calendar::turn );
     if( current_turn == lazy_omt_last_credit_turn_ ) {
         TracyPlot( "Lazy Border OMT Budget", int64_t{ 0 } );
+        TracyPlot( "Lazy Border Z Jobs Started", int64_t{ 0 } );
         return;
     }
     lazy_omt_last_credit_turn_ = current_turn;
@@ -583,6 +683,7 @@ auto submap_load_manager::process_lazy_border_preload() -> void
         TracyPlot( "Lazy Border OMT Deadline", static_cast<int64_t>( deadline ) );
         TracyPlot( "Lazy Border Credit x1000", int64_t{ 0 } );
         TracyPlot( "Lazy Border OMT Budget", int64_t{ 0 } );
+        TracyPlot( "Lazy Border Z Jobs Started", int64_t{ 0 } );
         return;
     }
 
@@ -595,14 +696,26 @@ auto submap_load_manager::process_lazy_border_preload() -> void
                static_cast<int64_t>( lazy_omt_budget_credit_ * 1000.0 ) );
     TracyPlot( "Lazy Border OMT Budget", static_cast<int64_t>( budget ) );
 
-    load_budget_matching( budget, [&]( const retained_omt_key & key ) {
+    const auto started = load_budget_matching( budget, [&]( const omt_key & key ) {
         return lazy_omt_priority( key ) > 0;
     } );
+    TracyPlot( "Lazy Border Z Jobs Started", static_cast<int64_t>( started ) );
 }
 
 void submap_load_manager::drain_lazy_loads()
 {
     ZoneScopedN( "drain_lazy_loads" );
+    auto generated = false;
+    std::ranges::for_each( lazy_omt_futures_, [&]( auto & entry ) {
+        generated |= apply_lazy_omt_result( entry.first, entry.second.get() );
+    } );
+    lazy_omt_futures_.clear();
+    if( generated ) {
+        run_deferred_mapgen_hooks();
+        flush_deferred_zones();
+        run_deferred_autonotes();
+    }
+
     // Drain in-flight presave futures so no worker holds raw submap pointers
     // across a dimension switch, shutdown, or full game save.
     // dirty_omts_ is NOT cleared here — the presaved data is in pending_writes_
@@ -637,6 +750,7 @@ void submap_load_manager::update()
             return false;
         } );
     }
+    reap_lazy_omt_jobs();
 
     TracyPlot( "Thread Pool Workers", static_cast<int64_t>( get_thread_pool().num_workers() ) );
     TracyPlot( "Thread Pool Queue", static_cast<int64_t>( get_thread_pool().queue_size() ) );
@@ -723,6 +837,7 @@ void submap_load_manager::update()
             for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
                 const tripoint_abs_omt omt_addr{ omt_xy, z };
                 const omt_key qk{ dim_id, omt_addr };
+                finish_lazy_omt_job( qk );
 
                 // If a presave is in-flight for this omt, wait for it before
                 // allowing game logic to modify the submaps.  The worker holds
@@ -1029,7 +1144,7 @@ auto submap_load_manager::non_bubble_requests() const -> std::vector<submap_load
 
 auto submap_load_manager::is_fully_drained() const noexcept -> bool
 {
-    return presave_futures_.empty();
+    return presave_futures_.empty() && lazy_omt_futures_.empty();
 }
 
 void submap_load_manager::flush_prev_desired()
@@ -1040,7 +1155,9 @@ void submap_load_manager::flush_prev_desired()
     prev_centers_.clear();
     retained_omts_.clear();
     retained_omt_index_.clear();
-    lazy_omt_queue_.clear();
+    lazy_omt_jobs_.clear();
+    lazy_omt_job_index_.clear();
+    lazy_omt_futures_.clear();
     lazy_omt_preload_direction_ = point_zero;
     lazy_omt_focus_.reset();
     lazy_omt_budget_credit_ = 0.0;

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -839,7 +839,7 @@ void submap_load_manager::update()
     // Mark ALL z-levels for newly-simulated horizontal OMTs as dirty: they
     // will receive game logic and must be saved to disk when evicted.
     for( const auto &[dim_id, omt_xy] : new_omts ) {
-        for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+        for( const auto z : std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ) ) {
             dirty_omts_.insert( { dim_id, tripoint_abs_omt{ omt_xy, z } } );
         }
     }
@@ -848,12 +848,14 @@ void submap_load_manager::update()
     // preload_omt() is thread-safe (disk I/O outside submaps_mutex_; add
     // under the lock).  Running multiple omts in parallel hides disk latency.
     // Each horizontal OMT drives a z-level loop internally.
+    auto resident_zlevels = std::size_t{ 0 };
+    auto preloaded_zlevels = std::size_t{ 0 };
     {
         ZoneScopedN( "slm_preload_new_omts" );
         std::vector<std::future<void>> preload_futures;
         for( const auto &[dim_id, omt_xy] : new_omts ) {
             auto &mb = MAPBUFFER_REGISTRY.get( dim_id );
-            for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+            for( const auto z : std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ) ) {
                 const tripoint_abs_omt omt_addr{ omt_xy, z };
                 const omt_key qk{ dim_id, omt_addr };
                 finish_lazy_omt_job( qk );
@@ -867,8 +869,10 @@ void submap_load_manager::update()
                     && mb.lookup_submap_in_memory( ( sm_base + point_south ) )
                     && mb.lookup_submap_in_memory( ( sm_base + point_south_east ) );
                 if( all_loaded ) {
+                    ++resident_zlevels;
                     continue;
                 }
+                ++preloaded_zlevels;
                 preload_futures.push_back( get_thread_pool().submit_returning(
                 [&mb, omt_addr]() {
                     mb.preload_omt( omt_addr );
@@ -879,6 +883,8 @@ void submap_load_manager::update()
             f.get();
         } );
     } // slm_preload_new_omts
+    TracyPlot( "New Sim OMT Z Resident Hits", static_cast<int64_t>( resident_zlevels ) );
+    TracyPlot( "New Sim OMT Z Preload Attempts", static_cast<int64_t>( preloaded_zlevels ) );
 
     // Drain duplicate submaps created by concurrent preload_omt workers.
     // Must happen on the main thread (safe_reference / cata_arena not thread-safe).
@@ -896,11 +902,12 @@ void submap_load_manager::update()
     // Lua is not reentrant, so this must always run on the main thread.
     // Skip omts already fully resident: preload_omt loaded them from disk or
     // the pending_writes cache, so no generation is needed.
+    auto generated_zlevels = std::size_t{ 0 };
     {
         ZoneScopedN( "slm_generate_new_omts" );
         for( const auto &[dim_id, omt_xy] : new_omts ) {
             auto &mb = MAPBUFFER_REGISTRY.get( dim_id );
-            for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+            for( const auto z : std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ) ) {
                 const tripoint_abs_omt omt_addr{ omt_xy, z };
                 const tripoint_abs_sm sm_base = project_to<coords::sm>( omt_addr );
                 const bool all_loaded =
@@ -909,6 +916,7 @@ void submap_load_manager::update()
                     && mb.lookup_submap_in_memory( ( sm_base + point_south ) )
                     && mb.lookup_submap_in_memory( ( sm_base + point_south_east ) );
                 if( !all_loaded ) {
+                    ++generated_zlevels;
                     mb.generate_omt( omt_addr, {
                         .defer_postprocess_hooks = true,
                     } );
@@ -916,6 +924,7 @@ void submap_load_manager::update()
             }
         }
     }
+    TracyPlot( "New Sim OMT Z Generated", static_cast<int64_t>( generated_zlevels ) );
 
     // Drain Lua postprocess hooks queued by mapgen above.
     {
@@ -932,7 +941,7 @@ void submap_load_manager::update()
         ZoneScopedN( "slm_listener_notifications" );
         for( const desired_key &key : simulated ) {
             if( prev_simulated_.count( key ) == 0 ) {
-                for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+                for( const auto z : std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ) ) {
                     const tripoint_abs_sm pos{ key.second, z };
                     for( submap_load_listener *listener : listeners_ ) {
                         listener->on_submap_loaded( pos, key.first );
@@ -943,7 +952,7 @@ void submap_load_manager::update()
 
         for( const desired_key &key : prev_simulated_ ) {
             if( simulated.count( key ) == 0 ) {
-                for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+                for( const auto z : std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ) ) {
                     const tripoint_abs_sm pos{ key.second, z };
                     for( submap_load_listener *listener : listeners_ ) {
                         listener->on_submap_unloaded( pos, key.first );

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -21,6 +21,8 @@
 #include "mapgen_async.h"
 #include "mapgen_functions.h"
 #include "mapbuffer_registry.h"
+#include "omdata.h"
+#include "overmapbuffer.h"
 #include "point.h"
 #include "profile.h"
 #include "thread_pool.h"
@@ -387,7 +389,8 @@ auto submap_load_manager::process_retained_omt_eviction() -> void
 }
 
 auto submap_load_manager::load_lazy_omt_zlevel_data( mapbuffer &mb,
-        const tripoint_abs_omt &omt_addr ) -> lazy_omt_load_result
+        const tripoint_abs_omt &omt_addr,
+        const lazy_omt_load_options &options ) -> lazy_omt_load_result
 {
     ZoneScopedN( "slm_lazy_load_omt_zlevel_data" );
     auto result = lazy_omt_load_result {};
@@ -402,9 +405,31 @@ auto submap_load_manager::load_lazy_omt_zlevel_data( mapbuffer &mb,
         if( is_pool_worker_thread() && is_any_omt_zlevel_loaded( mb, omt_addr ) ) {
             return result;
         }
-        result.generated = mb.generate_omt( omt_addr );
+        result.generation = mb.generate_omt( omt_addr, {
+            .defer_postprocess_hooks = options.defer_postprocess_hooks,
+            .worker_safe = options.worker_safe,
+            .use_selected_mapgen = options.use_selected_mapgen,
+            .selected_mapgen = options.selected_mapgen,
+        } );
     }
     return result;
+}
+
+auto submap_load_manager::complete_lazy_omt_result_on_main_thread( const omt_key &key,
+        lazy_omt_load_result result ) -> lazy_omt_load_result
+{
+    if( !result.generation.needs_main_thread() ) {
+        return result;
+    }
+
+    auto &mb = MAPBUFFER_REGISTRY.get( key.first );
+    auto completed = load_lazy_omt_zlevel_data( mb, key.second, {
+        .defer_postprocess_hooks = true,
+        .use_selected_mapgen = true,
+        .selected_mapgen = result.generation.selected_mapgen,
+    } );
+    completed.dirty = completed.dirty || result.dirty;
+    return completed;
 }
 
 auto submap_load_manager::erase_lazy_omt_job( const omt_key &key ) -> void
@@ -421,10 +446,10 @@ auto submap_load_manager::apply_lazy_omt_result( const omt_key &key,
         const lazy_omt_load_result &result ) -> bool
 {
     MAPBUFFER_REGISTRY.get( key.first ).drain_pending_submap_destroy();
-    if( result.dirty || result.generated ) {
+    if( result.dirty || result.generated() ) {
         dirty_omts_.insert( key );
     }
-    return result.generated;
+    return result.generated();
 }
 
 auto submap_load_manager::finish_lazy_omt_job( const omt_key &key ) -> bool
@@ -440,6 +465,7 @@ auto submap_load_manager::finish_lazy_omt_job( const omt_key &key ) -> bool
         ZoneScopedN( "slm_lazy_z_wait" );
         result = it->second.get();
     }
+    result = complete_lazy_omt_result_on_main_thread( key, std::move( result ) );
     const auto generated = apply_lazy_omt_result( key, result );
     lazy_omt_futures_.erase( it );
     if( generated ) {
@@ -460,7 +486,8 @@ auto submap_load_manager::reap_lazy_omt_jobs() -> void
         if( future.wait_for( std::chrono::seconds( 0 ) ) != std::future_status::ready ) {
             return false;
         }
-        generated |= apply_lazy_omt_result( key, future.get() );
+        auto result = complete_lazy_omt_result_on_main_thread( key, future.get() );
+        generated |= apply_lazy_omt_result( key, result );
         ++completed;
         return true;
     } );
@@ -485,21 +512,48 @@ auto submap_load_manager::start_lazy_omt_job( const omt_key &key ) -> bool
         return false;
     }
 
-    if( get_thread_pool().num_workers() == 0 || is_any_omt_zlevel_loaded( mb, key.second ) ||
-        omt_mapgen_uses_lua( key.first, key.second ) ) {
-        auto result = load_lazy_omt_zlevel_data( mb, key.second );
-        const auto generated = apply_lazy_omt_result( key, result );
-        if( generated ) {
-            run_deferred_mapgen_hooks();
-            flush_deferred_zones();
-            run_deferred_autonotes();
-        }
+    if( get_thread_pool().num_workers() == 0 || is_any_omt_zlevel_loaded( mb, key.second ) ) {
+        auto result = load_lazy_omt_zlevel_data( mb, key.second, {
+            .defer_postprocess_hooks = true,
+        } );
+        apply_lazy_omt_result( key, result );
         return true;
+    }
+
+    if( mapgen_has_any_direct_lua_generator() ) {
+        const auto terrain_type = get_overmapbuffer( key.first ).ter( key.second );
+        const auto mapgen_id = terrain_type->get_mapgen_id();
+        if( mapgen_id_has_direct_lua_generator( mapgen_id ) ) {
+            const auto selected_mapgen = pick_mapgen_func( mapgen_id );
+            if( mapgen_function_needs_main_thread( selected_mapgen ) ) {
+                auto result = load_lazy_omt_zlevel_data( mb, key.second, {
+                    .defer_postprocess_hooks = true,
+                    .use_selected_mapgen = true,
+                    .selected_mapgen = selected_mapgen,
+                } );
+                apply_lazy_omt_result( key, result );
+                return true;
+            }
+
+            lazy_omt_futures_.emplace( key,
+            get_thread_pool().submit_returning( [&mb, omt_addr = key.second, selected_mapgen]() {
+                return load_lazy_omt_zlevel_data( mb, omt_addr, {
+                    .defer_postprocess_hooks = true,
+                    .worker_safe = true,
+                    .use_selected_mapgen = true,
+                    .selected_mapgen = selected_mapgen,
+                } );
+            } ) );
+            return true;
+        }
     }
 
     lazy_omt_futures_.emplace( key,
     get_thread_pool().submit_returning( [&mb, omt_addr = key.second]() {
-        return load_lazy_omt_zlevel_data( mb, omt_addr );
+        return load_lazy_omt_zlevel_data( mb, omt_addr, {
+            .defer_postprocess_hooks = true,
+            .worker_safe = true,
+        } );
     } ) );
     return true;
 }
@@ -646,6 +700,11 @@ auto submap_load_manager::process_lazy_border_preload() -> void
         const auto started = load_budget_matching( budget, []( const omt_key & ) {
             return true;
         } );
+        if( started > 0 ) {
+            run_deferred_mapgen_hooks();
+            flush_deferred_zones();
+            run_deferred_autonotes();
+        }
         TracyPlot( "Lazy Border Z Jobs Started", static_cast<int64_t>( started ) );
         return;
     }
@@ -682,6 +741,11 @@ auto submap_load_manager::process_lazy_border_preload() -> void
     const auto started = load_budget_matching( budget, [&]( const omt_key & key ) {
         return lazy_omt_priority( key ) > 0;
     } );
+    if( started > 0 ) {
+        run_deferred_mapgen_hooks();
+        flush_deferred_zones();
+        run_deferred_autonotes();
+    }
     TracyPlot( "Lazy Border Z Jobs Started", static_cast<int64_t>( started ) );
 }
 
@@ -690,7 +754,8 @@ void submap_load_manager::drain_lazy_loads()
     ZoneScopedN( "drain_lazy_loads" );
     auto generated = false;
     std::ranges::for_each( lazy_omt_futures_, [&]( auto & entry ) {
-        generated |= apply_lazy_omt_result( entry.first, entry.second.get() );
+        auto result = complete_lazy_omt_result_on_main_thread( entry.first, entry.second.get() );
+        generated |= apply_lazy_omt_result( entry.first, result );
     } );
     lazy_omt_futures_.clear();
     if( generated ) {
@@ -844,7 +909,9 @@ void submap_load_manager::update()
                     && mb.lookup_submap_in_memory( ( sm_base + point_south ) )
                     && mb.lookup_submap_in_memory( ( sm_base + point_south_east ) );
                 if( !all_loaded ) {
-                    mb.generate_omt( omt_addr );
+                    mb.generate_omt( omt_addr, {
+                        .defer_postprocess_hooks = true,
+                    } );
                 }
             }
         }

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -337,10 +337,6 @@ auto submap_load_manager::evict_omt_column( const retained_omt_key &key ) -> voi
         finish_lazy_omt_job( qk );
         const auto was_dirty = dirty_omts_.contains( qk );
         if( was_dirty ) {
-            if( auto it = presave_futures_.find( qk ); it != presave_futures_.end() ) {
-                it->second.get();
-                presave_futures_.erase( it );
-            }
             dirty_omts_.erase( qk );
             mb.unload_omt( omt_addr, true );
         } else {
@@ -485,24 +481,13 @@ auto submap_load_manager::start_lazy_omt_job( const omt_key &key ) -> bool
     }
 
     auto &mb = MAPBUFFER_REGISTRY.get( key.first );
-    auto dirty = false;
-    if( auto it = presave_futures_.find( key ); it != presave_futures_.end() ) {
-        it->second.get();
-        presave_futures_.erase( it );
-        dirty = true;
-    }
-
     if( is_omt_zlevel_loaded( mb, key.second ) ) {
-        if( dirty ) {
-            dirty_omts_.insert( key );
-        }
         return false;
     }
 
     if( get_thread_pool().num_workers() == 0 || is_any_omt_zlevel_loaded( mb, key.second ) ||
         omt_mapgen_uses_lua( key.first, key.second ) ) {
         auto result = load_lazy_omt_zlevel_data( mb, key.second );
-        result.dirty |= dirty;
         const auto generated = apply_lazy_omt_result( key, result );
         if( generated ) {
             run_deferred_mapgen_hooks();
@@ -513,10 +498,8 @@ auto submap_load_manager::start_lazy_omt_job( const omt_key &key ) -> bool
     }
 
     lazy_omt_futures_.emplace( key,
-    get_thread_pool().submit_returning( [&mb, omt_addr = key.second, dirty]() {
-        auto result = load_lazy_omt_zlevel_data( mb, omt_addr );
-        result.dirty |= dirty;
-        return result;
+    get_thread_pool().submit_returning( [&mb, omt_addr = key.second]() {
+        return load_lazy_omt_zlevel_data( mb, omt_addr );
     } ) );
     return true;
 }
@@ -715,41 +698,12 @@ void submap_load_manager::drain_lazy_loads()
         flush_deferred_zones();
         run_deferred_autonotes();
     }
-
-    // Drain in-flight presave futures so no worker holds raw submap pointers
-    // across a dimension switch, shutdown, or full game save.
-    // dirty_omts_ is NOT cleared here — the presaved data is in pending_writes_
-    // (in-memory cache), not on disk yet.  flush_prev_desired() clears dirty_omts_
-    // and the subsequent mapbuffer::save() call flushes pending_writes_ to disk.
-    std::ranges::for_each( presave_futures_, []( auto & entry ) {
-        entry.second.get();
-    } );
-    presave_futures_.clear();
 }
 
 void submap_load_manager::update()
 {
     ZoneScoped;
 
-    // Non-blocking reap: collect completed presave futures.  When a presave
-    // finishes we remove it from the in-flight set, but intentionally keep
-    // dirty_omts_ intact.  presave_omt() only writes to the pending-writes
-    // cache (no disk I/O); between the snapshot and eventual eviction, border
-    // submaps can still be modified (e.g. fire spreading in from the bubble).
-    // Keeping the dirty mark ensures eviction re-serialises the current state
-    // rather than silently discarding those post-presave modifications.
-    {
-        ZoneScopedN( "slm_presave_reap" );
-        std::erase_if( presave_futures_, []( auto & entry ) {
-            auto &[key, fut] = entry;
-            if( fut.wait_for( std::chrono::seconds( 0 ) ) == std::future_status::ready ) {
-                fut.get();
-                // dirty_omts_ deliberately NOT cleared here — see comment above.
-                return true;
-            }
-            return false;
-        } );
-    }
     reap_lazy_omt_jobs();
 
     TracyPlot( "Thread Pool Workers", static_cast<int64_t>( get_thread_pool().num_workers() ) );
@@ -838,17 +792,6 @@ void submap_load_manager::update()
                 const tripoint_abs_omt omt_addr{ omt_xy, z };
                 const omt_key qk{ dim_id, omt_addr };
                 finish_lazy_omt_job( qk );
-
-                // If a presave is in-flight for this omt, wait for it before
-                // allowing game logic to modify the submaps.  The worker holds
-                // raw submap pointers and reads them for serialization; concurrent
-                // writes would corrupt the save.
-                if( auto it = presave_futures_.find( qk ); it != presave_futures_.end() ) {
-                    it->second.get();
-                    presave_futures_.erase( it );
-                    // dirty_omts_ left intact — omt was re-inserted above and
-                    // must still be saved on eventual eviction.
-                }
 
                 // Skip omts already fully resident (e.g. re-entered from
                 // pending_writes cache).
@@ -942,73 +885,6 @@ void submap_load_manager::update()
             }
         }
     } // slm_listener_notifications
-
-    // ---- Submit async presaves for dirty omts leaving simulation ----
-    // Omts entering the border zone are no longer touched by game logic.
-    // We can serialize them to the pending-writes cache on a worker thread so eviction
-    // (when they later leave the border zone) is just a fast memory free.
-    // The 2-D simulated set means each departing horizontal position drives a
-    // z-level loop; presaved_this_turn prevents duplicate submissions when
-    // multiple submap positions in prev_simulated_ map to the same omt.
-    {
-        ZoneScopedN( "slm_presave_departing" );
-        std::unordered_set<omt_key, coord_pair_hash<tripoint_abs_omt>> presaved_this_turn;
-        for( const desired_key &key : prev_simulated_ ) {
-            if( simulated.count( key ) ) {
-                continue;  // still simulated — not departing
-            }
-            if( !all_desired.count( key ) ) {
-                continue;  // direct sim→evict is handled by departed dirty OMT presave below
-            }
-            for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
-                const omt_key qk{ key.first,
-                                  tripoint_abs_omt{ project_to<coords::omt>( key.second ), z } };
-                if( presave_futures_.count( qk ) ) {
-                    continue;  // already has an in-flight presave
-                }
-                if( !dirty_omts_.count( qk ) ) {
-                    continue;  // omt was never simulated (guard, shouldn't happen here)
-                }
-                if( !presaved_this_turn.insert( qk ).second ) {
-                    continue;  // multiple SM positions map to same omt — only submit once
-                }
-                auto &mb = MAPBUFFER_REGISTRY.get( qk.first );
-                presave_futures_.emplace( qk,
-                get_thread_pool().submit_returning( [&mb, omt_addr = qk.second]() {
-                    mb.presave_omt( omt_addr );
-                } ) );
-            }
-        }
-        TracyPlot( "Presave Futures In-Flight", static_cast<int64_t>( presave_futures_.size() ) );
-    }
-
-    {
-        ZoneScopedN( "slm_presave_departed_dirty_omts" );
-        auto presaved_columns =
-            std::unordered_set<retained_omt_key, coord_pair_hash<point_abs_omt>> {};
-        for( const desired_key &key : prev_desired_ ) {
-            if( all_desired.count( key ) != 0 ) {
-                continue;
-            }
-            const auto column = retained_omt_key{ key.first, project_to<coords::omt>( key.second ) };
-            if( !presaved_columns.insert( column ).second ) {
-                continue;
-            }
-            auto &mb = MAPBUFFER_REGISTRY.get( column.first );
-            std::ranges::for_each( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ),
-            [&]( const auto z ) {
-                const auto qk = omt_key{ column.first, tripoint_abs_omt{ column.second, z } };
-                if( presave_futures_.count( qk ) != 0 || dirty_omts_.count( qk ) == 0 ) {
-                    return;
-                }
-                presave_futures_.emplace( qk,
-                get_thread_pool().submit_returning( [&mb, omt_addr = qk.second]() {
-                    mb.presave_omt( omt_addr );
-                } ) );
-            } );
-        }
-        TracyPlot( "Presave Futures In-Flight", static_cast<int64_t>( presave_futures_.size() ) );
-    }
 
     // ---- Retain departed omts (full set: simulated + border) ----
     // prev_desired_ is now 2-D (horizontal SM positions).  Multiple entries
@@ -1144,7 +1020,7 @@ auto submap_load_manager::non_bubble_requests() const -> std::vector<submap_load
 
 auto submap_load_manager::is_fully_drained() const noexcept -> bool
 {
-    return presave_futures_.empty() && lazy_omt_futures_.empty();
+    return lazy_omt_futures_.empty();
 }
 
 void submap_load_manager::flush_prev_desired()

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "calendar.h"
 #include "cata_cartesian_product.h"
 #include "cached_options.h"
 #include "game_constants.h"
@@ -41,6 +42,49 @@ auto divide_round_up_size( const std::size_t numerator, const std::size_t denomi
 auto signum( const int value ) -> int
 {
     return ( value > 0 ) - ( value < 0 );
+}
+
+auto steps_to_omt_edge_axis( const int local, const int direction ) -> std::size_t
+{
+    const auto clamp_steps = []( const int steps ) -> std::size_t {
+        return static_cast<std::size_t>( std::max( 1, steps ) );
+    };
+
+    if( direction > 0 ) {
+        return clamp_steps( static_cast<int>( lazy_border_steps_to_cross_omt ) - local );
+    }
+    if( direction < 0 ) {
+        return clamp_steps( local + 1 );
+    }
+    return lazy_border_steps_to_cross_omt;
+}
+
+struct omt_edge_deadlines {
+    std::size_t x = lazy_border_steps_to_cross_omt;
+    std::size_t y = lazy_border_steps_to_cross_omt;
+    std::size_t next = lazy_border_steps_to_cross_omt;
+};
+
+auto omt_edge_deadlines_for( const tripoint_abs_ms &pos,
+                             const point &direction ) -> omt_edge_deadlines
+{
+    if( direction == point_zero ) {
+        return {};
+    }
+
+    const auto local = project_remain<coords::omt>( pos.xy() ).remainder;
+    auto result = omt_edge_deadlines {
+        .x = steps_to_omt_edge_axis( local.x(), direction.x ),
+        .y = steps_to_omt_edge_axis( local.y(), direction.y ),
+        .next = lazy_border_steps_to_cross_omt
+    };
+    result.next = std::min( result.x, result.y );
+    return result;
+}
+
+auto turns_to_omt_edge( const tripoint_abs_ms &pos, const point &direction ) -> std::size_t
+{
+    return omt_edge_deadlines_for( pos, direction ).next;
 }
 
 auto is_omt_zlevel_loaded( mapbuffer &mb, const tripoint_abs_omt &omt_addr ) -> bool
@@ -81,8 +125,38 @@ void submap_load_manager::update_request( load_request_handle handle,
     it->second.center = new_center;
 }
 
+auto submap_load_manager::update_lazy_border_focus( const std::string &dim_id,
+        const tripoint_abs_ms &pos ) -> void
+{
+    if( lazy_omt_focus_ && lazy_omt_focus_->dimension_id == dim_id ) {
+        const auto delta = point{
+            signum( pos.x() - lazy_omt_focus_->pos.x() ),
+            signum( pos.y() - lazy_omt_focus_->pos.y() )
+        };
+        if( delta != point_zero ) {
+            if( delta != lazy_omt_preload_direction_ ) {
+                lazy_omt_budget_credit_ = 0.0;
+            }
+            lazy_omt_preload_direction_ = delta;
+        }
+    } else {
+        lazy_omt_budget_credit_ = 0.0;
+    }
+
+    lazy_omt_focus_ = lazy_omt_focus{
+        .dimension_id = dim_id,
+        .pos = pos
+    };
+}
+
 void submap_load_manager::release_load( load_request_handle handle )
 {
+    if( const auto it = requests_.find( handle );
+        it != requests_.end() && it->second.source == load_request_source::lazy_border ) {
+        lazy_omt_queue_.clear();
+        lazy_omt_budget_credit_ = 0.0;
+        lazy_omt_last_credit_turn_ = -1;
+    }
     requests_.erase( handle );
 }
 
@@ -379,6 +453,15 @@ auto submap_load_manager::lazy_omt_priority( const retained_omt_key &key ) const
         return 0;
     }
 
+    auto prioritize_x = lazy_omt_preload_direction_.x != 0;
+    auto prioritize_y = lazy_omt_preload_direction_.y != 0;
+    if( lazy_omt_focus_ ) {
+        const auto deadlines = omt_edge_deadlines_for( lazy_omt_focus_->pos,
+                               lazy_omt_preload_direction_ );
+        prioritize_x = prioritize_x && deadlines.x == deadlines.next;
+        prioritize_y = prioritize_y && deadlines.y == deadlines.next;
+    }
+
     auto best = 0;
     const auto &[dim_id, omt_xy] = key;
     std::ranges::for_each( requests_, [&]( const auto & kv ) {
@@ -392,15 +475,15 @@ auto submap_load_manager::lazy_omt_priority( const retained_omt_key &key ) const
         const auto max_omt = project_to<coords::omt>( point_abs_sm{ c.x() + r, c.y() + r } );
 
         auto score = 0;
-        if( lazy_omt_preload_direction_.x > 0 && omt_xy.x() > max_omt.x() ) {
+        if( prioritize_x && lazy_omt_preload_direction_.x > 0 && omt_xy.x() > max_omt.x() ) {
             score += 2;
-        } else if( lazy_omt_preload_direction_.x < 0 && omt_xy.x() < min_omt.x() ) {
+        } else if( prioritize_x && lazy_omt_preload_direction_.x < 0 && omt_xy.x() < min_omt.x() ) {
             score += 2;
         }
 
-        if( lazy_omt_preload_direction_.y > 0 && omt_xy.y() > max_omt.y() ) {
+        if( prioritize_y && lazy_omt_preload_direction_.y > 0 && omt_xy.y() > max_omt.y() ) {
             score += 2;
-        } else if( lazy_omt_preload_direction_.y < 0 && omt_xy.y() < min_omt.y() ) {
+        } else if( prioritize_y && lazy_omt_preload_direction_.y < 0 && omt_xy.y() < min_omt.y() ) {
             score += 2;
         }
 
@@ -457,23 +540,64 @@ auto submap_load_manager::process_lazy_border_preload() -> void
     } ) );
     TracyPlot( "Lazy Border Leading OMTs", static_cast<int64_t>( urgent ) );
 
-    auto budget = divide_round_up_size( queued, lazy_border_steps_to_cross_omt );
-    const auto movement_axes = static_cast<std::size_t>(
-                                   std::abs( lazy_omt_preload_direction_.x ) +
-                                   std::abs( lazy_omt_preload_direction_.y ) );
-    const auto urgent_steps = movement_axes > 1 ? SEEX / movement_axes : SEEX;
-    budget = std::max( budget, divide_round_up_size( urgent, urgent_steps ) );
-    budget = std::max( std::size_t{ 1 }, budget );
+    const auto load_budget_matching = [&]( std::size_t budget, const auto &can_load ) {
+        while( budget > 0 && !lazy_omt_queue_.empty() ) {
+            const auto key = lazy_omt_queue_.front();
+            if( !can_load( key ) ) {
+                return;
+            }
+            lazy_omt_queue_.pop_front();
+            if( is_omt_column_loaded( key ) ) {
+                continue;
+            }
+            load_lazy_omt_column( key );
+            --budget;
+        }
+    };
+
+    if( lazy_omt_preload_direction_ == point_zero ) {
+        auto budget = divide_round_up_size( queued, lazy_border_steps_to_cross_omt );
+        budget = std::max( std::size_t{ 1 }, budget );
+        TracyPlot( "Lazy Border OMT Deadline",
+                   static_cast<int64_t>( lazy_border_steps_to_cross_omt ) );
+        TracyPlot( "Lazy Border Credit x1000", int64_t{ 0 } );
+        TracyPlot( "Lazy Border OMT Budget", static_cast<int64_t>( budget ) );
+        load_budget_matching( budget, []( const retained_omt_key & ) {
+            return true;
+        } );
+        return;
+    }
+
+    const auto current_turn = to_turn<int>( calendar::turn );
+    if( current_turn == lazy_omt_last_credit_turn_ ) {
+        TracyPlot( "Lazy Border OMT Budget", int64_t{ 0 } );
+        return;
+    }
+    lazy_omt_last_credit_turn_ = current_turn;
+
+    const auto deadline = lazy_omt_focus_
+                          ? turns_to_omt_edge( lazy_omt_focus_->pos, lazy_omt_preload_direction_ )
+                          : lazy_border_steps_to_cross_omt;
+    if( urgent == 0 ) {
+        lazy_omt_budget_credit_ = 0.0;
+        TracyPlot( "Lazy Border OMT Deadline", static_cast<int64_t>( deadline ) );
+        TracyPlot( "Lazy Border Credit x1000", int64_t{ 0 } );
+        TracyPlot( "Lazy Border OMT Budget", int64_t{ 0 } );
+        return;
+    }
+
+    lazy_omt_budget_credit_ += static_cast<double>( urgent ) / static_cast<double>( deadline );
+
+    auto budget = std::min( urgent, static_cast<std::size_t>( lazy_omt_budget_credit_ ) );
+    lazy_omt_budget_credit_ -= static_cast<double>( budget );
+    TracyPlot( "Lazy Border OMT Deadline", static_cast<int64_t>( deadline ) );
+    TracyPlot( "Lazy Border Credit x1000",
+               static_cast<int64_t>( lazy_omt_budget_credit_ * 1000.0 ) );
     TracyPlot( "Lazy Border OMT Budget", static_cast<int64_t>( budget ) );
 
-    while( budget > 0 && !lazy_omt_queue_.empty() ) {
-        const auto key = lazy_omt_queue_.front();
-        lazy_omt_queue_.pop_front();
-        if( !is_omt_column_loaded( key ) ) {
-            load_lazy_omt_column( key );
-        }
-        --budget;
-    }
+    load_budget_matching( budget, [&]( const retained_omt_key & key ) {
+        return lazy_omt_priority( key ) > 0;
+    } );
 }
 
 void submap_load_manager::drain_lazy_loads()
@@ -917,6 +1041,10 @@ void submap_load_manager::flush_prev_desired()
     retained_omts_.clear();
     retained_omt_index_.clear();
     lazy_omt_queue_.clear();
+    lazy_omt_preload_direction_ = point_zero;
+    lazy_omt_focus_.reset();
+    lazy_omt_budget_credit_ = 0.0;
+    lazy_omt_last_credit_turn_ = -1;
     dirty_omts_.clear();
 }
 

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -670,9 +670,10 @@ auto submap_load_manager::process_lazy_border_preload() -> void
     TracyPlot( "Lazy Border Leading OMTs", static_cast<int64_t>( urgent ) );
     TracyPlot( "Lazy Border Leading Z Jobs", static_cast<int64_t>( urgent ) );
 
-    const auto load_budget_matching = [&]( std::size_t budget, const auto &can_load ) -> std::size_t {
+    const auto load_budget_matching = [&]( std::size_t budget, const auto & can_load ) -> std::size_t {
         auto started = std::size_t{ 0 };
-        while( budget > 0 && !lazy_omt_jobs_.empty() ) {
+        while( budget > 0 && !lazy_omt_jobs_.empty() )
+        {
             const auto key = lazy_omt_jobs_.front();
             if( !can_load( key ) ) {
                 return started;

--- a/src/submap_load_manager.h
+++ b/src/submap_load_manager.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <list>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -142,6 +143,10 @@ class submap_load_manager
          */
         void update();
 
+        /** Update the player position used to budget lazy-border preloading. */
+        auto update_lazy_border_focus( const std::string &dim_id,
+                                       const tripoint_abs_ms &pos ) -> void;
+
         /**
          * Block until all in-flight background presave_omt tasks complete.
          *
@@ -275,6 +280,10 @@ class submap_load_manager
         using horizontal_omt_set = std::unordered_set<retained_omt_key,
               coord_pair_hash<point_abs_omt>>;
         using retained_omt_list = std::list<retained_omt_key>;
+        struct lazy_omt_focus {
+            std::string dimension_id;
+            tripoint_abs_ms pos;
+        };
 
         load_request_handle next_handle_ = 1;
         std::map<load_request_handle, submap_load_request> requests_;
@@ -348,6 +357,9 @@ class submap_load_manager
         std::vector<std::pair<load_request_handle, tripoint>> prev_centers_;
 
         point lazy_omt_preload_direction_ = point_zero;
+        std::optional<lazy_omt_focus> lazy_omt_focus_;
+        double lazy_omt_budget_credit_ = 0.0;
+        int lazy_omt_last_credit_turn_ = -1;
 };
 
 extern submap_load_manager submap_loader;

--- a/src/submap_load_manager.h
+++ b/src/submap_load_manager.h
@@ -16,6 +16,8 @@
 #include "coordinates.h"
 #include "point.h"
 
+class mapbuffer;
+
 /**
  * Interface for objects that need to react when submaps enter or leave the
  * *simulated* set — i.e. the fully-active zone driven by all non-lazy load
@@ -77,8 +79,8 @@ struct submap_load_request {
     tripoint_abs_sm center;
     int radius = 0;  ///< Half-width in submaps.  For reality_bubble this defines the circle
     ///< radius; for other sources a (2*radius+1)^2 square is loaded per z-level.
-    ///< Always covers the full z-range (-OVERMAP_DEPTH to OVERMAP_HEIGHT); omts are
-    ///< full vertical pillars and cannot be loaded one slice at a time.
+    ///< Always covers the full z-range (-OVERMAP_DEPTH to OVERMAP_HEIGHT); lazy-border
+    ///< preloading may stage individual z-level OMT jobs internally.
 };
 
 /**
@@ -280,9 +282,14 @@ class submap_load_manager
         using horizontal_omt_set = std::unordered_set<retained_omt_key,
               coord_pair_hash<point_abs_omt>>;
         using retained_omt_list = std::list<retained_omt_key>;
+        using lazy_omt_job_list = std::list<omt_key>;
         struct lazy_omt_focus {
             std::string dimension_id;
             tripoint_abs_ms pos;
+        };
+        struct lazy_omt_load_result {
+            bool dirty = false;
+            bool generated = false;
         };
 
         load_request_handle next_handle_ = 1;
@@ -302,8 +309,11 @@ class submap_load_manager
         std::unordered_map<retained_omt_key, retained_omt_list::iterator,
             coord_pair_hash<point_abs_omt>> retained_omt_index_;
 
-        /** OMT-space lazy-border columns waiting for amortized preload. */
-        retained_omt_list lazy_omt_queue_;
+        /** OMT z-levels waiting for amortized lazy-border preload. */
+        lazy_omt_job_list lazy_omt_jobs_;
+        std::unordered_map<omt_key, lazy_omt_job_list::iterator,
+            coord_pair_hash<tripoint_abs_omt>> lazy_omt_job_index_;
+        std::map<omt_key, std::future<lazy_omt_load_result>> lazy_omt_futures_;
 
         /** Compute the simulated desired set (excludes lazy_border). */
         key_set compute_desired_set() const;
@@ -326,10 +336,17 @@ class submap_load_manager
         auto evict_omt_column( const retained_omt_key &key ) -> void;
         auto evict_oldest_retained_omts( std::size_t count ) -> void;
         auto process_retained_omt_eviction() -> void;
-        auto is_omt_column_loaded( const retained_omt_key &key ) -> bool;
-        auto mark_omt_column_dirty( const retained_omt_key &key ) -> void;
-        auto load_lazy_omt_column( const retained_omt_key &key ) -> void;
+        static auto load_lazy_omt_zlevel_data( mapbuffer &mb,
+                                               const tripoint_abs_omt &omt_addr )
+        -> lazy_omt_load_result;
+        auto erase_lazy_omt_job( const omt_key &key ) -> void;
+        auto apply_lazy_omt_result( const omt_key &key,
+                                    const lazy_omt_load_result &result ) -> bool;
+        auto finish_lazy_omt_job( const omt_key &key ) -> bool;
+        auto reap_lazy_omt_jobs() -> void;
+        auto start_lazy_omt_job( const omt_key &key ) -> bool;
         auto lazy_omt_priority( const retained_omt_key &key ) const -> int;
+        auto lazy_omt_priority( const omt_key &key ) const -> int;
         auto queue_lazy_border_omts( const horizontal_omt_set &border_omts ) -> void;
         auto process_lazy_border_preload() -> void;
 

--- a/src/submap_load_manager.h
+++ b/src/submap_load_manager.h
@@ -150,7 +150,7 @@ class submap_load_manager
                                        const tripoint_abs_ms &pos ) -> void;
 
         /**
-         * Block until all in-flight background presave_omt tasks complete.
+         * Block until all in-flight background lazy-load tasks complete.
          *
          * Must be called before saving the game, switching dimensions, or
          * shutting down the thread pool so that no worker holds raw submap
@@ -238,9 +238,8 @@ class submap_load_manager
         void flush_prev_desired();
 
         /**
-         * Returns true if all background presave work has been drained
-         * (presave_futures_ is empty).  Used by flush_prev_desired() to assert
-         * correct call ordering during dimension switches.
+         * Returns true if all background lazy-load work has been drained. Used by
+         * flush_prev_desired() to assert correct call ordering during dimension switches.
          */
         auto is_fully_drained() const noexcept -> bool;
 
@@ -352,12 +351,6 @@ class submap_load_manager
 
         /** Cached (dx, dy) offsets for the full reality-bubble square footprint. */
         std::vector<point> bubble_offsets_;
-
-        /** In-flight presave_omt futures for dirty omts that left simulation.
-         *  Keyed by omt_key (dim + 3-D OMT address) for O(log N) lookup and erase.
-         *  Eviction waits for these before freeing the in-memory submaps.
-         *  Presence in the map also serves as the in-flight guard. */
-        std::map<omt_key, std::future<void>> presave_futures_;
 
         /**
          * Omts that have entered the simulated zone at least once since they

--- a/src/submap_load_manager.h
+++ b/src/submap_load_manager.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <list>
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <string>
@@ -14,6 +15,7 @@
 #include <future>
 
 #include "coordinates.h"
+#include "mapgen_functions.h"
 #include "point.h"
 
 class mapbuffer;
@@ -288,7 +290,17 @@ class submap_load_manager
         };
         struct lazy_omt_load_result {
             bool dirty = false;
-            bool generated = false;
+            mapgen_result generation;
+
+            auto generated() const -> bool {
+                return generation.is_generated();
+            }
+        };
+        struct lazy_omt_load_options {
+            bool defer_postprocess_hooks = false;
+            bool worker_safe = false;
+            bool use_selected_mapgen = false;
+            std::shared_ptr<mapgen_function> selected_mapgen;
         };
 
         load_request_handle next_handle_ = 1;
@@ -336,8 +348,11 @@ class submap_load_manager
         auto evict_oldest_retained_omts( std::size_t count ) -> void;
         auto process_retained_omt_eviction() -> void;
         static auto load_lazy_omt_zlevel_data( mapbuffer &mb,
-                                               const tripoint_abs_omt &omt_addr )
+                                               const tripoint_abs_omt &omt_addr,
+                                               const lazy_omt_load_options &options )
         -> lazy_omt_load_result;
+        auto complete_lazy_omt_result_on_main_thread( const omt_key &key,
+                lazy_omt_load_result result ) -> lazy_omt_load_result;
         auto erase_lazy_omt_job( const omt_key &key ) -> void;
         auto apply_lazy_omt_result( const omt_key &key,
                                     const lazy_omt_load_result &result ) -> bool;


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #9073
Post processing Lua mapgen was slow.
Lazy loading border didn't do it's job very well.

## Describe the solution (The How)

Spread work better for lazy loading border, including optional multi-threading that accounts for Lua mapgen better than before.
Batches post processing step for main thread.
General improvements to mapgen such as using generate_uniform in all generate paths instead of just loadn.
Removed redundant presave path.
Mildly improved nested mapgen performance by caching ids upon call time.

## Testing

Base results:
<img width="1233" height="640" alt="Tracy_eIdqUiWQIy" src="https://github.com/user-attachments/assets/a4f06e14-165b-4254-a68c-6fb8519d681a" />
With Overgrowth mod:
<img width="1228" height="640" alt="Tracy_zV2cidUMF3" src="https://github.com/user-attachments/assets/a77e5b15-f630-4481-adba-4d8882a892e7" />

## Additional context

This might be the highest ratio of failed to successful performance implementation concepts so far, unfortunately.

## AI disclosure:
gpt-5.5 xhigh used as assistant. I wish I could say it was more useful than it actually was for this.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [851a05f](https://github.com/cataclysmbn/Cataclysm-BN/commit/851a05f45c4ff7a9a9ea44e298ea5acb3b2a913e) (style(autofix.ci): automated formatting) on 2026-05-27 07:18:57

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26494482072/artifacts/7234015258)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26494482072/artifacts/7234017863)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26494482072/artifacts/7233726257)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26494482072/artifacts/7233629429)
<!-- END artifact comment -->