### PR TITLE
feat(balance): add additional blankets to makeshift sling recipe

### DIFF
--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -570,7 +570,18 @@
     "time": "48 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "sheet", 1 ], [ "blanket", 1 ], [ "electric_blanket", 1 ] ] ],
+    "components": [
+      [
+        [ "blanket", 1 ],
+        [ "down_blanket", 1 ],
+        [ "fur_blanket", 1 ],
+        [ "electric_blanket", 1 ],
+        [ "emer_blanket", 1 ],
+        [ "afs_quilt", 1 ],
+        [ "afs_quilt_patchwork", 1 ],
+        [ "sheet", 1 ]
+      ]
+    ],
     "flags": [ "BLIND_EASY" ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Was pointed out in the BN subreddit (https://www.reddit.com/r/cataclysmbn/comments/1tsnto3/played_bright_nights_now_what/) that we can use sheets, blankets, and electric blankets to make makeshift slings, but not emergency blankets. Idly went to check to see if DDA had thought of this idea yet and oops, they have. Easy port I guess.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Added down blankets, fur blankets, emergency blankets, quilts, and patchwork quilts to the recipe.

## Describe alternatives you've considered

Bundling any other easy additions we overlooked into this PR that people can find?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Checked affected file for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Relevant PRs:
1. https://github.com/CleverRaven/Cataclysm-DDA/pull/60226
2. https://github.com/CleverRaven/Cataclysm-DDA/pull/49084

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c3e1f5f](https://github.com/cataclysmbn/Cataclysm-BN/commit/c3e1f5f15e6cdb745d963a52d470ac8ecc499e56) (Update storage.json) on 2026-05-31 18:40:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26719679857/artifacts/7318747656)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26719679857/artifacts/7319021882)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26719679857/artifacts/7318754640)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26719679857/artifacts/7318869016)
<!-- END artifact comment -->