### PR TITLE
feat: shrapnel effects

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -425,14 +425,23 @@
     "explosion": {
       "damage": 50,
       "radius": 2,
-      "incend_shrapnel": true,
+      "fragment_effect": [
+          { "effect": "onfire", "odds": 2, "min_turns": 4, "max_turns": 8 }
+        ],
       "fragment": { "impact": { "damage_type": "bullet", "amount": 70, "armor_multiplier": 1 }, "range": 5 }
     }
   },
   {
     "id": "AMMO_25MM_HEI",
     "type": "ammo_effect",
-    "explosion": { "incend_shrapnel": true, "damage": 10, "radius": 1 }
+    "explosion": {
+      "damage": 10,
+      "radius": 1,
+      "fragment_effect": [
+          { "effect": "onfire", "odds": 2, "min_turns": 4, "max_turns": 8 }
+        ],
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 5, "armor_multiplier": 1 }, "range": 2 }
+    }
   },
   {
     "id": "AMMO_155MM_FRAG",

--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -420,10 +420,19 @@
     "//": "Nearly-immeasurable chance to fail to fire."
   },
   {
+    "id": "AMMO_50BMG_RAUFOSS",
+    "type": "ammo_effect",
+    "explosion": {
+      "damage": 50,
+      "radius": 2,
+      "incend_shrapnel": true,
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 70, "armor_multiplier": 1 }, "range": 5 }
+    }
+  },
+  {
     "id": "AMMO_25MM_HEI",
     "type": "ammo_effect",
-    "aoe": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "size": 1, "radius": 1, "chance": 25 },
-    "explosion": { "damage": 10, "radius": 1 }
+    "explosion": { "incend_shrapnel": true, "damage": 10, "radius": 1 }
   },
   {
     "id": "AMMO_155MM_FRAG",

--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -425,9 +425,7 @@
     "explosion": {
       "damage": 50,
       "radius": 2,
-      "fragment_effect": [
-          { "effect": "onfire", "odds": 2, "min_turns": 4, "max_turns": 8 }
-        ],
+      "fragment_effect": [ { "effect": "onfire", "odds": 2, "min_turns": 4, "max_turns": 8 } ],
       "fragment": { "impact": { "damage_type": "bullet", "amount": 70, "armor_multiplier": 1 }, "range": 5 }
     }
   },
@@ -437,9 +435,7 @@
     "explosion": {
       "damage": 10,
       "radius": 1,
-      "fragment_effect": [
-          { "effect": "onfire", "odds": 2, "min_turns": 4, "max_turns": 8 }
-        ],
+      "fragment_effect": [ { "effect": "onfire", "odds": 2, "min_turns": 4, "max_turns": 8 } ],
       "fragment": { "impact": { "damage_type": "bullet", "amount": 5, "armor_multiplier": 1 }, "range": 2 }
     }
   },

--- a/data/json/items/ammo/50.json
+++ b/data/json/items/ammo/50.json
@@ -63,7 +63,7 @@
     "price_postapoc": "75 USD",
     "description": "This variant of the .50 BMG round makes the most of the caliber's potential payload delivery: the tip is loaded with an incendiary mix, which ignites on impact, detonating the RDX or PETN charge.  This also ignites a secondary zirconium powder incendiary charge that surrounds a tungsten carbide penetrator, both encased by a mild steel cup.  Fragments from the cup and burning metallic powder follow the penetrator through armored targets, increasing lethality.",
     "//": "NO_PENETRATE_OBSTACLES so it detonates on impact",
-    "effects": [ "INCENDIARY", "EXPLOSIVE_BIG", "NO_PENETRATE_OBSTACLES" ],
+    "effects": [ "INCENDIARY", "AMMO_50BMG_RAUFOSS", "NO_PENETRATE_OBSTACLES" ],
     "//2": "mk 211 is estimated to be as effective as 20mm, which would have 65kJ energy, or 255 damage. ~181 damage is fair.",
     "relative": { "damage": { "damage_type": "bullet", "amount": 50, "armor_penetration": 25 } },
     "dispersion": 100

