### PR TITLE
fix(UI): align compass panel widths with their sidebar layouts

### DIFF
--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -2443,7 +2443,7 @@ static std::vector<window_panel> initialize_default_compact_panels()
     ret.emplace_back( draw_messages_classic, translate_marker( "Log" ), -2, 32, true );
     ret.emplace_back( draw_compass, translate_marker( "Compass" ), 8, 32, true );
     ret.emplace_back( draw_compass, translate_marker( "Comp.Compass" ), 3, 32, false );
-    ret.emplace_back( draw_simple_compass, translate_marker( "Sim.Compass" ), 1, 44, false );
+    ret.emplace_back( draw_simple_compass, translate_marker( "Sim.Compass" ), 1, 32, false );
 #if defined(TILES)
     ret.emplace_back( draw_mminimap, translate_marker( "Map" ), -1, 32, true,
                       default_render, true );
@@ -2479,7 +2479,7 @@ static std::vector<window_panel> initialize_default_label_narrow_panels()
                       true );
     ret.emplace_back( draw_compass_padding, translate_marker( "Comp.Compass" ), 3, 32,
                       false );
-    ret.emplace_back( draw_simple_compass, translate_marker( "Sim.Compass" ), 1, 44, false );
+    ret.emplace_back( draw_simple_compass, translate_marker( "Sim.Compass" ), 1, 32, false );
 #if defined(TILES)
     ret.emplace_back( draw_mminimap, translate_marker( "Map" ), -1, 32, true,
                       default_render, true );
@@ -2514,7 +2514,7 @@ static std::vector<window_panel> initialize_default_label_panels()
     ret.emplace_back( draw_armor_comp, translate_marker( "comp.Armor" ), 1, 32, false );
     ret.emplace_back( draw_compass_padding, translate_marker( "Compass" ), 8, 44,
                       true );
-    ret.emplace_back( draw_compass_padding, translate_marker( "Comp.Compass" ), 3, 32,
+    ret.emplace_back( draw_compass_padding, translate_marker( "Comp.Compass" ), 3, 44,
                       false );
     ret.emplace_back( draw_simple_compass, translate_marker( "Sim.Compass" ), 1, 44, false );
 #if defined(TILES)


### PR DESCRIPTION
  ## Purpose of change (The Why)

  The simple/compact compass sidebar panels had hardcoded widths that didn't match the sidebar layout they live in. - closes #7712  

  ## Describe the solution (The How)

- Changed the simple compass width from 44 to 32 for compact panels and compact labels
- Changed the compact compass width in the default labels panel from 32 to 44 to resolve label bleed



 ## Describe alternatives you've considered

I don't really see any realistic alternatives with the way panels.cpp is structured. This is a minor width change.


  ## Testing

Load up the new build artifacts and verify that simple compass no longer extends outside the panels for compact panels and compact labels, also verify that default labels panel no longer has label bleed for compact compass

I have loaded up the build artifacts as well as my local linux build. The Windows and Linux versions I confirmed that they launched without error and that the expected changes are there. 


**Before:**
<img width="2549" height="1440" alt="{691C684F-E936-47B8-954F-7BD1522628DB}" src="https://github.com/user-attachments/assets/0743338b-c09e-414f-9705-60b470abf420" />
<img width="2560" height="1440" alt="{A987D48D-7BC2-4002-919E-866ED6185919}" src="https://github.com/user-attachments/assets/b184c9eb-599e-4e00-bb30-493083907902" />
<img width="2559" height="1440" alt="{AC2D62D9-B385-4E55-B49D-B3ABB24D9B64}" src="https://github.com/user-attachments/assets/8e384b71-3e80-4d47-994f-26d570eb1753" />

**After:**
<img width="3840" height="2160" alt="{B44998A2-07F7-4AE7-84C9-A96120E3EF41}" src="https://github.com/user-attachments/assets/13fe751a-f0b5-4f81-9029-5f10a50de554" />
<img width="3834" height="2160" alt="{0BFB3EF0-AD75-4284-8D18-6211D14629CB}" src="https://github.com/user-attachments/assets/de8913b8-94b9-4048-ba81-e02db2d94af6" />
<img width="3840" height="2160" alt="{44121579-6B00-4C9E-AF99-9DA3EC07C720}" src="https://github.com/user-attachments/assets/f259b110-b932-4f7d-b194-d3085d6c7c5b" />




  ## Additional context

No other related issues or PRs found with `gh search issues/prs "compass panel width"`.

  ## Checklist

  ### Mandatory

  - [x] I wrote the PR title in conventional commit format.
  - [x] I ran the code formatter.
  - [x] I linked any relevant issues using github keyword syntax like `closes #1234`.

  ### Optional

  - [x] This PR used AI assistance.
    - [x] I added an `Assisted-by:` trailer to every AI-assisted commit in the Linux kernel format.
  - To be honest, I just used Claude to help me find where this was in the codebase, but I am leaving this disclaimer here and in the commit.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c5fcbbf](https://github.com/cataclysmbn/Cataclysm-BN/commit/c5fcbbf196f0003a9ed7f4166d89d9b78b0b27bc) (fix: align compass panel widths with their sidebar layouts) on 2026-06-03 00:47:43

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26852966950/artifacts/7373165473)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26852966950/artifacts/7372887297)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26852966950/artifacts/7372829337)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26852966950/artifacts/7373015652)
<!-- END artifact comment -->