### PR TITLE
feat(UI): Allows autopickup to use filter by categories, materials, qualities, notes, and skills taught

### DIFF
--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -34,17 +34,17 @@
 
 using namespace auto_pickup;
 
-bool auto_pickup::test_pattern_function(const itype& type, std::string filter) 
+bool auto_pickup::test_pattern_function( const itype &type, std::string filter )
 {
     auto func = filter_from_string<itype>( filter, wildcard_itype_filter );
-    return func(type);
-} 
+    return func( type );
+}
 
-bool auto_pickup::autopickup_item_function(const item& object, std::string filter) 
+bool auto_pickup::autopickup_item_function( const item &object, std::string filter )
 {
-    auto func = filter_from_string<item>( filter, wildcard_item_filter);
-    return func(object);
-} 
+    auto func = filter_from_string<item>( filter, wildcard_item_filter );
+    return func( object );
+}
 
 auto_pickup::player_settings &get_auto_pickup()
 {
@@ -323,7 +323,7 @@ void user_interface::show()
                                         "M:copper        matches items made purely of copper\n"
                                         "q:drilling      matches items with drilling qualites\n"
                                         "k:fabrication   matches books that teach fabrication\n"
-                                        "b:c:food;*meat* matches conditions c:food and *meat*")
+                                        "b:c:food;*meat* matches conditions c:food and *meat*" )
                                   );
 
                     draw_border( w_help );
