### PR TITLE
fix(balance): adjust unhealthy values for milkshake and antibiotics

### DIFF
--- a/data/json/items/comestibles/frozen.json
+++ b/data/json/items/comestibles/frozen.json
@@ -104,7 +104,7 @@
     "calories": 265,
     "quench": 40,
     "fun": 25,
-    "healthy": -6,
+    "healthy": -3,
     "price": "4 USD",
     "price_postapoc": "150 cent",
     "material": [ "milk", "junk" ],

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1667,7 +1667,7 @@
     "charges": 5,
     "symbol": "!",
     "color": "white",
-    "healthy": -10,
+    "healthy": -5,
     "flags": [ "NPC_SAFE" ],
     "use_action": { "type": "STRONG_ANTIBIOTIC" }
   }


### PR DESCRIPTION
## Purpose of change (The Why)

Addresses #8529.

The issue points out that the current `healthy` values are inconsistent: deluxe milkshake has a health penalty of `-6`, which is harsher than ice cream at `-2` and even harsher than most recreational drugs, which are commonly around `-5`.

I also noticed a similar inconsistency with strong antibiotics. Their current health penalty is unusually high among medicine items, and higher than all recreational drugs I checked, including stronger ones. This makes the relative health impact look disproportionate.

## Describe the solution (The How)

* Changed deluxe milkshake's `healthy` value from `-6` to `-3`.
* Changed strong antibiotics' `healthy` value to `-5`.

The intent is to keep both items as unhealthy, but make their penalties more consistent relative to comparable food, medicine, and recreational drug items.

## Describe alternatives you've considered

I considered leaving the deluxe milkshake value unchanged and only adjusting recreational drugs upward, but that would make this PR much broader. I kept the change limited to two clearly inconsistent values.

## Testing

Not run in-game; JSON-only balance change.

## Additional context

This is a small data balance adjustment related to #8529.

## Checklist

### Mandatory

* [x] I wrote the PR title in conventional commit format.
* [ ] I ran the code formatter.
* [x] I linked any relevant issues using github keyword syntax like `closes #1234` in Summary of the PR so it can be closed automatically.

### Optional

* [x] This PR used AI assistance.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [618f3f3](https://github.com/cataclysmbn/Cataclysm-BN/commit/618f3f30375f8ec5d0ec0079bb11e77c2d6b5c62) (Rebalance health values for milkshake and antibiotics) on 2026-06-02 14:28:12

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26822919683/artifacts/7359140976)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26822919683/artifacts/7360246118)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26822919683/artifacts/7359277369)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26822919683/artifacts/7359613017)
<!-- END artifact comment -->