### PR TITLE
fix: keep preserved food fresh when queried

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6330,6 +6330,17 @@ time_duration item::get_shelf_life() const
     return 0_turns;
 }
 
+namespace
+{
+
+auto is_in_preserving_container( const item &it ) -> bool
+{
+    const auto *parent = it.parent_item();
+    return parent != nullptr && parent->type->container && parent->type->container->preserves;
+}
+
+} // namespace
+
 double item::get_relative_rot() const
 {
     if( goes_bad() ) {
@@ -9904,6 +9915,12 @@ detached_ptr<item> item::actualize_rot( detached_ptr<item> &&self, const tripoin
         return process_rot( std::move( self ), false, pnt, nullptr, temperature, weather );
     } else if( self->type->container && self->type->container->preserves ) {
         // Containers like tin cans preserves all items inside, they do not rot at all.
+        self->visit_items( []( item * it, item * parent ) {
+            if( parent != nullptr && it->goes_bad() ) {
+                it->last_rot_check = calendar::turn;
+            }
+            return VisitResponse::NEXT;
+        } );
         return std::move( self );
     } else if( self->type->container && self->type->container->seals ) {
         // Items inside rot but do not vanish as the container seals them in.
@@ -10074,6 +10091,10 @@ static units::temperature clip_by_temperature_flag( units::temperature temperatu
 void item::update_rot_from_location( const temperature_flag temperature )
 {
     if( !goes_bad() || last_rot_check == calendar::turn ) {
+        return;
+    }
+    if( is_in_preserving_container( *this ) ) {
+        last_rot_check = calendar::turn;
         return;
     }
 

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 
+#include <array>
 #include <memory>
 #include <ranges>
 
@@ -8,6 +9,7 @@
 #include "coordinates.h"
 #include "enums.h"
 #include "item.h"
+#include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "game.h" // Just for get_convection_temperature(), TODO: Remove
@@ -101,6 +103,87 @@ static auto add_sashimi_to_map( const tripoint_bub_ms &pos ) -> void
 {
     get_map().add_item( pos, item::spawn( "sashimi" ) );
     REQUIRE( get_map().i_at( pos ).size() == 1 );
+}
+
+static auto contained_food( item &container ) -> item & // *NOPAD*
+{
+    REQUIRE_FALSE( container.contents.empty() );
+    auto &food = container.contents.front();
+    REQUIRE( food.goes_bad() );
+    return food;
+}
+
+TEST_CASE( "Preserving containers keep contents fresh when queried" )
+{
+    clear_all_state();
+    set_map_temperature( get_weather(), 18_c );
+
+    SECTION( "preserving containers suppress stale rot on content freshness queries" ) {
+        const auto preserving_containers = std::array {
+            itype_id( "can_food" ),
+            itype_id( "jar_glass_sealed" ),
+            itype_id( "plastic_bag_vac" ),
+        };
+
+        for( const auto &container_type : preserving_containers ) {
+            INFO( container_type.c_str() );
+            calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+            auto sealed_food = item::in_container( container_type, item::spawn( "offal_canned" ) );
+            REQUIRE( sealed_food->type->container );
+            REQUIRE( sealed_food->type->container->preserves );
+            auto &food = contained_food( *sealed_food );
+
+            calendar::turn += 365_days;
+
+            CHECK_FALSE( food.rotten() );
+            CHECK( food.get_relative_rot() == 0.0 );
+            CHECK( food.get_rot() == 0_turns );
+            CHECK( food.is_fresh() );
+        }
+    }
+
+    SECTION( "sealed but non-preserving containers still allow contained food to rot" ) {
+        calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+        auto sealed_food = item::in_container( itype_id( "jar_glass" ), item::spawn( "offal_canned" ) );
+        REQUIRE( sealed_food->type->container );
+        REQUIRE( sealed_food->type->container->seals );
+        REQUIRE_FALSE( sealed_food->type->container->preserves );
+        auto &food = contained_food( *sealed_food );
+
+        calendar::turn += 365_days;
+
+        CHECK( food.rotten() );
+        CHECK( food.get_rot() > food.get_shelf_life() );
+    }
+
+    SECTION( "map load actualization keeps preserving container contents fresh" ) {
+        calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+        auto sealed_food = item::in_its_container( item::spawn( "offal_canned" ) );
+        auto &food = contained_food( *sealed_food );
+        REQUIRE( food.get_rot() == 0_turns );
+
+        auto m = tinymap();
+        constexpr auto test_location = tripoint_abs_sm( 100, 100, 0 );
+        constexpr auto non_tested_location = tripoint_abs_sm( 0, 0, 0 );
+        const auto pos = tripoint_bub_ms( 14, 13, 0 );
+        m.load( test_location, false );
+        m.ter_set( pos, t_grass );
+        m.i_clear( pos );
+        m.add_item( pos, std::move( sealed_food ) );
+
+        m.load( non_tested_location, false );
+        calendar::turn += 365_days;
+        m.load( test_location, false );
+
+        auto sealed_stack = m.i_at( pos );
+        REQUIRE( sealed_stack.size() == 1 );
+        auto &sealed_item = sealed_stack.only_item();
+        REQUIRE( sealed_item.type->container );
+        REQUIRE( sealed_item.type->container->preserves );
+        auto &stored_food = contained_food( sealed_item );
+        CHECK_FALSE( stored_food.rotten() );
+        CHECK( stored_food.get_rot() == 0_turns );
+    }
 }
 
 TEST_CASE( "Rate of rotting" )


### PR DESCRIPTION
## Purpose of change (The Why)

close #9121

Caused by: #9010

Sealed preserving containers could still show rotten contents after enough time passed because freshness queries actualized the contained food's stale rot without applying the parent container's preservation.

## Describe the solution (The How)

- Refresh perishable contents' `last_rot_check` when map load actualization sees a preserving container.
- Skip rot catch-up for perishable items while their parent container preserves contents.
- Keep sealed non-preserving containers rotting their contents normally.

## Describe alternatives you've considered

Only changing inventory display would leave other freshness-query paths such as eating, crafting, and NPC evaluation able to actualize stale rot.

## Testing

- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles -j2`
- `./out/build/linux-full/tests/cata_test-tiles "Preserving containers keep contents fresh when queried"`
- `./out/build/linux-full/tests/cata_test-tiles "*rot*"`

Reviewer steps: spawn or find a sealed canned/jarred food with `spoils_in`, advance a year, inspect/eat it while still sealed; it should not be rotten. Put the same food in a sealed non-preserving jar and advance time; it should still rot.

## Additional context

The regression test covers cans, sealed glass jars, vacuum-packed bags, map-load actualization, and sealed non-preserving containers.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [8e956e9](https://github.com/cataclysmbn/Cataclysm-BN/commit/8e956e9edecfed5349aa18a033d165ce016fd1ab) (fix: keep preserved food fresh when queried) on 2026-05-29 02:39:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26612593272/artifacts/7281380390)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26612593272/artifacts/7281770479)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26612593272/artifacts/7281525073)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26612593272/artifacts/7281413893)
<!-- END artifact comment -->