--- a/docs/en/mod/json/reference/items/item_creation.md
+++ b/docs/en/mod/json/reference/items/item_creation.md
@@ -66,6 +66,7 @@
   "damage": 10,                              // Damage the explosion deals to player at epicenter. Damage is halved above 50% radius.
   "radius": 8,                               // Radius of the explosion. 0 means only the epicenter is affected.
   "fire": true,                              // Should the explosion leave fire
+  "incend_shrapnel": true,                   // Should the shrapnel apply the onfire status effect to targets
   "fragment": {                              // Projectile data of "shrapnel". This projectile will hit every target in its range and field of view exactly once.
     "damage": {                              // Damage data of the shrapnel projectile.  Uses damage_instance syntax (see below)
       "damage_type": "acid",                 // Type of damage dealt.

--- a/docs/en/mod/json/reference/items/item_creation.md
+++ b/docs/en/mod/json/reference/items/item_creation.md
@@ -66,7 +66,13 @@
   "damage": 10,                              // Damage the explosion deals to player at epicenter. Damage is halved above 50% radius.
   "radius": 8,                               // Radius of the explosion. 0 means only the epicenter is affected.
   "fire": true,                              // Should the explosion leave fire
-  "incend_shrapnel": true,                   // Should the shrapnel apply the onfire status effect to targets
+  "fragment_effect": [ {                     // Effects data of "shrapnel"
+      "effect": "onfire",                    // Effect to apply (note that onfire has special hardcoded behaviour to check the target is flamable)
+      "odds": 2,                             // One in x chance to apply this effect
+      "min_turns": 4,                        // Min turn duration for effect
+      "max_turns": 8                         // Max turn duration for effect
+    }
+  ],
   "fragment": {                              // Projectile data of "shrapnel". This projectile will hit every target in its range and field of view exactly once.
     "damage": {                              // Damage data of the shrapnel projectile.  Uses damage_instance syntax (see below)
       "damage_type": "acid",                 // Type of damage dealt.

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -160,7 +160,26 @@ explosion_data load_explosion_data( const JsonObject &jo )
     }
 
     ret.fire = jo.get_bool( "fire", false );
-    ret.incend_shrapnel = jo.get_bool( "incend_shrapnel", false );
+    std::vector<std::tuple<std::string, int, int, int>> frag_effect;
+
+    for( const JsonValue entry : jo.get_array( "fragment_effect" ) ) {
+        std::string effect;
+        int odds = 0;
+        int min_turns;
+        int max_turns;
+        if( entry.test_object() ) {
+            JsonObject jc = entry.get_object();
+            effect = jc.get_string( "effect", "" );
+            odds = jc.get_int( "odds", 0 );
+            min_turns = jc.get_int( "min_turns", 0 );
+            max_turns = jc.get_int( "max_turns", 0 );
+        }
+        if( effect != "" && odds > 0 && max_turns > 0 ) {
+            frag_effect.emplace_back(effect, odds, min_turns, max_turns);
+        }
+    }
+
+    ret.fragment_effect = frag_effect;
 
     return ret;
 }
@@ -326,8 +345,8 @@ class ExplosionProcess
         // Is the fire created by the explosion actually left behind?
         const bool is_fiery;
 
-        // Will the shrapnel inflict onfire
-        const bool incend_shrapnel;
+        //Effects shrapnel may influct, nullopt to disable
+        const std::optional<std::vector<std::tuple<std::string, int, int, int>>> fragment_effect;
 
         // Shrapnel data, nullopt to disable
         const std::optional<projectile> shrapnel;
@@ -366,15 +385,16 @@ class ExplosionProcess
             const tripoint_bub_ms blast_center,
             const int blast_power,
             const int blast_radius,
+             const std::optional<std::vector<std::tuple<std::string, int, int, int>>> &fragment_effect = std::nullopt,
             const std::optional<projectile> &proj = std::nullopt,
             const bool is_fiery = false,
-            const bool incend_shrapnel = false,
+            
             const std::optional<Creature *> responsible = std::nullopt
         ) : center( blast_center ),
             blast_power( blast_power ),
             blast_radius( blast_radius ),
             is_fiery( is_fiery ),
-            incend_shrapnel( incend_shrapnel ),
+            fragment_effect( fragment_effect ),
             shrapnel( proj ),
             emitter( responsible ),
             player_flung( std::nullopt ),
@@ -648,11 +668,25 @@ void ExplosionProcess::project_shrapnel( const tripoint_bub_ms position )
             critter->check_dead_state();
         }
 
