### PR TITLE
feat(lua): add mission start/end lua hooks

### DIFF
--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -869,6 +869,23 @@ void cata::detail::reg_hooks_examples( sol::state &lua )
     DOC_PARAMS( "params" );
     luna::set_fx( lib, "on_mapgen_postprocess", []( const sol::table & ) {} );
 
+    DOC( "Called right after mission has started.  " );
+    DOC( "The hook receives a table with keys:  " );
+    DOC( "* `mission_type_id` (mission_type_id): The type id of the mission.  " );
+    DOC( "* `mission_id` (int): The reference id of this mission instance.  " );
+    DOC( "* `target_omt` (tripoint_abs_omt): Position of the target.  " );
+    DOC_PARAMS( "params" );
+    luna::set_fx( lib, "on_mission_start", []( const sol::table & ) {} );
+
+    DOC( "Called right after mission has ended.  " );
+    DOC( "The hook receives a table with keys:  " );
+    DOC( "* `mission_type_id` (mission_type_id): The type id of the mission.  " );
+    DOC( "* `mission_id` (int): The reference id of this mission instance.  " );
+    DOC( "* `target_omt` (tripoint_abs_omt): Position of the target.  " );
+    DOC( "* `success` (bool): Successful if true else failed.  " );
+    DOC_PARAMS( "params" );
+    luna::set_fx( lib, "on_mission_end", []( const sol::table & ) {} );
+
     luna::finalize_lib( lib );
 }
 

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -871,17 +871,15 @@ void cata::detail::reg_hooks_examples( sol::state &lua )
 
     DOC( "Called right after mission has started.  " );
     DOC( "The hook receives a table with keys:  " );
-    DOC( "* `mission_type_id` (mission_type_id): The type id of the mission.  " );
-    DOC( "* `mission_id` (int): The reference id of this mission instance.  " );
-    DOC( "* `target_omt` (tripoint_abs_omt): Position of the target.  " );
+    DOC( "* `mission_type` (mission_type): The type of the mission.  " );
+    DOC( "* `mission` (mission): The mission instance.  " );
     DOC_PARAMS( "params" );
     luna::set_fx( lib, "on_mission_start", []( const sol::table & ) {} );
 
     DOC( "Called right after mission has ended.  " );
     DOC( "The hook receives a table with keys:  " );
-    DOC( "* `mission_type_id` (mission_type_id): The type id of the mission.  " );
-    DOC( "* `mission_id` (int): The reference id of this mission instance.  " );
-    DOC( "* `target_omt` (tripoint_abs_omt): Position of the target.  " );
+    DOC( "* `mission_type` (mission_type): The type of the mission.  " );
+    DOC( "* `mission` (mission): The mission instance.  " );
     DOC( "* `success` (bool): Successful if true else failed.  " );
     DOC_PARAMS( "params" );
     luna::set_fx( lib, "on_mission_end", []( const sol::table & ) {} );

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -51,6 +51,8 @@ constexpr auto hook_names = std::array
     "on_npc_do_turn",
     "on_monster_do_turn",
     "on_make_mapgen_factory_list",
+    "on_mission_start",
+    "on_mission_end"
 };
 
 void define_hooks( lua_state &state )

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -32,7 +32,7 @@
 #include "requirements.h"
 #include "string_formatter.h"
 #include "translations.h"
-#include "sol/sol.hpp"
+#include "catalua_sol.h"
 
 mission mission_type::create( const character_id &npc_id ) const
 {

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "avatar.h"
+#include "catalua_hooks.h"
 #include "creature.h"
 #include "debug.h"
 #include "enum_conversions.h"
@@ -31,6 +32,7 @@
 #include "requirements.h"
 #include "string_formatter.h"
 #include "translations.h"
+#include "sol/sol.hpp"
 
 mission mission_type::create( const character_id &npc_id ) const
 {
@@ -257,6 +259,11 @@ void mission::assign( avatar &u )
         }
         type->start( this );
         status = mission_status::in_progress;
+        cata::run_hooks( "on_mission_start", [&]( auto & params ) {
+            params["mission_type_id"] = this->type->id;
+            params["mission_id"] = this->get_id();
+            params["target_omt"] = this->get_target();
+        } );
     }
 }
 
