### PR TITLE
feat: Add Grid version of Aftershock crafting Rigs

### DIFF
--- a/data/mods/Aftershock/construction/construction.json
+++ b/data/mods/Aftershock/construction/construction.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "construction",
+    "id": "constr_grid_afs_kitchen_rig",
+    "group": "place_afs_kitchen_rig",
+    "category": "WORKSHOP",
+    "required_skills": [ [ "electronics", 1 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "components": [ [ [ "afs_kitchen_rig", 1 ] ], [ [ "cable", 5 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_furniture": "f_afs_kitchen_rig"
+  }
+]

--- a/data/mods/Aftershock/construction/construction.json
+++ b/data/mods/Aftershock/construction/construction.json
@@ -1,6 +1,20 @@
 [
   {
     "type": "construction",
+    "id": "constr_grid_afs_cooking_rig",
+    "group": "place_afs_cooking_rig",
+    "category": "WORKSHOP",
+    "required_skills": [ [ "electronics", 1 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "components": [ [ [ "afs_cooking_rig", 1 ] ], [ [ "cable", 5 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_furniture": "f_afs_cooking_rig"
+  },
+  {
+    "type": "construction",
     "id": "constr_grid_afs_kitchen_rig",
     "group": "place_afs_kitchen_rig",
     "category": "WORKSHOP",
@@ -12,5 +26,19 @@
     "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
     "pre_special": "check_empty",
     "post_furniture": "f_afs_kitchen_rig"
+  },
+  {
+    "type": "construction",
+    "id": "constr_grid_afs_metal_rig",
+    "group": "place_afs_metal_rig",
+    "category": "WORKSHOP",
+    "required_skills": [ [ "electronics", 1 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "components": [ [ [ "afs_metal_rig", 1 ] ], [ [ "cable", 5 ] ], [ [ "power_supply", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_furniture": "f_afs_metal_rig"
   }
 ]

--- a/data/mods/Aftershock/construction/construction_group.json
+++ b/data/mods/Aftershock/construction/construction_group.json
@@ -1,0 +1,3 @@
+[
+  { "type": "construction_group", "id": "place_afs_kitchen_rig", "name": "Place KitchenMaster Cooking Buddy" }
+]

--- a/data/mods/Aftershock/construction/construction_group.json
+++ b/data/mods/Aftershock/construction/construction_group.json
@@ -1,3 +1,17 @@
 [
-  { "type": "construction_group", "id": "place_afs_kitchen_rig", "name": "Place KitchenMaster Cooking Buddy" }
+  {
+    "type": "construction_group",
+    "id": "place_afs_cooking_rig",
+    "name": "Place cooking rig"
+  },
+  {
+    "type": "construction_group",
+    "id": "place_afs_kitchen_rig",
+    "name": "Place KitchenMaster Cooking Buddy"
+  },
+  {
+    "type": "construction_group",
+    "id": "place_afs_metal_rig",
+    "name": "Place MetalMaster forge buddy"
+  }
 ]

--- a/data/mods/Aftershock/furniture_and_terrain/furniture-appliances.json
+++ b/data/mods/Aftershock/furniture_and_terrain/furniture-appliances.json
@@ -1,27 +1,56 @@
 [
   {
     "type": "furniture",
+    "id": "f_afs_cooking_rig",
+    "looks_like": "afs_cooking_rig",
+    "name": "grid cooking rig",
+    "symbol": "&",
+    "color": "yellow",
+    "description": "An all-in-one kitchen unit and chemistry lab, wired into the building's electric grid.  If you attempt to craft an item that needs one of its functions, it will automatically be selected as a tool.",
+    "move_cost_mod": -1,
+    "coverage": 60,
+    "required_str": -1,
+    "crafting_pseudo_item": [ "fake_oven", "fake_chemistry_set", "fake_gridelectrolysis_kit", "pot", "pan" ],
+    "flags": [ "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT", "TRANSPARENT" ],
+    "deconstruct": {
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "afs_cooking_rig", "count": 1 },
+        { "item": "cable", "charges": 5 }
+      ]
+    },
+    "bash": {
+      "str_min": 18,
+      "str_max": 50,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
+        { "item": "steel_lump", "count": [ 6, 9 ] },
+        { "item": "steel_chunk", "count": [ 6, 9 ] },
+        { "item": "scrap", "count": [ 6, 9 ] },
+        { "item": "pot", "prob": 50 },
+        { "item": "pan", "prob": 50 },
+        { "item": "chemistry_set", "charges": 0, "prob": 50 },
+        { "item": "hotplate", "charges": 0, "prob": 50 }
+      ],
+      "//": "Variable reduction since might hit more or less material.",
+      "ranged": { "reduction": [ 11, 22 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_afs_kitchen_rig",
-    "looks_like": "f_craftrig",
+    "copy-from": "f_craftrig",
+    "looks_like": "afs_kitchen_rig",
     "name": "grid KitchenMaster cooking buddy",
     "symbol": "&",
-    "color": "blue",
+    "color": "yellow",
     "description": "An all-in-one kitchen unit, chemistry lab, and food preparation area, wired into the building's electric grid.  If you attempt to craft an item that needs one of its functions, it will automatically be selected as a tool.",
     "move_cost_mod": -1,
     "coverage": 60,
     "required_str": -1,
-    "crafting_pseudo_item": [
-      "fake_oven",
-      "fake_chemistry_set",
-      "fake_gridelectrolysis_kit",
-      "fake_griddehydrator",
-      "fake_gridvac_sealer",
-      "fake_gridfood_processor",
-      "fake_gridwater_purifier",
-      "pot",
-      "pan",
-      "press"
-    ],
+    "crafting_pseudo_item": [ "fake_oven", "fake_chemistry_set", "fake_gridelectrolysis_kit", "pot", "pan" ],
     "flags": [ "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT", "TRANSPARENT" ],
     "deconstruct": {
       "items": [
@@ -31,22 +60,65 @@
       ]
     },
     "bash": {
-      "str_min": 22,
-      "str_max": 60,
+      "str_min": 18,
+      "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
         { "item": "solder_wire", "charges": [ 10, 20 ] },
-        { "count": [ 9, 18 ], "item": "steel_lump" },
-        { "count": [ 9, 18 ], "item": "steel_chunk" },
-        { "count": [ 9, 18 ], "item": "scrap" },
-        { "charges": 0, "item": "water_purifier", "prob": 50 },
-        { "charges": 0, "item": "vac_sealer", "prob": 50 },
-        { "charges": 0, "item": "dehydrator", "prob": 50 },
-        { "charges": 0, "item": "food_processor", "prob": 50 },
-        { "charges": 0, "item": "press", "prob": 50 },
-        { "charges": 0, "item": "hotplate", "prob": 50 },
-        { "charges": 0, "item": "chemistry_set", "prob": 50 }
+        { "item": "steel_lump", "count": [ 9, 18 ] },
+        { "item": "steel_chunk", "count": [ 9, 18 ] },
+        { "item": "scrap", "count": [ 9, 18 ] },
+        { "item": "pot", "prob": 50 },
+        { "item": "pan", "prob": 50 },
+        { "item": "chemistry_set", "charges": 0, "prob": 50 },
+        { "item": "hotplate", "charges": 0, "prob": 50 },
+        { "item": "water_purifier", "charges": 0, "prob": 50 },
+        { "item": "vac_sealer", "charges": 0, "prob": 50 },
+        { "item": "dehydrator", "charges": 0, "prob": 50 },
+        { "item": "food_processor", "charges": 0, "prob": 50 },
+        { "item": "press", "charges": 0, "prob": 50 }
+      ],
+      "//": "Variable reduction since might hit more or less material.",
+      "ranged": { "reduction": [ 11, 22 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_afs_metal_rig",
+    "copy-from": "f_welderrig",
+    "looks_like": "afs_metal_rig",
+    "name": "grid MetalMaster forge buddy",
+    "symbol": "&",
+    "color": "red",
+    "description": "A welding and metalworking station, wired into the building's electric grid. 'e'xamine the forge rig to utilize its welder or soldering iron; you'll still need glare protection.",
+    "move_cost_mod": -1,
+    "coverage": 60,
+    "required_str": -1,
+    "crafting_pseudo_item": [ "fake_gridforge", "fake_gridkiln" ],
+    "flags": [ "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT", "TRANSPARENT" ],
+    "deconstruct": {
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "afs_metal_rig", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
+    },
+    "bash": {
+      "str_min": 18,
+      "str_max": 50,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
+        { "item": "power_supply", "count": [ 0, 1 ] },
+        { "item": "steel_lump", "count": [ 3, 6 ] },
+        { "item": "steel_chunk", "count": [ 3, 6 ] },
+        { "item": "scrap", "count": [ 3, 6 ] },
+        { "item": "welder", "charges": 0, "prob": 50 },
+        { "item": "forge", "charges": 0, "prob": 50 },
+        { "item": "kiln", "charges": 0, "prob": 50 }
       ],
       "//": "Variable reduction since might hit more or less material.",
       "ranged": { "reduction": [ 11, 22 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }

--- a/data/mods/Aftershock/furniture_and_terrain/furniture-appliances.json
+++ b/data/mods/Aftershock/furniture_and_terrain/furniture-appliances.json
@@ -1,0 +1,55 @@
+[
+  {
+    "type": "furniture",
+    "id": "f_afs_kitchen_rig",
+    "looks_like": "f_craftrig",
+    "name": "grid KitchenMaster cooking buddy",
+    "symbol": "&",
+    "color": "blue",
+    "description": "An all-in-one kitchen unit, chemistry lab, and food preparation area, wired into the building's electric grid.  If you attempt to craft an item that needs one of its functions, it will automatically be selected as a tool.",
+    "move_cost_mod": -1,
+    "coverage": 60,
+    "required_str": -1,
+    "crafting_pseudo_item": [
+      "fake_oven",
+      "fake_chemistry_set",
+      "fake_gridelectrolysis_kit",
+      "fake_griddehydrator",
+      "fake_gridvac_sealer",
+      "fake_gridfood_processor",
+      "fake_gridwater_purifier",
+      "pot",
+      "pan",
+      "press"
+    ],
+    "flags": [ "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT", "TRANSPARENT" ],
+    "deconstruct": {
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "afs_kitchen_rig", "count": 1 },
+        { "item": "cable", "charges": 5 }
+      ]
+    },
+    "bash": {
+      "str_min": 22,
+      "str_max": 60,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
+        { "count": [ 9, 18 ], "item": "steel_lump" },
+        { "count": [ 9, 18 ], "item": "steel_chunk" },
+        { "count": [ 9, 18 ], "item": "scrap" },
+        { "charges": 0, "item": "water_purifier", "prob": 50 },
+        { "charges": 0, "item": "vac_sealer", "prob": 50 },
+        { "charges": 0, "item": "dehydrator", "prob": 50 },
+        { "charges": 0, "item": "food_processor", "prob": 50 },
+        { "charges": 0, "item": "press", "prob": 50 },
+        { "charges": 0, "item": "hotplate", "prob": 50 },
+        { "charges": 0, "item": "chemistry_set", "prob": 50 }
+      ],
+      "//": "Variable reduction since might hit more or less material.",
+      "ranged": { "reduction": [ 11, 22 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+    }
+  }
+]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

I've found that the crafting rigs from the Aftershock mod (Cooking Rig, Kitchenmaster Cooking Buddy, Metalmaster Forge Buddy) doesn't have grid version so i can't install them into my base. I've decided to take matters into my own hand and resolves #9208

## Describe the solution (The How)

Adds plug-able versions of the crafting rigs from the Aftershock mod. They can now be plugged into the building's power grid, making them able to be installed into your base.

## Describe alternatives you've considered

Having to create a vehicle consisting of just a frame and the crafting rig in question and having to deal with issue #2638

## Testing

1. Create a new world with Aftershock mod on.
2. Spawn in the crafting rigs and their required materials.
3. Try to install them as Grid furniture.
4. Now you have a grid version of the crafting rigs

## Additional context

My test character with the installed Aftershock crafting rigs
<img width="1108" height="1079" alt="image" src="https://github.com/user-attachments/assets/2858a40c-9b67-40e2-8d51-e706241eb188" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

## AI Disclosure
Assisted-by: minimax:minimax-m3 opencode clang-tidy
The 1st commit was generated by ai and i revise the results and i use it as template for the other commit

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a517259](https://github.com/cataclysmbn/Cataclysm-BN/commit/a51725908a54a2103aa4dfbe6d95dfeb1d29404b) (Merge branch 'main' into more-plugable-items) on 2026-06-02 19:49:02

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26840831030/artifacts/7366959912)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26840831030/artifacts/7367877197)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26840831030/artifacts/7367828971)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26840831030/artifacts/7367355413)
<!-- END artifact comment -->