### PR TITLE
fix: remove redundant copy of northeast aluminum quarterpanel, add missing part shapes

### DIFF
--- a/data/json/vehicleparts/boards.json
+++ b/data/json/vehicleparts/boards.json
@@ -839,13 +839,6 @@
   {
     "id": "aluminum_halfboard_ne",
     "looks_like": "halfboard_ne",
-    "copy-from": "carbon_halfboard",
-    "type": "vehicle_part",
-    "symbol": "u"
-  },
-  {
-    "id": "aluminum_halfboard_ne",
-    "looks_like": "halfboard_ne",
     "copy-from": "aluminum_halfboard",
     "type": "vehicle_part",
     "symbol": "u"
@@ -898,6 +891,34 @@
     "copy-from": "aluminum_halfboard",
     "type": "vehicle_part",
     "symbol": "H"
+  },
+  {
+    "id": "aluminum_halfboard_vertical_2_left",
+    "looks_like": "halfboard_vertical_2_left",
+    "copy-from": "aluminum_halfboard",
+    "type": "vehicle_part",
+    "symbol": "H"
+  },
+  {
+    "id": "aluminum_halfboard_vertical_2_right",
+    "looks_like": "halfboard_vertical_2_right",
+    "copy-from": "aluminum_halfboard",
+    "type": "vehicle_part",
+    "symbol": "H"
+  },
+  {
+    "id": "aluminum_halfboard_vertical_T_right",
+    "looks_like": "halfboard_vertical_T_right",
+    "copy-from": "aluminum_halfboard",
+    "type": "vehicle_part",
+    "symbol": "]"
+  },
+  {
+    "id": "aluminum_halfboard_vertical_T_left",
+    "looks_like": "halfboard_vertical_T_left",
+    "copy-from": "aluminum_halfboard",
+    "type": "vehicle_part",
+    "symbol": "["
   },
   {
     "id": "aluminum_board_horizontal",

--- a/data/json/vehicleparts/controls.json
+++ b/data/json/vehicleparts/controls.json
@@ -145,38 +145,6 @@
   },
   {
     "type": "vehicle_part",
-    "id": "programmable_autopilot",
-    "name": { "str": "programmable autopilot" },
-    "symbol": "A",
-    "color": "light_blue",
-    "broken_symbol": "#",
-    "broken_color": "red",
-    "damage_modifier": 80,
-    "durability": 100,
-    "description": "A computer system hooked up to the steering and engine of the vehicle to allow it to follow simple paths.",
-    "item": "programmable_autopilot",
-    "difficulty": 5,
-    "looks_like": "cam_control",
-    "epower": -15,
-    "flags": [ "ENABLED_DRAINS_EPOWER", "AUTOPILOT", "SHOCK_RESISTANT" ],
-    "requirements": {
-      "install": {
-        "time": "12 m",
-        "skills": [ [ "mechanics", 5 ], [ "electronics", 5 ], [ "computer", 5 ] ],
-        "qualities": [ { "id": "SCREW", "level": 1 } ]
-      },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "3 m", "using": [ [ "adhesive", 1 ], [ "vehicle_repair_electronics", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 3 ] ], "qualities": [ { "id": "SCREW", "level": 1 } ] }
-    },
-    "breaks_into": [
-      { "item": "steel_lump", "prob": 50 },
-      { "item": "steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 0, 3 ] }
-    ],
-    "damage_reduction": { "all": 8 }
-  },
-  {
-    "type": "vehicle_part",
     "id": "drive_by_wire_controls",
     "name": { "str": "drive by wire controls" },
     "symbol": "$",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fixes something Nyaa spotted in the BN server, and something I spotted while fixing that.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Deleted an extra instance of `aluminum_halfboard_ne` that mysteriously inherited from carbon fiber panels instead.
2. Added part shapes for aluminum panels that were missing, for parity with normal steel panels.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Used notepad++ to confirm the number of IDs for aluminum panel and board variants match the number regular panels and boards have.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f103d85](https://github.com/cataclysmbn/Cataclysm-BN/commit/f103d85f4e8d041076dc4dac63d9cd4e346d218b) (Extrapilot...) on 2026-05-29 10:03:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26628443143/artifacts/7287274356)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26628443143/artifacts/7287912245)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26628443143/artifacts/7287169889)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26628443143/artifacts/7287487526)
<!-- END artifact comment -->