@@ -268,6 +275,13 @@ void mission::fail()
     }
 
     type->fail( this );
+    cata::run_hooks( "on_mission_end", [&]( auto & params ) {
+        params["mission_type_id"] = this->type->id;
+        params["mission_id"] = this->get_id();
+        params["target_omt"] = this->get_target();
+        params["success"] = false;
+    } );
+
 }
 
 void mission::set_target_to_mission_giver()
@@ -364,6 +378,12 @@ void mission::wrap_up()
     }
 
     type->end( this );
+    cata::run_hooks( "on_mission_end", [&]( auto & params ) {
+        params["mission_type_id"] = this->type->id;
+        params["mission_id"] = this->get_id();
+        params["target_omt"] = this->get_target();
+        params["success"] = true;
+    } );
 }
 
 bool mission::is_complete( const character_id &_npc_id ) const

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -260,9 +260,8 @@ void mission::assign( avatar &u )
         type->start( this );
         status = mission_status::in_progress;
         cata::run_hooks( "on_mission_start", [&]( auto & params ) {
-            params["mission_type_id"] = this->type->id;
-            params["mission_id"] = this->get_id();
-            params["target_omt"] = this->get_target();
+            params["mission_type"] = this->type;
+            params["mission"] = this;
         } );
     }
 }
@@ -276,10 +275,8 @@ void mission::fail()
 
     type->fail( this );
     cata::run_hooks( "on_mission_end", [&]( auto & params ) {
-        params["mission_type_id"] = this->type->id;
-        params["mission_id"] = this->get_id();
-        params["target_omt"] = this->get_target();
-        params["success"] = false;
+        params["mission_type"] = this->type;
+        params["mission"] = this;
     } );
 
 }
@@ -379,10 +376,8 @@ void mission::wrap_up()
 
     type->end( this );
     cata::run_hooks( "on_mission_end", [&]( auto & params ) {
-        params["mission_type_id"] = this->type->id;
-        params["mission_id"] = this->get_id();
-        params["target_omt"] = this->get_target();
-        params["success"] = true;
+        params["mission_type"] = this->type;
+        params["mission"] = this;
     } );
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

Being able to do post-processing of missions with Lua seems a good option for modding.

## Describe the solution (The How)

Call run_hooks at mission start/end, pass in relevant params, `mission_type_id,mission_id,target_omt,(success)`

## Describe alternatives you've considered

## Testing

Added a test mod for hooks, created a new world, requested a new mission and completed it.
Spawned another NPC, requested a new mission then killed all npcs to fail the mission.
<img width="632" height="93" alt="image" src="https://github.com/user-attachments/assets/d758fcb5-73bd-4611-bf68-a122c50408be" />


fyi, the position is always that of the target, despite my lua mod test saying "started at"


## Additional context

This is 100% home grown code, No AI involved.

Here is the lua script I used to test
```
local mod = game.mod_runtime[game.current_mod]

mod.on_mission_start_hook = function(params)
    local mission = params.mission
    local mission_name = mission:name()
    local mission_type_id = mission:mission_id()
    local target_omt = mission:get_target_point()

    gdebug.log_info(
            string.format(
                    "Mission[%s](%s) started at (%s).",
                    mission_name, mission_type_id, target_omt
            )
    )
end

mod.on_mission_end_hook = function(params)
    local mission = params.mission
    local mission_name = mission:name()
    local mission_type_id = mission:mission_id()

    local target_omt = mission:get_target_point()
    local has_failed = mission:has_failed()

    if has_failed then
        gdebug.log_info(
                string.format(
                        "Mission[%s](%s) failed at (%s).",
                        mission_name, mission_type_id, target_omt
                )
        )
    else
        gdebug.log_info(
                string.format(
                        "Mission[%s](%s) successful at (%s).",
                        mission_name, mission_type_id, target_omt
                )
        )
    end
end

```

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7d4f797](https://github.com/cataclysmbn/Cataclysm-BN/commit/7d4f7973f39f43b4a3837ec399c57d03fd3a1e18) (Use lua class instead of fields) on 2026-05-31 20:20:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26721855747/artifacts/7319377120)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26721855747/artifacts/7319692816)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26721855747/artifacts/7319373132)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26721855747/artifacts/7319504890)
<!-- END artifact comment -->