### PR TITLE
fix: restore missing starting fire in Really Bad Day scenario

### DIFF
--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -400,20 +400,27 @@ void start_location::place_player( player &u ) const
     }
 }
 
-void start_location::burn( const tripoint_abs_omt &omtstart, const size_t count,
+void start_location::burn( const tripoint_abs_omt &/*omtstart*/, const size_t count,
                            const int rad ) const
 {
-    const tripoint_abs_sm player_location = project_to<coords::sm>( omtstart );
-    tinymap m;
-    m.load( player_location, false );
-    m.build_outside_cache( m.get_abs_sub().z() );
-    const point u( g->u.bub_pos().x() % g_half_mapsize_x, g->u.bub_pos().y() % g_half_mapsize_y );
+    // Ignite flammable interior tiles on the live reality-bubble map (g->m). A
+    // throwaway single-z tinymap cannot model the z+1 roof level its outside cache
+    // depends on, so build_outside_cache() ends up marking every tile "outside" and
+    // burn() selects nothing (see #9169). g->m is a full multi-z map, so its outside
+    // cache is computed correctly here, mirroring how the sibling place_player() works.
+    map &m = get_map();
+    const tripoint_bub_ms u = g->u.bub_pos();
+    // Make sure the outside cache is current for the player's z (a no-op if already built).
+    m.build_outside_cache( u.z() );
+    const tripoint_bub_ms from( u.x() - SEEX, u.y() - SEEY, u.z() );
+    const tripoint_bub_ms to( u.x() + SEEX, u.y() + SEEY, u.z() );
     std::vector<tripoint_bub_ms> valid;
-    for( const tripoint_bub_ms &p : m.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : m.points_in_rectangle( from, to ) ) {
         if( !( m.has_flag_ter( "DOOR", p ) ||
                m.has_flag_ter( "OPENCLOSE_INSIDE", p ) ||
                m.is_outside( p ) ||
-               ( p.x() >= u.x - rad && p.x() <= u.x + rad && p.y() >= u.y - rad && p.y() <= u.y + rad ) ) ) {
+               ( p.x() >= u.x() - rad && p.x() <= u.x() + rad &&
+                 p.y() >= u.y() - rad && p.y() <= u.y() + rad ) ) ) {
             if( m.has_flag( "FLAMMABLE", p ) || m.has_flag( "FLAMMABLE_ASH", p ) ) {
                 valid.push_back( p );
             }

--- a/tests/start_location_fire_test.cpp
+++ b/tests/start_location_fire_test.cpp
@@ -1,0 +1,77 @@
+#include "catch/catch.hpp"
+
+#include "avatar.h"
+#include "coordinates.h"
+#include "field_type.h"
+#include "game.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "point.h"
+#include "start_location.h"
+#include "state_helpers.h"
+#include "type_id.h"
+
+// Regression test for #9169 ("Challenge - Really Bad Day" starts with no fire).
+//
+// The bad_day scenario carries FIRE_START, so game::start_game() calls
+// start_location::burn(), which is meant to ignite interior FLAMMABLE tiles around
+// the player. On current main burn() builds a single-z `tinymap` and queries
+// is_outside(); a zlevels=false map cannot model the z+1 roof level, so its
+// outside_cache is filled all-true and is_outside() returns true for EVERY tile.
+// burn()'s interior filter then rejects all candidates and places zero fires.
+//
+// This test paints a roofed (=> "inside") flammable building on the live map around
+// the avatar and asserts that burn() actually places fd_fire on interior tiles.
+// It FAILS on the buggy single-z-tinymap implementation and PASSES once burn()
+// operates on the live multi-z map (g->m), whose outside cache is correct.
+
+TEST_CASE( "start_location_burn_places_fire_on_interior_flammable_tiles",
+           "[start_location][field][fire]" )
+{
+    clear_all_state();
+    map &here = get_map();
+    REQUIRE( here.has_zlevels() );
+
+    const ter_str_id floor_primitive( "t_floor_primitive" ); // interior floor, FLAMMABLE_ASH
+    const ter_str_id floor_roof( "t_floor" );                // used as a roof on z+1
+
+    // Build an 11x11 flammable interior at z=0 with a roof one tile larger at z=1,
+    // so the 3x3-above check marks every interior tile as "inside".
+    for( int x = 54; x <= 66; ++x ) {
+        for( int y = 54; y <= 66; ++y ) {
+            here.ter_set( tripoint_bub_ms( x, y, 1 ), floor_roof );
+            if( x >= 55 && x <= 65 && y >= 55 && y <= 65 ) {
+                here.ter_set( tripoint_bub_ms( x, y, 0 ), floor_primitive );
+            }
+        }
+    }
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    // Place the avatar inside the building.
+    const tripoint_bub_ms center( 60, 60, 0 );
+    get_avatar().setpos( center );
+
+    // Preconditions: a flammable interior tile, inside, beyond burn()'s safe radius (3).
+    const tripoint_bub_ms interior_far( 64, 60, 0 );
+    REQUIRE_FALSE( here.is_outside( interior_far ) );
+    REQUIRE( ( here.has_flag( "FLAMMABLE", interior_far ) ||
+               here.has_flag( "FLAMMABLE_ASH", interior_far ) ) );
+
+    // bad_day passes the player's OMT to burn().
+    const tripoint_abs_omt omtstart =
+        project_to<coords::omt>( here.bub_to_abs( get_avatar().bub_pos() ) );
+
+    const start_location sl;
+    sl.burn( omtstart, /*count=*/3, /*rad=*/3 );
+
+    int fires = 0;
+    for( const tripoint_bub_ms &p : here.points_in_rectangle(
+             tripoint_bub_ms( 55, 55, 0 ), tripoint_bub_ms( 65, 65, 0 ) ) ) {
+        if( here.get_field( p, fd_fire ) != nullptr ) {
+            ++fires;
+        }
+    }
+    INFO( "fd_fire fields placed inside the building: " << fires );
+    CHECK( fires > 0 );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9169

The "Challenge - Really Bad Day" scenario is meant to start the player inside a
burning building, but on current `main` it spawns with no fire or smoke at all,
removing the scenario's defining hazard. The same code path affects the
"Burning Building" scenario.

## Describe the solution (The How)

The scenario plumbing is intact `bad_day` still carries `FIRE_START` and
`game::start_game()` still calls `start_location::burn()`. The bug is inside
`burn()`: it built a throwaway single-z `tinymap` (`zlevels=false`) and queried
`is_outside()` on it. A single-z map can't represent the z+1 roof level the
outside cache is derived from (`inbounds_z(z+1)` is false, so `build_outside_cache`
hits `rebuild_outside_cache(above=nullptr)`, which fills every tile "outside").
`burn()`'s interior filter (`!is_outside(p)`) then rejects every candidate,
`valid` stays empty, and no `fd_fire` is placed.

The fix ignites tiles on the live, multi-z reality-bubble map `g->m` instead of a
throwaway tinymap mirroring the sibling `place_player()`, which already operates
on `g->m`. `g->m` is `zlevels=true`, so its outside cache correctly distinguishes
interior from exterior. The scan is restricted to a window around the player
(`points_in_rectangle( u ± SEEX )`) so fire stays in the starting building.

## Describe alternatives you've considered

- **Keep `omtstart`: Make the tinymap multi-z (`tinymap m( 2, true )`)**: This *would* work
(`load()` loops the full z-column and runs `add_roofs`, so the roof level is present). 
But this would be more costly and fragile than using `g->m`: it reloads roofs and caches a  
~21-level z-column for the start OMT just to scan one z, whereas `g->m` is already loaded.
- **Re-add the old `m.save()`** (a diff visible vs. very old trees): doesn't
 compile (the API was removed) and fixes nothing.
- **Keep `omtstart`; decide "inside" without the roof model** with  a flat `TFLAG_INDOORS` scan
could introduce a second concept of what is inside that could disagree with the engine's `is_outside`
and could mishandled multilevel structures. 


## Testing

- Added `tests/start_location_fire_test.cpp`: paints a roofed (=> "inside")
  flammable building on `g->m`, places the player inside, runs
  `start_location::burn()`, and counts `fd_fire`. It fails on the old code
  (0 fires) and passes with the fix.
- Ran the new test under both `cata_test` (curses, gcc-14) and `cata_test-tiles`
  (clang-20)  green in both; the `[field]`/`[start_location]` slice is green.
- Verified in a TILES build: starting "Challenge - Really Bad Day" now spawns
  with fire and smoke.

Reviewer check recommendation: Start a Challenge - Really Bad Day run, check for spawned fires, the map gen may generate a legitimate no fires condition such as small cemetery where there may not be indoor flammable tiles >= 3 tiles away from the player. A brick/stone building with no wooden furniture is also a map gen scenario I saw where fire couldn't be present. 

## Additional context

The same single-z-`tinymap` + `build_outside_cache` pattern also affects
`start_location::prepare_map()`/`board_up()` for `BOARDED` scenarios (interior
doors get over-boarded). That's a separate latent bug from the same root cause,
left for a follow-up PR to keep this change focused.

## Checklist

### Mandatory
- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter.
- [x] I linked relevant issues using github keyword syntax (`closes #9169`).

### Optional
- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e4d22ff](https://github.com/cataclysmbn/Cataclysm-BN/commit/e4d22ff1e845a2a21ff68c4f95c086bbb25eed1c) (fix: restore missing starting fire in Really Bad Day scenario) on 2026-05-31 16:51:27

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26717169233/artifacts/7318047289)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26717169233/artifacts/7318320443)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26717169233/artifacts/7318061706)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26717169233/artifacts/7318155728)
<!-- END artifact comment -->