### PR TITLE
feat(balance): set TCL holdouts to a different faction so attacking them doesn't aggro the old guard doc

### DIFF
--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -670,5 +670,29 @@
       "marloss": { "kill on sight": true }
     },
     "description": "A small group of churchgoers that formed a community in the woods.  They welcome anyone in their faction, but hate the unnatural."
+  },
+  {
+    "type": "faction",
+    "id": "tcl_holdouts",
+    "name": "TCL Personnel",
+    "likes_u": 0,
+    "respects_u": 0,
+    "known_by_u": false,
+    "size": 5,
+    "power": 5,
+    "food_supply": 10000,
+    "wealth": 10000,
+    "relations": {
+      "old_guard": {
+        "kill on sight": false,
+        "watch your back": true,
+        "share my stuff": true,
+        "guard your stuff": true,
+        "lets you in": true,
+        "defends your space": true,
+        "knows your voice": true
+      }
+    },
+    "description": "A small handful of survivors who have taken shelter in the research facility they used to work at."
   }
 ]

--- a/data/json/npcs/refugee_center/surface_staff/NPC_labguard1_docmission.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_labguard1_docmission.json
@@ -8,7 +8,7 @@
     "attitude": 0,
     "mission": 8,
     "chat": "TALK_LABGUARD1_DOCMISSION",
-    "faction": "old_guard"
+    "faction": "tcl_holdouts"
   },
   {
     "id": [ "TALK_LABGUARD1_DOCMISSION" ],

--- a/data/json/npcs/refugee_center/surface_staff/NPC_labguard2_docmission.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_labguard2_docmission.json
@@ -8,7 +8,7 @@
     "attitude": 0,
     "mission": 8,
     "chat": "TALK_LABGUARD2_DOCMISSION",
-    "faction": "old_guard"
+    "faction": "tcl_holdouts"
   },
   {
     "id": [ "TALK_LABGUARD2_DOCMISSION" ],

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -220,7 +220,7 @@
     "start": {
       "assign_mission_target": { "om_terrain": "underground_lab_cargo_stationA_sub_station", "reveal_radius": 1, "search_range": 1000, "z": -4 },
       "update_mapgen": {
-        "faction_owner": [ { "id": "old_guard", "x": [ 5, 21 ], "y": [ 3, 17 ] } ],
+        "faction_owner": [ { "id": "tcl_holdouts", "x": [ 5, 21 ], "y": [ 3, 17 ] } ],
         "rows": [
           "                        ",
           "                        ",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_scientist_docmission.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_scientist_docmission.json
@@ -8,7 +8,7 @@
     "attitude": 0,
     "mission": 3,
     "chat": "TALK_TCLSCIENTIST_DOCMISSION",
-    "faction": "old_guard"
+    "faction": "tcl_holdouts"
   },
   {
     "id": [ "TALK_TCLSCIENTIST_DOCMISSION" ],

--- a/data/json/npcs/refugee_center/surface_staff/NPC_scientistquestgiver_docmission.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_scientistquestgiver_docmission.json
@@ -8,7 +8,7 @@
     "attitude": 0,
     "mission": 3,
     "chat": "TALK_TCLHSCIENTIST_DOCMISSION",
-    "faction": "old_guard",
+    "faction": "tcl_holdouts",
     "mission_offered": "MISSION_TCL_CLEANUP_1"
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/9215

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Set a new faction for the TCL holdouts to use, so resolving the old guard doc's mission with violence doesn't piss him off.
2. Updated faction ownership of stuff spawned in the holdout.

## Describe alternatives you've considered

Not accepting cold-blooded murder as one of the valid solutions to this mission.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Load-tested in compiled test build.
2. Debugged old guard doc to add the logistics mission early.
3. Triggered it and warped to mission location.
4. Talked to one of the guards before shooting one to death.
5. Checked factions menu. TCL holdouts hate me, old guard doesn't.
6. Warped back to the refugee center, the old guard isn't hostile.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
