### PR TITLE
feat(balance): add option to scale animal reproduction and growth

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -151,6 +151,11 @@ enum {
     UPGRADE_MAX_ITERS = 5
 };
 
+static int scaled_animal_days( const int days )
+{
+    return std::max( 1, static_cast<int>( std::ceil( days * calendar::season_ratio() ) ) );
+}
+
 static const std::map<creature_size, translation> size_names {
     { creature_size::tiny, to_translation( "size adj", "tiny" ) },
     { creature_size::small, to_translation( "size adj", "small" ) },
@@ -426,7 +431,10 @@ void monster::allow_upgrade()
 int monster::next_upgrade_time()
 {
     if( type->age_grow > 0 ) {
-        return type->age_grow;
+        const int scaled_grow_days = type->has_flag( MF_ANIMAL ) &&
+                                     get_option<bool>( "ANIMAL_LIFE_CYCLE_SEASON_SCALING" ) ?
+                                     scaled_animal_days( type->age_grow ) : type->age_grow;
+        return scaled_grow_days;
     }
     const int scaled_half_life = type->half_life * get_option<float>( "MONSTER_UPGRADE_FACTOR" );
     int day = 1; // 1 day of guaranteed evolve time
@@ -520,10 +528,16 @@ void monster::try_reproduce()
     if( !type->baby_timer ) {
         return;
     }
+    const int base_days = to_days<int>( *type->baby_timer );
+    const int scaled_days = type->has_flag( MF_ANIMAL ) &&
+                            get_option<bool>( "ANIMAL_LIFE_CYCLE_SEASON_SCALING" ) ?
+                            scaled_animal_days( base_days ) :
+                            base_days;
+    const time_duration repro_interval = time_duration::from_days( scaled_days );
 
     if( !baby_timer ) {
         // Assume this is a freshly spawned monster (because baby_timer is not set yet), set the point when it reproduce to somewhere in the future.
-        baby_timer.emplace( calendar::turn + *type->baby_timer );
+        baby_timer.emplace( calendar::turn + repro_interval );
     }
 
     bool season_spawn = false;
@@ -561,7 +575,7 @@ void monster::try_reproduce()
         if( ( season_match && female && one_in( chance ) ) ) {
             reproduce();
         }
-        *baby_timer += *type->baby_timer;
+        *baby_timer += repro_interval;
     }
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -429,11 +429,11 @@ int monster::next_upgrade_time()
         const int scaling = get_option<int>( "ANIMAL_LIFE_CYCLE_SCALING" );
         if( type->has_flag( MF_ANIMAL ) && scaling == 0 ) {
             return std::max( 1, static_cast<int>( std::ceil( type->age_grow *
-                                      calendar::season_ratio() ) ) );
+                                                  calendar::season_ratio() ) ) );
         }
         if( type->has_flag( MF_ANIMAL ) ) {
             return std::max( 1, static_cast<int>( std::ceil( type->age_grow * scaling /
-                                      100.0 ) ) );
+                                                  100.0 ) ) );
         }
         return type->age_grow;
     }
@@ -534,11 +534,11 @@ void monster::try_reproduce()
     if( type->has_flag( MF_ANIMAL ) && scaling == 0 ) {
         baby_timer_scaling = time_duration::from_days( std::max( 1,
                              static_cast<int>( std::ceil( to_days<int>( *type->baby_timer ) *
-                                                calendar::season_ratio() ) ) ) );
+                                               calendar::season_ratio() ) ) ) );
     } else if( type->has_flag( MF_ANIMAL ) ) {
         baby_timer_scaling = time_duration::from_days( std::max( 1,
                              static_cast<int>( std::ceil( to_days<int>( *type->baby_timer ) *
-                                                scaling / 100.0 ) ) ) );
+                                               scaling / 100.0 ) ) ) );
     }
 
     if( !baby_timer ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -520,10 +520,13 @@ void monster::try_reproduce()
     if( !type->baby_timer ) {
         return;
     }
+    const int base_days = to_days<int>( *type->baby_timer );
+    const int scaled_days = std::max( 1, static_cast<int>( std::ceil( base_days * calendar::season_ratio() ) ) );
+    const time_duration repro_interval = time_duration::from_days( scaled_days );
 
     if( !baby_timer ) {
         // Assume this is a freshly spawned monster (because baby_timer is not set yet), set the point when it reproduce to somewhere in the future.
-        baby_timer.emplace( calendar::turn + *type->baby_timer );
+        baby_timer.emplace( calendar::turn + repro_interval );
     }
 
     bool season_spawn = false;
@@ -561,7 +564,7 @@ void monster::try_reproduce()
         if( ( season_match && female && one_in( chance ) ) ) {
             reproduce();
         }
-        *baby_timer += *type->baby_timer;
+        *baby_timer += repro_interval;
     }
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -521,7 +521,8 @@ void monster::try_reproduce()
         return;
     }
     const int base_days = to_days<int>( *type->baby_timer );
