### PR TITLE
ci: cache affected files dependencies

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -95,6 +95,9 @@ jobs:
       - uses: denoland/setup-deno@v2
         with: { cache: true }
 
+      - name: cache affected-files dependencies
+        run: deno cache --frozen scripts/affected_files.ts
+
       - name: build clang-tidy plugin
         run: |
           pip install --break-system-packages lit
@@ -106,7 +109,7 @@ jobs:
       #     clang-tidy --version
 
       - name: gather affected files
-        run: deno task affected-files ${{ github.event.pull_request.number }} --output "$AFFECTED_FILES"
+        run: deno run --cached-only -RWEN --allow-run scripts/affected_files.ts ${{ github.event.pull_request.number }} --output "$AFFECTED_FILES"
 
       - name: run clang-tidy
         run: bash ./build-scripts/run-clang-tidy-plugin.sh

--- a/deno.lock
+++ b/deno.lock
@@ -12,7 +12,7 @@
     "jsr:@david/which@~0.4.1": "0.4.1",
     "jsr:@scarf/json-map@^0.0.4": "0.0.4",
     "jsr:@std/assert@^1.0.15": "1.0.15",
-    "jsr:@std/async@*": "1.0.9",
+    "jsr:@std/async@*": "1.0.15",
     "jsr:@std/async@^1.0.15": "1.0.15",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
     "jsr:@std/collections@*": "1.1.3",
@@ -21,6 +21,7 @@
     "jsr:@std/fmt@^1.0.8": "1.0.8",
     "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/front-matter@^1.0.9": "1.0.9",
+    "jsr:@std/fs@*": "1.0.21",
     "jsr:@std/fs@1": "1.0.21",
     "jsr:@std/fs@^1.0.19": "1.0.19",
     "jsr:@std/fs@^1.0.20": "1.0.21",
@@ -39,6 +40,7 @@
     "jsr:@std/yaml@^1.0.5": "1.0.10",
     "jsr:@valibot/valibot@*": "0.42.1",
     "jsr:@valibot/valibot@^1.1.0": "1.1.0",
+    "npm:@octokit/rest@21.0.2": "21.0.2",
     "npm:dprint@*": "0.47.5",
     "npm:json-order@*": "1.1.3",
     "npm:sharp@~0.33.5": "0.33.5",
