### PR TITLE
feat: craftable ski pants and jacket

### DIFF
--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -182,6 +182,19 @@
     "components": [ [ [ "rag", 7 ] ] ]
   },
   {
+    "result": "pants_ski",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "skill_used": "tailor",
+    "difficulty": 5,
+    "time": "1 h 20 m",
+    "autolearn": true,
+    "book_learn": [ [ "textbook_tailor", 4 ], [ "tailor_portfolio", 4 ] ],
+    "using": [ [ "sewing_standard", 25 ] ],
+    "components": [ [ [ "rag", 20 ] ] ]
+  },
+  {
     "result": "kilt",
     "type": "recipe",
     "category": "CC_ARMOR",

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -192,7 +192,7 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_tailor", 4 ], [ "tailor_portfolio", 4 ] ],
     "using": [ [ "sewing_standard", 25 ] ],
-    "components": [ [ [ "rag", 20 ] ] ]
+    "components": [ [ [ "rag", 14 ] ] ]
   },
   {
     "result": "kilt",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -515,7 +515,7 @@
     "difficulty": 6,
     "time": "2 h",
     "autolearn": true,
-    "book_learn": [ [ "textbook_tailor", 5 ], [ "tailor_portfolio", 5 ]  ],
+    "book_learn": [ [ "textbook_tailor", 5 ], [ "tailor_portfolio", 5 ] ],
     "using": [ [ "sewing_standard", 35 ] ],
     "components": [ [ [ "rag", 8 ] ], [ [ "nylon", 13 ] ] ]
   },

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -507,6 +507,19 @@
     "components": [ [ [ "rag", 17 ] ] ]
   },
   {
+    "result": "ski_jacket",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "time": "2 h",
+    "autolearn": true,
+    "book_learn": [ [ "textbook_tailor", 5 ], [ "tailor_portfolio", 5 ]  ],
+    "using": [ [ "sewing_standard", 35 ] ],
+    "components": [ [ [ "rag", 15 ] ], [ [ "nylon", 15 ] ] ]
+  },
+  {
     "result": "coat_lab",
     "type": "recipe",
     "category": "CC_ARMOR",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -517,7 +517,7 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_tailor", 5 ], [ "tailor_portfolio", 5 ]  ],
     "using": [ [ "sewing_standard", 35 ] ],
-    "components": [ [ [ "rag", 15 ] ], [ [ "nylon", 15 ] ] ]
+    "components": [ [ [ "rag", 8 ] ], [ [ "nylon", 13 ] ] ]
   },
   {
     "result": "coat_lab",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Ski pants and ski jackets aren't craftable, even though there's no good reason to forbid players from doing so, and ski pants are some of the few non-fur winter pants available to the player 

## Describe the solution (The How)

Add crafting recipes for ski pants (Level 5 tailoring due to being just as warm as the winter coat) and ski jacket (Level 6 tailoring, as it's an upgrade from the winter coat), providing crafting options for players who want to get winter pants without scavenging or having to hunt furred animals, as well as for those who need something better than a pure-cotton winter coat. 

## Describe alternatives you've considered

Slightly reducing fabric requirements for both. 

## Testing

Made sure that the recipes display and work correctly, and that you don't create fabric from nowhere by repeatedly crafting and salvaging ski clothes. 

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4d5cc2a](https://github.com/cataclysmbn/Cataclysm-BN/commit/4d5cc2ab97bb398a896f4bea47a7826f7328d33a) (style(autofix.ci): automated formatting) on 2026-06-01 15:14:49

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26756102003/artifacts/7332094783)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26756102003/artifacts/7334972129)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26756102003/artifacts/7332126709)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26756102003/artifacts/7332463957)
<!-- END artifact comment -->