### PR TITLE
fix: artifacts no longer save legacy mass, money and volume values

### DIFF
--- a/src/artifact.cpp
+++ b/src/artifact.cpp
@@ -1152,8 +1152,8 @@ void it_artifact_tool::deserialize( const JsonObject &jo )
             materials.emplace_back( id );
         }
     }
-    volume = jo.get_int( "volume" ) * units::legacy_volume_factor;
-    weight = units::from_gram<std::int64_t>( jo.get_int( "weight" ) );
+    assign( jo, "volume", volume, false, 1_ml );
+    assign( jo, "weight", weight, false, 1_gram );
     melee[DT_BASH] = jo.get_int( "melee_dam" );
     melee[DT_CUT] = jo.get_int( "melee_cut" );
     m_to_hit = jo.get_int( "m_to_hit" );
@@ -1262,8 +1262,8 @@ void it_artifact_armor::deserialize( const JsonObject &jo )
             materials.emplace_back( id );
         }
     }
-    volume = jo.get_int( "volume" ) * units::legacy_volume_factor;
-    weight = units::from_gram<std::int64_t>( jo.get_int( "weight" ) );
+    assign( jo, "volume", volume, false, 1_ml );
+    assign( jo, "weight", weight, false, 1_gram );
     melee[DT_BASH] = jo.get_int( "melee_dam" );
     melee[DT_CUT] = jo.get_int( "melee_cut" );
     m_to_hit = jo.get_int( "m_to_hit" );
@@ -1278,7 +1278,7 @@ void it_artifact_armor::deserialize( const JsonObject &jo )
     armor->thickness = jo.get_int( "material_thickness" );
     armor->env_resist = jo.get_int( "env_resist" );
     armor->warmth = jo.get_int( "warmth" );
-    armor->storage = jo.get_int( "storage" ) * units::legacy_volume_factor;
+    assign( jo, "storage", armor->storage, false, 1_ml );
 
     for( const int entry : jo.get_array( "effects_worn" ) ) {
         artifact->effects_worn.push_back( static_cast<art_effect_passive>( entry ) );
@@ -1333,15 +1333,15 @@ void it_artifact_tool::serialize( JsonOut &json ) const
     json.member( "description", description.translated() );
     json.member( "sym", sym );
     json.member( "color", color );
-    json.member( "price", units::to_cent( price ) );
+    json.member( "price", price );
     json.member( "materials" );
     json.start_array();
     for( const material_id &mat : materials ) {
         json.write( mat );
     }
     json.end_array();
-    json.member( "volume", volume / units::legacy_volume_factor );
-    json.member( "weight", to_gram( weight ) );
+    json.member( "volume", volume );
+    json.member( "weight", weight );
 
     json.member( "melee_dam", melee[DT_BASH] );
     json.member( "melee_cut", melee[DT_CUT] );
@@ -1390,15 +1390,15 @@ void it_artifact_armor::serialize( JsonOut &json ) const
     json.member( "description", description.translated() );
     json.member( "sym", sym );
     json.member( "color", color );
-    json.member( "price", units::to_cent( price ) );
+    json.member( "price", price );
     json.member( "materials" );
     json.start_array();
     for( const material_id &mat : materials ) {
         json.write( mat );
     }
     json.end_array();
-    json.member( "volume", volume / units::legacy_volume_factor );
-    json.member( "weight", to_gram( weight ) );
+    json.member( "volume", volume );
+    json.member( "weight", weight );
 
     json.member( "melee_dam", melee[DT_BASH] );
     json.member( "melee_cut", melee[DT_CUT] );
@@ -1419,7 +1419,7 @@ void it_artifact_armor::serialize( JsonOut &json ) const
     json.member( "material_thickness", armor->thickness );
     json.member( "env_resist", armor->env_resist );
     json.member( "warmth", armor->warmth );
-    json.member( "storage", armor->storage / units::legacy_volume_factor );
+    json.member( "storage", armor->storage );
 
     // artifact data
     serialize_enum_vector_as_int( json, "effects_worn", artifact->effects_worn );

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -39,6 +39,22 @@ void energy::serialize( JsonOut &jsout ) const
 }
 
 template<>
+void money::serialize( JsonOut &jsout ) const
+{
+    if( value_ % 100 == 0 ) {
+        jsout.write( string_format( "%d USD", value_ / 100 ) );
+    } else {
+        jsout.write( string_format( "%d cent", value_ / 100 ) );
+    }
+}
+
+template<>
+void money::deserialize( JsonIn &jsin )
+{
+    *this = read_from_json_string<money>( jsin, units::money_units );
+}
+
+template<>
 void energy::deserialize( JsonIn &jsin )
 {
     *this = read_from_json_string( jsin, units::energy_units );


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #9239 
Artifacts were using bespoke logic
Me kill bespoke logic

## Describe the solution (The How)
Praise be to assign
Directly use json.member instead of manually assigning
Add serialize and deserialize for money values

## Describe alternatives you've considered
None

## Testing
Spawned world with artifact before this
Artifact loaded
Saved
Compiled this
Got errors
Saved
Loaded
No errors

## Additional context
~~Honestly I might do a writeup on how we should support defining artifacts like we do here through lua~~

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] If applicable, add checks on game load that would validate the loaded data.
  - [x] If it modifies format of save files, please add migration from the old format.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6293286](https://github.com/cataclysmbn/Cataclysm-BN/commit/629328643f2ff1853c30cbe604c2e08134285328) (fix: artifacts no longer save legacy mass, money and volume values) on 2026-06-02 22:25:57

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26848057300/artifacts/7370754599)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26848057300/artifacts/7371051291)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26848057300/artifacts/7370689979)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26848057300/artifacts/7370675604)
<!-- END artifact comment -->