-        if( incend_shrapnel ) {
-            if( critter->made_of( material_id( "veggy" ) ) || critter->made_of_any( critter->cmat_flammable ) ) {
-                critter->add_effect( effect_onfire, rng( 4_turns, 8_turns ), bps[0]->id );
-            } else if( critter->made_of_any( critter->cmat_flesh ) && one_in( 2 ) ) {
-                critter->add_effect( effect_onfire, rng( 4_turns, 6_turns ), bps[0]->id );
+        if ( fragment_effect != std::nullopt ) {
+            for( auto data : fragment_effect.value() ) {
+                const std::string effect = std::get<0>( data );
+                const int odds = std::get<1>( data );
+                const auto min_turns = time_duration::from_turns( std::get<2>( data ) );
+                const auto max_turns = time_duration::from_turns( std::get<3>( data ) );
+
+                if ( effect == "onfire" ) {
+                    //onfire is hardcoded to check if the target is actually flamable
+                    if( critter->made_of( material_id( "veggy" ) ) || critter->made_of_any( critter->cmat_flammable ) ) {
+                        critter->add_effect( efftype_id( effect ), rng( min_turns, max_turns ), bps[0]->id );
+                    } else if( critter->made_of_any( critter->cmat_flesh ) && one_in( odds ) ) {
+                        critter->add_effect( efftype_id( effect ), rng( min_turns, max_turns ), bps[0]->id );
+                    }
+                } else {
+                    if ( one_in( odds) ) {
+                        critter->add_effect( efftype_id( effect ), rng( min_turns, max_turns ), bps[0]->id );                       
+                    }
+                }
             }
         }
 
@@ -1607,7 +1641,7 @@ void explosion_funcs::regular( const queued_explosion &qe )
         }
         damaged_by_blast = legacy_blast( p, ex.damage, ex.radius, ex.fire, qe.source );
     } else {
-        ExplosionProcess process( p, ex.damage, ex.radius, shr, ex.fire, ex.incend_shrapnel, std::make_optional( qe.source ) );
+        ExplosionProcess process( p, ex.damage, ex.radius, ex.fragment_effect, shr, ex.fire, std::make_optional( qe.source ) );
         process.run();
         damaged_by_blast = process.get_blasted();
         damaged_by_shrapnel = process.get_shrapneled();

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -175,7 +175,7 @@ explosion_data load_explosion_data( const JsonObject &jo )
             max_turns = jc.get_int( "max_turns", 0 );
         }
         if( effect != "" && odds > 0 && max_turns > 0 ) {
-            frag_effect.emplace_back(effect, odds, min_turns, max_turns);
+            frag_effect.emplace_back( effect, odds, min_turns, max_turns );
         }
     }
 
@@ -385,10 +385,11 @@ class ExplosionProcess
             const tripoint_bub_ms blast_center,
             const int blast_power,
             const int blast_radius,
-             const std::optional<std::vector<std::tuple<std::string, int, int, int>>> &fragment_effect = std::nullopt,
+            const std::optional<std::vector<std::tuple<std::string, int, int, int>>> &fragment_effect =
+                std::nullopt,
             const std::optional<projectile> &proj = std::nullopt,
             const bool is_fiery = false,
