### PR TITLE
fix: stop vehicle collisions hanging on hallucinations

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -822,18 +822,21 @@ auto vehicle::part_collision( const vehicle_part_collision_options &options ) ->
             // analysis.
             assert( critter );
 
-            // No blood from hallucinations
-            if( !critter->is_hallucination() ) {
-                // Get critter health for determining max damage to apply
-                critter_health = critter->get_hp_max();
-                if( part_flag( ret.part, "SHARP" ) ) {
-                    parts[ret.part].blood += ( 20 + obj_dmg ) * 5;
-                } else if( obj_dmg > rng( 10, 30 ) ) {
-                    parts[ret.part].blood += ( 10 + obj_dmg / 2 ) * 5;
-                }
-
-                check_environmental_effects = true;
+            if( critter->is_hallucination() ) {
+                critter->die( driver );
+                smashed = true;
+                break;
             }
+
+            // Get critter health for determining max damage to apply
+            critter_health = critter->get_hp_max();
+            if( part_flag( ret.part, "SHARP" ) ) {
+                parts[ret.part].blood += ( 20 + obj_dmg ) * 5;
+            } else if( obj_dmg > rng( 10, 30 ) ) {
+                parts[ret.part].blood += ( 10 + obj_dmg / 2 ) * 5;
+            }
+
+            check_environmental_effects = true;
 
             time_stunned = time_duration::from_turns( ( rng( 0, obj_dmg ) > 10 ) + ( rng( 0, obj_dmg ) > 40 ) );
             if( time_stunned > 0_turns ) {

--- a/tests/vehicle_collision_test.cpp
+++ b/tests/vehicle_collision_test.cpp
@@ -1,8 +1,10 @@
 #include "catch/catch.hpp"
 
 #include "coordinates.h"
+#include "game.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "monster.h"
 #include "state_helpers.h"
 #include "type_id.h"
 #include "vehicle.h"
@@ -15,8 +17,8 @@ TEST_CASE( "mps_cmps_round_trip_converges_to_zero", "[vehicle]" )
         auto coll_velocity = v;
         auto iterations = 0;
         while( coll_velocity > 0 && iterations < max_iterations ) {
-            auto const vel_mps = cmps_to_mps( coll_velocity );
-            auto const new_velocity = mps_to_cmps( vel_mps * 0.9 );
+            const auto vel_mps = cmps_to_mps( coll_velocity );
+            const auto new_velocity = mps_to_cmps( vel_mps * 0.9 );
             coll_velocity = ( std::abs( new_velocity ) >= std::abs( coll_velocity ) )
                             ? 0
                             : new_velocity;
@@ -35,8 +37,8 @@ TEST_CASE( "vehicle_collision_with_wall_terminates", "[vehicle]" )
     build_test_map( ter_id( "t_pavement" ) );
     clear_vehicles();
 
-    auto const veh_pos = tripoint_bub_ms( 60, 60, 0 );
-    auto const wall_pos = tripoint_bub_ms( 60, 59, 0 );
+    const auto veh_pos = tripoint_bub_ms( 60, 60, 0 );
+    const auto wall_pos = tripoint_bub_ms( 60, 59, 0 );
 
     auto *veh_ptr = here.add_vehicle( vproto_id( "bicycle_test" ), veh_pos, 270_degrees, 0, 0 );
     REQUIRE( veh_ptr != nullptr );
@@ -49,7 +51,7 @@ TEST_CASE( "vehicle_collision_with_wall_terminates", "[vehicle]" )
     REQUIRE( here.impassable_ter_furn( wall_pos ) );
 
     veh_ptr->velocity = 222;
-    auto const probe = veh_ptr->part_collision( vehicle_part_collision_options{
+    const auto probe = veh_ptr->part_collision( vehicle_part_collision_options{
         .part = 0,
         .pos = wall_pos,
         .just_detect = true,
@@ -57,11 +59,39 @@ TEST_CASE( "vehicle_collision_with_wall_terminates", "[vehicle]" )
     REQUIRE( probe.type != veh_coll_nothing );
 
     veh_ptr->velocity = 222;
-    auto const ret = veh_ptr->part_collision( vehicle_part_collision_options{
+    const auto ret = veh_ptr->part_collision( vehicle_part_collision_options{
         .part = 0,
         .pos = wall_pos,
     } );
 
     CHECK( ret.type != veh_coll_nothing );
     CHECK( std::abs( veh_ptr->velocity ) < 222 );
+}
+
+TEST_CASE( "vehicle_collision_with_hallucination_terminates", "[vehicle]" )
+{
+    clear_all_state();
+    auto &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+    clear_vehicles();
+
+    const auto veh_pos = tripoint_bub_ms( 60, 60, 0 );
+    const auto hallucination_pos = tripoint_bub_ms( 60, 59, 0 );
+
+    auto *veh_ptr = here.add_vehicle( vproto_id( "bicycle_test" ), veh_pos, 270_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    auto &hallucination = spawn_test_monster( "mon_chicken", hallucination_pos );
+    hallucination.hallucination = true;
+    REQUIRE( g->critter_at<monster>( hallucination_pos, true ) == &hallucination );
+
+    veh_ptr->velocity = 222;
+    const auto ret = veh_ptr->part_collision( vehicle_part_collision_options{
+        .part = 0,
+        .pos = hallucination_pos,
+    } );
+
+    CHECK( ret.type == veh_coll_body );
+    CHECK( hallucination.is_dead() );
+    CHECK( veh_ptr->velocity == 222 );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

close #9133

Vehicles could hang forever when colliding with hallucinatory monsters.

## Describe the solution (The How)

- Dispel hallucinatory critters immediately during vehicle body collisions.
- Treat the collision as resolved without reducing the vehicle's real velocity.
- Add a regression test for a vehicle hitting a hallucinatory chicken.

## Describe alternatives you've considered

Allowing `fling_creature` to move hallucinations would also terminate the loop, but hallucinations should not affect real vehicle movement.

## Testing

- [x] `cmake --build out/build/linux-full --target format`
- [x] `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- [x] `./out/build/linux-full/tests/cata_test-tiles "vehicle_collision_with_hallucination_terminates"`
- [x] `./out/build/linux-full/tests/cata_test-tiles "vehicle_collision*,mps_cmps*"`

Reviewer check: spawn a hallucinatory small monster in front of a moving vehicle; it should disappear and the game should continue without hanging.

## Additional context

Related: #9133

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [8055059](https://github.com/cataclysmbn/Cataclysm-BN/commit/8055059f4edb34aef3447e66ad90503242acd1d0) (fix: stop vehicle collisions hanging on hallucinations) on 2026-05-30 12:10:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26682304895/artifacts/7307770972)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26682304895/artifacts/7307996224)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26682304895/artifacts/7307782747)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26682304895/artifacts/7307862185)
<!-- END artifact comment -->