### PR TITLE
feat(balance): make cvd machine add armor penetration, add armor penetration to bionic weapons

### DIFF
--- a/data/json/items/melee/fake.json
+++ b/data/json/items/melee/fake.json
@@ -6,14 +6,20 @@
     "weapon_category": [ "BIONIC_WEAPONRY", "FIST_WEAPONS" ],
     "name": { "str_sp": "bionic claws" },
     "description": "Short and sharp claws made from a high-tech metal and edged with bonded nanocrystals.",
-    "to_hit": 3,
     "color": "light_gray",
     "symbol": "{",
     "material": [ "superalloy" ],
     "volume": "250 ml",
-    "bashing": 10,
-    "cutting": 20,
-    "flags": [ "STAB", "UNARMED_WEAPON", "NO_DROP", "NO_UNWIELD", "UNBREAKABLE_MELEE", "TRADER_AVOID" ],
+    "attacks": [
+      {
+        "id": "STRIKE",
+        "to_hit": 3,
+        "damage": {
+          "values": [ { "damage_type": "bash", "amount": 10 }, { "damage_type": "stab", "amount": 20, "armor_penetration": 15 } ]
+        }
+      }
+    ],
+    "flags": [ "UNARMED_WEAPON", "NO_DROP", "NO_UNWIELD", "UNBREAKABLE_MELEE", "TRADER_AVOID" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 12 ] ]
   },
   {
@@ -24,13 +30,18 @@
     "name": { "str": "monomolecular blade" },
     "description": "A 30cm-long blade made from high-tech alloy and edged with bonded nanocrystals.",
     "weight": "100 g",
-    "to_hit": 3,
     "color": "dark_gray",
     "symbol": "{",
     "material": [ "superalloy" ],
     "techniques": [ "WBLOCK_2" ],
     "volume": "750 ml",
-    "cutting": 36,
+    "attacks": [
+      {
+        "id": "STRIKE",
+        "to_hit": 3,
+        "damage": { "values": [ { "damage_type": "cut", "amount": 36, "armor_penetration": 28 } ] }
+      }
+    ],
     "flags": [ "UNARMED_WEAPON", "NO_DROP", "NO_UNWIELD", "UNBREAKABLE_MELEE", "TRADER_AVOID" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 22 ] ]
   },
@@ -42,13 +53,18 @@
     "name": { "str": "monofilament whip" },
     "description": "A long, sharp thread of high-tech material, with a small counterweight at the end.",
     "weight": "100 g",
-    "to_hit": 3,
     "color": "dark_gray",
     "symbol": "{",
     "material": [ "superalloy" ],
     "techniques": [ "WIDE" ],
     "volume": "250 ml",