-            
+
             const std::optional<Creature *> responsible = std::nullopt
         ) : center( blast_center ),
             blast_power( blast_power ),
@@ -668,23 +669,24 @@ void ExplosionProcess::project_shrapnel( const tripoint_bub_ms position )
             critter->check_dead_state();
         }
 
-        if ( fragment_effect != std::nullopt ) {
+        if( fragment_effect != std::nullopt ) {
             for( auto data : fragment_effect.value() ) {
                 const std::string effect = std::get<0>( data );
                 const int odds = std::get<1>( data );
                 const auto min_turns = time_duration::from_turns( std::get<2>( data ) );
                 const auto max_turns = time_duration::from_turns( std::get<3>( data ) );
 
-                if ( effect == "onfire" ) {
+                if( effect == "onfire" ) {
                     //onfire is hardcoded to check if the target is actually flamable
-                    if( critter->made_of( material_id( "veggy" ) ) || critter->made_of_any( critter->cmat_flammable ) ) {
+                    if( critter->made_of( material_id( "veggy" ) ) ||
+                        critter->made_of_any( critter->cmat_flammable ) ) {
                         critter->add_effect( efftype_id( effect ), rng( min_turns, max_turns ), bps[0]->id );
                     } else if( critter->made_of_any( critter->cmat_flesh ) && one_in( odds ) ) {
                         critter->add_effect( efftype_id( effect ), rng( min_turns, max_turns ), bps[0]->id );
                     }
                 } else {
-                    if ( one_in( odds) ) {
-                        critter->add_effect( efftype_id( effect ), rng( min_turns, max_turns ), bps[0]->id );                       
+                    if( one_in( odds ) ) {
+                        critter->add_effect( efftype_id( effect ), rng( min_turns, max_turns ), bps[0]->id );
                     }
                 }
             }
@@ -1641,7 +1643,8 @@ void explosion_funcs::regular( const queued_explosion &qe )
         }
         damaged_by_blast = legacy_blast( p, ex.damage, ex.radius, ex.fire, qe.source );
     } else {
-        ExplosionProcess process( p, ex.damage, ex.radius, ex.fragment_effect, shr, ex.fire, std::make_optional( qe.source ) );
+        ExplosionProcess process( p, ex.damage, ex.radius, ex.fragment_effect, shr, ex.fire,
+                                  std::make_optional( qe.source ) );
         process.run();
         damaged_by_blast = process.get_blasted();
         damaged_by_shrapnel = process.get_shrapneled();

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -81,6 +81,7 @@ static const efftype_id effect_deaf( "deaf" );
 static const efftype_id effect_emp( "emp" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_teleglow( "teleglow" );
+static const efftype_id effect_onfire( "onfire" );
 
 static const species_id ROBOT( "ROBOT" );
 
@@ -159,6 +160,7 @@ explosion_data load_explosion_data( const JsonObject &jo )
     }
 
     ret.fire = jo.get_bool( "fire", false );
+    ret.incend_shrapnel = jo.get_bool( "incend_shrapnel", false );
 
     return ret;
 }
@@ -324,6 +326,9 @@ class ExplosionProcess
         // Is the fire created by the explosion actually left behind?
         const bool is_fiery;
 
+        // Will the shrapnel inflict onfire
+        const bool incend_shrapnel;
+
         // Shrapnel data, nullopt to disable
         const std::optional<projectile> shrapnel;
 
@@ -363,11 +368,13 @@ class ExplosionProcess
             const int blast_radius,
             const std::optional<projectile> &proj = std::nullopt,
             const bool is_fiery = false,
+            const bool incend_shrapnel = false,
             const std::optional<Creature *> responsible = std::nullopt
         ) : center( blast_center ),
             blast_power( blast_power ),
             blast_radius( blast_radius ),
             is_fiery( is_fiery ),
+            incend_shrapnel( incend_shrapnel ),
             shrapnel( proj ),
             emitter( responsible ),
             player_flung( std::nullopt ),
@@ -640,6 +647,15 @@ void ExplosionProcess::project_shrapnel( const tripoint_bub_ms position )
             }
             critter->check_dead_state();
         }
