### PR TITLE
fix: boarded start locations open interior doors and place barricades

### DIFF
--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -271,7 +271,9 @@ void start_location::prepare_map( const tripoint_abs_omt &omtstart ) const
 {
     // Now prepare the initial map (change terrain etc.)
     const tripoint_abs_sm player_location = project_to<coords::sm>( omtstart );
-    tinymap player_start;
+    // Multi-z so load() pulls the z+1 roof into this throwaway map and is_outside() is correct
+    // for BOARDED starts (one-time at game start; add_roofs is idempotent, so it is cheap).
+    tinymap player_start( 2, true );
     // TODO: fix point types
     player_start.load( player_location, false );
     prepare_map( player_start );

--- a/tests/start_location_board_test.cpp
+++ b/tests/start_location_board_test.cpp
@@ -1,0 +1,87 @@
+#include "catch/catch.hpp"
+
+#include "coordinates.h"
+#include "game.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "point.h"
+#include "start_location.h"
+#include "state_helpers.h"
+#include "type_id.h"
+
+// Regression test for the BOARDED start-location bug (sibling of #9169).
+//
+// sloc_house_boarded (offered by 7 scenarios) carries the BOARDED flag, so
+// start_location::prepare_map() boards up the building via a throwaway tinymap.
+// On the buggy SINGLE-z tinymap, build_outside_cache() has no z+1 roof, so
+// is_outside() is true for every tile; board_up() then boards INTERNAL doors
+// shut (t_door_boarded) instead of opening them (t_door_o). The fix makes the
+// throwaway tinymap MULTI-z ( tinymap player_start( 2, true ) ) so is_outside()
+// is correct and interior doors are opened.
+//
+// The reality bubble's submaps are shared with the throwaway tinymap via
+// MAPBUFFER, so painting the building on get_map() and then driving the public
+// prepare_map(omt) path exercises the real boarding code against our building.
+//
+// A window is painted as a PLUMBING DISCRIMINATOR: board_up boards windows
+// UNCONDITIONALLY of is_outside (start_location.cpp:140-143), so window-not-boarded
+// means board_up never ran on these submaps (infrastructure problem, not the bug),
+// window+door boarded is clean RED, and window-boarded + door-open is clean GREEN.
+// FAILS on the single-z tinymap (door -> t_door_boarded); PASSES after the fix.
+
+TEST_CASE( "boarded_start_opens_interior_doors", "[start_location][boarded]" )
+{
+    clear_all_state();
+    map &here = get_map();
+    REQUIRE( here.has_zlevels() );
+    // Fail clearly (not via a confusing crash) if start_locations aren't in the test DB.
+    REQUIRE( start_location_id( "sloc_house_boarded" ).is_valid() );
+
+    const ter_str_id floor( "t_floor" );          // interior floor; also used as a z+1 roof
+    const ter_str_id door_closed( "t_door_c" );
+    const ter_str_id door_open( "t_door_o" );
+    const ter_str_id door_boarded( "t_door_boarded" );
+    const ter_str_id window( "t_window" );
+    const ter_str_id window_boarded( "t_window_boarded" );
+
+    // Paint a generously sized roofed interior around map center, so the door and
+    // all four of its orthogonal neighbours are interior-with-roof and fall inside
+    // a single OMT (board_up only processes the player's starting OMT, so keep the
+    // painted area generous to survive OMT-boundary alignment).
+    for( int x = 50; x <= 70; ++x ) {
+        for( int y = 50; y <= 70; ++y ) {
+            here.ter_set( tripoint_bub_ms( x, y, 1 ), floor );   // roof above => "inside"
+            here.ter_set( tripoint_bub_ms( x, y, 0 ), floor );   // interior floor
+        }
+    }
+
+    // A CLOSED interior door fully surrounded by interior floor (no outside neighbour),
+    // and a window two tiles away as the unconditional-boarding plumbing probe.
+    const tripoint_bub_ms interior_door( 60, 60, 0 );
+    const tripoint_bub_ms window_pos( 62, 60, 0 );
+    here.ter_set( interior_door, door_closed );
+    here.ter_set( window_pos, window );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    // Preconditions: the door is closed and reads as INSIDE (and so do its neighbours).
+    REQUIRE( here.ter( interior_door ) == door_closed.id() );
+    REQUIRE_FALSE( here.is_outside( interior_door ) );
+    REQUIRE_FALSE( here.is_outside( interior_door + tripoint_north ) );
+
+    // Drive boarding through the public OMT entry of the real BOARDED start location.
+    const start_location &sl = start_location_id( "sloc_house_boarded" ).obj();
+    const tripoint_abs_omt omtstart =
+        project_to<coords::omt>( here.bub_to_abs( interior_door ) );
+    sl.prepare_map( omtstart );
+
+    // Plumbing discriminator FIRST: if the window did not board, board_up never ran
+    // on these submaps -- the failure is infrastructure, not the is_outside bug.
+    REQUIRE( here.ter( window_pos ) == window_boarded.id() );
+
+    // The fix: with a correct is_outside the interior door is OPENED, not boarded shut.
+    INFO( "interior door terrain after boarding: " << here.ter( interior_door ).id().str() );
+    CHECK( here.ter( interior_door ) == door_open.id() );
+    CHECK( here.ter( interior_door ) != door_boarded.id() );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

Start locations with the `BOARDED` flag only `sloc_house_boarded`, offered by 7 scenarios (Missed, Surrounded, Infected, Challenge - Hunted, Burning Building, Challenge - Really Bad Day, Challenge - The Lost And Damned) are meant to spawn the player in a barricaded building. On current `main` this is broken: **internal doors are boarded shut** instead of opened (you can be sealed into a sub-room), and **no furniture barricades are placed**. (Windows still board, since that path is unconditional.)

Root cause: `start_location::prepare_map(const tripoint_abs_omt&)` boards the building on a throwaway **single-z** `tinymap`. A single-z map has no z+1 roof, so `build_outside_cache()` marks every tile "outside"; `board_up()` then boards every interior door (each reads an "outside" neighbour) instead of opening it, and `add_boardable()` early-returns on `is_outside` for every tile (so the barricade-target list stays empty).

## Describe the solution (The How)

Make that one throwaway map multi-z `tinymap player_start( 2, true )` so `load()` pulls the z+1 roof and `build_outside_cache()` computes `is_outside()` correctly. The existing `board_up()` logic then opens interior doors (`t_door_o`) and places furniture barricades as designed. It is a one-line change; the multi-z load is one-time at game start and `add_roofs` is idempotent over the shared MAPBUFFER submaps, so the cost is negligible.

## Describe alternatives you've considered

- **Operate on the live `g->m` after `place_player` (mirror the merged `burn()` fix).** Verified viable however, unlike `burn()` - which runs after the player is already placed and only the fire is missing - boarding must happen *around* player placement instead. 
- **Roof-independent interior test** (decide inside/outside from a single-z-safe signal such as `TFLAG_INDOORS` instead of the roof-model `is_outside`). however this option would change the semantics `board_up` uses to define inside/outside, risking conflicts from how the rest of the engine reasons about "outside".

## Testing

- Added `tests/start_location_board_test.cpp` (`[start_location][boarded]`): paints a roofed interior with a closed interior door and a window, drives the public `prepare_map(omt)` path on the real `sloc_house_boarded`, and asserts the interior door is **opened** (`t_door_o`, not `t_door_boarded`). A window assertion serves as a plumbing discriminator (windows board unconditionally), so an infrastructure miss cannot masquerade as a pass. **Fails before the fix** (door boarded shut); **passes after**.
- `cata_test "[start_location]"` passes under gcc-14/curses and clang-20/tiles — the new test plus the sibling fire test, no regression. `astyle` clean.
- Verified in a TILES build: starting the 7 scenarios while selecting the house boarded up starting location option

Reviewer check recommendation: Start any of the 7 scenarios that has the house boarded up option with the house boarded up option selected in the final stage of character creation. 

## Additional context

Follow-up to PR #9185 (the sibling fire fix), which corrected the same single-z-`tinymap` `is_outside` root cause in `start_location::burn()`.

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter (`astyle`).
- [ ] I linked any relevant issues. <!-- No existing BOARDED issue is linked; per contributing.md, referencing an issue is optional and the problem is described in full above. -->

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit (Linux kernel format).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [60801fc](https://github.com/cataclysmbn/Cataclysm-BN/commit/60801fc7c873ccc28efbdec7e640f0051c11aafc) (fix: boarded start locations open interior doors and place barricades) on 2026-06-01 00:07:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26727067132/artifacts/7320834637)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26727067132/artifacts/7321095967)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26727067132/artifacts/7320851557)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26727067132/artifacts/7320938352)
<!-- END artifact comment -->