### PR TITLE
feat(balance): buff 40mm grenades

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -433,5 +433,39 @@
       "fragment": { "impact": { "damage_type": "bullet", "amount": 400, "armor_multiplier": 3 }, "range": 10 },
       "radius": 10
     }
+  },
+  {
+    "id": "AMMO_M430A1_HEDP",
+    "type": "ammo_effect",
+    "explosion": {
+      "damage": 80,
+      "radius": 1,
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 60, "armor_multiplier": 1.3 }, "range": 7 }
+    }
+  },
+  {
+    "id": "AMMO_40x53_MAKESHIFT_HE",
+    "type": "ammo_effect",
+    "explosion": {
+      "damage": 70,
+      "radius": 6
+    }
+  },
+  {
+    "id": "AMMO_M433_HEDP",
+    "type": "ammo_effect",
+    "explosion": {
+      "damage": 70,
+      "radius": 1,
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 60, "armor_multiplier": 1.6 }, "range": 7 }
+    }
+  },
+  {
+    "id": "AMMO_40x46_MAKESHIFT_HE",
+    "type": "ammo_effect",
+    "explosion": {
+      "damage": 60,
+      "radius": 5
+    }
   }
 ]

--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -446,10 +446,7 @@
   {
     "id": "AMMO_40x53_MAKESHIFT_HE",
     "type": "ammo_effect",
-    "explosion": {
-      "damage": 70,
-      "radius": 6
-    }
+    "explosion": { "damage": 70, "radius": 6 }
   },
   {
     "id": "AMMO_M433_HEDP",
@@ -463,9 +460,6 @@
   {
     "id": "AMMO_40x46_MAKESHIFT_HE",
     "type": "ammo_effect",
-    "explosion": {
-      "damage": 60,
-      "radius": 5
-    }
+    "explosion": { "damage": 60, "radius": 5 }
   }
 ]

--- a/data/json/items/ammo/40x46mm.json
+++ b/data/json/items/ammo/40x46mm.json
@@ -42,7 +42,7 @@
     "damage": { "damage_type": "bullet", "amount": 125, "armor_penetration": 30 },
     "casing": "40x46mm_m118_casing",
     "loudness": 80,
-    "extend": { "effects": [ "FRAG", "NO_PENETRATE_OBSTACLES" ] }
+    "extend": { "effects": [ "AMMO_M433_HEDP", "NO_PENETRATE_OBSTACLES" ] }
   },
   {
     "id": "40x46mm_m576",
@@ -148,8 +148,8 @@
     "name": { "str": "improvised 40x46mm HE" },
     "description": "A high velocity 40x46mm HEDP grenade, loaded with a homemade explosive round.  Packs quite a punch, though less effective against armor than proper HEDP.",
     "proportional": { "price_postapoc": 0.8, "damage": { "damage_type": "bullet", "amount": 0.6, "armor_penetration": 0.4 } },
-    "extend": { "effects": [ "EXPLOSIVE" ] },
-    "delete": { "effects": [ "FRAG" ] }
+    "extend": { "effects": [ "AMMO_40x46_MAKESHIFT_HE" ] },
+    "delete": { "effects": [ "AMMO_M433_HEDP" ] }
   },
   {
     "id": "40x46mm_makeshift_he_m199",

--- a/data/json/items/ammo/40x53mm.json
+++ b/data/json/items/ammo/40x53mm.json
@@ -44,7 +44,7 @@
     "damage": { "damage_type": "bullet", "amount": 145, "armor_penetration": 45 },
     "casing": "40x53mm_m169_casing",
     "loudness": 100,
-    "extend": { "effects": [ "FRAG", "NO_PENETRATE_OBSTACLES" ] }
+    "extend": { "effects": [ "AMMO_M430A1_HEDP", "NO_PENETRATE_OBSTACLES" ] }
   },
   {
     "id": "40x53mm_buckshot_m169",
@@ -80,7 +80,7 @@
     "name": { "str": "improvised 40x53mm HE" },
     "description": "A high velocity 40x53mm HEDP grenade, loaded with a homemade explosive round.  Packs quite a punch, though less effective against armor than proper HEDP.",
     "proportional": { "price_postapoc": 0.8, "damage": { "damage_type": "bullet", "amount": 0.6, "armor_penetration": 0.4 } },
-    "extend": { "effects": [ "EXPLOSIVE" ] },
-    "delete": { "effects": [ "FRAG" ] }
+    "extend": { "effects": [ "AMMO_40x53_MAKESHIFT_HE" ] },
+    "delete": { "effects": [ "AMMO_M430A1_HEDP" ] }
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
40mm grenades (both low and high velocity) are currently extremely underwhelming for munitions that are extremely underwhelming for being grenades. They are for some reason weaker than hand grenades.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Overhauls the effects for 40mm high and low velocity hedp and makeshift he. Real life figures say that hedp has a kill radius of about 5m and a wound radius of about 15m against lightly armored infantry, and proper he has a wound radius of about 15m as well. I've simulated this by making the hedp spawn a small but powerful explosion of radius 1 (cause 1 cata tile is apparently about 2m) and a shrapnel radius of 7. I've also differentiated between the high and low velocity grenades by making the high velocity shrapnel have higher armor penetration. The makeshift he has lower damage and radius than actual he cause its makeshift or whatever.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
No cool explosions
## Testing
Debug shot groups of zombies, both armored and unarmored with the grenades, everything seems to work as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Might make more balance changes depending on how this turns out
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e5d8a51](https://github.com/cataclysmbn/Cataclysm-BN/commit/e5d8a510fc6413062e753e6de08a8de28c38de5e) (style(autofix.ci): automated formatting) on 2026-05-27 22:25:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26539516682/artifacts/7252453174)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26539516682/artifacts/7253123410)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26539516682/artifacts/7252626150)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26539516682/artifacts/7252642954)
<!-- END artifact comment -->