-    "cutting": 28,
+    "attacks": [
+      {
+        "id": "STRIKE",
+        "to_hit": 3,
+        "damage": { "values": [ { "damage_type": "cut", "amount": 28, "armor_penetration": 24 } ] }
+      }
+    ],
     "flags": [ "REACH_ATTACK", "NO_DROP", "NO_UNWIELD", "UNBREAKABLE_MELEE", "TRADER_AVOID", "WHIP" ],
     "qualities": [ [ "SAW_M", 1 ], [ "SAW_W", 1 ] ],
     "use_action": [ "HACKSAW" ]

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1167,7 +1167,7 @@ void melee::roll_cut_damage( const Character &c, bool crit, damage_instance &di,
 
     int arpen = attack.damage.get_armor_pen( DT_CUT );
     if( weap.has_flag( flag_DIAMOND ) ) {
-        arpen += cut_dam * 0.35;
+        arpen += cut_dam * 0.35 + 10;
     }
     float armor_mult = attack.damage.get_armor_mult( DT_CUT );
 
@@ -1251,7 +1251,7 @@ void melee::roll_stab_damage( const Character &c, bool crit, damage_instance &di
     int arpen = attack.damage.get_armor_pen( DT_STAB );
     arpen += c.mabuff_arpen_bonus( DT_STAB );
     if( weap.has_flag( flag_DIAMOND ) ) {
-        arpen += stab_dam * 0.35;
+        arpen += stab_dam * 0.35 + 10;
     }
     armor_mult *= c.mabuff_tg_armor_mult( DT_STAB );
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1251,7 +1251,7 @@ void melee::roll_stab_damage( const Character &c, bool crit, damage_instance &di
     int arpen = attack.damage.get_armor_pen( DT_STAB );
     arpen += c.mabuff_arpen_bonus( DT_STAB );
     if( weap.has_flag( flag_DIAMOND ) ) {
-        arpen += 35;
+        arpen += stab_dam * 0.35;
     }
     armor_mult *= c.mabuff_tg_armor_mult( DT_STAB );
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1166,6 +1166,9 @@ void melee::roll_cut_damage( const Character &c, bool crit, damage_instance &di,
     }
 
     int arpen = attack.damage.get_armor_pen( DT_CUT );
+    if (weap.has_flag(flag_DIAMOND)) {
+        arpen += 35;
+    }
     float armor_mult = attack.damage.get_armor_mult( DT_CUT );
 
     // 80%, 88%, 96%, 104%, 112%, 116%, 120%, 124%, 128%, 132%
@@ -1247,6 +1250,9 @@ void melee::roll_stab_damage( const Character &c, bool crit, damage_instance &di
     float armor_mult = attack.damage.get_armor_mult( DT_STAB );
     int arpen = attack.damage.get_armor_pen( DT_STAB );
     arpen += c.mabuff_arpen_bonus( DT_STAB );
+    if (weap.has_flag(flag_DIAMOND)) {
+        arpen += 35;
+    }
     armor_mult *= c.mabuff_tg_armor_mult( DT_STAB );
 
     if( crit ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1167,7 +1167,7 @@ void melee::roll_cut_damage( const Character &c, bool crit, damage_instance &di,
 
     int arpen = attack.damage.get_armor_pen( DT_CUT );
     if( weap.has_flag( flag_DIAMOND ) ) {
-        arpen += 35;
+        arpen += cut_dam * 0.35;
     }
     float armor_mult = attack.damage.get_armor_mult( DT_CUT );
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1166,7 +1166,7 @@ void melee::roll_cut_damage( const Character &c, bool crit, damage_instance &di,
     }
 
     int arpen = attack.damage.get_armor_pen( DT_CUT );
-    if (weap.has_flag(flag_DIAMOND)) {
+    if (weap.has_flag(flag_DIAMOND) ) {
         arpen += 35;
     }
     float armor_mult = attack.damage.get_armor_mult( DT_CUT );
@@ -1250,7 +1250,7 @@ void melee::roll_stab_damage( const Character &c, bool crit, damage_instance &di
     float armor_mult = attack.damage.get_armor_mult( DT_STAB );
     int arpen = attack.damage.get_armor_pen( DT_STAB );
     arpen += c.mabuff_arpen_bonus( DT_STAB );
-    if (weap.has_flag(flag_DIAMOND)) {
+    if (weap.has_flag(flag_DIAMOND) ) {
         arpen += 35;
     }
     armor_mult *= c.mabuff_tg_armor_mult( DT_STAB );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1166,7 +1166,7 @@ void melee::roll_cut_damage( const Character &c, bool crit, damage_instance &di,
     }
 
     int arpen = attack.damage.get_armor_pen( DT_CUT );
-    if (weap.has_flag(flag_DIAMOND) ) {
+    if( weap.has_flag( flag_DIAMOND ) ) {
         arpen += 35;
     }
     float armor_mult = attack.damage.get_armor_mult( DT_CUT );
@@ -1250,7 +1250,7 @@ void melee::roll_stab_damage( const Character &c, bool crit, damage_instance &di
     float armor_mult = attack.damage.get_armor_mult( DT_STAB );
     int arpen = attack.damage.get_armor_pen( DT_STAB );
     arpen += c.mabuff_arpen_bonus( DT_STAB );
-    if (weap.has_flag(flag_DIAMOND) ) {
+    if( weap.has_flag( flag_DIAMOND ) ) {
         arpen += 35;
     }
     armor_mult *= c.mabuff_tg_armor_mult( DT_STAB );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The cvd machine was always kind of underpowered for a lab finale that requires massive resource investment to even use. Also, a major problem for melee weapons is that melee weapons do not have any sort of armor penetration to offset late game armor values unlike guns. Finally, bionic weapons have no armor pen despite being described as being made of supermaterial that can molecularly slice things.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes the diamond flag which is gained upon using the cvd machine on a valid weapon grant armor penetration equal to 35% of cut and stab damage + 10. does the same for bionic weapons but with 50% of damage instead.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Weak cvd
Monomolecular blade with no armor pen
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [796c146](https://github.com/cataclysmbn/Cataclysm-BN/commit/796c146630cac962d6462a883d7080721c9f477a) (Do the thing!) on 2026-06-01 17:49:13

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26768509268/artifacts/7338053249)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26768509268/artifacts/7338451073)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26768509268)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26768509268/artifacts/7338688566)
<!-- END artifact comment -->