### PR TITLE
feat: add 152mm atgm launcher to beagle ugv

### DIFF
--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -452,7 +452,7 @@
     "armor_electric": 72,
     "vision_day": 50,
     "revert_to_itype": "bot_tankbot",
-    "starting_ammo": { "556": 1000, "40x46mm_m433": 20 },
+    "starting_ammo": { "556": 1000, "40x46mm_m433": 20, "atgm_heat": 4 },
     "path_settings": { "max_dist": 20 },
     "special_attacks": [ [ "MULTI_ROBOT", 3 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "tankbot", 1 ] ] },

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4199,7 +4199,7 @@ bool mattack::multi_robot( monster *z )
             }
             break;
         case 5:
-            if(dist <= 50 ) {
+            if( dist <= 50 ) {
                 atgm( z, target );
             }
             break;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -3620,6 +3620,68 @@ void mattack::tankgun( monster *z, Creature *target )
                             burst ) * tmp->primary_weapon().ammo_required();
 }
 
+void mattack::atgm( monster *z, Creature *target )
+{
+    if( z->type->monster_weapon && z->has_effect( effect_monster_disarmed ) ) {
+        return;
+    }
+    const itype_id ammo_type( "atgm_heat" );
+    // Make sure our ammo isn't weird.
+    if( z->ammo[ammo_type] > 4 ) {
+        debugmsg( "Generated too much ammo (%d) for %s in mattack::atgm", z->ammo[ammo_type],
+                  z->name() );
+        z->ammo[ammo_type] = 4;
+    }
+
+    int dist = rl_dist( z->bub_pos(), target->bub_pos() );
+    if( dist > 50 ) {
+        return;
+    }
+
+    if( !z->has_effect( effect_targeted ) ) {
+        //~ There will be a ATGM HEAT sent at high speed to your location next turn.
+        target->add_msg_if_player( m_warning, _( "You're not sure why you've got a laser dot on you…" ) );
+        //~ Sound of a atgm tube uncovering swiveling into place
+        sounds::sound( z->bub_pos(), 10, sounds::sound_t::combat, _( "whirrrrrclick." ), false, "misc",
+                       "servomotor" );
+        z->add_effect( effect_targeted, 1_minutes );
+        target->add_effect( effect_laserlocked, 1_minutes );
+        z->moves -= 200;
+        // Should give some ability to get behind cover,
+        // even though it's patently unrealistic.
+        return;
+    }
+    std::unique_ptr<npc> tmp = make_fake_npc( z, 12, 8, 8, 8 );
+    tmp->set_skill_level( skill_launcher, 1 );
+    tmp->set_skill_level( skill_gun, 1 );
+    // No need to aim
+    tmp->recoil = 0;
+    // It takes a while
+    z->moves -= 150;
+
+    if( z->ammo[ammo_type] <= 0 ) {
+        if( one_in( 3 ) ) {
+            sounds::sound( z->bub_pos(), 2, sounds::sound_t::combat, _( "a chk!" ), false, "fire_gun",
+                           "empty" );
+        } else if( one_in( 4 ) ) {
+            sounds::sound( z->bub_pos(), 6, sounds::sound_t::combat, _( "clank!" ), false, "fire_gun",
+                           "empty" );
+        }
+        return;
+    }
+    if( g->u.sees( *z ) ) {
+        add_msg( m_warning, _( "The %s's ATGM tube fires!" ), z->name() );
+    }
+
+    detached_ptr<item> gun = item::spawn( "atgm_launcher" );
+    gun->ammo_set( ammo_type, z->ammo[ ammo_type ] );
+    tmp->set_primary_weapon( std::move( gun ) );
+    int burst = std::max( tmp->primary_weapon().gun_get_mode( gun_mode_id( "AUTO" ) ).qty, 1 );
+
+    z->ammo[ ammo_type ] -= ranged::fire_gun( *tmp, target->bub_pos(),
+                            burst ) * tmp->primary_weapon().ammo_required();
+}
+
 bool mattack::searchlight( monster *z )
 {
 
@@ -4134,6 +4196,11 @@ bool mattack::multi_robot( monster *z )
         case 2:
             if( dist <= 30 ) {
                 frag( z, target );
+            }
+            break;
+        case 5:
+            if(dist <= 50 ) {
+                atgm( z, target );
             }
             break;
         default:

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -129,6 +129,8 @@ void rifle( monster *z, Creature *target );
 void frag( monster *z, Creature *target );
 /// Tankbot primary
 void tankgun( monster *z, Creature *target );
+/// ATGM for Beagle
+void atgm( monster *z, Creature *target );
 void flame( monster *z, Creature *target );
 
 bool dodge_check( monster *z, Creature *target );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The beagle ugv's description mentions an anti-tank missile launcher, yet the ugv doesn't actually have the ability to do this, and thus has no ability against vehicles.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds an inaccurate atgm attack that should only activate against vehicles at long distance.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Weak beagle
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [957766e](https://github.com/cataclysmbn/Cataclysm-BN/commit/957766e9cf94cca7306baeb1abb94946d647122a) (style(autofix.ci): automated formatting) on 2026-05-28 01:16:35

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26546566921/artifacts/7255056715)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26546566921/artifacts/7255456796)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26546566921/artifacts/7255143006)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26546566921/artifacts/7255092132)
<!-- END artifact comment -->