@@ -653,7 +653,7 @@ void rule_list::refresh_map_items( cache &map_items ) const
             //only re-exclude items from the existing mapping for now
             //new exclusions will process during pickup attempts
             for( auto &map_item : map_items ) {
-                if( !test_pattern_function( *(map_items.temp_items[ map_item.first ]), elem.sRule ) &&
+                if( !test_pattern_function( *( map_items.temp_items[ map_item.first ] ), elem.sRule ) &&
                     !wildcard_match( map_item.first, elem.sRule ) ) {
                     continue;
                 }

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -30,11 +30,21 @@
 #include "type_id.h"
 #include "ui_manager.h"
 #include "world.h"
+#include "item_search.h"
 
 using namespace auto_pickup;
 
-static bool check_special_rule( const std::vector<material_id> &materials,
-                                const std::string &rule );
+bool auto_pickup::test_pattern_function(const itype& type, std::string filter) 
+{
+    auto func = filter_from_string<itype>( filter, wildcard_itype_filter );
+    return func(type);
+} 
+
+bool auto_pickup::autopickup_item_function(const item& object, std::string filter) 
+{
+    auto func = filter_from_string<item>( filter, wildcard_item_filter);
+    return func(object);
+} 
 
 auto_pickup::player_settings &get_auto_pickup()
 {
@@ -287,7 +297,7 @@ void user_interface::show()
                 const auto init_help_window = [&]( ui_adaptor & help_ui ) {
                     const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
                                          TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-                    w_help = catacurses::newwin( FULL_SCREEN_HEIGHT / 2 + 2,
+                    w_help = catacurses::newwin( FULL_SCREEN_HEIGHT * ( 2.0 / 3 ) + 2,
                                                  FULL_SCREEN_WIDTH * 3 / 4,
                                                  iOffset + point( 19 / 2, 7 + FULL_SCREEN_HEIGHT / 2 / 2 ) );
                     help_ui.position_from_window( w_help );
@@ -307,10 +317,13 @@ void user_interface::show()
                                         "*avy fle*fi*arrow     multiple * are allowed\n"
                                         "heAVY*woOD*arrOW      case insensitive search\n"
                                         "\n"
-                                        "Pickup based on item materials:\n"
+                                        "Pickup using:\n"
+                                        "c:food          matches item in category food\n"
                                         "m:kevlar        matches items made of Kevlar\n"
                                         "M:copper        matches items made purely of copper\n"
-                                        "M:steel,iron    multiple materials allowed (OR search)" )
+                                        "q:drilling      matches items with drilling qualites\n"
+                                        "k:fabrication   matches books that teach fabrication\n"
+                                        "b:c:food;*meat* matches conditions c:food and *meat*")
                                   );
 
                     draw_border( w_help );
@@ -423,7 +436,7 @@ void rule::test_pattern() const
     //APU now ignores prefixes, bottled items and suffix combinations still not generated
     for( const itype *e : item_controller->all() ) {
         const std::string sItemName = e->nname( 1 );
-        if( !check_special_rule( e->materials, sRule ) && !wildcard_match( sItemName, sRule ) ) {
+        if( !test_pattern_function( *e, sRule ) && !wildcard_match( sItemName, sRule ) ) {
             continue;
         }
 
@@ -569,38 +582,6 @@ bool player_settings::empty() const
     return global_rules.empty() && character_rules.empty();
 }
 
-bool check_special_rule( const std::vector<material_id> &materials, const std::string &rule )
-{
-    char type = ' ';
-    std::vector<std::string> filter;
-    if( rule[1] == ':' ) {
-        type = rule[0];
-        filter = string_split( rule.substr( 2 ), ',' );
-    }
-
-    if( filter.empty() || materials.empty() ) {
-        return false;
-    }
-
-    if( type == 'm' ) {
-        return std::ranges::any_of( materials, [&filter]( const material_id & mat ) {
-            return std::ranges::any_of( filter, [&mat]( const std::string & search ) {
-                return lcmatch( mat->name(), search );
-            } );
-        } );
-
-    } else if( type == 'M' ) {
-        return std::ranges::all_of( materials, [&filter]( const material_id & mat ) {
-            return std::ranges::any_of( filter, [&mat]( const std::string & search ) {
-                return lcmatch( mat->name(), search );
-            } );
-        } );
-    }
-
-    return false;
-}
-
-//Special case. Required for NPC harvest autopickup. Ignores material rules.
 void npc_settings::create_rule( const std::string &to_match )
 {
     rules.create_rule( map_items, to_match );
@@ -631,7 +612,7 @@ void rule_list::create_rule( cache &map_items, const item &it )
     for( const rule &elem : *this ) {
         if( !elem.bActive ) {
             continue;
-        } else if( !check_special_rule( it.made_of(), elem.sRule ) &&
+        } else if( !autopickup_item_function( it, elem.sRule ) &&
                    !wildcard_match( to_match, elem.sRule ) ) {
             continue;
         }
@@ -661,7 +642,7 @@ void rule_list::refresh_map_items( cache &map_items ) const
             for( const itype *e : item_controller->all() ) {
                 const std::string &cur_item = e->nname( 1 );
 
-                if( !check_special_rule( e->materials, elem.sRule ) && !wildcard_match( cur_item, elem.sRule ) ) {
+                if( !test_pattern_function( *e, elem.sRule ) && !wildcard_match( cur_item, elem.sRule ) ) {
                     continue;
                 }
 
@@ -672,7 +653,7 @@ void rule_list::refresh_map_items( cache &map_items ) const
             //only re-exclude items from the existing mapping for now
             //new exclusions will process during pickup attempts
             for( auto &map_item : map_items ) {
-                if( !check_special_rule( map_items.temp_items[ map_item.first ]->materials, elem.sRule ) &&
+                if( !test_pattern_function( *(map_items.temp_items[ map_item.first ]), elem.sRule ) &&
                     !wildcard_match( map_item.first, elem.sRule ) ) {
                     continue;
                 }

--- a/src/auto_pickup.h
+++ b/src/auto_pickup.h
@@ -15,7 +15,6 @@ struct itype;
 
 namespace auto_pickup
 {
-
 /**
  * The currently-active set of auto-pickup rules, in a form that allows quick
  * lookup. When this is filled (by @ref auto_pickup::create_rule()), every
@@ -39,7 +38,7 @@ class cache : public std::unordered_map<std::string, rule_state>
 class rule
 {
     public:
-        std::string sRule;
+        std::string sRule = "";
         bool bActive = false;
         bool bExclude = false;
 
@@ -155,6 +154,9 @@ class npc_settings : public base_settings
 
         bool empty() const;
 };
+
+bool test_pattern_function( const itype &type, std::string filter );
+bool autopickup_item_function( const item &object, std::string filter );
 
 } // namespace auto_pickup
 

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -12,6 +12,7 @@
 #include "skill.h"
 #include "string_id.h"
 #include "type_id.h"
+#include "string_utils.h"
 
 std::pair<std::string, std::string> get_both( const std::string &a );
 
@@ -88,9 +89,92 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
     }
 }
 
+std::function<bool( const itype & )> basic_itype_filter( std::string filter )
+{
+    size_t colon;
+    char flag = '\0';
+    if( ( colon = filter.find( ':' ) ) != std::string::npos ) {
+        if( colon >= 1 ) {
+            flag = filter[colon - 1];
+            filter = filter.substr( colon + 1 );
+        }
+    }
+    switch( flag ) {
+        // category
+        case 'c':
+            return [filter]( const itype & i ) {
+                return lcmatch( i.category_force->name(), filter );
+            };
+        // material
+        case 'm':
+            return [filter]( const itype & i ) {
+                return std::any_of( i.materials.begin(), i.materials.end(),
+                [&filter]( const material_id & mat ) {
+                    return lcmatch( mat->name(), filter );
+                } );
+            };
+        case 'M':
+            return [filter]( const itype & i ) {
+                bool pure_material = true;
+                for( auto &mat : i.materials ) {
+                    if( !lcmatch( mat->name(), filter ) ) {
+                        pure_material = false;
+                    }
+                }
+                return pure_material;
+            };
+        // qualities
+        case 'q':
+            return [filter]( const itype & i ) {
+                return std::any_of( i.qualities.begin(), i.qualities.end(),
+                [&filter]( const std::pair<quality_id, int> &e ) {
+                    return lcmatch( e.first->name, filter );
+                } );
+            };
+        // both
+        case 'b':
+            return [filter]( const itype & i ) {
+                auto pair = get_both( filter );
+                return itype_filter_from_string( pair.first )( i )
+                       && itype_filter_from_string( pair.second )( i );
+            };
+        // disassembled components
+        // TODO: Move dissambled components into itype so we can implement this
+        // case 'd':
+        //     return [filter]( const item & i ) {
+        //         const auto &components = i.get_uncraft_components();
+        //         for( auto &component : components ) {
+        //             if( lcmatch( component.to_string(), filter ) ) {
+        //                 return true;
+        //             }
+        //         }
+        //         return false;
+        //     };
+        // skill taught
+        case 'k':
+            return [filter]( const itype & i ) {
+                if( i.book != NULL ) {
+                    const islot_book &book = *i.book;
+                    return lcmatch( book.skill->name(), filter );
+                }
+                return false;
+            };
+        // by name
+        default:
+            return [filter]( const itype & a ) {
+                return lcmatch( a.nname( 1 ), filter );
+            };
+    }
+}
+
 std::function<bool( const item & )> item_filter_from_string( const std::string &filter )
 {
     return filter_from_string<item>( filter, basic_item_filter );
+}
+
+std::function<bool( const itype & )> itype_filter_from_string( const std::string &filter )
+{
+    return filter_from_string<itype>( filter, basic_itype_filter );
 }
 
 std::pair<std::string, std::string> get_both( const std::string &a )
@@ -98,4 +182,159 @@ std::pair<std::string, std::string> get_both( const std::string &a )
     size_t split_mark = a.find( ';' );
     return std::make_pair( a.substr( 0, split_mark - 1 ),
                            a.substr( split_mark + 1 ) );
+}
+
+std::function<bool( const item & )> wildcard_item_filter( std::string filter )
+{
+    size_t colon;
+    char flag = '\0';
+    if( ( colon = filter.find( ':' ) ) != std::string::npos ) {
+        if( colon >= 1 ) {
+            flag = filter[colon - 1];
+            filter = filter.substr( colon + 1 );
+        }
+    }
+    switch( flag ) {
+        // category
+        case 'c':
+            return [filter]( const item & i ) {
+                return wildcard_match( i.get_category().name(), filter );
+            };
+        // material
+        case 'm':
+            return [filter]( const item & i ) {
+                return std::any_of( i.made_of().begin(), i.made_of().end(),
+                [&filter]( const material_id & mat ) {
+                    return wildcard_match( mat->name(), filter );
+                } );
+            };
+        // qualities
+        case 'q':
+            return [filter]( const item & i ) {
+                return std::any_of( i.quality_of().begin(), i.quality_of().end(),
+                [&filter]( const std::pair<quality_id, int> &e ) {
+                    return wildcard_match( e.first->name.translated(), filter );
+                } );
+            };
+        // both
+        case 'b':
+            return [filter]( const item & i ) {
+                auto pair = get_both( filter );
+                auto func1 = filter_from_string<item>( pair.first, wildcard_item_filter );
+                auto func2 = filter_from_string<item>( pair.second, wildcard_item_filter );
+
+                return func1( i ) && func2( i );
+            };
+        // disassembled components
+        case 'd':
+            return [filter]( const item & i ) {
+                const auto &components = i.get_uncraft_components();
+                for( auto &component : components ) {
+                    if( wildcard_match( component.to_string(), filter ) ) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+        // item notes
+        case 'n':
+            return [filter]( const item & i ) {
+                const std::string note = i.get_var( "item_note" );
+                return !note.empty() && wildcard_match( note, filter );
+            };
+        // skill taught
+        case 'k':
+            return [filter]( const item & i ) {
+                if( i.is_book() ) {
+                    const islot_book &book = *i.type->book;
+                    return wildcard_match( book.skill->name(), filter );
+                }
+                return false;
+            };
+        // by name
+        default:
+            return [filter]( const item & a ) {
+                return wildcard_match( a.tname(), filter );
+            };
+    }
+}
+
+std::function<bool( const itype & )> wildcard_itype_filter( std::string filter )
+{
+    size_t colon;
+    char flag = '\0';
+    if( ( colon = filter.find( ':' ) ) != std::string::npos ) {
+        if( colon >= 1 ) {
+            flag = filter[colon - 1];
+            filter = filter.substr( colon + 1 );
+        }
+    }
+    switch( flag ) {
+        // category
+        case 'c':
+            return [filter]( const itype & i ) {
+                return wildcard_match( i.category_force->name(), filter );
+            };
+        // material
+        case 'm':
+            return [filter]( const itype & i ) {
+                return std::any_of( i.materials.begin(), i.materials.end(),
+                [&filter]( const material_id & mat ) {
+                    return wildcard_match( mat->name(), filter );
+                } );
+            };
+        case 'M':
+            return [filter]( const itype & i ) {
+                bool pure_material = true;
+                for( auto &mat : i.materials ) {
+                    if( !wildcard_match( mat->name(), filter ) ) {
+                        pure_material = false;
+                    }
+                }
+                return pure_material;
+            };
+        // qualities
+        case 'q':
+            return [filter]( const itype & i ) {
+                return std::any_of( i.qualities.begin(), i.qualities.end(),
+                [&filter]( const std::pair<quality_id, int> &e ) {
+                    return wildcard_match( e.first->name.translated(), filter );
+                } );
+            };
+        // both
+        case 'b':
+            return [filter]( const itype & i ) {
+                auto pair = get_both( filter );
+                auto func1 = filter_from_string<itype>( pair.first, wildcard_itype_filter );
+                auto func2 = filter_from_string<itype>( pair.second, wildcard_itype_filter );
+
+                return func1( i ) && func2( i );
+            };
+        // disassembled components
+        // TODO: Move dissambled components into itype so we can implement this
+        // case 'd':
+        //     return [filter]( const item & i ) {
+        //         const auto &components = i.get_uncraft_components();
+        //         for( auto &component : components ) {
+        //             if( lcmatch( component.to_string(), filter ) ) {
+        //                 return true;
+        //             }
+        //         }
+        //         return false;
+        //     };
+        // skill taught
+        case 'k':
+            return [filter]( const itype & i ) {
+                if( i.book != NULL ) {
+                    const islot_book &book = *i.book;
+                    return wildcard_match( book.skill->name(), filter );
+                }
+                return false;
+            };
+        // by name
+        default:
+            return [filter]( const itype & a ) {
+                return wildcard_match( a.nname( 1 ), filter );
+            };
+    }
 }

--- a/src/item_search.h
+++ b/src/item_search.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "string_utils.h"
+#include "itype.h"
 
 /**
  * Get a function that returns true if the value matches the query.
@@ -88,10 +89,18 @@ class item;
  * Get a function that returns true if the item matches the query.
  */
 std::function<bool( const item & )> item_filter_from_string( const std::string &filter );
-
+/**
+ * @brief Get a function that returns true if the itype matches the query.
+ */
+std::function<bool( const itype & )> itype_filter_from_string( const std::string &filter );
 /**
  * Get a function that returns true if the value matches the basic query (no commas or minuses).
  */
 std::function<bool( const item & )> basic_item_filter( std::string filter );
+/**
+ * Similar to basic_item_filter, but for item type instead
+ */
+std::function<bool( const itype & )> basic_itype_filter( std::string filter );
 
-
+std::function<bool( const item & )> wildcard_item_filter( std::string filter );
+std::function<bool( const itype & )> wildcard_itype_filter( std::string filter );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Implements #9158 without crashing game hopefully.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Replaced the previous check_special_rule function that filtered by materials with a new function that can check more properties of the item.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
I considered using a cache of itype_id to rule_states like in #9158, but I realized this would make it impossible to achieve constant time autopickup of fake items like "clean water (plastic bottle" which the system previously could do because it wasn't really mapping items to rule_states, but just names to rule_states. This system also makes it impossible to fix the bug #9234, but I want categories so spaghetti is is.
## Testing
Loaded world, set "c:workshop tools" and picked up pocket knife item from that category successfully.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
<img width="1919" height="1079" alt="Screenshot 2026-06-02 105733" src="https://github.com/user-attachments/assets/0b76fa78-3147-40a4-92a3-289cea3606f8" />
Also the reviewer should test this, but it shouldn't break like the issues from #9213 because the code is largely the same, I just replaced one function instead of actually trying to swap to an itype_id map.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d934043](https://github.com/cataclysmbn/Cataclysm-BN/commit/d93404378f06bc54693f6b85733ef00469498a3c) (style(autofix.ci): automated formatting) on 2026-06-03 00:20:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26852238653/artifacts/7372793047)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26852238653/artifacts/7372505417)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26852238653/artifacts/7372262574)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26852238653/artifacts/7372314556)
<!-- END artifact comment -->