### PR TITLE
fix(lua): separate hook run results

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -594,16 +594,17 @@ auto has_hooks( std::string_view hook_name, const hook_opts &opts ) -> bool
     return !entries.empty();
 }
 
-auto run_hooks( std::string_view hook_name,
-                std::function < auto( sol::table &params ) -> void > init,
-                const hook_opts &opts ) -> sol::table
+auto run_hooks( std::string_view hook_name, hook_init_fn init,
+                const hook_opts &opts ) -> hook_run_result
 {
     auto &state = opts.state ? *opts.state : *DynamicDataLoader::get_instance().lua;
     auto &lua = state.lua;
 
     auto params = lua.create_table();
     auto results = lua.create_table();
-    results["allowed"] = true;
+    auto returns = std::vector<hook_return> {};
+    auto allowed = true;
+    results["allowed"] = allowed;
 
     params["results"] = results;
     params["prev"] = sol::lua_nil;
@@ -614,13 +615,12 @@ auto run_hooks( std::string_view hook_name,
 
     const auto maybe_hooks = lua.globals()["game"]["hooks"][hook_name].get<sol::optional<sol::table>>();
     if( !maybe_hooks ) {
-        return results;
+        return { .allowed = allowed, .results = results, .returns = returns };
     }
 
     const auto &hooks = *maybe_hooks;
     const auto &entries = get_hook_entries( lua, hook_name, hooks );
 
-    auto out_idx = 1;
     auto i = size_t{ 0 };
     while( i < entries.size() ) {
         const hook_entry &e = entries[i];
@@ -649,17 +649,11 @@ auto run_hooks( std::string_view hook_name,
             }
 
             params["prev"] = result;
-
-            sol::table one = lua.create_table();
-            one["mod_id"] = e.mod_id;
-            one["priority"] = e.priority;
-            if( result != sol::lua_nil ) {
-                one["result"] = result;
-            }
-            results[out_idx++] = one;
+            returns.push_back( { .mod_id = e.mod_id, .priority = e.priority, .value = result } );
 
             if( result.is<bool>() && !result.as<bool>() ) {
-                results["allowed"] = false;
+                allowed = false;
+                results["allowed"] = allowed;
                 if( opts.exit_early ) {
                     break;
                 }
@@ -671,7 +665,7 @@ auto run_hooks( std::string_view hook_name,
         ++i;
     }
 
-    return results;
+    return { .allowed = allowed, .results = results, .returns = returns };
 }
 
 

--- a/src/catalua_hooks.h
+++ b/src/catalua_hooks.h
@@ -1,18 +1,36 @@
 #pragma once
 
 #include <functional>
+#include <string>
 #include <string_view>
+#include <vector>
 
-#include "catalua_sol_fwd.h"
+#include "catalua_sol.h"
 
 namespace cata
 {
 
 struct lua_state;
 
+using hook_init_fn = std::function < auto( sol::table &params ) -> void >;
+
 struct hook_opts {
     bool exit_early = false;
     lua_state *state = nullptr;
+};
+
+/// One Lua callback return value from a hook run.
+struct hook_return {
+    std::string mod_id;
+    int priority = 0;
+    sol::object value;
+};
+
+/// C++ result of running every callback for one hook.
+struct hook_run_result {
+    bool allowed = true;
+    sol::table results;
+    std::vector<hook_return> returns;
 };
 
 /// Run Lua hooks registered with given name.
@@ -25,10 +43,10 @@ struct hook_opts {
 ///
 /// During execution, `params.results` is a table shared by all hooks, and `params.prev`
 /// contains the previous hook's return value.
-/// Returns `params.results`.
-auto run_hooks( std::string_view hook_name,
-                std::function < auto( sol::table &params ) -> void > init = nullptr,
-const hook_opts &opts = {} ) -> sol::table;
+/// Returns a C++ struct with the shared `params.results`, aggregate `allowed` flag, and
+/// each callback return value kept separate.
+auto run_hooks( std::string_view hook_name, hook_init_fn init = nullptr, const hook_opts &opts = {} )
+-> hook_run_result;
 
 /// Return whether a hook currently has registered entries without building params/results tables.
 auto has_hooks( std::string_view hook_name, const hook_opts &opts = {} ) -> bool;

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -921,7 +921,7 @@ static void draw_skills_info( const catacurses::window &w_info, const Character 
             params["character"] = &you;
             params["skill"] = selectedSkill->ident();
         } );
-        const auto extra_text = hook_results.get_or( "text", std::string() );
+        const auto extra_text = hook_results.results.get_or( "text", std::string() );
         if( !extra_text.empty() ) {
             description += "\n\n" + extra_text;
         }
@@ -1235,7 +1235,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
                         params["character"] = &you;
                         params["skill"] = selectedSkill->ident();
                     } );
-                    if( !hook_results.get_or( "handled", false ) ) {
+                    if( !hook_results.results.get_or( "handled", false ) ) {
                         you.get_skill_level_object( selectedSkill->ident() ).toggleTraining();
                     }
                 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7916,7 +7916,7 @@ bool game::npc_menu( npc &who, const bool &force )
 {
     if( !force ) {
         const auto allowed = cata::run_hooks( "on_try_npc_interaction",
-        [&]( auto & params ) { params["npc"] = &who; }, { .exit_early = true } ).get_or( "allowed", true );
+        [&]( auto & params ) { params["npc"] = &who; }, { .exit_early = true } ).allowed;
         if( !allowed ) { return false; }
     }
     cata::run_hooks( "on_npc_interaction", [&]( auto & params ) { params["npc"] = &who; } );
@@ -8468,7 +8468,7 @@ void game::examine( const tripoint_bub_ms &examp )
             }
 
             const auto allowed = cata::run_hooks( "on_try_monster_interaction", [&]( auto & params ) { params["monster"] = mon; },
-            { .exit_early = true } ).get_or( "allowed", true );
+            { .exit_early = true } ).allowed;
             if( allowed ) {
                 if( mon->has_effect( effect_pet ) && !u.is_mounted() ) {
                     if( monexamine::pet_menu( *mon ) ) {
@@ -12541,8 +12541,8 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
             }
         } );
 
-        if( !hook_results.get_or( "allowed", true ) ||
-            !char_hook_results.get_or( "allowed", true ) ) {
+        if( !hook_results.allowed ||
+            !char_hook_results.allowed ) {
             return false;
         }
     }

--- a/src/iexamine_elevator.cpp
+++ b/src/iexamine_elevator.cpp
@@ -242,7 +242,7 @@ void iexamine::elevator( player &p, const tripoint_bub_ms &examp )
         params["pos"] = cata::detail::lua_coords::to_lua( examp );
         params["om_terrain"] = om_terrain;
     }, { .exit_early = true } );
