### PR TITLE
feat(balance): adds `HELMET_COMPAT` to ghillie suits

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -3358,7 +3358,7 @@
     "warmth": 30,
     "material_thickness": 8,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "STURDY", "NATURE_CAMO", "OUTER", "HOOD" ]
+    "flags": [ "VARSIZE", "STURDY", "NATURE_CAMO", "OUTER", "HOOD", "HELMET_COMPAT" ]
   },
   {
     "id": "urban_ghillie",
@@ -3379,6 +3379,6 @@
     "warmth": 30,
     "material_thickness": 8,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "STURDY", "URBAN_CAMO", "OUTER", "HOOD" ]
+    "flags": [ "VARSIZE", "STURDY", "URBAN_CAMO", "OUTER", "HOOD", "HELMET_COMPAT" ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Needed to allow wearing over an army helmet, something you'd expect for military camo.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Added the `HELMET_COMPAT` flag to woodland and urban ghillie suits.

## Describe alternatives you've considered

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported change to playthrough build, confirmed I can wear urban camo ghillie suit over my army helmet.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [26a852b](https://github.com/cataclysmbn/Cataclysm-BN/commit/26a852bd263b4c5386aa55f08836af392c46af39) (feat (balance): adds `HELMET_COMPAT` to ghillie suits) on 2026-06-01 04:01:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26732847676/artifacts/7322700177)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26732847676/artifacts/7323043953)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26732847676/artifacts/7322906920)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26732847676/artifacts/7322859498)
<!-- END artifact comment -->