### PR TITLE
feat(balance): add three new professions, some adjustments to existing professions

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -59,6 +59,17 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "temporal_soldier_garand",
+    "entries": [
+      { "item": "garandclip", "ammo-item": "3006", "charges": 8 },
+      { "item": "garandclip", "ammo-item": "3006", "charges": 8 },
+      { "item": "garandclip", "ammo-item": "3006", "charges": 8 },
+      { "item": "garandclip", "ammo-item": "3006", "charges": 8 }
+ ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "army_mags_mp5",
     "entries": [ { "item": "mp5mag", "ammo-item": "9mm", "charges": 30 }, { "item": "mp5mag", "ammo-item": "9mm", "charges": 30 } ]
   },
@@ -746,7 +757,8 @@
           "smart_phone",
           "matches",
           "wristwatch"
-        ]
+        ],
+        "entries": [ { "item": "lighter", "charges": 25 } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -1482,6 +1494,42 @@
       "male": [ "boxer_shorts" ],
       "female": [ "boy_shorts", "sports_bra" ]
     }
+  },
+  {
+    "type": "profession",
+    "id": "soldier_wwii",
+    "copy-from": "soldier",
+    "name": "Army Infantry",
+    "description": "One moment you were scrambling for cover in a shell crater, on some burnt-out island in the Pacific.  Then a bright flash, and next thing you know you're stateside again.  Except the cities don't look anything like how you remember them, and the smell of death hangs in the air like it followed you home",
+    "traits": [ "PROF_MILITARY" ],
+    "//": "About as close as we can get with current existing items.",
+    "items": {
+      "both": {
+        "items": [
+          "pants",
+          "tshirt",
+          "jacket_army",
+          "helmet_liner",
+          "helmet_steel",
+          "socks",
+          "boots",
+          "wristwatch",
+          "canteen",
+          "mess_tin",
+          "shovel_short",
+          "rucksack"
+        ],
+        "entries": [
+          { "item": "chestrig", "contents-group": "temporal_soldier_garand" },
+          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "grenadebandolier", "contents-item": [ "grenade", "grenade" ] },
+          { "item": "garand", "ammo-item": "3006", "charges": 8, "contents-item": [ "shoulder_strap" ] }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "boy_shorts", "sports_bra" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
   },
   {
     "type": "profession",
@@ -3430,6 +3478,19 @@
   },
   {
     "type": "profession",
+    "id": "wolfpack_mutant",
+    "name": "Mutant Pack Leader",
+    "description": "They treated you like an animal in that lab.  Now that you're free, you wonder if they had the right idea.  Your new friends don't seem afraid of you like they are of humans, after all.",
+    "starting_cash": 0,
+    "points": 4,
+    "skills": [ { "level": 1, "name": "survival" } ],
+    "traits": [ "LUPINE_FUR", "TAIL_FLUFFY", "LUPINE_EARS", "THRESH_LUPINE" ],
+    "pets": [ { "name": "mon_wolf", "amount": 2 } ],
+    "items": { "both": [ "subsuit_xl" ], "male": [ "briefs" ], "female": [ "bra", "panties" ] },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
     "id": "broken_cyborg",
     "name": "Defective Cyborg",
     "description": "You were normal once.  Before the tests, before the procedures, before they stripped away every outward sign of your humanity.  You're more machine than man now, but that might prove an advantage against the horrors that await.",
@@ -4205,6 +4266,35 @@
         ]
       },
       "male": [ "briefs" ],
+      "female": [ "bra", "panties" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "rioter",
+    "name": "Rioter",
+    "description": "The first protest you were at started peaceful, until they hosed the crowd down with machinegun fire instead of water cannons.  You escaped, and came prepared for a fight next time.  You weren't prepared for the cops and protesters to tear themselves apart in a cannibalistic frenzy.",
+    "points": 0,
+    "items": {
+      "both": {
+        "items": [
+          "jeans",
+          "longshirt",
+          "socks",
+          "sneakers",
+          "mbag",
+          "mask_rioter",
+          "helmet_bike",
+          "sunglasses",
+          "pockknife",
+          "wristwatch"
+        ],
+        "entries": [
+          { "item": "molotov", "count": 2 },
+          { "item": "lighter", "charges": 25 }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     }
   },
@@ -6113,7 +6203,7 @@
         "items": [
           "hat_ball",
           "knit_scarf",
-          "tshirt",
+          "alohashirt",
           "jacket_light",
           "gloves_light",
           "pants",
@@ -6736,7 +6826,7 @@
           "matches",
           "wristwatch"
         ],
-        "entries": [ { "item": "makeshift_crowbar", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [ { "item": "lighter", "charges": 25 }, { "item": "makeshift_crowbar", "custom-flags": [ "auto_wield" ] } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -65,7 +65,7 @@
       { "item": "garandclip", "ammo-item": "3006", "charges": 8 },
       { "item": "garandclip", "ammo-item": "3006", "charges": 8 },
       { "item": "garandclip", "ammo-item": "3006", "charges": 8 }
- ]
+    ]
   },
   {
     "type": "item_group",
@@ -1453,6 +1453,7 @@
     "id": "soldier",
     "name": "Military Rifleman",
     "description": "You were hoping to see some action, only to get more than you bargained for deployed stateside responding to a national emergency.  As far as you can tell, military command abandoned you to this hellhole.",
+    "age": { "min": 17, "max": 35 },
     "points": 4,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -1516,7 +1517,7 @@
           "wristwatch",
           "canteen",
           "mess_tin",
-          "shovel_short",
+          "e_tool",
           "rucksack"
         ],
         "entries": [
@@ -1536,6 +1537,7 @@
     "id": "mil_auto_rifleman",
     "name": "Military Automatic Rifleman",
     "description": "You were trained to lay down suppressing fire, and are armed accordingly.  But they just seem to keep coming without end, you're not sure you have the firepower for this.",
+    "age": { "min": 17, "max": 35 },
     "points": 5,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -1585,6 +1587,7 @@
     "id": "mil_grenadier",
     "name": "Military Grenadier",
     "description": "You were the one assigned the team's grenade launcher, something you thought was overkill for a stateside deployment at first.  Now you're starting to wish you joined the Field Artillery Branch.",
+    "age": { "min": 17, "max": 35 },
     "points": 5,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -1634,6 +1637,7 @@
     "id": "mil_marksman",
     "name": "Military Designated Marksman",
     "description": "You aren't a dedicated sniper, but every squad needs someone who can handle targets beyond their effective range.  Without the rest of your squad, things are getting too close quarters for your liking.",
+    "age": { "min": 17, "max": 35 },
     "points": 5,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -1688,6 +1692,7 @@
     "id": "prof_combat_engineer",
     "name": "Combat Engineer",
     "description": "Your military training focused on field fortifications and demolitions, along with the basics on modern autonomous defenses.  You never expected to need that training on the home front, not that it's helped so far given the bots are all on free-fire mode.",
+    "age": { "min": 20, "max": 40 },
     "points": 6,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -1743,6 +1748,7 @@
     "id": "specops",
     "name": "Special Operator",
     "description": "You were the best of the best, the military's finest.  That's why you're still alive, even after all your comrades fell to the undead.  As far as you can tell, military command abandoned you in this hellhole when you missed the emergency evac.",
+    "age": { "min": 20, "max": 40 },
     "points": 5,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -1793,6 +1799,7 @@
     "id": "specops_frogman",
     "name": "Spec Ops Combat Diver",
     "description": "You were the best of the best, the military's finest.  Trained in underwater sabotage and boarding operations, you've survived where others became shark bait.  As far as you can tell, military command has left you high and dry.",
+    "age": { "min": 20, "max": 40 },
     "points": 5,
     "traits": [ "PROF_MILITARY", "PROF_SWIMMER" ],
     "skills": [
@@ -1842,6 +1849,7 @@
     "id": "military_saboteur",
     "name": "Military Saboteur",
     "description": "You were transferred to the lab's security department in an advisory position.  In actuality, in the event things went wrong your orders were to locate and disable some sort of portal experiment, and issued a backpack nuke.  Unfortunately, you discovered too late that this facility doesn't contain the equipment you were looking for.",
+    "age": { "min": 20, "max": 40 },
     "points": 4,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -1890,6 +1898,7 @@
     "id": "power_armor_soldier",
     "name": "Power Armor Soldier",
     "description": "Those new plutonium power banks they were rolling out never arrived, nevermind the experimental new weapons, but at least your unit received the latest generation of powered armor.  The rest of your squad has fallen, but your gear might see you through.",
+    "age": { "min": 20, "max": 40 },
     "points": 8,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -1965,6 +1974,7 @@
     "id": "combat_mech_pilot",
     "name": "Combat Mech Pilot",
     "description": "You were field-testing the latest in military firepower, with Mechanical Exoskeleton Suits planned to fill the niche left after power armor development shifted to lighter models.  Your mech's built to lay down heavy fire support, but the power cell the technicians provided has been mostly depleted from earlier tests.",
+    "age": { "min": 20, "max": 40 },
     "points": 8,
     "traits": [ "PROF_MILITARY" ],
     "pets": [ { "name": "mon_mech_combat", "amount": 1 } ],
@@ -2014,6 +2024,7 @@
     "id": "recon_mech_pilot",
     "name": "Recon Mech Pilot",
     "description": "You were field-testing the latest in military firepower, with Mechanical Exoskeleton Suits planned to fill the niche left after power armor development shifted to lighter models.  Your mech's built for scouting and sniping, but the power cell the technicians provided has been mostly depleted from earlier tests.",
+    "age": { "min": 20, "max": 40 },
     "points": 8,
     "traits": [ "PROF_MILITARY" ],
     "pets": [ { "name": "mon_mech_recon", "amount": 1 } ],
@@ -3712,6 +3723,7 @@
     "id": "bio_soldier",
     "name": "Bionic Soldier",
     "description": "You are the result of one of the military's latest and final research programs, a prototype cyborg soldier.  You're still alive thanks to your augmentations, even after all your comrades fell to the undead.",
+    "age": { "min": 20, "max": 40 },
     "points": 6,
     "CBMs": [
       "bio_targeting",
@@ -3775,6 +3787,7 @@
     "name": "Bionic Sniper",
     "description": "Your bionics, equipment, and extensive field training enable you to drop targets from implausible distances, even after weeks of total isolation in enemy territory.",
     "points": 8,
+    "age": { "min": 20, "max": 40 },
     "CBMs": [
       "bio_eye_enhancer",
       "bio_targeting",
@@ -3842,6 +3855,7 @@
     "id": "bio_specops",
     "name": "Bionic Operator",
     "description": "You were the best of the best, the military's finest, and your bionics have only enhanced your abilities.  Specializing in close quarters combat, you were sent on the most dangerous and critical missions.",
+    "age": { "min": 20, "max": 40 },
     "points": 8,
     "traits": [ "PROF_MILITARY" ],
     "CBMs": [ "bio_cqb", "bio_carbon", "bio_night_vision", "bio_torsionratchet", "bio_claws", "bio_power_storage_mkII" ],
@@ -4289,10 +4303,7 @@
           "pockknife",
           "wristwatch"
         ],
-        "entries": [
-          { "item": "molotov", "count": 2 },
-          { "item": "lighter", "charges": 25 }
-        ]
+        "entries": [ { "item": "molotov", "count": 2 }, { "item": "lighter", "charges": 25 } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -4954,6 +4965,7 @@
     "id": "national_guard",
     "name": "National Guard",
     "description": "Your National Guard unit was activated when the epidemic struck.  Despite your best efforts you did not manage to meet up with them before all communications ceased and you found yourself alone amongst the dead.",
+    "age": { "min": 17, "max": 35 },
     "points": 3,
     "traits": [ "PROF_MILITARY" ],
     "skills": [ { "level": 1, "name": "swimming" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "firstaid" } ],
@@ -5204,6 +5216,7 @@
     "id": "winter_army",
     "name": "Military Holdout",
     "description": "You must have paid attention to your survival training in boot camp, otherwise you would never have lived long enough to outlast the chain of command and find yourself in this predicament.  The only mission left now is to survive.",
+    "age": { "min": 18, "max": 36 },
     "points": 6,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -6612,6 +6625,7 @@
     "id": "mili_pilot",
     "name": "Military Pilot",
     "description": "You got to see things fall apart from the sky, transporting soldiers and survivors from one holdout to the next.  You knew it was only a matter of time before the horrors patrolling the skies shot you down.",
+    "age": { "min": 20, "max": 40 },
     "points": 5,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -6662,6 +6676,7 @@
     "id": "fighter_pilot",
     "name": "Fighter Pilot",
     "description": "They had you pushing your aircraft to the breaking point dropping ordinance on the undead.  After a mid-air collision forced you to eject, you were picked up by the unit you were providing air support for only for them to be wiped out to the last man.",
+    "age": { "min": 20, "max": 40 },
     "points": 6,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -7070,6 +7085,7 @@
     "name": "Feral Soldier",
     "//": "Contains a Full Metal Jacket reference.  One higher point cost due to added gear.",
     "description": "As far as you can tell, command abandoned you to this hellhole.  How can you take care of a bunch of panicked civilians in need of assistance with no backup?  Easy, you just don't lead 'em so much.",
+    "age": { "min": 17, "max": 35 },
     "points": 5,
     "traits": [ "PROF_MILITARY", "PROF_FERAL" ],
     "skills": [
@@ -7543,6 +7559,7 @@
     "id": "mili_burner",
     "name": "Military Corpse Disposal",
     "description": "In response to the outbreak, you were dispatched to contain the infection by burning the corpses.  With command consumed by the undead, your priorities have shifted to basic survival.",
+    "age": { "min": 17, "max": 35 },
     "points": 6,
     "skills": [
       { "level": 3, "name": "gun" },
@@ -7589,6 +7606,7 @@
     "id": "major-general",
     "name": "Major General",
     "description": "You worked your way up through the ranks from a no-name private to a big shot Major General, respected and decorated.  On the downside, years of desk duty have left your shooting skills rusty, and all the medals in the world won't protect you now.",
+    "age": { "min": 30, "max": 62 },
     "points": 4,
     "skills": [
       { "level": 1, "name": "swimming" },
@@ -7941,6 +7959,7 @@
     "id": "elite_specops",
     "name": "Elite Operator",
     "description": "You were the best of the best, the military's finest, and among them you were better still.  Movies have been made about the missions you went on, and that's only the declassified ones. After getting back from yet another top secret mission, all you wanted to do was relax. Unfortunately, the Cataclysm had other plans, and now, stuck without your gear, you'll just have to show them what makes you tier one.",
+    "age": { "min": 20, "max": 40 },
     "points": 8,
     "traits": [ "PROF_MILITARY", "PROF_SWIMMER" ],
     "skills": [

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -746,18 +746,7 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "longshirt",
-          "socks",
-          "sneakers",
-          "mbag",
-          "pockknife",
-          "water_clean",
-          "smart_phone",
-          "matches",
-          "wristwatch"
-        ],
+        "items": [ "jeans", "longshirt", "socks", "sneakers", "mbag", "pockknife", "water_clean", "smart_phone", "wristwatch" ],
         "entries": [ { "item": "lighter", "charges": 25 } ]
       },
       "male": [ "boxer_shorts" ],
@@ -821,9 +810,9 @@
           "sneakers",
           "multitool",
           "water_clean",
-          "matches",
           "wristwatch"
-        ]
+        ],
+        "entries": [ { "item": "lighter", "charges": 25 } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -6829,18 +6818,7 @@
     "traits": [ "PROF_FERAL" ],
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "longshirt",
-          "socks",
-          "sneakers",
-          "mbag",
-          "pockknife",
-          "water_clean",
-          "smart_phone",
-          "matches",
-          "wristwatch"
-        ],
+        "items": [ "jeans", "longshirt", "socks", "sneakers", "mbag", "pockknife", "water_clean", "smart_phone", "wristwatch" ],
         "entries": [ { "item": "lighter", "charges": 25 }, { "item": "makeshift_crowbar", "custom-flags": [ "auto_wield" ] } ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -801,17 +801,7 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants",
-          "tshirt",
-          "socks",
-          "smart_phone",
-          "sweater",
-          "sneakers",
-          "multitool",
-          "water_clean",
-          "wristwatch"
-        ],
+        "items": [ "pants", "tshirt", "socks", "smart_phone", "sweater", "sneakers", "multitool", "water_clean", "wristwatch" ],
         "entries": [ { "item": "lighter", "charges": 25 } ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -277,7 +277,7 @@
     "description": "A temporal distortion has hurled you into this collapsing world. You arrive carrying only the few items that mattered most to you - the things tied to who you are, or who you were meant to become.",
     "start_name": "Wilderness",
     "allowed_locs": [ "sloc_forest", "sloc_field", "sloc_swamp" ],
-    "professions": [ "churl", "caveman", "prospector", "knight", "frontiersman", "dogsledder" ],
+    "professions": [ "churl", "caveman", "prospector", "knight", "frontiersman", "dogsledder", "soldier_wwii" ],
     "forbids_bionics": true,
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
@@ -471,6 +471,7 @@
     "flags": [ "WIN_START", "LONE_START" ],
     "add_professions": true,
     "professions": [
+      "wolfpack_mutant",
       "sheltered_survivor",
       "sheltered_militia",
       "winter_scavenger",
@@ -511,6 +512,7 @@
     "flags": [ "SUM_ADV_START", "LONE_START" ],
     "add_professions": true,
     "professions": [
+      "wolfpack_mutant",
       "sheltered_survivor",
       "sheltered_militia",
       "winter_scavenger",
@@ -622,7 +624,16 @@
     "description": "Since birth, your sole purpose in life has been the advancement of genetic science, willingly or not.  Once the Cataclysm struck, you left the lab, and wandered aimlessly, ending up in a forest.",
     "start_name": "Wilderness",
     "allowed_locs": [ "sloc_forest", "sloc_field", "sloc_swamp" ],
-    "professions": [ "unemployed", "mutant_patient", "mutant_volunteer", "broken_cyborg", "faulty_bionic", "cykotic", "convict_political" ],
+    "professions": [
+      "unemployed",
+      "mutant_patient",
+      "mutant_volunteer",
+      "wolfpack_mutant",
+      "broken_cyborg",
+      "faulty_bionic",
+      "cykotic",
+      "convict_political"
+    ],
     "traits": [
       "ELFAEYES",
       "NIGHTVISION2",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Profession stuffs. :D

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added three new professions: rioter, army infantry, and mutant pack leader. Rioter takes its cues from the standard evacuee profession and swaps out some of the basic items (don't take your phone to a protest, for example) for a couple molotovs and a small bit of improvised armor, plus of course the rioter mask. Not really meant to be flavored as properly geared up for clashing with police since doing so would warrant bumping up the point cost. Army infantry meanwhile is a scenario-only profession based off the standard military rifleman, flavored as being time-displaced from WWII (as much as existing items allow), armed with a Garand (few extra en-blocs than normal since low capacity and it's their only ranged weapon). The mutant pack leader meanwhile is a scenario-locked wolf mutant that starts with 3 pet wolves.
2. Added army infantry profession to Temporal Anomaly scenario, and added mutant pack leader to the Experiment scenario along with the two post-apoc scenarios.
3. Expanded use of age ranges for professions: set age range for standard military professions at a typical 17-35 (it's implied for most they haven't been in the military for super long, so used the lowest one can legally join - 17 being permitted with parental permission - up to typical upper bound), a higher range of 20-40 for soldier professions implied to have been there for a while, then finally 30-62 for the major general profession (62 being mandatory retirement age).
4. Misc: replaced matches on the standard survivor profession with a more typical disposable lighter.
5. Misc: Replaced the tourist's tshirt with a hawaiian shirt because it's THE definitive tourist shirt according to Nethack.

## Describe alternatives you've considered

Not age-locking military professions I guess.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