-    if( !hook_results.get_or( "allowed", true ) ) {
+    if( !hook_results.allowed ) {
         return;
     }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -394,8 +394,10 @@ class mapgen_factory
             // Stuff used in lua code only
             // Yes a mod could blow something up...
             // But it makes itself widely known
-            result = cata::run_hooks( "on_make_mapgen_factory_list", [&]( auto & params ) { params["results"] = &result; } ).get_or( "results",
-                    result );
+            const auto hook_results = cata::run_hooks( "on_make_mapgen_factory_list", [&]( auto & params ) {
+                params["results"] = &result;
+            } );
+            result = hook_results.results.get_or( "results", result );
             return result;
         }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2416,7 +2416,7 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
         params["to"] = cata::detail::lua_coords::to_lua( p );
         params["force"] = force;
     } );
-    const auto can_move = hook_results.get_or( "allowed", true );
+    const auto can_move = hook_results.allowed;
     if( !can_move ) {
         return false;
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2636,8 +2636,8 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         }
     } );
 
-    if( !hook_results.get_or( "allowed", true ) ||
-        !char_hook_results.get_or( "allowed", true ) ) {
+    if( !hook_results.allowed ||
+        !char_hook_results.allowed ) {
         return;
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1212,9 +1212,11 @@ void npc::talk_to_u( bool radio_contact, bool enforce_first_topic )
         params["npc"] = this;
         params["next_topic"] = d.topic_stack.back().id;
     } );
-    for( const auto &result : hook_results ) {
-        if( !result.second.is<sol::table>() ) { continue; };
-        auto new_topic = result.second.as<sol::table>().get<std::string>( "result" );
+    for( const auto &hook_return : hook_results.returns ) {
+        if( !hook_return.value.is<std::string>() ) {
+            continue;
+        }
+        const auto new_topic = hook_return.value.as<std::string>();
         if( !new_topic.empty() && new_topic != d.topic_stack.back().id ) {
             d.add_topic( new_topic );
         }
@@ -1245,12 +1247,12 @@ void npc::talk_to_u( bool radio_contact, bool enforce_first_topic )
             params["next_topic"] = next.id;
         } );
         auto final_result = d.topic_stack.back().id;
