### PR TITLE
ci: scope Windows ccache by build flavor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,11 +206,12 @@ jobs:
         if: runner.os == 'Windows'
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: windows-${{ matrix.artifact }}-${{ github.ref_name }}
+          # Build mode changes MSVC compiler inputs.
+          key: windows-${{ matrix.artifact }}-${{ inputs.mode }}-${{ github.ref_name }}
           restore-keys: |
-            windows-${{ matrix.artifact }}-${{ github.ref_name }}
-            windows-${{ matrix.artifact }}-main
-            windows-${{ matrix.artifact }}-
+            windows-${{ matrix.artifact }}-${{ inputs.mode }}-${{ github.ref_name }}
+            windows-${{ matrix.artifact }}-${{ inputs.mode }}-main
+            windows-${{ matrix.artifact }}-${{ inputs.mode }}-
           max-size: 3G
           verbose: 2
           save: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Purpose of change (The Why)

Windows PR CI was restoring release ccache entries with incompatible compiler inputs, causing 0% ccache hits.

Related: #8823, #8915, #8937.

## Describe the solution (The How)

Scope the Windows ccache key by build mode so PR CI no longer restores release-mode ccache entries. Keep the existing Linux-style cache save policy: PRs restore cache but only non-PR runs save cache.

## Describe alternatives you've considered

Leaving PRs to restore the release cache was rejected because `Release` objects do not match the PR CI `RelWithDebInfo` compiler inputs. Letting Windows PRs save their own caches was rejected to avoid extra GitHub Actions cache quota pressure.

## Testing

- `deno fmt .github/workflows/build.yml`
- `actionlint .github/workflows/build.yml`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`

Reviewer check: after a successful main CI run creates a `windows-*-ci-main` cache, Windows PR CI should restore a `ci` cache instead of a release cache.

## Additional context

Prepared with AI assistance.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This is a PR that modifies build process or code organization.
  - [x] This only changes CI cache keying; no user build documentation changed.
  - [x] This does not alter versions of software required to build or work with the game.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0d2a9be](https://github.com/cataclysmbn/Cataclysm-BN/commit/0d2a9be86cd7a52d7329941f30c0cdef83804b04) (ci: scope Windows ccache by build flavor) on 2026-05-30 02:47:23

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26670979920/artifacts/7304385395)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26670979920/artifacts/7304603365)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26670979920/artifacts/7304384290)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26670979920/artifacts/7304454451)
<!-- END artifact comment -->