### PR TITLE
fix: make sea scooter parts `NOINSTALL`

### DIFF
--- a/data/json/vehicleparts/battery.json
+++ b/data/json/vehicleparts/battery.json
@@ -147,7 +147,8 @@
     "copy-from": "medium_storage_battery",
     "type": "vehicle_part",
     "name": { "str": "sea scooter battery" },
-    "item": "sea_scooter_battery"
+    "item": "sea_scooter_battery",
+    "extend": { "flags": [ "NOINSTALL" ] }
   },
   {
     "id": "small_storage_battery",

--- a/data/json/vehicleparts/engine.json
+++ b/data/json/vehicleparts/engine.json
@@ -72,7 +72,8 @@
     "type": "vehicle_part",
     "name": { "str": "sea scooter motor" },
     "item": "motor_small",
-    "energy_consumption": 1500
+    "energy_consumption": 1500,
+    "extend": { "flags": [ "NOINSTALL" ] }
   },
   {
     "id": "engine_electric",


### PR DESCRIPTION
## Purpose of change (The Why)
Sea scooter parts shouldn't be installable, I messed up.

## Describe the solution (The How)
Finally fixes them to not be installable.

## Describe alternatives you've considered
Leaving the cheese alone

## Testing
Tried installing them in game, noticed they no longer show up in the menu.

## Additional context

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c23bb37](https://github.com/cataclysmbn/Cataclysm-BN/commit/c23bb37f3c6268c9670c915be0d1e22148da9a22) (fix sea scooter parts) on 2026-05-27 15:38:06

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26516742901/artifacts/7242939659)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26516742901/artifacts/7243731019)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26516742901/artifacts/7242726141)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26516742901/artifacts/7243207096)
<!-- END artifact comment -->