-    const int scaled_days = std::max( 1, static_cast<int>( std::ceil( base_days * calendar::season_ratio() ) ) );
+    const int scaled_days = std::max( 1,
+                                      static_cast<int>( std::ceil( base_days * calendar::season_ratio() ) ) );
     const time_duration repro_interval = time_duration::from_days( scaled_days );
 
     if( !baby_timer ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2902,6 +2902,12 @@ void options_manager::add_options_world_default()
          translate_marker( "When reaching the maximum half lives, instead of never evolving they will evolve at that time." ),
          false );
 
+    add( "ANIMAL_LIFE_CYCLE_SEASON_SCALING", world_default,
+         translate_marker( "Animal life cycle season scaling" ),
+         translate_marker( "If true, animal reproduction and growth timers are multiplied by "
+                           "the current season length ratio." ),
+         true );
+
     add_empty_line();
 
     add( "RESTOCK_DELAY_MULT", world_default, translate_marker( "Merchant restock scaling factor" ),


### PR DESCRIPTION
## Purpose of change (The Why)

Addresses the animal reproduction and growth timer parts of #4411.

Monster reproduction and animal age-based growth timers can use fixed JSON day values regardless of the world's configured season length. This means the same animal life cycle values can produce different pacing depending on whether the player uses shorter or longer seasons.

This PR adds a world option to scale animal reproduction and growth timers, so animal life cycle timing can remain proportional to the configured seasonal timescale.

## Describe the solution (The How)

Adds an `ANIMAL_LIFE_CYCLE_SCALING` world option.

This option follows the existing crop growth scaling style:
- `0` automatically scales animal reproduction and growth timers by `calendar::season_ratio()`.
- Percentage values scale animal reproduction and growth timers directly.
- Non-animal monster growth and evolution behavior is unchanged.

Updates `monster::try_reproduce()` to use the scaled animal reproduction interval when scheduling future reproduction.

Updates `monster::next_upgrade_time()` so age-based animal growth timers can use the same scaling option.

Renames the crop option display text from `Growth scaling percentage` to `Crop growth scaling percentage` so it is clearer next to the new animal option.

## Describe alternatives you've considered

I considered keeping this as a simple season-length multiplier, but maintainers requested making the behavior configurable like construction and farming scaling.

I also considered using a boolean option, but matching crop growth scaling gives players the same percentage-based control and keeps the world option behavior consistent.

## Testing

Built `cataclysm-bn-tiles` locally with MSYS2 UCRT64.

The build completed successfully after applying the local `vehicle.cpp` GCC 16 workaround needed for my compiler environment.

No runtime testing performed.

## Additional context

This PR keeps the JSON data unchanged and applies scaling at the point where animal reproduction and age-based growth timers are scheduled.

The local `vehicle.cpp` compiler workaround used for testing is not included in this PR.

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [ ] I ran the code formatter.
- [x] I linked relevant issues using github keyword syntax like addresses #1234.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit in the Linux kernel format.
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e02b1d9](https://github.com/cataclysmbn/Cataclysm-BN/commit/e02b1d9032faa913616048543b44647a94f73d51) (style(autofix.ci): automated formatting) on 2026-06-04 09:44:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26941064306/artifacts/7407122800)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26941064306/artifacts/7407903270)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26941064306/artifacts/7407087722)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26941064306/artifacts/7407446630)
<!-- END artifact comment -->