### PR TITLE
feat: New athletics themed profession, blackbelt buff

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4729,7 +4729,7 @@
     "points": 8,
     "traits": [ "PROF_MA_BLACK" ],
     "skills": [
-      { "level": 2, "name": "swimming" },
+      { "level": 5, "name": "swimming" },
       { "level": 8, "name": "melee" },
       { "level": 8, "name": "unarmed" },
       { "level": 8, "name": "dodge" }
@@ -4738,6 +4738,19 @@
       "both": [ "karate_gi", "judo_belt_black", "mouthpiece", "geta" ],
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boy_shorts" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "worlds_greatest",
+    "name": "World's Greatest Athlete",
+    "description": "Back in the summer of '48 your name reverberated across the world as you set record after record in the Olympics, becoming the greatest of all time. Alas, even with your face plastered across billboards and cereals, the zombies are still more interested in turning you into gold medalist goulash.",
+    "points": 10,
+    "skills": [ { "level": 10, "name": "swimming" }, { "level": 2, "name": "dodge" }, { "level": 2, "name": "melee" }, { "level": 2, "name": "throw" } ],
+    "items": {
+      "both": [ "tshirt", "sneakers", "jacket_light" ],
+      "male": [ "briefs", "socks", "pants" ],
+      "female": [ "bra", "panties", "stockings", "skirt" ]
     }
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

1. Blackbelt kinda lagged behind elite op a decent bit balance wise 
2. No good athletics themed profession 

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Blackbelt athletics from 2 to 5 so it's still not as good but significantly better.

New profession 
World's Greatest Athlete (a decathlon winner) 
10 athletics
2 throwing, melee, dodge
Normal clothes


<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

No

## Testing

Loaded in game, both worked fine, unsure about grammur tho so check if i fat fingered description 
Couldnt find code formatted, yes skill issue i know

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### 