### PR TITLE
fix: place translocate self at the selected translocator gate

### DIFF
--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -26,6 +26,7 @@
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "translations.h"
+#include "translocator_utils.h"
 #include "type_id.h"
 #include "ui.h"
 
@@ -84,7 +85,9 @@ bool teleporter_list::place_avatar_overmap( Character &you, const tripoint_abs_o
     if( !global_dest ) {
         return false;
     }
-    auto local_dest = omt_dest.abs_to_bub( *global_dest ) + point( 60, 60 );
+    const auto omt_local_dest = omt_dest.abs_to_bub( *global_dest );
+    const auto local_dest = translocator::local_dest( omt_local_dest,
+                            point_bub_ms( g_half_mapsize_x, g_half_mapsize_y ) );
     you.add_effect( efftype_id( "ignore_fall_damage" ), 1_seconds, bodypart_str_id::NULL_ID(), 0,
                     true );
     g->place_player_overmap( omt_pt );

--- a/src/translocator_utils.cpp
+++ b/src/translocator_utils.cpp
@@ -1,0 +1,12 @@
+#include "translocator_utils.h"
+
+namespace translocator
+{
+
+auto local_dest( const tripoint_bub_ms &omt_local_dest,
+                 const point_bub_ms & ) -> tripoint_bub_ms
+{
+    return omt_local_dest + point( 60, 60 );
+}
+
+} // namespace translocator

--- a/src/translocator_utils.cpp
+++ b/src/translocator_utils.cpp
@@ -4,9 +4,9 @@ namespace translocator
 {
 
 auto local_dest( const tripoint_bub_ms &omt_local_dest,
-                 const point_bub_ms & ) -> tripoint_bub_ms
+                 const point_bub_ms &bubble_center ) -> tripoint_bub_ms
 {
-    return omt_local_dest + point( 60, 60 );
+    return tripoint_bub_ms( omt_local_dest.raw() + bubble_center.raw() );
 }
 
 } // namespace translocator

--- a/src/translocator_utils.h
+++ b/src/translocator_utils.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "coordinates.h"
+
+namespace translocator
+{
+
+auto local_dest( const tripoint_bub_ms &omt_local_dest,
+                 const point_bub_ms &bubble_center ) -> tripoint_bub_ms;
+
+} // namespace translocator

--- a/tests/translocator_utils_test.cpp
+++ b/tests/translocator_utils_test.cpp
@@ -1,0 +1,14 @@
+#include "catch/catch.hpp"
+
+#include "coordinates.h"
+#include "translocator_utils.h"
+
+TEST_CASE( "translocator local destination uses runtime bubble center",
+           "[magic][translocator]" )
+{
+    const auto omt_local_dest = tripoint_bub_ms( 3, 4, 2 );
+    const auto bubble_center = point_bub_ms( 84, 84 );
+
+    CHECK( translocator::local_dest( omt_local_dest, bubble_center ) ==
+           tripoint_bub_ms( 87, 88, 2 ) );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

close #9222

Translocate Self was placing the avatar 24 tiles northwest of the selected Translocator Gate because the landing offset still used the old hardcoded `point( 60, 60 )` bubble center.

Related:
- https://github.com/cataclysmbn/Cataclysm-BN/pull/6234
- https://github.com/cataclysmbn/Cataclysm-BN/pull/8686

## Describe the solution (The How)

- route the local destination calculation through a small helper
- use the runtime bubble center instead of the legacy `60,60` offset
- add a regression test for a larger bubble center

## Describe alternatives you've considered

- replacing the literal inline in `magic_teleporter_list.cpp`
  - skipped so the offset math stays covered by a focused regression test

## Testing

- `cmake --build out/build/linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[magic][translocator]"`

Reviewer suggestion:
1. Build or load a known Translocator Gate.
2. Cast `translocate self` to that gate.
3. Confirm the avatar lands on the selected gate tile instead of 24 tiles northwest.

## Additional context

None.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.4 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b857a28](https://github.com/cataclysmbn/Cataclysm-BN/commit/b857a28f3ad2b328f784a64626b84e4f0d402e91) (fix: place translocators at the runtime bubble center) on 2026-06-02 12:56:05

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26817996562/artifacts/7357013423)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26817996562/artifacts/7357922268)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26817996562/artifacts/7357008009)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26817996562/artifacts/7357304624)
<!-- END artifact comment -->