### PR TITLE
fix(UI): Fix charged based items not being picked up properly

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2652,8 +2652,11 @@ inventory_selector::stats inventory_pickup_selector::get_raw_stats() const
             int needed_count = std::max(0, chosen_count - count);
             int to_add = std::min(needed_count, item->count());
             count += to_add;
-            weight_carried += (item->weight() / item->count()) * to_add;
-            volume_carried += (item->volume() / item->count()) * to_add;
+            //WARNING: This specific order of operations and casts are needed
+            //to ensure volume and weight are accurate, because of the fact the game
+            //works in base volumes of 1ml and 1mg
+            weight_carried += item->weight() * (static_cast<double>(to_add) / item->count());
+            volume_carried += item->volume() * (static_cast<double>(to_add) / item->count());
         }
     }
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -141,7 +141,7 @@ std::string pickup_inventory_preset::get_denial( const item *loc ) const
     if( !p.has_item( *loc ) ) {
         if( loc->made_of( LIQUID ) ) {
             return _( "Can't pick up spilt liquids" );
-        } 
+        }
         // else if( !p.can_pick_volume( *loc ) && p.is_armed() ) {
         //     return _( "Too big to pick up" );
         // } else if( !p.can_pick_weight( *loc, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
@@ -2590,13 +2590,14 @@ std::vector<pickup::pick_drop_selection> inventory_pickup_selector::execute()
             std::vector<int> counts;
 
             for( auto entry_ptr : get_selection_column_items() ) {
-                int count = 0; 
+                int count = 0;
                 int chosen_count = entry_ptr->chosen_count;
-                for( size_t i = 0; i < entry_ptr->locations.size() && count < chosen_count && count < max_chosen_count; ++i ) {
-                    item* item = entry_ptr->locations[i];
-                    int needed_count = std::max(0, chosen_count - count);
-                    int to_add = std::min(needed_count, item->count());
-                    if (to_add > 0) {
+                for( size_t i = 0; i < entry_ptr->locations.size() && count < chosen_count &&
+                     count < max_chosen_count; ++i ) {
+                    item *item = entry_ptr->locations[i];
+                    int needed_count = std::max( 0, chosen_count - count );
+                    int to_add = std::min( needed_count, item->count() );
+                    if( to_add > 0 ) {
                         locations.push_back( entry_ptr->locations[i] );
                         counts.push_back( to_add );
                     }
@@ -2648,16 +2649,17 @@ inventory_selector::stats inventory_pickup_selector::get_raw_stats() const
     for( auto entry_ptr : selected_items ) {
         int count = 0;
         int chosen_count = entry_ptr->chosen_count;
-        for (size_t i = 0; i < entry_ptr->locations.size() && count < chosen_count && count < max_chosen_count; ++i) {
-            item* item = entry_ptr->locations[i];
-            int needed_count = std::max(0, chosen_count - count);
-            int to_add = std::min(needed_count, item->count());
+        for( size_t i = 0; i < entry_ptr->locations.size() && count < chosen_count &&
+             count < max_chosen_count; ++i ) {
+            item *item = entry_ptr->locations[i];
+            int needed_count = std::max( 0, chosen_count - count );
+            int to_add = std::min( needed_count, item->count() );
             count += to_add;
             //WARNING: This specific order of operations and casts are needed
             //to ensure volume and weight are accurate, because of the fact the game
             //works in base volumes of 1ml and 1mg
-            weight_carried += item->weight() * (static_cast<double>(to_add) / item->count());
-            volume_carried += item->volume() * (static_cast<double>(to_add) / item->count());
+            weight_carried += item->weight() * ( static_cast<double>( to_add ) / item->count() );
+            volume_carried += item->volume() * ( static_cast<double>( to_add ) / item->count() );
         }
     }
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -141,11 +141,12 @@ std::string pickup_inventory_preset::get_denial( const item *loc ) const
     if( !p.has_item( *loc ) ) {
         if( loc->made_of( LIQUID ) ) {
             return _( "Can't pick up spilt liquids" );
-        } else if( !p.can_pick_volume( *loc ) && p.is_armed() ) {
-            return _( "Too big to pick up" );
-        } else if( !p.can_pick_weight( *loc, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
-            return _( "Too heavy to pick up" );
-        }
+        } 
+        // else if( !p.can_pick_volume( *loc ) && p.is_armed() ) {
+        //     return _( "Too big to pick up" );
+        // } else if( !p.can_pick_weight( *loc, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+        //     return _( "Too heavy to pick up" );
+        // }
     }
 
     return std::string();

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2589,9 +2589,16 @@ std::vector<pickup::pick_drop_selection> inventory_pickup_selector::execute()
             std::vector<int> counts;
 
             for( auto entry_ptr : get_selection_column_items() ) {
-                for( size_t i = 0; i < entry_ptr->locations.size() && i < entry_ptr->chosen_count; ++i ) {
-                    locations.push_back( entry_ptr->locations[i] );
-                    counts.push_back( entry_ptr->chosen_count );
+                int count = 0; 
+                int chosen_count = entry_ptr->chosen_count;
+                for( size_t i = 0; i < entry_ptr->locations.size() && count < chosen_count && count < max_chosen_count; ++i ) {
+                    item* item = entry_ptr->locations[i];
+                    int needed_count = std::max(0, chosen_count - count);
+                    int to_add = std::min(needed_count, item->count());
+                    if (to_add > 0) {
+                        locations.push_back( entry_ptr->locations[i] );
+                        counts.push_back( to_add );
+                    }
                 }
             }
 
@@ -2625,6 +2632,7 @@ std::vector<pickup::pick_drop_selection> inventory_pickup_selector::execute()
     return std::vector<pickup::pick_drop_selection>();
 }
 
+[[clang::optnone]]
 inventory_selector::stats inventory_pickup_selector::get_raw_stats() const
 {
     units::mass weight_carried = u.weight_carried();
@@ -2637,8 +2645,16 @@ inventory_selector::stats inventory_pickup_selector::get_raw_stats() const
     //Add the weights and volumes of selected items
     //which might be picked up
     for( auto entry_ptr : selected_items ) {
-        weight_carried += entry_ptr->any_item()->weight() * entry_ptr->chosen_count;
-        volume_carried += entry_ptr->any_item()->volume() * entry_ptr->chosen_count;
+        int count = 0;
+        int chosen_count = entry_ptr->chosen_count;
+        for (size_t i = 0; i < entry_ptr->locations.size() && count < chosen_count && count < max_chosen_count; ++i) {
+            item* item = entry_ptr->locations[i];
+            int needed_count = std::max(0, chosen_count - count);
+            int to_add = std::min(needed_count, item->count());
+            count += to_add;
+            weight_carried += (item->weight() / item->count()) * to_add;
+            volume_carried += (item->volume() / item->count()) * to_add;
+        }
     }
 
     return get_weight_and_volume_stats(

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2591,7 +2591,7 @@ std::vector<pickup::pick_drop_selection> inventory_pickup_selector::execute()
             for( auto entry_ptr : get_selection_column_items() ) {
                 for( size_t i = 0; i < entry_ptr->locations.size() && i < entry_ptr->chosen_count; ++i ) {
                     locations.push_back( entry_ptr->locations[i] );
-                    counts.push_back( 1 );
+                    counts.push_back( entry_ptr->chosen_count );
                 }
             }
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->
## Purpose of change (The Why)
closes #9186 
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes charged based items properly get picked up in experimental pickup menu. Also fixed the inaccurate weight/volume selector and allows the player to try and pickup more than there volume and weight limit like old pickup menu.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Loaded a world, spawned a charged based item, in this case .22 LR bullets like in the bug report, and selected amount to pickup. Properly picked up selected amount. Checked manually that the weight and volume of 100 .22 LR bullets was correct for specific amount. Also tested trying to pickup more then weight and volume limit, properly asks the player to try and wield the additional items.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [105e847](https://github.com/cataclysmbn/Cataclysm-BN/commit/105e8476dda2f7e242f8e9d5570a627e477ee199) (Ran astyle) on 2026-06-02 00:14:58

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26770977635/artifacts/7339906152)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26770977635/artifacts/7339683483)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26770977635/artifacts/7341949867)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26770977635/artifacts/7340316577)
<!-- END artifact comment -->