### PR TITLE
ci: publish PR artifacts per platform

### DIFF
--- a/.github/actions/publish-pr-artifact-body/action.yml
+++ b/.github/actions/publish-pr-artifact-body/action.yml
@@ -1,0 +1,103 @@
+name: Publish PR artifact body
+
+description: Publish the Build Artifacts block for a pull request
+
+inputs:
+  repository:
+    description: owner/repo containing the pull request
+    required: true
+  pr-number:
+    description: Pull request number
+    required: true
+  run-id:
+    description: Workflow run id containing uploaded artifacts
+    required: true
+  run-url:
+    description: Workflow run URL for failed or pending artifact links
+    required: true
+  head-sha:
+    description: Pull request head SHA built by the workflow run
+    required: true
+  token:
+    description: GitHub token with actions:read and pull-requests:write
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Build artifact block
+      id: body
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REPOSITORY: ${{ inputs.repository }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        RUN_ID: ${{ inputs.run-id }}
+        RUN_URL: ${{ inputs.run-url }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+      run: |
+        set -euo pipefail
+
+        artifact_url() {
+          local artifact_name="$1"
+          local artifact_id=""
+
+          for attempt in 1 2 3 4 5; do
+            artifact_id=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/artifacts?name=${artifact_name}" \
+              --jq '.artifacts[0] | select(.expired == false) | .id // empty')
+            if [ -n "$artifact_id" ]; then
+              break
+            fi
+            if [ "$attempt" != 5 ]; then
+              sleep 2
+            fi
+          done
+
+          if [ -n "$artifact_id" ]; then
+            printf 'https://github.com/%s/actions/runs/%s/artifacts/%s' "$REPOSITORY" "$RUN_ID" "$artifact_id"
+          fi
+        }
+
+        artifact_line() {
+          local label="$1"
+          local url="$2"
+          if [ -n "$url" ]; then
+            printf -- '- [✅ %s — download](%s)\n' "$label" "$url"
+          elif [ "$run_status" = "completed" ]; then
+            printf -- '- [❌ %s — build failed](%s)\n' "$label" "$RUN_URL"
+          else
+            printf -- '- [⏳ %s — pending](%s)\n' "$label" "$RUN_URL"
+          fi
+        }
+
+        run_status=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.status')
+        sha_short=${HEAD_SHA:0:7}
+        commit_subject=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.head_commit.message // "" | split("\n")[0]')
+        timestamp=$(date -u "+%F %T")
+
+        artifact_label="pr-${PR_NUMBER}"
+        linux_url=$(artifact_url "linux-tiles-x64-${artifact_label}")
+        windows_url=$(artifact_url "windows-tiles-x64-msvc-${artifact_label}")
+        macos_url=$(artifact_url "osx-tiles-x64-${artifact_label}")
+        android_url=$(artifact_url "android-x64-${artifact_label}")
+
+        {
+          echo 'content<<EOF'
+          echo '## Build Artifacts'
+          echo
+          echo "PR build for commit [${sha_short}](https://github.com/${REPOSITORY}/commit/${HEAD_SHA}) (${commit_subject}) on ${timestamp}"
+          echo
+          artifact_line 'Linux tiles' "$linux_url"
+          artifact_line 'Windows tiles' "$windows_url"
+          artifact_line 'macOS tiles' "$macos_url"
+          artifact_line 'Android tiles' "$android_url"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Update pull request body
+      uses: ./.github/actions/update-pr-artifact-body
+      with:
+        repository: ${{ inputs.repository }}
+        pr-number: ${{ inputs.pr-number }}
+        content: ${{ steps.body.outputs.content }}
+        token: ${{ inputs.token }}

--- a/.github/actions/publish-pr-artifact-body/action.yml
+++ b/.github/actions/publish-pr-artifact-body/action.yml
@@ -21,12 +21,19 @@ inputs:
   token:
     description: GitHub token with actions:read and pull-requests:write
     required: true
+  watch:
+    description: Keep publishing until the workflow run completes
+    required: false
+    default: "false"
+  poll-interval-seconds:
+    description: Seconds to wait between watched updates
+    required: false
+    default: "120"
 
 runs:
   using: composite
   steps:
-    - name: Build artifact block
-      id: body
+    - name: Publish Build Artifacts block
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -35,6 +42,8 @@ runs:
         RUN_ID: ${{ inputs.run-id }}
         RUN_URL: ${{ inputs.run-url }}
         HEAD_SHA: ${{ inputs.head-sha }}
+        WATCH: ${{ inputs.watch }}
+        POLL_INTERVAL_SECONDS: ${{ inputs.poll-interval-seconds }}
       run: |
         set -euo pipefail
 
@@ -70,34 +79,65 @@ runs:
           fi
         }
 
-        run_status=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.status')
-        sha_short=${HEAD_SHA:0:7}
-        commit_subject=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.head_commit.message // "" | split("\n")[0]')
-        timestamp=$(date -u "+%F %T")
+        publish_once() {
+          local current_head
+          current_head=$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          if [ "$current_head" != "$HEAD_SHA" ]; then
+            echo "Pull request head changed; stopping artifact body updates."
+            exit 0
+          fi
 
-        artifact_label="pr-${PR_NUMBER}"
-        linux_url=$(artifact_url "linux-tiles-x64-${artifact_label}")
-        windows_url=$(artifact_url "windows-tiles-x64-msvc-${artifact_label}")
-        macos_url=$(artifact_url "osx-tiles-x64-${artifact_label}")
-        android_url=$(artifact_url "android-x64-${artifact_label}")
+          run_status=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.status')
+          sha_short=${HEAD_SHA:0:7}
+          commit_subject=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.head_commit.message // "" | split("\n")[0]')
+          timestamp=$(date -u "+%F %T")
 
-        {
-          echo 'content<<EOF'
-          echo '## Build Artifacts'
-          echo
-          echo "PR build for commit [${sha_short}](https://github.com/${REPOSITORY}/commit/${HEAD_SHA}) (${commit_subject}) on ${timestamp}"
-          echo
-          artifact_line 'Linux tiles' "$linux_url"
-          artifact_line 'Windows tiles' "$windows_url"
-          artifact_line 'macOS tiles' "$macos_url"
-          artifact_line 'Android tiles' "$android_url"
-          echo 'EOF'
-        } >> "$GITHUB_OUTPUT"
+          artifact_label="pr-${PR_NUMBER}"
+          linux_url=$(artifact_url "linux-tiles-x64-${artifact_label}")
+          windows_url=$(artifact_url "windows-tiles-x64-msvc-${artifact_label}")
+          macos_url=$(artifact_url "osx-tiles-x64-${artifact_label}")
+          android_url=$(artifact_url "android-x64-${artifact_label}")
 
-    - name: Update pull request body
-      uses: ./.github/actions/update-pr-artifact-body
-      with:
-        repository: ${{ inputs.repository }}
-        pr-number: ${{ inputs.pr-number }}
-        content: ${{ steps.body.outputs.content }}
-        token: ${{ inputs.token }}
+          content=$(
+            {
+              echo '## Build Artifacts'
+              echo
+              echo "PR build for commit [${sha_short}](https://github.com/${REPOSITORY}/commit/${HEAD_SHA}) (${commit_subject}) on ${timestamp}"
+              echo
+              artifact_line 'Linux tiles' "$linux_url"
+              artifact_line 'Windows tiles' "$windows_url"
+              artifact_line 'macOS tiles' "$macos_url"
+              artifact_line 'Android tiles' "$android_url"
+            }
+          )
+
+          block=$(cat <<EOF
+        <!-- BEGIN artifact comment -->
+
+        ${content}
+        <!-- END artifact comment -->
+        EOF
+          )
+
+          body=$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')
+          clean_body=$(printf '%s' "$body" | perl -0pe 's/\n*<!-- BEGIN artifact comment -->.*?<!-- END artifact comment -->\s*//sg; s/[ \t]+\n/\n/g; s/\s+\z//')
+
+          if [ -n "$clean_body" ]; then
+            printf -v new_body '%s\n\n%s' "$clean_body" "$block"
+          else
+            new_body="$block"
+          fi
+
+          jq -n --arg body "$new_body" '{body: $body}' > "$RUNNER_TEMP/pr-body.json"
+          gh api -X PATCH "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --input "$RUNNER_TEMP/pr-body.json" >/dev/null
+          echo "Published artifact links for ${run_status} workflow run ${RUN_ID}."
+        }
+
+        publish_once
+
+        if [ "$WATCH" = "true" ]; then
+          while [ "$run_status" != "completed" ]; do
+            sleep "$POLL_INTERVAL_SECONDS"
+            publish_once
+          done
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -534,6 +534,18 @@ jobs:
           path: ${{ runner.os == 'Windows' && format('cataclysmbn-{0}/', inputs.version-label) || format('cbn-{0}-{1}.{2}', matrix.artifact, inputs.version-label, matrix.ext) }}
           if-no-files-found: error
 
+      - name: Publish platform artifact link
+        if: github.event_name == 'pull_request' && inputs.upload-artifacts && matrix.upload-artifact == true
+        continue-on-error: true
+        uses: ./.github/actions/publish-pr-artifact-body
+        with:
+          repository: ${{ github.repository }}
+          pr-number: ${{ github.event.pull_request.number }}
+          run-id: ${{ github.run_id }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          token: ${{ github.token }}
+
       - name: Run tests (windows msvc)
         if: runner.os == 'Windows' && inputs.run-tests
         run: |

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -16,6 +16,11 @@ concurrency:
   group: matrix-build-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
 jobs:
   skip-duplicates:
     continue-on-error: true
@@ -152,6 +157,35 @@ jobs:
           cmake --build build --target style-json-parallel
           tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*/*/*
 
+      - name: create Linux tiles playtest package
+        if: ${{ success() && env.SKIP == 'false' && matrix.upload-artifact == true }}
+        env:
+          VERSION_LABEL: pr-${{ github.event.pull_request.number || github.run_id }}
+        run: |
+          mkdir -p lang/mo
+          cmake --install build --prefix cataclysmbn-${VERSION_LABEL}
+          tar -czvf cbn-linux-tiles-x64-${VERSION_LABEL}.tar.gz cataclysmbn-${VERSION_LABEL}
+
+      - name: upload Linux tiles playtest package
+        if: ${{ success() && env.SKIP == 'false' && matrix.upload-artifact == true }}
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: linux-tiles-x64-pr-${{ github.event.pull_request.number || github.run_id }}
+          path: cbn-linux-tiles-x64-pr-${{ github.event.pull_request.number || github.run_id }}.tar.gz
+          if-no-files-found: error
+
+      - name: Publish Linux artifact link
+        if: ${{ success() && github.event_name == 'pull_request' && env.SKIP == 'false' && matrix.upload-artifact == true }}
+        continue-on-error: true
+        uses: ./.github/actions/publish-pr-artifact-body
+        with:
+          repository: ${{ github.repository }}
+          pr-number: ${{ github.event.pull_request.number }}
+          run-id: ${{ github.run_id }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          token: ${{ github.token }}
+
       - name: run tests
         if: ${{ github.ref_name != 'main' && env.SKIP == 'false' }}
         run: |
@@ -171,23 +205,6 @@ jobs:
                 $test_bin $test_opts '~*' --user-dir=all_modded --mods="${mods}"
               done
           fi
-
-      - name: create Linux tiles playtest package
-        if: ${{ success() && env.SKIP == 'false' && matrix.upload-artifact == true }}
-        env:
-          VERSION_LABEL: pr-${{ github.event.pull_request.number || github.run_id }}
-        run: |
-          mkdir -p lang/mo
-          cmake --install build --prefix cataclysmbn-${VERSION_LABEL}
-          tar -czvf cbn-linux-tiles-x64-${VERSION_LABEL}.tar.gz cataclysmbn-${VERSION_LABEL}
-
-      - name: upload Linux tiles playtest package
-        if: ${{ success() && env.SKIP == 'false' && matrix.upload-artifact == true }}
-        uses: actions/upload-artifact@v4.6.0
-        with:
-          name: linux-tiles-x64-pr-${{ github.event.pull_request.number || github.run_id }}
-          path: cbn-linux-tiles-x64-pr-${{ github.event.pull_request.number || github.run_id }}.tar.gz
-          if-no-files-found: error
 
       - name: upload artifacts if failed
         uses: actions/upload-artifact@v4.6.0

--- a/.github/workflows/pr-artifact-publish.yml
+++ b/.github/workflows/pr-artifact-publish.yml
@@ -3,7 +3,7 @@ name: PR Artifact Publisher
 on:
   workflow_run:
     workflows: [matrix]
-    types: [completed]
+    types: [requested, completed]
 
 permissions:
   actions: read
@@ -62,3 +62,4 @@ jobs:
           run-url: ${{ github.event.workflow_run.html_url }}
           head-sha: ${{ github.event.workflow_run.head_sha }}
           token: ${{ github.token }}
+          watch: ${{ github.event.action == 'requested' }}

--- a/.github/workflows/pr-artifact-publish.yml
+++ b/.github/workflows/pr-artifact-publish.yml
@@ -48,71 +48,17 @@ jobs:
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "number=$pr_number" >> "$GITHUB_OUTPUT"
 
-      - name: Build artifact block
-        id: body
-        if: steps.pr.outputs.found == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          set -euo pipefail
-
-          artifact_url() {
-            local artifact_name="$1"
-            local artifact_id
-            artifact_id=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/artifacts?name=${artifact_name}" \
-              --jq '.artifacts[0] | select(.expired == false) | .id // empty')
-            if [ -n "$artifact_id" ]; then
-              printf 'https://github.com/%s/actions/runs/%s/artifacts/%s' "$REPOSITORY" "$RUN_ID" "$artifact_id"
-            fi
-          }
-
-          artifact_line() {
-            local label="$1"
-            local url="$2"
-            if [ -n "$url" ]; then
-              printf -- '- [✅ %s — download](%s)\n' "$label" "$url"
-            else
-              printf -- '- [❌ %s — build failed](%s)\n' "$label" "$RUN_URL"
-            fi
-          }
-
-          sha_short=${HEAD_SHA:0:7}
-          commit_subject=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}" --jq '.head_commit.message // "" | split("\n")[0]')
-          timestamp=$(date -u "+%F %T")
-
-          artifact_label="pr-${PR_NUMBER}"
-          linux_url=$(artifact_url "linux-tiles-x64-${artifact_label}")
-          windows_url=$(artifact_url "windows-tiles-x64-msvc-${artifact_label}")
-          macos_url=$(artifact_url "osx-tiles-x64-${artifact_label}")
-          android_url=$(artifact_url "android-x64-${artifact_label}")
-
-          {
-            echo 'content<<EOF'
-            echo '## Build Artifacts'
-            echo
-            echo "PR build for commit [${sha_short}](https://github.com/${REPOSITORY}/commit/${HEAD_SHA}) (${commit_subject}) on ${timestamp}"
-            echo
-            artifact_line 'Linux tiles' "$linux_url"
-            artifact_line 'Windows tiles' "$windows_url"
-            artifact_line 'macOS tiles' "$macos_url"
-            artifact_line 'Android tiles' "$android_url"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-
       - name: Check out workflow actions
         if: steps.pr.outputs.found == 'true'
         uses: actions/checkout@v4
 
-      - name: Update pull request body
+      - name: Publish pull request artifact links
         if: steps.pr.outputs.found == 'true'
-        uses: ./.github/actions/update-pr-artifact-body
+        uses: ./.github/actions/publish-pr-artifact-body
         with:
           repository: ${{ github.repository }}
           pr-number: ${{ steps.pr.outputs.number }}
-          content: ${{ steps.body.outputs.content }}
+          run-id: ${{ github.event.workflow_run.id }}
+          run-url: ${{ github.event.workflow_run.html_url }}
+          head-sha: ${{ github.event.workflow_run.head_sha }}
           token: ${{ github.token }}


### PR DESCRIPTION
## Purpose of change (The Why)

Make PR build artifacts available as soon as each platform finishes packaging instead of waiting for the whole matrix to complete.

## Describe the solution (The How)

- Move the Linux playtest artifact package/upload steps before Linux tests.
- Publish PR artifact links immediately after each uploaded platform artifact.
- Reuse the same artifact-block rendering logic for per-platform updates and the final completed-workflow update.

## Describe alternatives you've considered

Keep only the completed-workflow artifact publisher, which delays PR artifact links until every platform and test finishes.

## Testing

- `deno fmt --check .github/workflows/matrix.yml .github/workflows/build.yml .github/workflows/pr-artifact-publish.yml .github/actions/publish-pr-artifact-body/action.yml .github/actions/update-pr-artifact-body/action.yml`
- `actionlint .github/workflows/matrix.yml .github/workflows/build.yml .github/workflows/pr-artifact-publish.yml`
- `git diff --check`
- Fork PR CI: https://github.com/scarf005/Cataclysm-BN/pull/42
  - General build matrix passed: https://github.com/scarf005/Cataclysm-BN/actions/runs/26672023727
  - The fork PR body artifact block was updated with Linux, Windows, macOS, and Android download links.

Reviewer test: open a PR from this branch and confirm each platform link appears in the Build Artifacts block after that platform uploads its artifact; once the matrix completes, all four links should remain valid.

## Additional context

Related: #8921, #8969, #8980, #8983, #9128

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ae1d148](https://github.com/cataclysmbn/Cataclysm-BN/commit/ae1d1481a5e9c473bfda3f1558580af81bbee7ac) (ci: watch PR artifact uploads) on 2026-05-30 03:34:11

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26672021947/artifacts/7304670897)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26672021947/artifacts/7304938076)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26672021947/artifacts/7304731262)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26672021947/artifacts/7304803807)
<!-- END artifact comment -->