+
+        if( incend_shrapnel ) {
+            if( critter->made_of( material_id( "veggy" ) ) || critter->made_of_any( critter->cmat_flammable ) ) {
+                critter->add_effect( effect_onfire, rng( 4_turns, 8_turns ), bps[0]->id );
+            } else if( critter->made_of_any( critter->cmat_flesh ) && one_in( 2 ) ) {
+                critter->add_effect( effect_onfire, rng( 4_turns, 6_turns ), bps[0]->id );
+            }
+        }
+
         mobs_shrapneled[critter] = damage_taken;
     }
 
@@ -1591,7 +1607,7 @@ void explosion_funcs::regular( const queued_explosion &qe )
         }
         damaged_by_blast = legacy_blast( p, ex.damage, ex.radius, ex.fire, qe.source );
     } else {
-        ExplosionProcess process( p, ex.damage, ex.radius, shr, ex.fire, std::make_optional( qe.source ) );
+        ExplosionProcess process( p, ex.damage, ex.radius, shr, ex.fire, ex.incend_shrapnel, std::make_optional( qe.source ) );
         process.run();
         damaged_by_blast = process.get_blasted();
         damaged_by_shrapnel = process.get_shrapneled();

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -81,7 +81,6 @@ static const efftype_id effect_deaf( "deaf" );
 static const efftype_id effect_emp( "emp" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_teleglow( "teleglow" );
-static const efftype_id effect_onfire( "onfire" );
 
 static const species_id ROBOT( "ROBOT" );
 

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -14,6 +14,7 @@ struct explosion_data {
     int damage              = 0;
     float radius            = 0;
     bool fire               = false;
+    bool incend_shrapnel    = false;
     std::optional<projectile> fragment = std::nullopt;
 
     /** Returns the range at which blast damage is 0 and shrapnel is out of range. */

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -14,7 +14,7 @@ struct explosion_data {
     int damage              = 0;
     float radius            = 0;
     bool fire               = false;
-    bool incend_shrapnel    = false;
+    std::optional<std::vector<std::tuple<std::string, int, int, int>>> fragment_effect = std::nullopt;
     std::optional<projectile> fragment = std::nullopt;
 
     /** Returns the range at which blast damage is 0 and shrapnel is out of range. */


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

HEI and HEIAP in game have very meh incendiary effects, as only the target you directly hit catches on fire... sometimes... for like 3 turns maybe

which is very very underwhelming

raufoss also despite being a incendiary fragmenting round lacks any fragmentation

## Describe the solution (The How)

Implement the fragment_effect property to explosions, which allows applying any effect to a creature hit by the shrapnel with a one in x chance

grant this ability to 25mm HEI along with a tiny bit of fragmenting, but remove its fire field spawning in exchange

also grant this ability to raufoss, additionally reduce the explosion radius from 5 to 2 and reduce its damage a tiny bit while adding a shrapnel effect with radius 5, damage 70 and ap mult 1

## Describe alternatives you've considered

- Literally not doing this

## Testing

Spawn in like 50 debug monsters, shoot a raufoss round into them and watch them all catch on fire

## Additional context

Dont exactly have an amazing reference for balancing this kinda thing in the game so balance feedback and or changes are welcome:tm:

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [346ae43](https://github.com/cataclysmbn/Cataclysm-BN/commit/346ae4328597f304e71aa18fb962d76971287c29) (remove unused thing) on 2026-06-02 22:42:46

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26848866153/artifacts/7371034327)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26848866153/artifacts/7371125907)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26848866153/artifacts/7371132687)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26848866153/artifacts/7370982592)
<!-- END artifact comment -->