### PR TITLE
fix(lua): pin spawned monster evolution time

### DIFF
--- a/src/catalua_bindings_game.cpp
+++ b/src/catalua_bindings_game.cpp
@@ -40,6 +40,16 @@ void add_msg_lua( game_message_type t, sol::variadic_args va )
     add_msg( t, msg );
 }
 
+auto place_lua_monster_around( const mtype_id &id, const tripoint_bub_ms &center,
+                               const int radius ) -> monster * // *NOPAD*
+{
+    const auto placed = g->place_critter_around( id, center, radius );
+    if( placed != nullptr ) {
+        placed->try_upgrade( true );
+    }
+    return placed;
+}
+
 auto direction_from_relative_delta( const cata::detail::lua_coords::lua_tripoint_coord &delta ) ->
 direction
 {
@@ -194,14 +204,14 @@ void cata::detail::reg_game_api( sol::state &lua )
         return g->critter_at<monster>( tripoint_bub_ms( p ), allow_hallucination.value_or( false ) );
     } ) );
     luna::set_fx( lib, "place_monster_at", sol::overload(
-    []( const mtype_id & id, const tripoint_bub_ms & p ) { return g->place_critter_at( id, p ); },
-    []( const mtype_id & id, const tripoint & p ) { return g->place_critter_at( id, tripoint_bub_ms( p ) ); } ) );
+    []( const mtype_id & id, const tripoint_bub_ms & p ) { return place_lua_monster_around( id, p, 0 ); },
+    []( const mtype_id & id, const tripoint & p ) { return place_lua_monster_around( id, tripoint_bub_ms( p ), 0 ); } ) );
     luna::set_fx( lib, "place_monster_around", sol::overload(
     []( const mtype_id & id, const tripoint_bub_ms & p, const int radius ) {
-        return g->place_critter_around( id, p, radius );
+        return place_lua_monster_around( id, p, radius );
     },
     []( const mtype_id & id, const tripoint & p, const int radius ) {
-        return g->place_critter_around( id, tripoint_bub_ms( p ), radius );
+        return place_lua_monster_around( id, tripoint_bub_ms( p ), radius );
     } ) );
     luna::set_fx( lib, "spawn_hallucination", sol::overload(
                       []( const tripoint_bub_ms & p ) -> bool { return g->spawn_hallucination( p ); },

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -2,6 +2,7 @@
 
 #include "avatar.h"
 #include "calendar.h"
+#include "cata_utility.h"
 #include "catacharset.h"
 #include "catalua.h"
 #include "catalua_coord.h"
@@ -193,6 +194,27 @@ TEST_CASE( "lua_nearby_omt_creature_queries_return_active_creatures", "[lua][cre
     CHECK( test_data.get<int>( "monster_count" ) == 1 );
     CHECK( test_data.get<bool>( "found_expected_npc" ) );
     CHECK( test_data.get<bool>( "found_expected_monster" ) );
+}
+
+TEST_CASE( "lua_place_monster_pins_upgrade_time", "[lua][monster]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    put_player_underground();
+    calendar::turn = calendar::start_of_cataclysm + 2 * calendar::season_length();
+
+    auto lua = make_lua_state();
+    auto test_data = lua.create_table();
+    lua.globals()["test_data"] = test_data;
+    test_data["monster_id"] = mtype_id( "mon_zombie" );
+    test_data["pos"] = tripoint_bub_ms{ 5, 5, 0 };
+
+    run_lua_test_script( lua, "place_monster_upgrade_time_test.lua" );
+
+    const auto current_day = to_days<int>( calendar::turn - calendar::turn_zero );
+    REQUIRE( test_data.get<bool>( "monster_spawned" ) );
+    CHECK( test_data.get<std::string>( "monster_type" ) == "mon_zombie" );
+    CHECK( test_data.get<int>( "upgrade_time" ) > current_day );
 }
 
 TEST_CASE( "lua_typed_coords_projection", "[lua]" )

--- a/tests/lua/place_monster_upgrade_time_test.lua
+++ b/tests/lua/place_monster_upgrade_time_test.lua
@@ -1,0 +1,8 @@
+local mon = gapi.place_monster_at(test_data["monster_id"], test_data["pos"])
+
+test_data["monster_spawned"] = mon ~= nil
+
+if mon then
+  test_data["monster_type"] = mon:get_type():str()
+  test_data["upgrade_time"] = mon:get_upgrade_time()
+end


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9224

Lua-spawned monsters could keep an uninitialized upgrade timer and instantly catch up on evolution after leaving and re-entering the reality bubble in older worlds.

## Describe the solution (The How)

Pins the monster upgrade timer to the current game day after `gapi.place_monster_at` or `gapi.place_monster_around` successfully spawns a monster.

## Describe alternatives you've considered

N/A

## Testing

- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "lua_place_monster_pins_upgrade_time"` — verifies Lua-spawned zombies get a future upgrade timer in an advanced world.
- `./out/build/linux-full/tests/cata_test-tiles "[lua]"`

## Additional context

Related issue: #9224

No related PRs found from GitHub search for `gapi.place_monster_at`.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [x] No new Lua functions or signatures were added, so no new type annotations are needed.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a633aff](https://github.com/cataclysmbn/Cataclysm-BN/commit/a633afffb2448f24d5cff5dbf1f1f0febea5f37b) (fix(lua): pin spawned monster evolution time) on 2026-06-10 16:47:05

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27287090621/artifacts/7540553367)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27287090621/artifacts/7541647709)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27287090621/artifacts/7540719778)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27287090621/artifacts/7541181712)
<!-- END artifact comment -->