### PR TITLE
fix: Fix bitmap font loading

### DIFF
--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -430,7 +430,7 @@ BitmapFont::BitmapFont(
                                        glyph_h, font_w, font_h );
 
         auto new_surf = create_surface_32( font_w * 16, font_h * 16 );
-        const auto new_fmt = SDL_GetPixelFormatDetails( glyphs->format );
+        const auto new_fmt = SDL_GetPixelFormatDetails( new_surf->format );
         const Uint32 new_key = SDL_MapRGB( new_fmt, nullptr, 0xFF, 0, 0xFF );
         SDL_FillSurfaceRect( new_surf.get(), nullptr, new_key );
 

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -3,6 +3,8 @@
 #include "output.h"
 #include "platform_win.h"
 #include "string_utils.h"
+#include "hsv_color.h"
+#include "sdl_utils.h"
 
 #define dbg(x) DebugLogFL((x),DC::SDL)
 
@@ -402,7 +404,6 @@ void CachedTTFFont::OutputChar( const SDL_Renderer_Ptr &renderer, const Geometry
     }
 }
 
-
 BitmapFont::BitmapFont(
     SDL_Renderer_Ptr &renderer, SDL_PixelFormat format,
     const int w, const int h,
@@ -411,39 +412,86 @@ BitmapFont::BitmapFont(
     : Font( w, h, palette )
 {
     dbg( DL::Info ) << "Loading bitmap font [" + typeface_path + "].";
-    SDL_Surface_Ptr asciiload = load_image( typeface_path.c_str() );
-    assert( asciiload );
-    if( asciiload->w * asciiload->h < ( width * height * 256 ) ) {
-        throw std::runtime_error( "bitmap for font is to small" );
-    }
-    Uint32 key = SDL_MapRGB( SDL_GetPixelFormatDetails( asciiload->format ), nullptr, 0xFF, 0, 0xFF );
-    SDL_SetSurfaceColorKey( asciiload.get(), true, key );
-    SDL_Surface_Ptr ascii_surf[std::tuple_size<decltype( ascii )>::value];
-    ascii_surf[0].reset( SDL_ConvertSurface( asciiload.get(), format ) );
-    SDL_SetSurfaceRLE( ascii_surf[0].get(), true );
-    asciiload.reset();
+    SDL_Surface_Ptr glyphs = load_image( typeface_path.c_str() );
+    assert( glyphs );
 
-    for( size_t a = 1; a < std::tuple_size<decltype( ascii )>::value; ++a ) {
-        ascii_surf[a].reset( SDL_ConvertSurface( ascii_surf[0].get(), format ) );
-        SDL_SetSurfaceRLE( ascii_surf[a].get(), true );
-    }
+    const auto glyph_w = glyphs->w / 16;
+    const auto glyph_h = glyphs->h / 16;
+    const auto font_w = width;
+    const auto font_h = height;
 
-    for( size_t a = 0; a < std::tuple_size<decltype( ascii )>::value - 1; ++a ) {
-        SDL_LockSurface( ascii_surf[a].get() );
-        int size = ascii_surf[a]->h * ascii_surf[a]->w;
-        Uint32 *pixels = static_cast<Uint32 *>( ascii_surf[a]->pixels );
-        Uint32 color = ( windowsPalette[a].r << 16 ) | ( windowsPalette[a].g << 8 ) | windowsPalette[a].b;
-        for( int i = 0; i < size; i++ ) {
-            if( pixels[i] == 0xFFFFFF ) {
-                pixels[i] = color;
+    if ( glyph_h == font_h && glyph_w == font_w ) {
+        /* Do Nothing */
+    } else {
+        /* Remap Glyphs to expected size */
+        /* TODO: Maybe scale if pixel perfect (eg 16x16 to 32x32) */
+        dbg( DL::Warn ) << string_format("Bitmap font glyph size (%d x %d) does not match game glyph size (%d x %d)", glyph_w, glyph_h, font_w, font_h );
+
+        auto new_surf = create_surface_32(font_w * 16, font_h * 16);
+        const auto new_fmt = SDL_GetPixelFormatDetails( glyphs->format );
+        const Uint32 new_key = SDL_MapRGB( new_fmt, nullptr, 0xFF, 0, 0xFF );
+        SDL_FillSurfaceRect(new_surf.get(), nullptr, new_key);
+
+        const auto dx = (font_w - glyph_w) / 2;
+        const auto dy = (font_h - glyph_h) / 2;
+
+        for (int yy = 0; yy < 16; ++yy) {
+            for (int xx = 0; xx < 16; ++xx) {
+                const auto srcRect = SDL_Rect { xx * glyph_w, yy * glyph_h, glyph_w, glyph_h };
+                const auto dstRect = SDL_Rect {xx * font_w + dx, yy * font_h + dy, font_w, font_h};
+                SDL_BlitSurface(glyphs.get(), &srcRect, new_surf.get(), &dstRect );
             }
         }
-        SDL_UnlockSurface( ascii_surf[a].get() );
+
+        glyphs.swap( new_surf );
+    }
+
+    constexpr auto COLORS = std::tuple_size_v<decltype(ascii)>;
+
+    const auto fmt = SDL_GetPixelFormatDetails( glyphs->format );
+    const Uint32 key = SDL_MapRGB( fmt, nullptr, 0xFF, 0, 0xFF );
+    SDL_SetSurfaceColorKey( glyphs.get(), true, key );
+
+    std::array<SDL_Surface_Ptr, COLORS> ascii_surf {};
+    ascii_surf[0] = std::move(glyphs);
+    for( size_t a = 1; a < COLORS; ++a ) {
+        ascii_surf[a].reset( SDL_ConvertSurface( ascii_surf[0].get(), format ) );
+    }
+
+    for( size_t a = 0; a < COLORS; ++a ) {
+        const auto surf = ascii_surf[a].get();
+        if (SDL_MUSTLOCK(surf)) {
+            SDL_LockSurface( surf );
+        }
+
+        const int pixel_count = ascii_surf[a]->h * ascii_surf[a]->w;
+        const auto raw_pixels = static_cast<SDL_Color*>(ascii_surf[a]->pixels);
+        const auto pixels = std::span(raw_pixels, pixel_count);
+        constexpr auto key_col = RGBColor(255,0,255, 255);
+        const auto dst_col = RGBColor(windowsPalette[a].r ,windowsPalette[a].g, windowsPalette[a].b, 255);
+
+        for (auto& pixel : pixels) {
+            auto src_col = RGBColor{pixel};
+            if (src_col == key_col) {
+                continue;
+            }
+
+            src_col.r = src_col.r * dst_col.r / 255;
+            src_col.g = src_col.g * dst_col.g / 255;
+            src_col.b = src_col.b * dst_col.b / 255;
+
+            pixel = src_col;
+        }
+
+        if (SDL_MUSTLOCK(surf)) {
+            SDL_UnlockSurface( ascii_surf[a].get() );
+        }
     }
     tilewidth = ascii_surf[0]->w / width;
 
     //convert ascii_surf to SDL_Texture
-    for( size_t a = 0; a < std::tuple_size<decltype( ascii )>::value; ++a ) {
+    for( size_t a = 0; a < COLORS; ++a ) {
+        SDL_SetSurfaceRLE( ascii_surf[a].get(), true );
         ascii[a] = CreateTextureFromSurface( renderer, ascii_surf[a] );
     }
 }

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -449,25 +449,17 @@ BitmapFont::BitmapFont(
     }
 
     constexpr auto COLORS = std::tuple_size_v<decltype( ascii )>;
-
-    const auto fmt = SDL_GetPixelFormatDetails( glyphs->format );
-    const Uint32 key = SDL_MapRGB( fmt, nullptr, 0xFF, 0, 0xFF );
-    SDL_SetSurfaceColorKey( glyphs.get(), true, key );
-
-    std::array<SDL_Surface_Ptr, COLORS> ascii_surf {};
-    ascii_surf[0] = std::move( glyphs );
-    for( size_t a = 1; a < COLORS; ++a ) {
-        ascii_surf[a].reset( SDL_ConvertSurface( ascii_surf[0].get(), format ) );
-    }
+    const auto fnt_fmt = SDL_GetPixelFormatDetails( format );
+    const Uint32 fnt_key = SDL_MapRGB( fnt_fmt, nullptr, 0xFF, 0, 0xFF );
 
     for( size_t a = 0; a < COLORS; ++a ) {
-        const auto surf = ascii_surf[a].get();
-        if( SDL_MUSTLOCK( surf ) ) {
-            SDL_LockSurface( surf );
+        const auto sdl_surf = SDL_Surface_Ptr { SDL_DuplicateSurface( glyphs.get() ) };
+        if( SDL_MUSTLOCK( sdl_surf.get() ) ) {
+            SDL_LockSurface( sdl_surf.get() );
         }
 
-        const int pixel_count = ascii_surf[a]->h * ascii_surf[a]->w;
-        const auto raw_pixels = static_cast<SDL_Color *>( ascii_surf[a]->pixels );
+        const int pixel_count = sdl_surf->h * sdl_surf->w;
+        const auto raw_pixels = static_cast<SDL_Color *>( sdl_surf->pixels );
         const auto pixels = std::span( raw_pixels, pixel_count );
         constexpr auto key_col = RGBColor( 255, 0, 255, 255 );
         const auto dst_col = RGBColor( windowsPalette[a].r, windowsPalette[a].g, windowsPalette[a].b, 255 );
@@ -485,17 +477,18 @@ BitmapFont::BitmapFont(
             pixel = src_col;
         }
 
-        if( SDL_MUSTLOCK( surf ) ) {
-            SDL_UnlockSurface( ascii_surf[a].get() );
+        if( SDL_MUSTLOCK( sdl_surf.get() ) ) {
+            SDL_UnlockSurface( sdl_surf.get() );
+        }
+
+        {
+            auto fnt_surf = SDL_Surface_Ptr { SDL_ConvertSurface( sdl_surf.get(), format ) };
+            SDL_SetSurfaceColorKey( fnt_surf.get(), true, fnt_key );
+            SDL_SetSurfaceRLE( fnt_surf.get(), true );
+            ascii[a] = CreateTextureFromSurface( renderer, fnt_surf );
         }
     }
-    tilewidth = ascii_surf[0]->w / width;
-
-    //convert ascii_surf to SDL_Texture
-    for( size_t a = 0; a < COLORS; ++a ) {
-        SDL_SetSurfaceRLE( ascii_surf[a].get(), true );
-        ascii[a] = CreateTextureFromSurface( renderer, ascii_surf[a] );
-    }
+    tilewidth = glyphs->w / width;
 }
 
 void BitmapFont::draw_ascii_lines( const SDL_Renderer_Ptr &renderer,

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -420,59 +420,61 @@ BitmapFont::BitmapFont(
     const auto font_w = width;
     const auto font_h = height;
 
-    if ( glyph_h == font_h && glyph_w == font_w ) {
+    if( glyph_h == font_h && glyph_w == font_w ) {
         /* Do Nothing */
     } else {
         /* Remap Glyphs to expected size */
         /* TODO: Maybe scale if pixel perfect (eg 16x16 to 32x32) */
-        dbg( DL::Warn ) << string_format("Bitmap font glyph size (%d x %d) does not match game glyph size (%d x %d)", glyph_w, glyph_h, font_w, font_h );
+        dbg( DL::Warn ) <<
+                        string_format( "Bitmap font glyph size (%d x %d) does not match game glyph size (%d x %d)", glyph_w,
+                                       glyph_h, font_w, font_h );
 
-        auto new_surf = create_surface_32(font_w * 16, font_h * 16);
+        auto new_surf = create_surface_32( font_w * 16, font_h * 16 );
         const auto new_fmt = SDL_GetPixelFormatDetails( glyphs->format );
         const Uint32 new_key = SDL_MapRGB( new_fmt, nullptr, 0xFF, 0, 0xFF );
-        SDL_FillSurfaceRect(new_surf.get(), nullptr, new_key);
+        SDL_FillSurfaceRect( new_surf.get(), nullptr, new_key );
 
-        const auto dx = (font_w - glyph_w) / 2;
-        const auto dy = (font_h - glyph_h) / 2;
+        const auto dx = ( font_w - glyph_w ) / 2;
+        const auto dy = ( font_h - glyph_h ) / 2;
 
-        for (int yy = 0; yy < 16; ++yy) {
-            for (int xx = 0; xx < 16; ++xx) {
+        for( int yy = 0; yy < 16; ++yy ) {
+            for( int xx = 0; xx < 16; ++xx ) {
                 const auto srcRect = SDL_Rect { xx * glyph_w, yy * glyph_h, glyph_w, glyph_h };
-                const auto dstRect = SDL_Rect {xx * font_w + dx, yy * font_h + dy, font_w, font_h};
-                SDL_BlitSurface(glyphs.get(), &srcRect, new_surf.get(), &dstRect );
+                const auto dstRect = SDL_Rect {xx *font_w + dx, yy *font_h + dy, font_w, font_h};
+                SDL_BlitSurface( glyphs.get(), &srcRect, new_surf.get(), &dstRect );
             }
         }
 
         glyphs.swap( new_surf );
     }
 
-    constexpr auto COLORS = std::tuple_size_v<decltype(ascii)>;
+    constexpr auto COLORS = std::tuple_size_v<decltype( ascii )>;
 
     const auto fmt = SDL_GetPixelFormatDetails( glyphs->format );
     const Uint32 key = SDL_MapRGB( fmt, nullptr, 0xFF, 0, 0xFF );
     SDL_SetSurfaceColorKey( glyphs.get(), true, key );
 
     std::array<SDL_Surface_Ptr, COLORS> ascii_surf {};
-    ascii_surf[0] = std::move(glyphs);
+    ascii_surf[0] = std::move( glyphs );
     for( size_t a = 1; a < COLORS; ++a ) {
         ascii_surf[a].reset( SDL_ConvertSurface( ascii_surf[0].get(), format ) );
     }
 
     for( size_t a = 0; a < COLORS; ++a ) {
         const auto surf = ascii_surf[a].get();
-        if (SDL_MUSTLOCK(surf)) {
+        if( SDL_MUSTLOCK( surf ) ) {
             SDL_LockSurface( surf );
         }
 
         const int pixel_count = ascii_surf[a]->h * ascii_surf[a]->w;
-        const auto raw_pixels = static_cast<SDL_Color*>(ascii_surf[a]->pixels);
-        const auto pixels = std::span(raw_pixels, pixel_count);
-        constexpr auto key_col = RGBColor(255,0,255, 255);
-        const auto dst_col = RGBColor(windowsPalette[a].r ,windowsPalette[a].g, windowsPalette[a].b, 255);
+        const auto raw_pixels = static_cast<SDL_Color *>( ascii_surf[a]->pixels );
+        const auto pixels = std::span( raw_pixels, pixel_count );
+        constexpr auto key_col = RGBColor( 255, 0, 255, 255 );
+        const auto dst_col = RGBColor( windowsPalette[a].r, windowsPalette[a].g, windowsPalette[a].b, 255 );
 
-        for (auto& pixel : pixels) {
+        for( auto &pixel : pixels ) {
             auto src_col = RGBColor{pixel};
-            if (src_col == key_col) {
+            if( src_col == key_col ) {
                 continue;
             }
 
@@ -483,7 +485,7 @@ BitmapFont::BitmapFont(
             pixel = src_col;
         }
 
-        if (SDL_MUSTLOCK(surf)) {
+        if( SDL_MUSTLOCK( surf ) ) {
             SDL_UnlockSurface( ascii_surf[a].get() );
         }
     }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3848,7 +3848,7 @@ void catacurses::init_interface()
         overmap_font = std::make_unique<FontFallbackList>( renderer, format, fl.overmap_fontwidth,
                        fl.overmap_fontheight,
                        windowsPalette, fl.overmap_typeface, fl.overmap_fontsize, fl.fontblending );
-    }catch ( std::exception & e ) {
+    } catch( std::exception &e ) {
         font.reset();
         map_font.reset();
         overmap_font.reset();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3839,14 +3839,22 @@ void catacurses::init_interface()
     // initialize sound set
     load_soundset();
 
-    font = std::make_unique<FontFallbackList>( renderer, format, fl.fontwidth, fl.fontheight,
-            windowsPalette, fl.typeface, fl.fontsize, fl.fontblending );
-    map_font = std::make_unique<FontFallbackList>( renderer, format, fl.map_fontwidth,
-               fl.map_fontheight,
-               windowsPalette, fl.map_typeface, fl.map_fontsize, fl.fontblending );
-    overmap_font = std::make_unique<FontFallbackList>( renderer, format, fl.overmap_fontwidth,
-                   fl.overmap_fontheight,
-                   windowsPalette, fl.overmap_typeface, fl.overmap_fontsize, fl.fontblending );
+    try {
+        font = std::make_unique<FontFallbackList>( renderer, format, fl.fontwidth, fl.fontheight,
+                windowsPalette, fl.typeface, fl.fontsize, fl.fontblending );
+        map_font = std::make_unique<FontFallbackList>( renderer, format, fl.map_fontwidth,
+                   fl.map_fontheight,
+                   windowsPalette, fl.map_typeface, fl.map_fontsize, fl.fontblending );
+        overmap_font = std::make_unique<FontFallbackList>( renderer, format, fl.overmap_fontwidth,
+                       fl.overmap_fontheight,
+                       windowsPalette, fl.overmap_typeface, fl.overmap_fontsize, fl.fontblending );
+    }catch ( std::exception & e ) {
+        font.reset();
+        map_font.reset();
+        overmap_font.reset();
+        throw;
+    }
+
     stdscr = newwin( get_terminal_height(), get_terminal_width(), point_zero );
     //newwin calls `new WINDOW`, and that will throw, but not return nullptr.
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<img width="1367" height="580" alt="image" src="https://github.com/user-attachments/assets/ec8214b4-78df-45d8-94f6-929d6955011f" />

## Describe the solution (The How)

* Remove magic constants from bitmap font loading
* Rewrite glyph recoloring code to also blend grayscales to output color, instead of just replacing white
* Remap glyphs to expected tile size (e.g 16x16 bitmap font to 18x18 game tile)
  * + Fix segfault when the above was true

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

N/A

## Testing

* Disable Overmap graphical tiles
* Enable bitmap font on config.json 
```
{
  "typeface": [ "data/font/Terminus.ttf", "data/font/unifont.ttf" ],
  "map_typeface": [ "data/font/Terminus.ttf", "data/font/unifont.ttf" ],
  "overmap_typeface": [ "data/font/map_font_LARWICK.png", "data/font/Terminus.ttf", "data/font/unifont.ttf" ]
}
```
* Start game and open overmap, bitmap font tiles should be colored

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e059730](https://github.com/cataclysmbn/Cataclysm-BN/commit/e0597303a4383f541e450db584a45e59ce68161d) (return the blood to the blood god) on 2026-05-30 01:52:34

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26669768885/artifacts/7304041901)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26669768885/artifacts/7304277736)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26669768885/artifacts/7304093064)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26669768885/artifacts/7304068124)
<!-- END artifact comment -->