-        for( const auto &result : hook_results ) {
-            if( !result.second.is<sol::table>() ) { continue; };
-            final_result = result.second.as<sol::table>().get_or<std::string>( "result", final_result );
+        for( const auto &hook_return : hook_results.returns ) {
+            if( hook_return.value.is<std::string>() ) {
+                final_result = hook_return.value.as<std::string>();
+            }
             // Allow higher priority topics to veto, but still trigger subsequent calls?
-            // auto allowed = result.second.as<sol::table>().get<sol::object>( "allowed" );
-            // if ( allowed.is<bool>() && !allowed.as<bool>() ) { break; };
+            // if( !hook_results.allowed ) { break; }
         }
         if( !final_result.empty() && final_result != d.topic_stack.back().id ) {
             next = talk_topic( final_result );

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -1694,10 +1694,10 @@ static auto init_test_lua_hook_state( cata::lua_state &state ) -> void
 
     sol::table cata_tbl = lua.create_table();
     cata_tbl.set_function( "run_hooks", [&state]( const std::string & name ) -> sol::table {
-        return cata::run_hooks( name, nullptr, { .state = &state } );
+        return cata::run_hooks( name, nullptr, { .state = &state } ).results;
     } );
     cata_tbl.set_function( "run_hooks_exit_early", [&state]( const std::string & name ) -> sol::table {
-        return cata::run_hooks( name, nullptr, { .exit_early = true, .state = &state } );
+        return cata::run_hooks( name, nullptr, { .exit_early = true, .state = &state } ).results;
     } );
     lua.globals()["cata"] = cata_tbl;
 }
@@ -1740,6 +1740,17 @@ TEST_CASE( "lua_hooks_order_and_chaining", "[lua]" )
 
     // Ensure hooks can override params.prev and affect downstream hooks.
     CHECK( results_tbl.get<std::string>( "prev_seen" ) == "p5_ret" );
+
+    const auto hook_results = cata::run_hooks( "on_game_load", nullptr, { .state = &state } );
+    CHECK( hook_results.allowed );
+    REQUIRE( hook_results.returns.size() == 3 );
+    CHECK( hook_results.returns[0].mod_id == "m10" );
+    CHECK( hook_results.returns[0].priority == 10 );
+    CHECK( hook_results.returns[0].value.as<std::string>() == "p10_ret" );
+    CHECK( hook_results.returns[1].mod_id == "m5" );
+    CHECK( hook_results.returns[1].priority == 5 );
+    CHECK( hook_results.returns[1].value.as<std::string>() == "p5_ret" );
+    CHECK( hook_results.returns[2].value.as<std::string>() == "legacy_ret" );
 }
 
 TEST_CASE( "lua_hooks_exit_early", "[lua]" )
@@ -1760,6 +1771,12 @@ TEST_CASE( "lua_hooks_exit_early", "[lua]" )
     CHECK( log_tbl.get<std::string>( 1 ) == "p10" );
     CHECK( results_tbl.get<bool>( "allowed" ) == false );
     CHECK( log_tbl.get<sol::optional<std::string>>( 2 ) == sol::nullopt );
+
+    const auto hook_results = cata::run_hooks( "on_game_save", nullptr, { .exit_early = true, .state = &state } );
+    CHECK( !hook_results.allowed );
+    REQUIRE( hook_results.returns.size() == 1 );
+    CHECK( hook_results.returns[0].mod_id == "m10" );
+    CHECK( hook_results.returns[0].value.as<bool>() == false );
 }
 
 // ─── Hook wiring tests ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Purpose of change (The Why)

C++ callers could confuse the shared `params.results` table with per-hook return values from `run_hooks`.

Related: #8771

## Describe the solution (The How)

Return a C++ `hook_run_result` with separate fields for aggregate `allowed`, shared `results`, and per-callback `returns`.

## Describe alternatives you've considered

Keep returning the Lua table and patch only the character display callers. That leaves the hook runner API stringly typed and easy to misuse.

## Testing

- [x] `cmake --build --preset linux-full --target format`
- [x] `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- [x] `./out/build/linux-full/tests/cata_test-tiles "[lua]"`

Reviewer/tester steps:
- Enable Skills Through Kills, open `@` → Skills, confirm a skill; expected: STK handles the action and the default training toggle does not run.
- Check the selected skill description; expected: STK skill info text still appears.
- With a Lua movement-veto hook, return `false`; expected: the move remains blocked through `hook_run_result.allowed`.

## Additional context

AI-assisted change. The commit contains the required assistance trailer.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I disclosed it in the PR description and added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [05ee040](https://github.com/cataclysmbn/Cataclysm-BN/commit/05ee0402038a62a38199b71dcc7cbbb4400fee6f) (fix(lua): separate hook run results) on 2026-06-26 14:51:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28242040228/artifacts/7907813225)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28242040228/artifacts/7908491370)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28242040228/artifacts/7908178146)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28242040228/artifacts/7907764640)
<!-- END artifact comment -->