@@ -352,6 +354,102 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
+    "@octokit/auth-token@5.1.2": {
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="
+    },
+    "@octokit/core@6.1.6": {
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+      "dependencies": [
+        "@octokit/auth-token",
+        "@octokit/graphql",
+        "@octokit/request",
+        "@octokit/request-error",
+        "@octokit/types@14.1.0",
+        "before-after-hook",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/endpoint@10.1.4": {
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "dependencies": [
+        "@octokit/types@14.1.0",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/graphql@8.2.2": {
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "dependencies": [
+        "@octokit/request",
+        "@octokit/types@14.1.0",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/openapi-types@24.2.0": {
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
+    },
+    "@octokit/openapi-types@25.1.0": {
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
+    },
+    "@octokit/plugin-paginate-rest@11.6.0_@octokit+core@6.1.6": {
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+      "dependencies": [
+        "@octokit/core",
+        "@octokit/types@13.10.0"
+      ]
+    },
+    "@octokit/plugin-request-log@5.3.1_@octokit+core@6.1.6": {
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "dependencies": [
+        "@octokit/core"
+      ]
+    },
+    "@octokit/plugin-rest-endpoint-methods@13.5.0_@octokit+core@6.1.6": {
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+      "dependencies": [
+        "@octokit/core",
+        "@octokit/types@13.10.0"
+      ]
+    },
+    "@octokit/request-error@6.1.8": {
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "dependencies": [
+        "@octokit/types@14.1.0"
+      ]
+    },
+    "@octokit/request@9.2.4": {
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "dependencies": [
+        "@octokit/endpoint",
+        "@octokit/request-error",
+        "@octokit/types@14.1.0",
+        "fast-content-type-parse",
+        "universal-user-agent"
+      ]
+    },
+    "@octokit/rest@21.0.2": {
+      "integrity": "sha512-+CiLisCoyWmYicH25y1cDfCrv41kRSvTq6pPWtRroRJzhsCZWZyCqGyI8foJT5LmScADSwRAnr/xo+eewL04wQ==",
+      "dependencies": [
+        "@octokit/core",
+        "@octokit/plugin-paginate-rest",
+        "@octokit/plugin-request-log",
+        "@octokit/plugin-rest-endpoint-methods"
+      ]
+    },
+    "@octokit/types@13.10.0": {
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dependencies": [
+        "@octokit/openapi-types@24.2.0"
+      ]
+    },
+    "@octokit/types@14.1.0": {
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dependencies": [
+        "@octokit/openapi-types@25.1.0"
+      ]
+    },
+    "before-after-hook@3.0.2": {
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
+    },
     "color-convert@2.0.1": {
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": [
@@ -392,6 +490,9 @@
       ],
       "scripts": true,
       "bin": true
+    },
+    "fast-content-type-parse@2.0.1": {
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
     },
     "is-arrayish@0.3.2": {
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
@@ -453,6 +554,9 @@
     },
     "type-fest@4.27.0": {
       "integrity": "sha512-3IMSWgP7C5KSQqmo1wjhKrwsvXAtF33jO3QY+Uy++ia7hqvgSK6iXbbg5PbDBc1P2ZbNEDgejOrN4YooXvhwCw=="
+    },
+    "universal-user-agent@7.0.3": {
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
     }
   },
   "redirects": {

--- a/scripts/affected_files.ts
+++ b/scripts/affected_files.ts
@@ -9,7 +9,7 @@
 import { walk, type WalkEntry, type WalkOptions } from "jsr:@std/fs"
 import { MuxAsyncIterator } from "jsr:@std/async"
 import { partition } from "jsr:@std/collections"
-import { Octokit, type RestEndpointMethodTypes } from "https://esm.sh/@octokit/rest@21.0.2"
+import { Octokit, type RestEndpointMethodTypes } from "npm:@octokit/rest@21.0.2"
 import { Command } from "@cliffy/command"
 
 const paths = ["src", "tests"]
@@ -19,8 +19,8 @@ type ListFileResponse = RestEndpointMethodTypes["pulls"]["listFiles"]["response"
 const ACMRT: Set<ListFileResponse["status"]> = new Set(
   ["added", "copied", "modified", "renamed", "changed"],
 )
-const octokit = new Octokit({ auth: Deno.env.get("GITHUB_TOKEN") })
 const getDiffs = async (pr: number) => {
+  const octokit = new Octokit({ auth: Deno.env.get("GITHUB_TOKEN") })
   const res = await octokit.paginate(
     octokit.rest.pulls.listFiles,
     { owner: "cataclysmbn", repo: "Cataclysm-BN", pull_number: pr },


### PR DESCRIPTION
## Purpose of change (The Why)

Avoid late clang-tidy failures when `affected_files.ts` dependencies are missing from the restored Deno cache or esm.sh is unavailable.

Failing run: https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26613025235/job/78422817323

```text
error: Import 'https://esm.sh/@octokit/rest@21.0.2' failed: 522 <unknown status code>
    at file:///home/runner/work/Cataclysm-BN/Cataclysm-BN/scripts/affected_files.ts:12:55
```

Related: #9138

## Describe the solution (The How)

- Imports Octokit through Deno's npm resolver instead of esm.sh.
- Warms the script dependency graph in clang-tidy with `deno cache --frozen scripts/affected_files.ts`.
- Runs the script directly with `deno run --cached-only` so missing cached dependencies fail immediately.

## Describe alternatives you've considered

Keeping the direct esm.sh import would keep the job vulnerable to transient esm.sh fetch failures.

## Testing

- `deno cache scripts/affected_files.ts`
- `deno fmt scripts/affected_files.ts deno.jsonc .github/workflows/clang-tidy.yml`
- `DENO_DIR="$cache_dir" deno cache --frozen scripts/affected_files.ts`
- `DENO_DIR="$cache_dir" deno run --cached-only -RWEN --allow-run scripts/affected_files.ts --help`
- `deno run --cached-only -RWEN --allow-run scripts/affected_files.ts 9138 --output /tmp/affected-files-9138.txt`
- `deno test --allow-read --allow-env=GITHUB_TOKEN,npm_package_config_libvips,TILESET_PYTHON --allow-ffi scripts/affected_files.ts`
- `actionlint .github/workflows/clang-tidy.yml`

Reviewer check: run `deno cache --frozen scripts/affected_files.ts`, then run `deno run --cached-only -RWEN --allow-run scripts/affected_files.ts <pr-number> --output /tmp/affected-files.txt`; the second command should use cached module dependencies.

## Additional context

AI assistance was used for this PR.

This is CI-only; no user-facing documentation changes are needed.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description; `Assisted-by` trailers are left to configured automation.

<sub>PR opened by gpt-5.5 high on pi</sub>

