### PR TITLE
feat(balance): massively increase dispersion on feral human thrown rocks

### DIFF
--- a/data/json/items/gun/monster_gun.json
+++ b/data/json/items/gun/monster_gun.json
@@ -63,7 +63,7 @@
     "to_hit": 1,
     "loudness": 2,
     "range": 6,
-    "dispersion": 150,
+    "dispersion": 6000,
     "durability": 8
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
As of now, feral humans are apparently all pro mlb pitchers who are able to consistently hit the player with thrown rocks. This isn't very accurate to how well an average person would actually be able to throw a rock at another person. We also don't use ferals throwing rocks to be annoying like in dda, as they can't actually spawn until at least a week or two has passed, so the whole thing of having a weak ranged attack to discourage roof camping is moot anyways.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Massively increases the dispersion of the hurled rubble fake gun to 6000 from 150, so they actually miss about half the time like some random person throwing rocks at you would. For reference, 150 dispersion is about equivalent to an actual gun.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
MLB pitchers everywhere
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9bf989d](https://github.com/cataclysmbn/Cataclysm-BN/commit/9bf989d4f120f80de4e3266e8292bb6a35725d1e) (Update monster_gun.json) on 2026-05-29 20:49:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26658746376/artifacts/7299906602)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26658746376/artifacts/7300547928)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26658746376/artifacts/7300230723)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26658746376/artifacts/7300094601)
<!-- END artifact comment -->