### PR TITLE
feat(balance): make rescued prototype cyborgs always recruitable

### DIFF
--- a/data/json/npcs/TALK_CYBORG_1.json
+++ b/data/json/npcs/TALK_CYBORG_1.json
@@ -23,7 +23,7 @@
         "default": true,
         "text": "That's because I saved you.  Listen, I could use your help…",
         "trial": { "type": "PERSUADE", "difficulty": 0 },
-        "success": { "topic": "TALK_CYBORG_FRIENDLY", "opinion": { "trust": 1, "value": 1 } },
+        "success": { "topic": "TALK_CYBORG_FRIENDLY", "opinion": { "trust": 3, "fear", -2, "value": 1 } },
         "failure": { "topic": "TALK_CYBORG_WARY", "opinion": { "anger": 1, "fear": 1 } }
       },
       {
@@ -63,7 +63,7 @@
     "responses": [
       {
         "text": "I wouldn't have pulled your chip out if I didn't want you to think for yourself.",
-        "trial": { "type": "PERSUADE", "difficulty": 5, "mod": [ [ "TRUST", 2 ], [ "VALUE", 2 ] ] },
+        "trial": { "type": "PERSUADE", "difficulty": 5, "mod": [ [ "TRUST", 3 ], [ "FEAR", -2], [ "VALUE", 2 ] ] },
         "success": { "topic": "TALK_CYBORG_FRIENDLY", "opinion": { "trust": 1, "value": 1 } },
         "failure": { "topic": "TALK_CYBORG_LEAVES" }
       },

--- a/data/json/npcs/TALK_CYBORG_1.json
+++ b/data/json/npcs/TALK_CYBORG_1.json
@@ -23,7 +23,7 @@
         "default": true,
         "text": "That's because I saved you.  Listen, I could use your help…",
         "trial": { "type": "PERSUADE", "difficulty": 0 },
-        "success": { "topic": "TALK_CYBORG_FRIENDLY", "opinion": { "trust": 3, "fear", -2, "value": 1 } },
+        "success": { "topic": "TALK_CYBORG_FRIENDLY", "opinion": { "trust": 3, "fear": -2, "value": 1 } },
         "failure": { "topic": "TALK_CYBORG_WARY", "opinion": { "anger": 1, "fear": 1 } }
       },
       {

--- a/data/json/npcs/TALK_CYBORG_1.json
+++ b/data/json/npcs/TALK_CYBORG_1.json
@@ -49,9 +49,9 @@
     "responses": [
       {
         "text": "Come with me.  We can help each other out.",
-        "topic": "TALK_AGREE_FOLLOW", 
-        "effect": "follow", 
-        "opinion": { "trust": 1, "value": 1 },
+        "topic": "TALK_AGREE_FOLLOW",
+        "effect": "follow",
+        "opinion": { "trust": 1, "value": 1 }
       },
       { "text": "We both go our separate ways.  Enjoy your freedom.", "topic": "TALK_DONE" }
     ]
@@ -63,7 +63,7 @@
     "responses": [
       {
         "text": "I wouldn't have pulled your chip out if I didn't want you to think for yourself.",
-        "trial": { "type": "PERSUADE", "difficulty": 5, "mod": [ [ "TRUST", 3 ], [ "FEAR", -2], [ "VALUE", 2 ] ] },
+        "trial": { "type": "PERSUADE", "difficulty": 5, "mod": [ [ "TRUST", 3 ], [ "FEAR", -2 ], [ "VALUE", 2 ] ] },
         "success": { "topic": "TALK_CYBORG_FRIENDLY", "opinion": { "trust": 1, "value": 1 } },
         "failure": { "topic": "TALK_CYBORG_LEAVES" }
       },

--- a/data/json/npcs/TALK_CYBORG_1.json
+++ b/data/json/npcs/TALK_CYBORG_1.json
@@ -49,9 +49,9 @@
     "responses": [
       {
         "text": "Come with me.  We can help each other out.",
-        "trial": { "type": "PERSUADE", "difficulty": 0, "mod": [ [ "value", 2 ] ] },
-        "success": { "topic": "TALK_AGREE_FOLLOW", "effect": "follow", "opinion": { "trust": 1, "value": 1 } },
-        "failure": { "topic": "TALK_DENY_FOLLOW", "effect": "deny_follow", "opinion": { "trust": -1, "fear": 1 } }
+        "topic": "TALK_AGREE_FOLLOW", 
+        "effect": "follow", 
+        "opinion": { "trust": 1, "value": 1 },
       },
       { "text": "We both go our separate ways.  Enjoy your freedom.", "topic": "TALK_DONE" }
     ]
@@ -68,7 +68,11 @@
         "failure": { "topic": "TALK_CYBORG_LEAVES" }
       },
       {
-        "text": "For all you know, I did.  I'm being nice for now.  You'd better hope that it lasts.",
+        "text": "I could be, but honestly, you're in no condition to make it out there. Trusting me is your only real option for survival.",
+        "topic": "TALK_AGREE_FOLLOW"
+      },
+      {
+        "text": "For all you know, I am.  I'm being nice for now.  You'd better hope that it lasts.",
         "trial": { "type": "INTIMIDATE", "difficulty": 20, "mod": [ [ "AGGRESSION", -2 ], [ "BRAVERY", -2 ] ] },
         "success": { "topic": "TALK_CYBORG_FEARFUL", "opinion": { "trust": -4, "fear": 3, "value": -1, "anger": 4 } },
         "failure": { "topic": "TALK_CYBORG_BREAKDOWN", "opinion": { "trust": -4, "value": -5, "anger": 10 } }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Failing to recruit a rescued prototype cyborg sucks for a number of reasons. 

First off, these guys are bottom-of-the-barrel new recruits; they come absolutely riddled with bionics that are actively killing them (and making annoying noises to boot). Removing these bionics is expensive in anesthesia and takes a long time, and each removal carries the risk of autodoc failure and damage which can demand recovery time too. Balance-wise, if anyone is going to be free, it's one of these poor charity cases.

Second, it makes no sense lore-wise. Not only are you saving these guys from endless waking torture with some very specialized tools you may well have had to seek out just for this purpose, which should massively predispose them to you once you explain the situation, the bigger and more pressing fact is that the outside is death and these guys are playing a -8 point challenge start in the best of condition. They're not going to make it without you, plain and simple.

Third, it is mechanically problematic. Right now, successfully persuading a prototype cyborg into an amicable state just takes you to a screen where you can do another roll to try and convince them to join. This means you need to get two checks in a row to recruit, which makes failure statistically much more likely. Some random guy with a shotgun on the street is way more likely to accept your invitation than the dying stranger who needs your help to live. I say, that's bad.

## Describe the solution (The How)

Added two new dialogue paths. If you successfully talk the cyborg into trusting you, the join/leave screen that follows is a choice, not a check. Join rewards trust as if you'd succeeded; you already passed a dialogue check to get here.

If you fail your check and the cyborg is wary of you, a new dialogue option has been added to tell them you're their only chance of survival. It cuts straight to recruitment without a check involved. Even shifty people normal folks wouldn't trust can recruit from the desperate like this.

## Describe alternatives you've considered

Make an existing persuasion check so hard to fail that every PC has a 100% chance to pass. Same mechanical effect but different aesthetic.

## Testing

I've opened up a copy of stable and dropped the modified JSON in. Tried spawning and recruiting prototypes until I got a chance to test both the new force-on-wary option and the on-success option that removes the extra check. I can confirm they at least lead to recruitment like they are supposed to.

## Additional context

Prototype survivors are still so terminally screwed that it still mostly only makes sense to save them as RP. This just makes it feel less bad to take on charity cases.

Right now the new force option appears between the [Persuade] and [Intimidate] checks. Don't know if a different position would be preferred.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.