### PR TITLE
chore: update repo owner credits

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,8 +21,9 @@ appearance, race, religion, or sexual identity and orientation.
 5. If other participants complain about the way you express your ideas, please make an effort to
    cater to them.
 6. Don't raise unrelated political issues.
-7. If you feel these standards are being violated, please alert the project's "ombudsman" Jakob at
-   lamandus@hotmail.com
+7. If you feel these standards are being violated, please alert one of the repository owners by
+   direct message on the [official Discord server](https://discord.gg/XW7XhXuZ89): scarf005,
+   RobbieNeko, chaosvolt, or Oren Audeles.
 
 ## Attribution
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,9 +21,9 @@ appearance, race, religion, or sexual identity and orientation.
 5. If other participants complain about the way you express your ideas, please make an effort to
    cater to them.
 6. Don't raise unrelated political issues.
-7. If you feel these standards are being violated, please alert one of the repository owners by
-   direct message on the [official Discord server](https://discord.gg/XW7XhXuZ89): scarf005,
-   RobbieNeko, chaosvolt, or Oren Audeles.
+7. If you feel these standards are being violated, please alert one of the repository owners
+   (scarf005, RobbieNeko, chaosvolt, or Oren Audeles) by direct message on the
+   [official Discord server](https://discord.gg/XW7XhXuZ89).
 
 ## Attribution
 

--- a/data/credits/en.credits
+++ b/data/credits/en.credits
@@ -1,15 +1,15 @@
 # Max length of a line is 78 characters; the following line is for reference
 # Longer lines will be automatically folded
 ##############################################################################
-<color_white>Project Manager:</color>
-<color_yellow>Coolthulhu</color>
+<color_white>Repository Owners:</color>
+<color_yellow>scarf005, RobbieNeko, chaosvolt, Oren Audeles</color>
 
 <color_white>Original creators:</color>
 <color_yellow>Whales, TheDarklingWolf, GlyphGryph</color> (<color_dark_gray>retired</color>)    
 <color_yellow>KevinGranade</color> (<color_dark_gray>from DDA fork</color>)
 
 <color_white>Special thanks to:</color>
-<color_yellow>Coolthulhu</color> - For re-starting the project.
+<color_yellow>Coolthulhu</color> - For re-starting the project. (<color_dark_gray>retired</color>)
 <color_yellow>Contributors</color> - For contributing to development.
 <color_yellow>Translators</color> - For translations.
 <color_yellow>Community</color> - For supporting us.

--- a/data/credits/ja.credits
+++ b/data/credits/ja.credits
@@ -1,15 +1,15 @@
 # 1行の最大長は78文字です。以下の行は参照用
 # 長い行は自動的に折り返されます
 ##############################################################################
-<color_white>プロジェクト管理者:</color>
-<color_yellow>Coolthulhu</color>
+<color_white>リポジトリオーナー:</color>
+<color_yellow>scarf005, RobbieNeko, chaosvolt, Oren Audeles</color>
 
 <color_white>オリジナルの作者:</color>
 <color_yellow>Whales, TheDarklingWolf, GlyphGryph</color> (<color_dark_gray>引退</color>)    
 <color_yellow>KevinGranade</color> (<color_dark_gray>DDAフォークより</color>)
 
 <color_white>スペシャルサンクス:</color>
-<color_yellow>Coolthulhu</color> - プロジェクトの再スタートをした方。
+<color_yellow>Coolthulhu</color> - プロジェクトの再スタートをした方。 (<color_dark_gray>引退</color>)
 <color_yellow>貢献者達</color> - 開発に協力してくれた方々。
 <color_yellow>翻訳者達</color> - 翻訳に協力してくれた方々。
 <color_yellow>コミュニティ</color> - 私たちへのサポートをしてくれた方々。

--- a/data/credits/ru.credits
+++ b/data/credits/ru.credits
@@ -1,15 +1,15 @@
 # Max length of a line is 78 characters; the following line is for reference
 # Longer lines will be automatically folded
 ##############################################################################
-<color_white>Менеджер проекта:</color>
-<color_yellow>Coolthulhu</color>
+<color_white>Владельцы репозитория:</color>
+<color_yellow>scarf005, RobbieNeko, chaosvolt, Oren Audeles</color>
 
 <color_white>Оригинальные создатели:</color>                                         
 <color_yellow>Whales, TheDarklingWolf, GlyphGryph</color> (<color_dark_gray>не активны</color>)                  
 <color_yellow>KevinGranade</color> (<color_dark_gray>из форка DDA</color>)
 
 <color_white>Особая благодарность:</color>
-<color_yellow>Coolthulhu</color> - За перезапуск проекта.
+<color_yellow>Coolthulhu</color> - За перезапуск проекта. (<color_dark_gray>не активен</color>)
 <color_yellow>Контрибюторам</color> - За вклад в разработку.
 <color_yellow>Переводчикам</color> - За вклад в перевод.
 <color_yellow>Коммюнити</color> - За поддержку.


### PR DESCRIPTION
## Purpose of change (The Why)

Update outdated single-person project/contact credits to current repository owners.

Related: #662, #1892

## Describe the solution (The How)

- Replace the code of conduct contact with repository owners via the official Discord.
- Replace Project Manager credits with Repository Owners in English, Japanese, and Russian credits.
- Move Coolthulhu to special thanks as retired.

## Testing

- `deno fmt --check CODE_OF_CONDUCT.md`

Reviewer steps:
- Open the credits screen and confirm the repository owner list appears in English, Japanese, and Russian credits.
- Review `CODE_OF_CONDUCT.md` and confirm the conduct contact points to current repository owners.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.kernel.org/process/coding-assistants.html) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [37eabec](https://github.com/cataclysmbn/Cataclysm-BN/commit/37eabec9bd2bd59150c3554f31308cee24c09241) (docs: clarify conduct contact owners) on 2026-05-28 02:17:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26548660863/artifacts/7255789220)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26548660863/artifacts/7256187225)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26548660863/artifacts/7256067788)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26548660863/artifacts/7255912126)
<!-- END artifact comment -->