### PR TITLE
feat: add save maintenance tools + overmap pruner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ auto print_button( const catacurses::window &w, const button_options &opts ) -> 
 ```
 
 - **SHOULD NOT** modify existing headers with >10 usages. Create new header with pure functions.
+- **MUST** place newly added task-specific C++ source/header/test files in purpose-named subdirectories, e.g. `src/save/` and `tests/save/`, instead of adding more top-level files.
 - **MUST** use modern C++23 features.
 - **MUST** preserve unused parameter names as comments instead of deleting them, e.g. `bool /*is_avatar*/` not `bool`; applies to functions and lambdas.
 - **MUST** keep Lua function parameters typed with EmmyLua/LuaLS annotations, including existing and local helper functions: `---@param` and table `---@class`/`---@field` shapes where parameters are tables. Do not require or add `---@return` solely for annotation enforcement when the return type is inferable. Before touching Lua, inspect the file's annotation style and preserve complete function typing.

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -91,6 +91,7 @@
 #include "popup.h"
 #include "recipe_dictionary.h"
 #include "rng.h"
+#include "save/save_tools.h"
 #include "sounds.h"
 #include "stomach.h"
 #include "string_formatter.h"
@@ -206,6 +207,7 @@ enum debug_menu_index {
     DEBUG_VEHICLE_EXPORT_JSON,
     DEBUG_HOUR_TIMER,
     DEBUG_NESTED_MAPGEN,
+    DEBUG_PRUNE_MAP_OUTSIDE_BUBBLE,
     DEBUG_RESET_IGNORED_MESSAGES,
     DEBUG_RELOAD_TILES,
     DEBUG_SWAP_CHAR,
@@ -350,6 +352,7 @@ static int map_uilist()
         { uilist_entry( DEBUG_OM_EDITOR, true, 'O', _( "Overmap editor" ) ) },
         { uilist_entry( DEBUG_MAP_EXTRA, true, 'm', _( "Spawn map extra" ) ) },
         { uilist_entry( DEBUG_NESTED_MAPGEN, true, 'n', _( "Spawn nested mapgen" ) ) },
+        { uilist_entry( DEBUG_PRUNE_MAP_OUTSIDE_BUBBLE, true, 'u', _( "Prune map outside overmap tile bubble" ) ) },
     };
 
     return uilist( _( "Map…" ), uilist_initializer );
@@ -1514,6 +1517,78 @@ static std::optional<tripoint_range<tripoint_bub_ms>> select_area()
                first.position.value(), second.position.value() );
 }
 
+static auto append_limited_name_list( std::string &message, const std::string &title,
+                                      const std::vector<std::string> &names ) -> void
+{
+    message += string_format( "%s (%zu):\n", title.c_str(), names.size() );
+    auto shown = 0;
+    for( const auto &name : names ) {
+        if( shown >= 20 ) {
+            message += string_format( _( "  …and %zu more.\n" ), names.size() - shown );
+            return;
+        }
+        message += "  ";
+        message += name;
+        message += "\n";
+        shown++;
+    }
+    if( names.empty() ) {
+        message += _( "  none\n" );
+    }
+}
+
+static auto prune_map_outside_overmap_tile_bubble() -> void
+{
+    const auto keep_level = string_input_popup()
+                            .title( _( "Prune map area" ) )
+                            .description( _( "Enter how many overmap tiles to keep from the center tile.\n"
+                                          "1 keeps only your current overmap tile.\n"
+                                          "2 keeps a 3x3 area.  3 keeps a 5x5 area." ) )
+                            .width( 64 )
+                            .text( "1" )
+                            .only_digits( true )
+                            .query_int();
+    if( keep_level < 1 ) {
+        return;
+    }
+
+    const auto center = get_avatar().abs_omt_pos().xy();
+    const auto bubble = save_tools::save_prune_bubble{ .center = center, .radius = keep_level - 1 };
+    const auto keep_width = bubble.radius * 2 + 1;
+
+    add_msg( _( "Saving current game before previewing saved map pruning." ) );
+    if( !g->save( false ) ) {
+        popup( _( "Saving failed. Map prune aborted." ) );
+        return;
+    }
+    g->get_active_world()->release_player_db();
+
+    try {
+        const auto world_path = std::filesystem::path( g->get_active_world()->info->folder_path() );
+        const auto preview = save_tools::preview_prune_world_outside_bubble( world_path, bubble );
+        auto message = string_format(
+                           _( "This will keep a %dx%d overmap-tile bubble, preserve %zu map-related SQLite rows, and prune %zu rows outside it.\nIgnored non-map rows: %zu.\n\nSafe bubble contents detected in saved data:\n" ),
+                           keep_width, keep_width, preview.kept_rows, preview.pruned_rows,
+                           preview.ignored_rows );
+        append_limited_name_list( message, _( "Vehicles" ), preview.vehicles );
+        append_limited_name_list( message, _( "NPCs" ), preview.npcs );
+        message +=
+            _( "\nA backup world will be created and the world seed will be changed before pruning. Continue?" );
+        if( !query_yn( "%s", message.c_str() ) ) {
+            return;
+        }
+
+        const auto result = save_tools::prune_world_outside_bubble( world_path, bubble );
+        popup( _( "Pruned %zu saved map rows outside the safe bubble. World seed changed from %u to %u. Backup created at:\n%s\n\nThe game will now return to the main menu without saving again." ),
+               result.preview.pruned_rows, result.old_seed, result.new_seed,
+               result.backup_path.string().c_str() );
+        g->u.moves = 0;
+        g->uquit = QUIT_NOSAVED;
+    } catch( const std::exception &err ) {
+        popup( _( "Map prune failed: %s" ), err.what() );
+    }
+}
+
 void debug()
 {
     bool debug_menu_has_hotkey = hotkey_for_action( ACTION_DEBUG, false ) != -1;
@@ -2167,6 +2242,9 @@ void debug()
         }
         case DEBUG_NESTED_MAPGEN:
             debug_menu::spawn_nested_mapgen();
+            break;
+        case DEBUG_PRUNE_MAP_OUTSIDE_BUBBLE:
+            prune_map_outside_overmap_tile_bubble();
             break;
         case DEBUG_DISPLAY_NPC_PATH:
             g->debug_pathfinding = !g->debug_pathfinding;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <locale>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <filesystem>
@@ -42,6 +43,7 @@
 #include "output.h"
 #include "path_info.h"
 #include "rng.h"
+#include "save/save_tools.h"
 #include "type_id.h"
 #include "ui_manager.h"
 #include "path_display.h"
@@ -235,6 +237,8 @@ int main( int argc, char *argv[] )
     dump_mode dmode = dump_mode::TSV;
     std::vector<std::string> opts;
     std::string world; /** if set try to load first save in this world on startup */
+    std::optional<save_tools::blob_compression_mode> save_blob_mode;
+    std::string save_blob_world;
 
 #if defined(__ANDROID__)
     // Start the standard output logging redirector
@@ -270,7 +274,7 @@ int main( int argc, char *argv[] )
         const char *section_default = nullptr;
         const char *section_map_sharing = "Map sharing";
         const char *section_user_directory = "User directories";
-        const std::array<arg_handler, 17> first_pass_arguments = {{
+        const std::array<arg_handler, 20> first_pass_arguments = {{
                 {
                     "--seed", "<string of letters and or numbers>",
                     "Sets the random number generator's seed value",
@@ -360,6 +364,51 @@ int main( int argc, char *argv[] )
                             return -1;
                         }
                         world = params[0];
+                        return 1;
+                    }
+                },
+                {
+                    "--save-compression-info", "<world>",
+                    "Print SQLite save blob compression statistics for a world and exit",
+                    section_default,
+                    [&save_blob_mode, &save_blob_world]( int n, const char *params[] ) -> int {
+                        if( n < 1 )
+                        {
+                            return -1;
+                        }
+                        test_mode = true;
+                        save_blob_mode = save_tools::blob_compression_mode::info;
+                        save_blob_world = params[0];
+                        return 1;
+                    }
+                },
+                {
+                    "--save-compress", "<world>",
+                    "Compress uncompressed SQLite save blobs for a world and exit",
+                    section_default,
+                    [&save_blob_mode, &save_blob_world]( int n, const char *params[] ) -> int {
+                        if( n < 1 )
+                        {
+                            return -1;
+                        }
+                        test_mode = true;
+                        save_blob_mode = save_tools::blob_compression_mode::compress;
+                        save_blob_world = params[0];
+                        return 1;
+                    }
+                },
+                {
+                    "--save-decompress", "<world>",
+                    "Decompress zlib SQLite save blobs for a world and exit",
+                    section_default,
+                    [&save_blob_mode, &save_blob_world]( int n, const char *params[] ) -> int {
+                        if( n < 1 )
+                        {
+                            return -1;
+                        }
+                        test_mode = true;
+                        save_blob_mode = save_tools::blob_compression_mode::decompress;
+                        save_blob_world = params[0];
                         return 1;
                     }
                 },
@@ -755,6 +804,25 @@ int main( int argc, char *argv[] )
     check_dir_good( PATH_INFO::savedir() );
 
     setupDebug( DebugOutput::file );
+
+    if( save_blob_mode ) {
+        try {
+            const auto world_path = std::filesystem::path( PATH_INFO::savedir() ) / save_blob_world;
+            const auto stats = save_tools::rewrite_world_blobs( world_path, *save_blob_mode );
+            cata_printf( "Databases: %zu\n", stats.databases );
+            cata_printf( "Rows: %zu\n", stats.rows );
+            cata_printf( "Compressed rows: %zu\n", stats.compressed_rows );
+            cata_printf( "Uncompressed rows: %zu\n", stats.uncompressed_rows );
+            cata_printf( "Unknown compression rows: %zu\n", stats.unknown_compression_rows );
+            cata_printf( "Changed rows: %zu\n", stats.changed_rows );
+            cata_printf( "Stored bytes: %llu\n", static_cast<unsigned long long>( stats.stored_bytes ) );
+            cata_printf( "Raw bytes: %llu\n", static_cast<unsigned long long>( stats.raw_bytes ) );
+            return stats.unknown_compression_rows == 0 ? 0 : 1;
+        } catch( const std::exception &err ) {
+            cata_printf( "Save blob operation failed: %s\n", err.what() );
+            return 1;
+        }
+    }
 
     if( !init_language_system() ) {
         exit_handler( -999 );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -19,6 +19,7 @@
 #include <point.h>
 #include <ranges>
 #include <set>
+#include <sstream>
 #include <submap.h>
 #include <tuple>
 #include <unordered_set>
@@ -6339,6 +6340,59 @@ void overmap::place_radios()
     }
 }
 
+static auto pruned_overmap_stash_path( const dimension_id &dim_id,
+                                       const point_abs_om &loc ) -> std::string
+{
+    const auto dim_id_str = dim_id.str();
+    const auto prefix = dim_id_str.empty() ? std::string{} : "dimensions/"
+                        + dim_id_str + "/";
+    return string_format( "pruned_overmap/%so.%d.%d", prefix, loc.x(), loc.y() );
+}
+
+auto overmap::load_pruned_overmap_stash( const dimension_id &dim_id ) -> void
+{
+    const auto stash_path = pruned_overmap_stash_path( dim_id, loc );
+    auto loaded = false;
+    g->get_active_world()->read_map_entry( stash_path, [&]( std::istream & fin ) {
+        auto json = JsonIn( fin, stash_path );
+        json.start_object();
+        while( !json.end_object() ) {
+            const auto member = json.get_member_name();
+            if( member == "tracked_vehicles" ) {
+                json.start_array();
+                while( !json.end_array() ) {
+                    const auto vehicle = json.get_object();
+                    if( !vehicle.has_int( "id" ) || !vehicle.has_int( "x" ) || !vehicle.has_int( "y" ) ) {
+                        continue;
+                    }
+                    auto tracker = om_vehicle{};
+                    tracker.p = point_om_omt( vehicle.get_int( "x" ), vehicle.get_int( "y" ) );
+                    if( vehicle.has_string( "name" ) ) {
+                        tracker.name = vehicle.get_string( "name" );
+                    }
+                    vehicles[vehicle.get_int( "id" )] = tracker;
+                }
+            } else if( member == "npcs" ) {
+                json.start_array();
+                while( !json.end_array() ) {
+                    auto new_npc = make_shared_fast<npc>();
+                    new_npc->deserialize( json );
+                    if( !new_npc->get_fac_id().str().empty() ) {
+                        new_npc->set_fac( new_npc->get_fac_id() );
+                    }
+                    npcs.push_back( new_npc );
+                }
+            } else {
+                json.skip_value();
+            }
+        }
+        loaded = true;
+    } );
+    if( loaded ) {
+        g->get_active_world()->delete_map_entry( stash_path );
+    }
+}
+
 auto overmap::open( const dimension_id &dim_id,
                     overmap_special_batch &enabled_specials ) -> void
 {
@@ -6365,6 +6419,7 @@ auto overmap::open( const dimension_id &dim_id,
 
         // pointers looks like (north, south, west, east)
         generate( pointers[0], pointers[3], pointers[1], pointers[2], enabled_specials );
+        load_pruned_overmap_stash( dim_id );
     }
 }
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -491,6 +491,7 @@ class overmap
 
         // Initialize
         void init_layers();
+        auto load_pruned_overmap_stash( const dimension_id &dim_id ) -> void;
         // open existing overmap, or generate a new one
         auto open( const dimension_id &dim_id, overmap_special_batch &enabled_specials ) -> void;
     public:

--- a/src/save/save_tools.cpp
+++ b/src/save/save_tools.cpp
@@ -1,0 +1,1140 @@
+#include "save_tools.h"
+
+#include "compress.h"
+#include "game_constants.h"
+#include "json.h"
+#include "sqlite3.h"
+#include "string_formatter.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <limits>
+#include <optional>
+#include <ranges>
+#include <sstream>
+#include <stdexcept>
+
+namespace save_tools {
+namespace {
+
+struct sqlite_db {
+    explicit sqlite_db(const std::filesystem::path& path) {
+        auto* opened = static_cast<sqlite3*>(nullptr);
+        auto ret = sqlite3_open_v2(path.string().c_str(), &opened, SQLITE_OPEN_READWRITE, nullptr);
+        if (ret != SQLITE_OK) {
+            const auto message =
+                opened != nullptr ? sqlite3_errmsg(opened) : "unknown sqlite error";
+            if (opened != nullptr) { sqlite3_close(opened); }
+            throw std::runtime_error(
+                string_format("Failed to open %s: %s", path.string().c_str(), message));
+        }
+        db = opened;
+    }
+
+    sqlite_db(const sqlite_db&) = delete;
+    auto operator=(const sqlite_db&) -> sqlite_db& = delete;
+
+    ~sqlite_db() {
+        if (db != nullptr) { sqlite3_close(db); }
+    }
+
+    auto get() const -> sqlite3* { // *NOPAD*
+        return db;
+    }
+
+private:
+    sqlite3* db = nullptr;
+};
+
+struct sqlite_stmt {
+    sqlite_stmt(sqlite3* db, const char* sql) {
+        auto* prepared = static_cast<sqlite3_stmt*>(nullptr);
+        if (sqlite3_prepare_v2(db, sql, -1, &prepared, nullptr) != SQLITE_OK) {
+            throw std::runtime_error(sqlite3_errmsg(db));
+        }
+        stmt = prepared;
+    }
+
+    sqlite_stmt(const sqlite_stmt&) = delete;
+    auto operator=(const sqlite_stmt&) -> sqlite_stmt& = delete;
+
+    ~sqlite_stmt() {
+        if (stmt != nullptr) { sqlite3_finalize(stmt); }
+    }
+
+    auto get() const -> sqlite3_stmt* { // *NOPAD*
+        return stmt;
+    }
+
+private:
+    sqlite3_stmt* stmt = nullptr;
+};
+
+struct transaction {
+    explicit transaction(sqlite3* db): db(db) { exec_sql("BEGIN TRANSACTION"); }
+
+    transaction(const transaction&) = delete;
+    auto operator=(const transaction&) -> transaction& = delete;
+
+    ~transaction() {
+        if (active) { sqlite3_exec(db, "ROLLBACK", nullptr, nullptr, nullptr); }
+    }
+
+    auto commit() -> void {
+        exec_sql("COMMIT");
+        active = false;
+    }
+
+private:
+    auto exec_sql(const char* sql) -> void {
+        auto* err = static_cast<char*>(nullptr);
+        if (sqlite3_exec(db, sql, nullptr, nullptr, &err) != SQLITE_OK) {
+            auto message = std::string(err != nullptr ? err : sqlite3_errmsg(db));
+            sqlite3_free(err);
+            throw std::runtime_error(message);
+        }
+    }
+
+    sqlite3* db;
+    bool active = true;
+};
+
+enum class save_path_kind {
+    unknown,
+    map_omt,
+    overmap,
+    overmap_seen,
+    map_memory,
+};
+
+struct save_path_info {
+    save_path_kind kind = save_path_kind::unknown;
+    point_abs_om overmap;
+    point_abs_omt omt;
+};
+
+auto sqlite_files(const std::filesystem::path& world_path) -> std::vector<std::filesystem::path> {
+    auto files = std::vector<std::filesystem::path>{};
+    if (!std::filesystem::exists(world_path)) {
+        throw std::runtime_error(
+            string_format("World path does not exist: %s", world_path.string().c_str()));
+    }
+    for (const auto& entry : std::filesystem::directory_iterator(world_path)) {
+        if (entry.is_regular_file() && entry.path().extension() == ".sqlite3") {
+            files.push_back(entry.path());
+        }
+    }
+    std::ranges::sort(files);
+    return files;
+}
+
+auto strip_dimension_prefix(const std::string& path) -> std::string {
+    constexpr auto prefix = std::string_view("dimensions/");
+    if (!path.starts_with(prefix)) { return path; }
+    const auto after_prefix = prefix.size();
+    const auto separator = path.find('/', after_prefix);
+    if (separator == std::string::npos) { return path; }
+    return path.substr(separator + 1);
+}
+
+auto parse_int_tail(const std::string& text, const char* format) -> std::optional<tripoint> {
+    auto x = 0;
+    auto y = 0;
+    auto z = 0;
+    if (std::sscanf(text.c_str(), format, &x, &y, &z) == 3) { return tripoint(x, y, z); }
+    return std::nullopt;
+}
+
+auto parse_point_tail(const std::string& text, const char* format) -> std::optional<point> {
+    auto x = 0;
+    auto y = 0;
+    if (std::sscanf(text.c_str(), format, &x, &y) == 2) { return point(x, y); }
+    return std::nullopt;
+}
+
+auto classify_save_path(const std::string& path) -> save_path_info {
+    const auto local_path = strip_dimension_prefix(path);
+    if (local_path.starts_with("maps/")) {
+        const auto file_start = local_path.find_last_of("/\\");
+        const auto filename =
+            file_start == std::string::npos ? local_path : local_path.substr(file_start + 1);
+        if (const auto parsed = parse_int_tail(filename, "%d.%d.%d.map")) {
+            const auto omt = tripoint_abs_omt(parsed->x, parsed->y, parsed->z);
+            return {
+                .kind = save_path_kind::map_omt,
+                .overmap = project_to<coords::om>(omt).xy(),
+                .omt = omt.xy(),
+            };
+        }
+    }
+    if (local_path.starts_with("o.")) {
+        if (const auto parsed = parse_point_tail(local_path, "o.%d.%d")) {
+            return {
+                .kind = save_path_kind::overmap,
+                .overmap = point_abs_om(parsed->x, parsed->y),
+                .omt = {},
+            };
+        }
+    }
+    if (local_path.starts_with(".seen.")) {
+        if (const auto parsed = parse_point_tail(local_path, ".seen.%d.%d")) {
+            return {
+                .kind = save_path_kind::overmap_seen,
+                .overmap = point_abs_om(parsed->x, parsed->y),
+                .omt = {},
+            };
+        }
+    }
+    if (local_path.ends_with(".mmr")) {
+        if (const auto parsed = parse_int_tail(local_path, "%d.%d.%d.mmr")) {
+            const auto mmr = tripoint_abs_mmr(parsed->x, parsed->y, parsed->z);
+            return {
+                .kind = save_path_kind::map_memory,
+                .overmap = project_to<coords::om>(mmr).xy(),
+                .omt = {},
+            };
+        }
+    }
+    return {};
+}
+
+auto is_inside_bubble(const point_abs_omt& pos, const save_prune_bubble& bubble) -> bool {
+    const auto dx = std::abs(pos.x() - bubble.center.x());
+    const auto dy = std::abs(pos.y() - bubble.center.y());
+    return std::max(dx, dy) <= bubble.radius;
+}
+
+auto overmap_origin_omt(const point_abs_om& overmap) -> point_abs_omt {
+    return {overmap.x() * OMAPX, overmap.y() * OMAPY};
+}
+
+auto overmap_intersects_bubble(const point_abs_om& overmap, const save_prune_bubble& bubble)
+    -> bool {
+    const auto origin = overmap_origin_omt(overmap);
+    const auto min_x = origin.x();
+    const auto max_x = origin.x() + OMAPX - 1;
+    const auto min_y = origin.y();
+    const auto max_y = origin.y() + OMAPY - 1;
+    const auto closest_x = std::clamp(bubble.center.x(), min_x, max_x);
+    const auto closest_y = std::clamp(bubble.center.y(), min_y, max_y);
+    return is_inside_bubble(point_abs_omt(closest_x, closest_y), bubble);
+}
+
+auto local_omt(const point_abs_om& overmap, const int x, const int y) -> point_abs_omt {
+    const auto origin = overmap_origin_omt(overmap);
+    return {origin.x() + x, origin.y() + y};
+}
+
+auto blob_to_string(const void* data, const int size) -> std::string {
+    if (data == nullptr || size <= 0) { return {}; }
+    return std::string(static_cast<const char*>(data), static_cast<std::size_t>(size));
+}
+
+auto row_data_to_string(sqlite3_stmt* stmt) -> std::string {
+    const auto* blob = sqlite3_column_blob(stmt, 1);
+    const auto blob_size = sqlite3_column_bytes(stmt, 1);
+    const auto* compression_raw = sqlite3_column_text(stmt, 2);
+    const auto compression =
+        compression_raw == nullptr ? std::string{} : reinterpret_cast<const char*>(compression_raw);
+    if (compression.empty()) { return blob_to_string(blob, blob_size); }
+    if (compression == "zlib") {
+        auto data = std::string{};
+        zlib_decompress(blob, blob_size, data);
+        return data;
+    }
+    return {};
+}
+
+auto strip_save_version_header(const std::string& data) -> std::string {
+    if (!data.starts_with('#')) { return data; }
+    const auto json_start = data.find('\n');
+    if (json_start == std::string::npos) { return {}; }
+    return data.substr(json_start + 1);
+}
+
+auto read_text_file(const std::filesystem::path& path) -> std::string {
+    auto input = std::ifstream(path, std::ios::binary);
+    if (!input.is_open()) {
+        throw std::runtime_error(string_format("Failed to open %s", path.string().c_str()));
+    }
+    auto stream = std::ostringstream{};
+    stream << input.rdbuf();
+    return stream.str();
+}
+
+auto write_text_file(const std::filesystem::path& path, const std::string& data) -> void {
+    auto output = std::ofstream(path, std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        throw std::runtime_error(string_format("Failed to write %s", path.string().c_str()));
+    }
+    output << data;
+}
+
+auto seed_digits_range(const std::string& data) -> std::pair<std::size_t, std::size_t> {
+    const auto seed_key = data.find("\"seed\"");
+    if (seed_key == std::string::npos) {
+        throw std::runtime_error("master.gsav does not contain a seed member");
+    }
+    const auto colon = data.find(':', seed_key);
+    if (colon == std::string::npos) {
+        throw std::runtime_error("master.gsav seed member is malformed");
+    }
+    auto first = colon + 1;
+    while (first < data.size() && std::isspace(static_cast<unsigned char>(data[first]))) {
+        first++;
+    }
+    auto last = first;
+    while (last < data.size() && std::isdigit(static_cast<unsigned char>(data[last]))) { last++; }
+    if (first == last) { throw std::runtime_error("master.gsav seed member is not numeric"); }
+    return {first, last};
+}
+
+auto read_seed_from_master(const std::string& data) -> unsigned int {
+    const auto [first, last] = seed_digits_range(data);
+    const auto seed = std::stoull(data.substr(first, last - first));
+    if (seed > std::numeric_limits<unsigned int>::max()) {
+        throw std::runtime_error("master.gsav seed member is out of range");
+    }
+    return static_cast<unsigned int>(seed);
+}
+
+auto make_replacement_seed(const unsigned int old_seed) -> unsigned int {
+    const auto now = static_cast<unsigned int>(
+        std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    auto new_seed = old_seed ^ now ^ 0x9e3779b9U;
+    if (new_seed == old_seed) { new_seed++; }
+    return new_seed;
+}
+
+auto replace_seed_in_master(std::string& data, const unsigned int new_seed) -> void {
+    const auto [first, last] = seed_digits_range(data);
+    data.replace(first, last - first, std::to_string(new_seed));
+}
+
+auto reroll_world_seed(const std::filesystem::path& world_path)
+    -> std::pair<unsigned int, unsigned int> {
+    const auto master_path = world_path / "master.gsav";
+    auto master = read_text_file(master_path);
+    const auto old_seed = read_seed_from_master(master);
+    const auto new_seed = make_replacement_seed(old_seed);
+    replace_seed_in_master(master, new_seed);
+    write_text_file(master_path, master);
+    return {old_seed, new_seed};
+}
+
+auto read_object_name(JsonIn& json) -> std::string {
+    auto name = std::string{};
+    json.start_object();
+    while (!json.end_object()) {
+        const auto member = json.get_member_name();
+        if (member == "name") {
+            json.read(name);
+        } else {
+            json.skip_value();
+        }
+    }
+    return name;
+}
+
+auto append_unique(std::vector<std::string>& out, const std::string& value) -> void {
+    if (value.empty() || std::ranges::contains(out, value)) { return; }
+    out.push_back(value);
+}
+
+auto read_compacted_terrain_layer(JsonIn& json) -> std::vector<std::string> {
+    auto values = std::vector<std::string>(OMAPX * OMAPY, "field");
+    auto index = std::size_t{0};
+    json.start_array();
+    while (!json.end_array()) {
+        auto terrain = std::string{};
+        auto count = 0;
+        json.start_array();
+        json.read(terrain);
+        json.read(count);
+        json.end_array();
+        for (auto i = 0; i < count && index < values.size(); i++) {
+            values[index] = terrain;
+            index++;
+        }
+    }
+    return values;
+}
+
+auto write_json_string(std::ostream& stream, const std::string& value) -> void {
+    auto json = JsonOut(stream, false);
+    json.write(value);
+}
+
+auto write_compacted_terrain_layer(std::ostream& stream, const std::vector<std::string>& values)
+    -> void {
+    auto count = 0;
+    auto last_value = std::string{};
+    auto have_value = false;
+    stream << '[';
+    for (const auto& value : values) {
+        if (!have_value || value != last_value) {
+            if (have_value) { stream << ',' << count << ']'; }
+            if (have_value) { stream << ','; }
+            stream << '[';
+            write_json_string(stream, value);
+            last_value = value;
+            count = 1;
+            have_value = true;
+        } else {
+            count++;
+        }
+    }
+    if (have_value) { stream << ',' << count << ']'; }
+    stream << ']';
+}
+
+auto default_terrain_for_layer(const int layer_index) -> std::string {
+    if (layer_index < OVERMAP_DEPTH) { return "empty_rock"; }
+    if (layer_index > OVERMAP_DEPTH) { return "open_air"; }
+    return "field";
+}
+
+auto prune_terrain_layer(
+    std::vector<std::string>& values, const int layer_index, const point_abs_om& overmap,
+    const save_prune_bubble& bubble) -> void {
+    auto index = std::size_t{0};
+    for (auto y = 0; y < OMAPY; y++) {
+        for (auto x = 0; x < OMAPX; x++) {
+            if (!is_inside_bubble(local_omt(overmap, x, y), bubble)) {
+                values[index] = default_terrain_for_layer(layer_index);
+            }
+            index++;
+        }
+    }
+}
+
+auto read_compacted_layer(JsonIn& json) -> std::vector<bool> {
+    auto values = std::vector<bool>(OMAPX * OMAPY, false);
+    auto index = std::size_t{0};
+    json.start_array();
+    while (!json.end_array()) {
+        auto value = false;
+        auto count = 0;
+        json.start_array();
+        json.read(value);
+        json.read(count);
+        json.end_array();
+        for (auto i = 0; i < count && index < values.size(); i++) {
+            values[index] = value;
+            index++;
+        }
+    }
+    return values;
+}
+
+auto write_compacted_layer(JsonOut& json, const std::vector<bool>& values) -> void {
+    auto count = 0;
+    auto last_value = false;
+    auto have_value = false;
+    json.start_array();
+    for (const auto value : values) {
+        if (!have_value || value != last_value) {
+            if (have_value) {
+                json.write(count);
+                json.end_array();
+            }
+            json.start_array();
+            json.write(value);
+            last_value = value;
+            count = 1;
+            have_value = true;
+        } else {
+            count++;
+        }
+    }
+    if (have_value) {
+        json.write(count);
+        json.end_array();
+    }
+    json.end_array();
+}
+
+auto prune_visibility_layer(
+    std::vector<bool>& values, const point_abs_om& overmap, const save_prune_bubble& bubble)
+    -> void {
+    auto index = std::size_t{0};
+    for (auto y = 0; y < OMAPY; y++) {
+        for (auto x = 0; x < OMAPX; x++) {
+            if (!is_inside_bubble(local_omt(overmap, x, y), bubble)) { values[index] = false; }
+            index++;
+        }
+    }
+}
+
+struct saved_note {
+    int z = 0;
+    int x = 0;
+    int y = 0;
+    std::string text;
+    bool dangerous = false;
+    int danger_radius = 0;
+};
+
+struct saved_extra {
+    int z = 0;
+    int x = 0;
+    int y = 0;
+    std::string id;
+};
+
+struct overmap_terrain_data {
+    std::array<std::vector<std::string>, OVERMAP_LAYERS> layers;
+    std::string region_id;
+    std::vector<std::string> tracked_vehicles;
+    std::vector<std::string> npcs;
+};
+
+struct visibility_data {
+    std::array<std::vector<bool>, OVERMAP_LAYERS> visible;
+    std::array<std::vector<bool>, OVERMAP_LAYERS> explored;
+    std::array<std::vector<bool>, OVERMAP_LAYERS> path;
+    std::vector<saved_note> notes;
+    std::vector<saved_extra> extras;
+};
+
+auto read_terrain_layers(JsonIn& json) -> std::array<std::vector<std::string>, OVERMAP_LAYERS> {
+    auto layers = std::array<std::vector<std::string>, OVERMAP_LAYERS>{};
+    json.start_array();
+    for (auto& layer : layers) { layer = read_compacted_terrain_layer(json); }
+    json.end_array();
+    return layers;
+}
+
+auto read_visibility_layers(JsonIn& json) -> std::array<std::vector<bool>, OVERMAP_LAYERS> {
+    auto layers = std::array<std::vector<bool>, OVERMAP_LAYERS>{};
+    json.start_array();
+    for (auto& layer : layers) { layer = read_compacted_layer(json); }
+    json.end_array();
+    return layers;
+}
+
+auto read_visibility_data(const std::string& data) -> visibility_data {
+    auto result = visibility_data{};
+    auto stream = std::istringstream(strip_save_version_header(data));
+    auto json = JsonIn(stream);
+    json.start_object();
+    while (!json.end_object()) {
+        const auto member = json.get_member_name();
+        if (member == "visible") {
+            result.visible = read_visibility_layers(json);
+        } else if (member == "explored") {
+            result.explored = read_visibility_layers(json);
+        } else if (member == "path") {
+            result.path = read_visibility_layers(json);
+        } else if (member == "notes") {
+            json.start_array();
+            for (auto z = 0; z < OVERMAP_LAYERS; z++) {
+                json.start_array();
+                while (!json.end_array()) {
+                    auto note = saved_note{};
+                    note.z = z;
+                    json.start_array();
+                    json.read(note.x);
+                    json.read(note.y);
+                    json.read(note.text);
+                    json.read(note.dangerous);
+                    json.read(note.danger_radius);
+                    json.end_array();
+                    result.notes.push_back(note);
+                }
+            }
+            json.end_array();
+        } else if (member == "extras") {
+            json.start_array();
+            for (auto z = 0; z < OVERMAP_LAYERS; z++) {
+                json.start_array();
+                while (!json.end_array()) {
+                    auto extra = saved_extra{};
+                    extra.z = z;
+                    json.start_array();
+                    json.read(extra.x);
+                    json.read(extra.y);
+                    json.read(extra.id);
+                    json.end_array();
+                    result.extras.push_back(extra);
+                }
+            }
+            json.end_array();
+        } else {
+            json.skip_value();
+        }
+    }
+    return result;
+}
+
+auto prune_visibility_data(
+    visibility_data& data, const point_abs_om& overmap, const save_prune_bubble& bubble) -> void {
+    for (auto& layer : data.visible) { prune_visibility_layer(layer, overmap, bubble); }
+    for (auto& layer : data.explored) { prune_visibility_layer(layer, overmap, bubble); }
+    for (auto& layer : data.path) { prune_visibility_layer(layer, overmap, bubble); }
+    std::erase_if(data.notes, [&](const saved_note& note) {
+        return !is_inside_bubble(local_omt(overmap, note.x, note.y), bubble);
+    });
+    std::erase_if(data.extras, [&](const saved_extra& extra) {
+        return !is_inside_bubble(local_omt(overmap, extra.x, extra.y), bubble);
+    });
+}
+
+auto write_visibility_data(const visibility_data& data) -> std::string {
+    auto stream = std::ostringstream{};
+    stream << "# version 29\n";
+    auto json = JsonOut(stream, false);
+    json.start_object();
+    const auto write_layers =
+        [&](const std::string& name, const std::array<std::vector<bool>, OVERMAP_LAYERS>& layers) {
+            json.member(name);
+            json.start_array();
+            for (const auto& layer : layers) { write_compacted_layer(json, layer); }
+            json.end_array();
+        };
+    write_layers("visible", data.visible);
+    write_layers("explored", data.explored);
+    write_layers("path", data.path);
+    json.member("notes");
+    json.start_array();
+    for (auto z = 0; z < OVERMAP_LAYERS; z++) {
+        json.start_array();
+        for (const auto& note :
+             data.notes | std::views::filter([&](const saved_note& n) { return n.z == z; })) {
+            json.start_array();
+            json.write(note.x);
+            json.write(note.y);
+            json.write(note.text);
+            json.write(note.dangerous);
+            json.write(note.danger_radius);
+            json.end_array();
+        }
+        json.end_array();
+    }
+    json.end_array();
+    json.member("extras");
+    json.start_array();
+    for (auto z = 0; z < OVERMAP_LAYERS; z++) {
+        json.start_array();
+        for (const auto& extra :
+             data.extras | std::views::filter([&](const saved_extra& e) { return e.z == z; })) {
+            json.start_array();
+            json.write(extra.x);
+            json.write(extra.y);
+            json.write(extra.id);
+            json.end_array();
+        }
+        json.end_array();
+    }
+    json.end_array();
+    json.end_object();
+    return stream.str();
+}
+
+auto collect_vehicle_names_from_map(const std::string& data, std::vector<std::string>& vehicles)
+    -> void {
+    auto stream = std::istringstream(data);
+    auto json = JsonIn(stream);
+    json.start_array();
+    while (!json.end_array()) {
+        json.start_object();
+        while (!json.end_object()) {
+            const auto member = json.get_member_name();
+            if (member == "vehicles") {
+                json.start_array();
+                while (!json.end_array()) { append_unique(vehicles, read_object_name(json)); }
+            } else {
+                json.skip_value();
+            }
+        }
+    }
+}
+
+auto collect_overmap_vehicles(
+    JsonIn& json, const point_abs_om& overmap, const save_prune_bubble& bubble,
+    std::vector<std::string>& out) -> void {
+    json.start_array();
+    while (!json.end_array()) {
+        auto name = std::string{};
+        auto x = 0;
+        auto y = 0;
+        json.start_object();
+        while (!json.end_object()) {
+            const auto member = json.get_member_name();
+            if (member == "name") {
+                json.read(name);
+            } else if (member == "x") {
+                json.read(x);
+            } else if (member == "y") {
+                json.read(y);
+            } else {
+                json.skip_value();
+            }
+        }
+        if (is_inside_bubble(local_omt(overmap, x, y), bubble)) { append_unique(out, name); }
+    }
+}
+
+auto read_abs_pos_omt(JsonIn& json) -> point_abs_omt {
+    auto x = 0;
+    auto y = 0;
+    auto z = 0;
+    json.start_array();
+    json.read(x);
+    json.read(y);
+    json.read(z);
+    json.end_array();
+    return project_to<coords::omt>(tripoint_abs_ms(x, y, z)).xy();
+}
+
+auto collect_overmap_npcs(
+    JsonIn& json, const save_prune_bubble& bubble, std::vector<std::string>& out) -> void {
+    json.start_array();
+    while (!json.end_array()) {
+        auto name = std::string{};
+        auto omt = std::optional<point_abs_omt>{};
+        json.start_object();
+        while (!json.end_object()) {
+            const auto member = json.get_member_name();
+            if (member == "name") {
+                json.read(name);
+            } else if (member == "abs_pos") {
+                omt = read_abs_pos_omt(json);
+            } else {
+                json.skip_value();
+            }
+        }
+        if (omt && is_inside_bubble(*omt, bubble)) { append_unique(out, name); }
+    }
+}
+
+auto collect_names_from_overmap(
+    const std::string& data, const point_abs_om& overmap, const save_prune_bubble& bubble,
+    save_prune_preview& preview) -> void {
+    auto stream = std::istringstream(strip_save_version_header(data));
+    auto json = JsonIn(stream);
+    json.start_object();
+    while (!json.end_object()) {
+        const auto member = json.get_member_name();
+        if (member == "npcs") {
+            collect_overmap_npcs(json, bubble, preview.npcs);
+        } else if (member == "tracked_vehicles") {
+            collect_overmap_vehicles(json, overmap, bubble, preview.vehicles);
+        } else {
+            json.skip_value();
+        }
+    }
+}
+
+auto vehicle_object_is_inside_bubble(
+    const JsonObject& vehicle, const point_abs_om& overmap, const save_prune_bubble& bubble)
+    -> bool {
+    if (!vehicle.has_int("x") || !vehicle.has_int("y")) { return false; }
+    return is_inside_bubble(local_omt(overmap, vehicle.get_int("x"), vehicle.get_int("y")), bubble);
+}
+
+auto npc_object_abs_omt(const JsonObject& npc) -> std::optional<point_abs_omt> {
+    if (!npc.has_array("abs_pos")) { return std::nullopt; }
+    const auto pos = npc.get_array("abs_pos");
+    if (pos.size() < 3) { return std::nullopt; }
+    return project_to<coords::omt>(tripoint_abs_ms(pos.get_int(0), pos.get_int(1), pos.get_int(2)))
+        .xy();
+}
+
+auto npc_object_is_inside_bubble(const JsonObject& npc, const save_prune_bubble& bubble) -> bool {
+    const auto omt = npc_object_abs_omt(npc);
+    return omt && is_inside_bubble(*omt, bubble);
+}
+
+auto read_overmap_terrain_data(
+    const std::string& data, const point_abs_om& overmap, const save_prune_bubble& bubble)
+    -> overmap_terrain_data {
+    auto result = overmap_terrain_data{};
+    auto stream = std::istringstream(strip_save_version_header(data));
+    auto json = JsonIn(stream);
+    json.start_object();
+    while (!json.end_object()) {
+        const auto member = json.get_member_name();
+        if (member == "layers") {
+            result.layers = read_terrain_layers(json);
+        } else if (member == "region_id") {
+            json.read(result.region_id);
+        } else if (member == "tracked_vehicles") {
+            json.start_array();
+            while (!json.end_array()) {
+                const auto vehicle = json.get_object();
+                if (vehicle_object_is_inside_bubble(vehicle, overmap, bubble)) {
+                    result.tracked_vehicles.push_back(vehicle.str());
+                }
+            }
+        } else if (member == "npcs") {
+            json.start_array();
+            while (!json.end_array()) {
+                const auto npc = json.get_object();
+                if (npc_object_is_inside_bubble(npc, bubble)) { result.npcs.push_back(npc.str()); }
+            }
+        } else {
+            json.skip_value();
+        }
+    }
+    return result;
+}
+
+auto prune_overmap_terrain_data(
+    overmap_terrain_data& data, const point_abs_om& overmap, const save_prune_bubble& bubble)
+    -> void {
+    for (auto layer_index = 0; layer_index < OVERMAP_LAYERS; layer_index++) {
+        prune_terrain_layer(data.layers[layer_index], layer_index, overmap, bubble);
+    }
+}
+
+auto json_value_without_separator(const std::string& raw) -> std::string {
+    auto first = raw.find_first_not_of(" \t\r\n,");
+    if (first == std::string::npos) { return {}; }
+    auto last = raw.find_last_not_of(" \t\r\n,");
+    return raw.substr(first, last - first + 1);
+}
+
+auto write_raw_json_array(std::ostream& stream, const std::vector<std::string>& values) -> void {
+    stream << '[';
+    auto first = true;
+    for (const auto& value : values) {
+        if (!first) { stream << ','; }
+        stream << json_value_without_separator(value);
+        first = false;
+    }
+    stream << ']';
+}
+
+auto write_pruned_overmap_stash(const overmap_terrain_data& data) -> std::string {
+    auto stream = std::ostringstream{};
+    stream << "{\"tracked_vehicles\":";
+    write_raw_json_array(stream, data.tracked_vehicles);
+    stream << ",\"npcs\":";
+    write_raw_json_array(stream, data.npcs);
+    stream << "}\n";
+    return stream.str();
+}
+
+auto stash_path_for_overmap_path(const std::string& path) -> std::string {
+    return "pruned_overmap/" + path;
+}
+
+auto insert_blob_row(sqlite3* db, const std::string& path, const std::string& data) -> void {
+    auto insert = sqlite_stmt(
+        db, "INSERT OR REPLACE INTO files(path, parent, compression, data) "
+            "VALUES(:path, '', NULL, :data)");
+    sqlite3_bind_text(insert.get(), sqlite3_bind_parameter_index(insert.get(), ":path"),
+                      path.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_blob(insert.get(), sqlite3_bind_parameter_index(insert.get(), ":data"),
+                      data.data(), static_cast<int>(data.size()), SQLITE_TRANSIENT);
+    if (sqlite3_step(insert.get()) != SQLITE_DONE) { throw std::runtime_error(sqlite3_errmsg(db)); }
+}
+
+auto collect_safe_bubble_names(
+    const std::filesystem::path& db_path, const save_prune_bubble& bubble,
+    save_prune_preview& preview) -> void {
+    auto db = sqlite_db(db_path);
+    auto stmt = sqlite_stmt(db.get(), "SELECT path, data, compression FROM files");
+    while (sqlite3_step(stmt.get()) == SQLITE_ROW) {
+        const auto* path_raw = sqlite3_column_text(stmt.get(), 0);
+        if (path_raw == nullptr) { continue; }
+        const auto path = std::string(reinterpret_cast<const char*>(path_raw));
+        const auto info = classify_save_path(path);
+        if (info.kind == save_path_kind::unknown
+            || !overmap_intersects_bubble(info.overmap, bubble)) {
+            continue;
+        }
+        try {
+            const auto data = row_data_to_string(stmt.get());
+            if (info.kind == save_path_kind::map_omt) {
+                collect_vehicle_names_from_map(data, preview.vehicles);
+            } else if (info.kind == save_path_kind::overmap) {
+                collect_names_from_overmap(data, info.overmap, bubble, preview);
+            }
+        } catch (const JsonError&) { continue; } catch (const std::exception&) {
+            continue;
+        }
+    }
+}
+
+auto update_blob_row(
+    sqlite3* db, const std::string& path, const std::string& data, const char* compression)
+    -> void {
+    auto update = sqlite_stmt(
+        db, "UPDATE files SET data = :data, compression = :compression WHERE "
+            "path = :path");
+    sqlite3_bind_blob(update.get(), sqlite3_bind_parameter_index(update.get(), ":data"),
+                      data.data(), static_cast<int>(data.size()), SQLITE_TRANSIENT);
+    if (compression == nullptr) {
+        sqlite3_bind_null(update.get(), sqlite3_bind_parameter_index(update.get(), ":compression"));
+    } else {
+        sqlite3_bind_text(update.get(), sqlite3_bind_parameter_index(update.get(), ":compression"),
+                          compression, -1, SQLITE_TRANSIENT);
+    }
+    sqlite3_bind_text(update.get(), sqlite3_bind_parameter_index(update.get(), ":path"),
+                      path.c_str(), -1, SQLITE_TRANSIENT);
+    if (sqlite3_step(update.get()) != SQLITE_DONE) { throw std::runtime_error(sqlite3_errmsg(db)); }
+}
+
+auto update_blob_row(
+    sqlite3* db, const std::string& path, const std::vector<std::byte>& data,
+    const char* compression) -> void {
+    auto update = sqlite_stmt(
+        db, "UPDATE files SET data = :data, compression = :compression WHERE "
+            "path = :path");
+    sqlite3_bind_blob(update.get(), sqlite3_bind_parameter_index(update.get(), ":data"),
+                      data.data(), static_cast<int>(data.size()), SQLITE_TRANSIENT);
+    sqlite3_bind_text(update.get(), sqlite3_bind_parameter_index(update.get(), ":compression"),
+                      compression, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(update.get(), sqlite3_bind_parameter_index(update.get(), ":path"),
+                      path.c_str(), -1, SQLITE_TRANSIENT);
+    if (sqlite3_step(update.get()) != SQLITE_DONE) { throw std::runtime_error(sqlite3_errmsg(db)); }
+}
+
+auto update_blob_row_preserving_compression(
+    sqlite3* db, const std::string& path, const std::string& data, const std::string& compression)
+    -> void {
+    if (compression == "zlib") {
+        auto compressed = std::vector<std::byte>{};
+        zlib_compress(data, compressed);
+        update_blob_row(db, path, compressed, "zlib");
+        return;
+    }
+    if (compression.empty()) {
+        update_blob_row(db, path, data, nullptr);
+        return;
+    }
+    throw std::runtime_error(
+        string_format("Unsupported compression '%s' for %s", compression, path.c_str()));
+}
+
+auto rewrite_db_blobs(const std::filesystem::path& db_path, blob_compression_mode mode)
+    -> blob_compression_stats {
+    auto stats = blob_compression_stats{.databases = 1};
+    auto db = sqlite_db(db_path);
+    auto tx =
+        mode == blob_compression_mode::info
+            ? std::optional<transaction>{}
+            : std::optional<transaction>{std::in_place, db.get()};
+    auto stmt = sqlite_stmt(db.get(), "SELECT path, data, compression FROM files");
+    while (sqlite3_step(stmt.get()) == SQLITE_ROW) {
+        stats.rows++;
+        const auto* path_raw = sqlite3_column_text(stmt.get(), 0);
+        const auto* blob = sqlite3_column_blob(stmt.get(), 1);
+        const auto blob_size = sqlite3_column_bytes(stmt.get(), 1);
+        const auto* compression_raw = sqlite3_column_text(stmt.get(), 2);
+        const auto compression =
+            compression_raw == nullptr
+                ? std::string{}
+                : reinterpret_cast<const char*>(compression_raw);
+        const auto path =
+            path_raw == nullptr ? std::string{} : reinterpret_cast<const char*>(path_raw);
+        stats.stored_bytes += static_cast<std::uint64_t>(blob_size);
+        if (compression.empty()) {
+            stats.uncompressed_rows++;
+            stats.raw_bytes += static_cast<std::uint64_t>(blob_size);
+            if (mode == blob_compression_mode::compress) {
+                const auto data = blob_to_string(blob, blob_size);
+                auto compressed = std::vector<std::byte>{};
+                zlib_compress(data, compressed);
+                update_blob_row(db.get(), path, compressed, "zlib");
+                stats.changed_rows++;
+            }
+        } else if (compression == "zlib") {
+            stats.compressed_rows++;
+            auto data = std::string{};
+            zlib_decompress(blob, blob_size, data);
+            stats.raw_bytes += static_cast<std::uint64_t>(data.size());
+            if (mode == blob_compression_mode::decompress) {
+                update_blob_row(db.get(), path, data, nullptr);
+                stats.changed_rows++;
+            }
+        } else {
+            stats.unknown_compression_rows++;
+        }
+    }
+    if (tx) { tx->commit(); }
+    return stats;
+}
+
+auto merge_stats(blob_compression_stats& lhs, const blob_compression_stats& rhs) -> void {
+    lhs.databases += rhs.databases;
+    lhs.rows += rhs.rows;
+    lhs.compressed_rows += rhs.compressed_rows;
+    lhs.uncompressed_rows += rhs.uncompressed_rows;
+    lhs.unknown_compression_rows += rhs.unknown_compression_rows;
+    lhs.changed_rows += rhs.changed_rows;
+    lhs.stored_bytes += rhs.stored_bytes;
+    lhs.raw_bytes += rhs.raw_bytes;
+}
+
+auto timestamp_suffix() -> std::string {
+    const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    auto tm = std::tm{};
+#if defined(_WIN32)
+    localtime_s(&tm, &now);
+#else
+    localtime_r(&now, &tm);
+#endif
+    auto buffer = std::array<char, 32>{};
+    std::strftime(buffer.data(), buffer.size(), "%Y%m%d-%H%M%S", &tm);
+    return buffer.data();
+}
+
+auto count_or_prune_db_rows(
+    const std::filesystem::path& db_path, const save_prune_bubble& bubble, const bool do_prune)
+    -> save_prune_preview {
+    auto preview = save_prune_preview{};
+    preview.databases = 1;
+    auto to_prune = std::vector<std::string>{};
+    auto db = sqlite_db(db_path);
+    auto tx =
+        do_prune ? std::optional<transaction>{std::in_place, db.get()}
+                 : std::optional<transaction>{};
+    auto select = sqlite_stmt(db.get(), "SELECT path, data, compression FROM files");
+    while (sqlite3_step(select.get()) == SQLITE_ROW) {
+        const auto* path_raw = sqlite3_column_text(select.get(), 0);
+        if (path_raw == nullptr) {
+            preview.ignored_rows++;
+            continue;
+        }
+        const auto path = std::string(reinterpret_cast<const char*>(path_raw));
+        const auto info = classify_save_path(path);
+        if (info.kind == save_path_kind::unknown) {
+            preview.ignored_rows++;
+        } else if (info.kind == save_path_kind::map_omt) {
+            if (is_inside_bubble(info.omt, bubble)) {
+                preview.kept_rows++;
+            } else {
+                preview.pruned_rows++;
+                to_prune.push_back(path);
+            }
+        } else if (info.kind == save_path_kind::overmap
+                   && overmap_intersects_bubble(info.overmap, bubble)) {
+            preview.pruned_rows++;
+            if (do_prune) {
+                const auto data = row_data_to_string(select.get());
+                const auto overmap_data = read_overmap_terrain_data(data, info.overmap, bubble);
+                insert_blob_row(db.get(), stash_path_for_overmap_path(path),
+                                write_pruned_overmap_stash(overmap_data));
+            }
+            to_prune.push_back(path);
+        } else if (overmap_intersects_bubble(info.overmap, bubble)) {
+            preview.kept_rows++;
+            if (do_prune && info.kind == save_path_kind::overmap_seen) {
+                const auto* compression_raw = sqlite3_column_text(select.get(), 2);
+                const auto compression =
+                    compression_raw == nullptr
+                        ? std::string{}
+                        : reinterpret_cast<const char*>(compression_raw);
+                const auto data = row_data_to_string(select.get());
+                auto visibility = read_visibility_data(data);
+                prune_visibility_data(visibility, info.overmap, bubble);
+                update_blob_row_preserving_compression(
+                    db.get(), path, write_visibility_data(visibility), compression);
+            }
+        } else {
+            preview.pruned_rows++;
+            to_prune.push_back(path);
+        }
+    }
+    if (do_prune && !to_prune.empty()) {
+        auto del = sqlite_stmt(db.get(), "DELETE FROM files WHERE path = :path");
+        for (const auto& path : to_prune) {
+            sqlite3_reset(del.get());
+            sqlite3_clear_bindings(del.get());
+            sqlite3_bind_text(del.get(), sqlite3_bind_parameter_index(del.get(), ":path"),
+                              path.c_str(), -1, SQLITE_TRANSIENT);
+            if (sqlite3_step(del.get()) != SQLITE_DONE) {
+                throw std::runtime_error(sqlite3_errmsg(db.get()));
+            }
+        }
+    }
+    if (tx) { tx->commit(); }
+    return preview;
+}
+
+auto merge_prune_preview(save_prune_preview& lhs, const save_prune_preview& rhs) -> void {
+    lhs.databases += rhs.databases;
+    lhs.kept_rows += rhs.kept_rows;
+    lhs.pruned_rows += rhs.pruned_rows;
+    lhs.ignored_rows += rhs.ignored_rows;
+    for (const auto& vehicle : rhs.vehicles) { append_unique(lhs.vehicles, vehicle); }
+    for (const auto& npc : rhs.npcs) { append_unique(lhs.npcs, npc); }
+}
+
+} // namespace
+
+auto rewrite_world_blobs(const std::filesystem::path& world_path, const blob_compression_mode mode)
+    -> blob_compression_stats {
+    auto total = blob_compression_stats{};
+    for (const auto& db_path : sqlite_files(world_path)) {
+        merge_stats(total, rewrite_db_blobs(db_path, mode));
+    }
+    return total;
+}
+
+auto preview_prune_world_outside_bubble(
+    const std::filesystem::path& world_path, const save_prune_bubble& bubble)
+    -> save_prune_preview {
+    auto total = save_prune_preview{};
+    for (const auto& db_path : sqlite_files(world_path)) {
+        auto db_preview = count_or_prune_db_rows(db_path, bubble, false);
+        collect_safe_bubble_names(db_path, bubble, db_preview);
+        merge_prune_preview(total, db_preview);
+    }
+    std::ranges::sort(total.vehicles);
+    std::ranges::sort(total.npcs);
+    return total;
+}
+
+auto make_world_backup(const std::filesystem::path& world_path) -> std::filesystem::path {
+    if (!std::filesystem::exists(world_path)) {
+        throw std::runtime_error(
+            string_format("World path does not exist: %s", world_path.string().c_str()));
+    }
+    auto backup_path = world_path;
+    backup_path += " (Pre-prune Backup ";
+    backup_path += timestamp_suffix();
+    backup_path += ")";
+    auto suffix = 1;
+    while (std::filesystem::exists(backup_path)) {
+        backup_path = world_path;
+        backup_path +=
+            string_format(" (Pre-prune Backup %s-%d)", timestamp_suffix().c_str(), suffix);
+        suffix++;
+    }
+    std::filesystem::copy(
+        world_path, backup_path,
+        std::filesystem::copy_options::recursive | std::filesystem::copy_options::copy_symlinks);
+    return backup_path;
+}
+
+auto prune_world_outside_bubble(
+    const std::filesystem::path& world_path, const save_prune_bubble& bubble) -> save_prune_result {
+    auto result = save_prune_result{};
+    result.preview = preview_prune_world_outside_bubble(world_path, bubble);
+    result.backup_path = make_world_backup(world_path);
+    const auto [old_seed, new_seed] = reroll_world_seed(world_path);
+    result.old_seed = old_seed;
+    result.new_seed = new_seed;
+    auto pruned = save_prune_preview{};
+    for (const auto& db_path : sqlite_files(world_path)) {
+        merge_prune_preview(pruned, count_or_prune_db_rows(db_path, bubble, true));
+    }
+    result.preview.kept_rows = pruned.kept_rows;
+    result.preview.pruned_rows = pruned.pruned_rows;
+    result.preview.ignored_rows = pruned.ignored_rows;
+    result.preview.databases = pruned.databases;
+    return result;
+}
+
+} // namespace save_tools

--- a/src/save/save_tools.h
+++ b/src/save/save_tools.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "coordinates.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace save_tools {
+
+enum class blob_compression_mode {
+    info,
+    compress,
+    decompress,
+};
+
+struct blob_compression_stats {
+    std::size_t databases = 0;
+    std::size_t rows = 0;
+    std::size_t compressed_rows = 0;
+    std::size_t uncompressed_rows = 0;
+    std::size_t unknown_compression_rows = 0;
+    std::size_t changed_rows = 0;
+    std::uint64_t stored_bytes = 0;
+    std::uint64_t raw_bytes = 0;
+};
+
+struct save_prune_bubble {
+    point_abs_omt center;
+    int radius = 0;
+};
+
+struct save_prune_preview {
+    std::size_t databases = 0;
+    std::size_t kept_rows = 0;
+    std::size_t pruned_rows = 0;
+    std::size_t ignored_rows = 0;
+    std::vector<std::string> vehicles;
+    std::vector<std::string> npcs;
+};
+
+struct save_prune_result {
+    save_prune_preview preview;
+    std::filesystem::path backup_path;
+    unsigned int old_seed = 0;
+    unsigned int new_seed = 0;
+};
+
+auto rewrite_world_blobs(const std::filesystem::path& world_path, blob_compression_mode mode)
+    -> blob_compression_stats;
+auto preview_prune_world_outside_bubble(
+    const std::filesystem::path& world_path, const save_prune_bubble& bubble) -> save_prune_preview;
+auto prune_world_outside_bubble(
+    const std::filesystem::path& world_path, const save_prune_bubble& bubble) -> save_prune_result;
+auto make_world_backup(const std::filesystem::path& world_path) -> std::filesystem::path;
+
+} // namespace save_tools

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <filesystem>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -489,6 +490,7 @@ class sqlite_map_db
         auto begin_transaction() -> void;
         auto commit_transaction() -> void;
         auto write( const std::string &path, file_write_fn writer ) -> void;
+        auto erase( const std::string &path ) -> bool;
         auto exists( const std::string &path ) const -> bool;
         auto read( const std::string &path, file_read_fn reader, bool optional ) const -> bool;
         auto read_json( const std::string &path, file_read_json_fn reader, bool optional ) const -> bool;
@@ -542,6 +544,20 @@ auto sqlite_map_db::write( const std::string &path, file_write_fn writer ) -> vo
     const auto payload = make_db_write_payload( path, writer );
     const auto lock = std::lock_guard<std::mutex>( write_mutex_ );
     write_payload_to_db( writer_db_, payload );
+}
+
+auto sqlite_map_db::erase( const std::string &path ) -> bool
+{
+    const auto lock = std::lock_guard<std::mutex>( write_mutex_ );
+    sqlite3_stmt *stmt = nullptr;
+    if( sqlite3_prepare_v2( writer_db_, "DELETE FROM files WHERE path = ?", -1, &stmt, nullptr ) !=
+        SQLITE_OK ) {
+        return false;
+    }
+    sqlite3_bind_text( stmt, 1, path.c_str(), -1, SQLITE_TRANSIENT );
+    const auto ret = sqlite3_step( stmt );
+    sqlite3_finalize( stmt );
+    return ret == SQLITE_DONE;
 }
 
 auto sqlite_map_db::exists( const std::string &path ) const -> bool
@@ -791,6 +807,22 @@ bool world::write_overmap_player_visibility( const std::string &dim_id, const po
     } else {
         return write_to_player_file( fname, writer );
     }
+}
+
+bool world::read_map_entry( const std::string &path, file_read_fn reader ) const
+{
+    if( info->world_save_format == save_format::V2_COMPRESSED_SQLITE3 ) {
+        return map_db->read( path, reader, true );
+    }
+    return read_from_file( path, reader, true );
+}
+
+bool world::delete_map_entry( const std::string &path ) const
+{
+    if( info->world_save_format == save_format::V2_COMPRESSED_SQLITE3 ) {
+        return map_db->erase( path );
+    }
+    return std::filesystem::remove( info->folder_path() + "/" + path );
 }
 
 bool world::read_player_mm_omt( const std::string &dim_id, const tripoint_abs_mmr &p,

--- a/src/world.h
+++ b/src/world.h
@@ -129,6 +129,8 @@ class world
                             file_write_fn writer ) const;
         bool write_overmap_player_visibility( const std::string &dim_id, const point_abs_om &p,
                                               file_write_fn writer );
+        bool read_map_entry( const std::string &path, file_read_fn reader ) const;
+        bool delete_map_entry( const std::string &path ) const;
 
         bool read_player_mm_omt( const std::string &dim_id, const tripoint_abs_mmr &p,
                                  file_read_json_fn reader );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING)
-    file(GLOB CATACLYSM_BN_TEST_SOURCES
+    file(GLOB_RECURSE CATACLYSM_BN_TEST_SOURCES CONFIGURE_DEPENDS
             ${CMAKE_SOURCE_DIR}/tests/*.cpp)
 
     # Enabling benchmarks
@@ -16,6 +16,7 @@ if (BUILD_TESTING)
     if (TILES)
         add_executable(cata_test-tiles ${CATACLYSM_BN_TEST_SOURCES})
         target_link_libraries(cata_test-tiles PRIVATE cataclysm-bn-tiles-common)
+        target_include_directories(cata_test-tiles PRIVATE ${CMAKE_SOURCE_DIR}/tests)
         target_compile_options(cata_test-tiles PRIVATE ${CATCH2_COMPILE_OPTIONS})
 
         add_test(
@@ -37,6 +38,7 @@ if (BUILD_TESTING)
     if (CURSES)
         add_executable(cata_test ${CATACLYSM_BN_TEST_SOURCES})
         target_link_libraries(cata_test PRIVATE cataclysm-bn-common)
+        target_include_directories(cata_test PRIVATE ${CMAKE_SOURCE_DIR}/tests)
         target_compile_options(cata_test PRIVATE ${CATCH2_COMPILE_OPTIONS})
 
         add_test(

--- a/tests/save/save_tools_test.cpp
+++ b/tests/save/save_tools_test.cpp
@@ -1,0 +1,258 @@
+#include "catch/catch.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "game_constants.h"
+#include "save/save_tools.h"
+#include "sqlite3.h"
+
+namespace
+{
+
+class temp_dir
+{
+    public:
+        temp_dir() {
+            const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+            path_ = std::filesystem::temp_directory_path() / ( "cbn_save_tools_test_" + std::to_string(
+                        stamp ) );
+            std::filesystem::create_directories( path_ );
+        }
+
+        temp_dir( const temp_dir & ) = delete;
+        auto operator=( const temp_dir & ) -> temp_dir & = delete;
+        temp_dir( temp_dir &&other ) noexcept : path_( std::move( other.path_ ) ) {
+            other.path_.clear();
+        }
+        auto operator=( temp_dir &&other ) noexcept -> temp_dir& { // *NOPAD*
+            if( this != &other ) {
+                std::filesystem::remove_all( path_ );
+                path_ = std::move( other.path_ );
+                other.path_.clear();
+            }
+            return *this;
+        }
+
+        ~temp_dir() {
+            std::filesystem::remove_all( path_ );
+        }
+
+        auto path() const -> const std::filesystem::path & { return path_; } // *NOPAD*
+
+    private:
+        std::filesystem::path path_;
+};
+
+auto exec_sql( sqlite3 *db, const char *sql ) -> void
+{
+    auto *err = static_cast<char *>( nullptr );
+    REQUIRE( sqlite3_exec( db, sql, nullptr, nullptr, &err ) == SQLITE_OK );
+    sqlite3_free( err );
+}
+
+auto open_test_db( const std::filesystem::path &path ) -> sqlite3 * // *NOPAD*
+{
+    auto *db = static_cast<sqlite3 *>( nullptr );
+    REQUIRE( sqlite3_open( path.string().c_str(), &db ) == SQLITE_OK );
+    return db;
+}
+
+auto insert_file( sqlite3 *db, const std::string &path, const std::string &data ) -> void
+{
+    auto *stmt = static_cast<sqlite3_stmt *>( nullptr );
+    REQUIRE( sqlite3_prepare_v2( db,
+                                 "INSERT INTO files(path, parent, compression, data) VALUES(:path, '', NULL, :data)",
+                                 -1, &stmt, nullptr ) == SQLITE_OK );
+    REQUIRE( sqlite3_bind_text( stmt, sqlite3_bind_parameter_index( stmt, ":path" ), path.c_str(),
+                                -1, SQLITE_TRANSIENT ) == SQLITE_OK );
+    REQUIRE( sqlite3_bind_blob( stmt, sqlite3_bind_parameter_index( stmt, ":data" ), data.data(),
+                                static_cast<int>( data.size() ), SQLITE_TRANSIENT ) == SQLITE_OK );
+    REQUIRE( sqlite3_step( stmt ) == SQLITE_DONE );
+    REQUIRE( sqlite3_finalize( stmt ) == SQLITE_OK );
+}
+
+auto read_file( const std::filesystem::path &path ) -> std::string
+{
+    auto input = std::ifstream( path, std::ios::binary );
+    auto stream = std::ostringstream{};
+    stream << input.rdbuf();
+    return stream.str();
+}
+
+auto row_count( sqlite3 *db, const std::string &where ) -> int
+{
+    auto *stmt = static_cast<sqlite3_stmt *>( nullptr );
+    const auto sql = "SELECT COUNT(*) FROM files WHERE " + where;
+    REQUIRE( sqlite3_prepare_v2( db, sql.c_str(), -1, &stmt, nullptr ) == SQLITE_OK );
+    REQUIRE( sqlite3_step( stmt ) == SQLITE_ROW );
+    const auto count = sqlite3_column_int( stmt, 0 );
+    REQUIRE( sqlite3_finalize( stmt ) == SQLITE_OK );
+    return count;
+}
+
+auto all_road_overmap() -> std::string
+{
+    const auto tile_count = std::to_string( OMAPX * OMAPY );
+    auto stream = std::ostringstream{};
+    stream << "# version 29\n{\"layers\":[";
+    for( auto z = 0; z < OVERMAP_LAYERS; z++ ) {
+        if( z > 0 ) {
+            stream << ',';
+        }
+        stream << "[[\"road\"," << tile_count << "]]";
+    }
+    stream << R"(],"region_id":"default","tracked_vehicles":[{"name":"Truck","x":0,"y":0}],"npcs":[{"name":"Bob","abs_pos":[0,0,0]},{"name":"Alice","abs_pos":[1,0,0]}]})";
+    stream << "\n";
+    return stream.str();
+}
+
+auto all_true_visibility() -> std::string
+{
+    const auto tile_count = OMAPX * OMAPY;
+    auto stream = std::ostringstream{};
+    const auto write_bool_layers = [&]( const std::string & name, const bool value ) {
+        stream << "\"" << name << "\":[";
+        for( auto z = 0; z < OVERMAP_LAYERS; z++ ) {
+            if( z > 0 ) {
+                stream << ',';
+            }
+            stream << "[[" << ( value ? "true" : "false" ) << ',' << std::to_string( tile_count ) << "]]";
+        }
+        stream << ']';
+    };
+    const auto write_empty_layers = [&]( const std::string & name ) {
+        stream << "\"" << name << "\":[";
+        for( auto z = 0; z < OVERMAP_LAYERS; z++ ) {
+            if( z > 0 ) {
+                stream << ',';
+            }
+            stream << "[]";
+        }
+        stream << ']';
+    };
+    stream << "# version 29\n{";
+    write_bool_layers( "visible", true );
+    stream << ',';
+    write_bool_layers( "explored", true );
+    stream << ',';
+    write_bool_layers( "path", false );
+    stream << ',';
+    write_empty_layers( "notes" );
+    stream << ',';
+    write_empty_layers( "extras" );
+    stream << "}\n";
+    return stream.str();
+}
+
+
+auto file_data( sqlite3 *db, const std::string &path ) -> std::string
+{
+    auto *stmt = static_cast<sqlite3_stmt *>( nullptr );
+    REQUIRE( sqlite3_prepare_v2( db, "SELECT data FROM files WHERE path = :path", -1, &stmt,
+                                 nullptr ) == SQLITE_OK );
+    REQUIRE( sqlite3_bind_text( stmt, sqlite3_bind_parameter_index( stmt, ":path" ), path.c_str(),
+                                -1, SQLITE_TRANSIENT ) == SQLITE_OK );
+    REQUIRE( sqlite3_step( stmt ) == SQLITE_ROW );
+    const auto *blob = sqlite3_column_blob( stmt, 0 );
+    const auto blob_size = sqlite3_column_bytes( stmt, 0 );
+    auto result = std::string( static_cast<const char *>( blob ),
+                               static_cast<std::size_t>( blob_size ) );
+    REQUIRE( sqlite3_finalize( stmt ) == SQLITE_OK );
+    return result;
+}
+
+auto make_world_with_sqlite() -> temp_dir
+{
+    auto dir = temp_dir{};
+    const auto world_path = dir.path() / "World";
+    std::filesystem::create_directories( world_path );
+    auto *db = open_test_db( world_path / "map.sqlite3" );
+    exec_sql( db, "CREATE TABLE files(path TEXT PRIMARY KEY NOT NULL, parent TEXT NOT NULL, "
+              "compression TEXT DEFAULT NULL, data BLOB NOT NULL)" );
+    insert_file( db, "maps/0.0.0/0.0.0.map", R"([{"vehicles":[{"name":"Car"}]}])" );
+    insert_file( db, "o.0.0", all_road_overmap() );
+    insert_file( db, ".seen.0.0", all_true_visibility() );
+    insert_file( db, "maps/1.0.0/180.0.0.map", R"([{"vehicles":[{"name":"Far car"}]}])" );
+    insert_file( db, "unrelated.json", "{}" );
+    REQUIRE( sqlite3_close( db ) == SQLITE_OK );
+    auto master = std::ofstream( world_path / "master.gsav" );
+    master << "# version 29\n{\"seed\": 12345}\n";
+    return dir;
+}
+
+} // namespace
+
+TEST_CASE( "save_tools can compress and decompress sqlite file blobs", "[save_tools]" )
+{
+    auto dir = make_world_with_sqlite();
+    const auto world_path = dir.path() / "World";
+
+    const auto info_before = save_tools::rewrite_world_blobs( world_path,
+                             save_tools::blob_compression_mode::info );
+    CHECK( info_before.databases == 1 );
+    CHECK( info_before.rows == 5 );
+    CHECK( info_before.uncompressed_rows == 5 );
+
+    const auto compressed = save_tools::rewrite_world_blobs( world_path,
+                            save_tools::blob_compression_mode::compress );
+    CHECK( compressed.changed_rows == 5 );
+
+    auto *db = open_test_db( world_path / "map.sqlite3" );
+    CHECK( row_count( db, "compression = 'zlib'" ) == 5 );
+    REQUIRE( sqlite3_close( db ) == SQLITE_OK );
+
+    const auto decompressed = save_tools::rewrite_world_blobs( world_path,
+                              save_tools::blob_compression_mode::decompress );
+    CHECK( decompressed.changed_rows == 5 );
+
+    db = open_test_db( world_path / "map.sqlite3" );
+    CHECK( row_count( db, "compression IS NULL" ) == 5 );
+    REQUIRE( sqlite3_close( db ) == SQLITE_OK );
+}
+
+TEST_CASE( "save_tools previews and prunes map rows outside overmap bubble", "[save_tools]" )
+{
+    auto dir = make_world_with_sqlite();
+    const auto world_path = dir.path() / "World";
+    const auto bubble = save_tools::save_prune_bubble{ .center = point_abs_omt( 0, 0 ), .radius = 1 };
+
+    const auto preview = save_tools::preview_prune_world_outside_bubble( world_path, bubble );
+    CHECK( preview.databases == 1 );
+    CHECK( preview.kept_rows == 2 );
+    CHECK( preview.pruned_rows == 2 );
+    CHECK( preview.ignored_rows == 1 );
+    CHECK_THAT( preview.vehicles, Catch::UnorderedEquals( std::vector<std::string> { "Car", "Truck" } ) );
+    CHECK_THAT( preview.npcs, Catch::UnorderedEquals( std::vector<std::string> { "Alice", "Bob" } ) );
+
+    const auto result = save_tools::prune_world_outside_bubble( world_path, bubble );
+    CHECK( std::filesystem::exists( result.backup_path / "map.sqlite3" ) );
+    CHECK( result.preview.pruned_rows == 2 );
+    CHECK( result.old_seed == 12345 );
+    CHECK( result.new_seed != 12345 );
+    CHECK( read_file( world_path / "master.gsav" ).find( std::to_string( result.new_seed ) ) !=
+           std::string::npos );
+    CHECK( read_file( result.backup_path / "master.gsav" ).find( "12345" ) != std::string::npos );
+
+    auto *db = open_test_db( world_path / "map.sqlite3" );
+    CHECK( row_count( db, "path = 'maps/1.0.0/180.0.0.map'" ) == 0 );
+    CHECK( row_count( db, "path = 'o.0.0'" ) == 0 );
+    CHECK( row_count( db, "path = 'pruned_overmap/o.0.0'" ) == 1 );
+    CHECK( file_data( db, "pruned_overmap/o.0.0" ).find( "Bob" ) != std::string::npos );
+    CHECK( file_data( db, "pruned_overmap/o.0.0" ).find( "Alice" ) != std::string::npos );
+    CHECK( file_data( db, "pruned_overmap/o.0.0" ).find( ",," ) == std::string::npos );
+    CHECK( row_count( db, "path = 'maps/0.0.0/0.0.0.map'" ) == 1 );
+    CHECK( row_count( db, "path = '.seen.0.0'" ) == 1 );
+    CHECK( file_data( db, ".seen.0.0" ).find( "true," + std::to_string( OMAPX * OMAPY ) ) ==
+           std::string::npos );
+    CHECK( row_count( db, "path = 'unrelated.json'" ) == 1 );
+    REQUIRE( sqlite3_close( db ) == SQLITE_OK );
+
+    db = open_test_db( result.backup_path / "map.sqlite3" );
+    CHECK( row_count( db, "path = 'maps/1.0.0/180.0.0.map'" ) == 1 );
+    REQUIRE( sqlite3_close( db ) == SQLITE_OK );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

Add scriptable save maintenance tools for SQLite save blobs and a debug menu option to prune saved map data outside a safe overmap-radius bubble around the player.

Related issue/PR search: none found for `save compression`, `sqlite save`, `sqlite save compression`, or `debug map prune` in `cataclysmbn/Cataclysm-BN`.

## Describe the solution (The How)

- Adds `--save-compression-info <world>`, `--save-compress <world>`, and `--save-decompress <world>` CLI options.
- Adds `save_tools` helpers under `src/save/` for SQLite blob compression rewrites, save previews, world backups, and map-data pruning.
- Adds a debug map action, `Prune map outside overmap radius`, that:
  - saves the current game,
  - previews vehicles and NPCs kept inside the safe bubble,
  - asks for confirmation before pruning,
  - creates a backup world,
  - prunes saved map-related rows outside the radius,
  - returns to the main menu without saving again so the pruned DB is reloaded cleanly.
- Adds `save_tools` tests under `tests/save/` for compression/decompression, version-header overmap NPC preview, and map pruning behavior.

## Describe alternatives you've considered

- Full-file gzip for SQLite saves was rejected because SQLite needs random reads/writes and transactional updates.
- SQLite compression extensions were rejected for now because they add platform, packaging, and SQLite ABI/version complexity.
- In-place reload after pruning was avoided because loaded map/overmap/NPC/vehicle state can otherwise rewrite pruned data; returning to the main menu is safer.

## Testing

<details><summary>Details</summary>

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/cd44f54c-9cc2-4a5d-aa03-10e93a212dc6" />
<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/de9011c0-dfad-42d0-b220-098d6eb048d2" />
<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/a99c7d26-2702-4fd7-9ee1-ae95d61f861e" />

go to debug menu > map and prune the map

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/a9781704-8f90-493d-81fa-323dec381fa2" />
<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/8233bd6c-da95-4be6-aa20-d024a36ccec9" />

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/0b7e221a-7014-44df-a7f0-a316e1de91f8" />
<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/2c39a23a-15ef-4348-b3c7-ffafe2428900" />
<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/42115d32-1ed7-4509-8b5f-6e5e10a8f5e3" />

now maps are recreated with your items, npcs and vehicles intact.

</details> 


- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles -j2`
- `./cata_test-tiles "[save_tools]"`
- CLI smoke test on a temporary SQLite world for `--save-compression-info`, `--save-compress`, and `--save-decompress`.

Reviewer suggestions:

- Run the three CLI options against a throwaway copied world and confirm row counts/changed rows are reported as expected.
- In a throwaway world, use debug menu `Prune map outside overmap radius`, confirm the listed vehicles/NPCs in the safe bubble, and verify the backup world exists before reloading the pruned world.

## Additional context

No related issues or PRs were found during GitHub search.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [33d86f4](https://github.com/cataclysmbn/Cataclysm-BN/commit/33d86f45da5a468ade5b09c7412b13eaa27401cb) (feat: add save maintenance tools) on 2026-06-26 14:54:23

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28240709450/artifacts/7907818222)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28240709450)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28240709450)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28240709450)
<!-- END artifact comment -->