### PR TITLE
fix(i18n): remove sound debug strings from translations

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -338,7 +338,7 @@ static short svol_at( const sound_instance_cache &sound_inst, const tripoint_bub
                                     vertical_escape_vol > sound_inst.base_distance_vol_by_dir[san_dir] ) ? ( (
                                                 sound_inst.origin.z() <= tri.z() ) ? SDI_UP : SDI_DOWN ) : san_dir;
         add_msg( m_debug,
-                 _( "Error in sounds::svol:at(). Sound [ %1s ] from %i:%i:%i with origin volume of %i dB, has impossible escape vol in %i direction of %i mdB." ),
+                 "Error in sounds::svol:at(). Sound [ %1s ] from %i:%i:%i with origin volume of %i dB, has impossible escape vol in %i direction of %i mdB.",
                  sound_inst.sound.description, sound_inst.sound.origin.x(), sound_inst.sound.origin.y(),
                  sound_inst.sound.origin.z(), sound_inst.sound.volume, actualdir, vol_escape );
     }
@@ -351,7 +351,7 @@ static short svol_at( const sound_instance_cache &sound_inst, const tripoint_bub
     if( zadj < 0 || zadj > MAXIMUM_VOLUME_ATMOSPHERE || cumulative_dist_loss < 0 ||
         cumulative_dist_loss > MAXIMUM_VOLUME_ATMOSPHERE ) {
         add_msg( m_debug,
-                 _( "Error in sounds::svol:at(). Calced Escape Vol of %i mdB, Calced vol_z_adjust of %i mdB, Calced cumulative distance loss of %i mdB across %i tiles from heard sound [ %1s ] at %i:%i:%i to heard location %i:%i:%i" ),
+                 "Error in sounds::svol:at(). Calced Escape Vol of %i mdB, Calced vol_z_adjust of %i mdB, Calced cumulative distance loss of %i mdB across %i tiles from heard sound [ %1s ] at %i:%i:%i to heard location %i:%i:%i",
                  vol_escape, zadj, cumulative_dist_loss, distance, sound_inst.sound.description,
                  sound_inst.sound.origin.x(), sound_inst.sound.origin.y(),
                  sound_inst.sound.origin.z(), tri.x(), tri.y(), tri.z() );
@@ -363,7 +363,7 @@ static short svol_at( const sound_instance_cache &sound_inst, const tripoint_bub
                                     vertical_escape_vol > sound_inst.base_distance_vol_by_dir[san_dir] ) ? ( (
                                                 sound_inst.origin.z() <= tri.z() ) ? SDI_UP : SDI_DOWN ) : san_dir;
         add_msg( m_debug,
-                 _( "Error in sounds::svol:at(). Sound [ %1s ] from %i:%i:%i with origin volume of %i dB, has impossible heard vol in %i direction of %i mdB at a distance of %i manhattan.xt" ),
+                 "Error in sounds::svol:at(). Sound [ %1s ] from %i:%i:%i with origin volume of %i dB, has impossible heard vol in %i direction of %i mdB at a distance of %i manhattan.xt",
                  sound_inst.sound.description, sound_inst.sound.origin.x(), sound_inst.sound.origin.y(),
                  sound_inst.sound.origin.z(), sound_inst.sound.volume, actualdir, heard_volume, distance );
     }
@@ -865,7 +865,7 @@ void map::flood_fill_sound( const sound_event soundevent, const int zlev )
 
         // The sound cache should be built out by now.
         // Add our new sound cache to the games sound_caches vector.
-        // add_msg(m_debug, _("Attempting to add sound_cache with origin %i x: %i y: %i z and source volume %i to sound_caches vector ."), temp_sound_cache.sound.origin.x, temp_sound_cache.sound.origin.y, temp_sound_cache.sound.origin.z, temp_sound_cache.sound.volume );
+        // add_msg(m_debug, "Attempting to add sound_cache with origin %i x: %i y: %i z and source volume %i to sound_caches vector .", temp_sound_cache.sound.origin.x, temp_sound_cache.sound.origin.y, temp_sound_cache.sound.origin.z, temp_sound_cache.sound.volume );
         m_sound_cache.sound_instances.push_back( temp_sound_cache );
     }
 
@@ -1242,9 +1242,9 @@ void map::batch_flood_fill_sounds()
 
                 // The sound cache should be built out by now.
                 // Add our new sound cache to the games sound_caches vector.
-                // add_msg(m_debug, _("Attempting to add sound_cache with origin %i x: %i y: %i z and source volume %i to sound_caches vector ."), temp_sound_cache.sound.origin.x, temp_sound_cache.sound.origin.y, temp_sound_cache.sound.origin.z, temp_sound_cache.sound.volume );
+                // add_msg(m_debug, "Attempting to add sound_cache with origin %i x: %i y: %i z and source volume %i to sound_caches vector .", temp_sound_cache.sound.origin.x, temp_sound_cache.sound.origin.y, temp_sound_cache.sound.origin.z, temp_sound_cache.sound.volume );
                 m_sound_cache.sound_instances.push_back( temp_sound_cache );
-                // add_msg(m_debug, _("Sound cache added to vector"));
+                // add_msg(m_debug, "Sound cache added to vector");
                 if( temp_sound_cache.from_monster ) {
                     num_processed_mon_sounds++;
                 } else if( temp_sound_cache.from_npc ) {
@@ -1859,10 +1859,10 @@ void sounds::sound( const sound_event &soundevent )
         map.m_sound_cache.sounds_this_turn++;
     } else {
         add_msg( m_debug,
-                 _( "Maximum number of attempted floodfills in a turn reached!" ) );
+                 "Maximum number of attempted floodfills in a turn reached!" );
         map.m_sound_cache.sounds_this_turn = 0;
         add_msg( m_debug,
-                 _( "Sound instances vector contained %i sounds before emergency flush." ),
+                 "Sound instances vector contained %i sounds before emergency flush.",
                  map.m_sound_cache.sound_instances.size() );
         map.m_sound_cache.sound_instances.clear();
 
@@ -1884,7 +1884,7 @@ void sounds::sound( const sound_event &soundevent )
     if( temp_se.volume < 16 ) {
 
         add_msg( m_debug,
-                 _( "Sound with description [ %1s ] at %i:%i with a volume %i too quiet for propagation." ),
+                 "Sound with description [ %1s ] at %i:%i with a volume %i too quiet for propagation.",
                  temp_se.description, temp_se.origin.x(), temp_se.origin.y(),
                  temp_se.volume );
 
@@ -1899,7 +1899,7 @@ void sounds::sound( const sound_event &soundevent )
     //}
     else if( temp_se.volume > mdBspl_to_dBspl( MAXIMUM_VOLUME_ATMOSPHERE ) ) {
         add_msg( m_debug,
-                 _( "Sound with description [ %1s ] at %i:%i attempted to propagate with a volume of %i dB which is louder than possible in atmosphere!" ),
+                 "Sound with description [ %1s ] at %i:%i attempted to propagate with a volume of %i dB which is louder than possible in atmosphere!",
                  temp_se.description, temp_se.origin.x(), temp_se.origin.y(),
                  temp_se.volume );
     }
@@ -2025,7 +2025,7 @@ static int get_signal_for_hordes( const sound_event centr, const short ambient_v
         sig_power = std::max( sig_power, min_sig_cap );
         //Capping extremely high signal to hordes
         sig_power = std::min( sig_power, max_sig_cap );
-        add_msg( m_debug, _( "vol %i  vol_hordes %i sig_power %i " ), centr.volume, vol, sig_power );
+        add_msg( m_debug, "vol %i  vol_hordes %i sig_power %i ", centr.volume, vol, sig_power );
         return sig_power;
     }
 }
@@ -2195,7 +2195,7 @@ void sounds::process_sounds()
         // We should have a fancy new filtered list by now. If we still dont, skip this monster because something funky happened.
         if( !filtered_sounds.contains( filter_key ) ) {
             add_msg( m_debug,
-                     _( "Monster %1s at %i:%i:%i attempted to make a filtered sound list but could not find it after generation!" ),
+                     "Monster %1s at %i:%i:%i attempted to make a filtered sound list but could not find it after generation!",
                      critter.disp_name(), critterloc.x(), critterloc.y(), critterloc.z() );
             continue;
         }
@@ -2639,7 +2639,7 @@ void sounds::process_sound_markers( Character *who )
         if( element.sound.volume >= mdBspl_to_dBspl( MAXIMUM_VOLUME_ATMOSPHERE ) ) {
             // Dont count impossibly loud sounds.
             add_msg( m_debug,
-                     _( "Player given sound louder than possible in Atmosphere! Sound with description [ %1s ] from %i:%i:%i with an origin volume of %i dB is louder than possible." ),
+                     "Player given sound louder than possible in Atmosphere! Sound with description [ %1s ] from %i:%i:%i with an origin volume of %i dB is louder than possible.",
                      element.sound.description, element.sound.origin.x(), element.sound.origin.y(),
                      element.sound.origin.z(),
                      element.sound.volume );
@@ -2841,16 +2841,16 @@ void sounds::process_sound_markers( Character *who )
     // We can make a copy of the much smaller sound event rather than the whole sound instance, and just record bits of relevant info.
     // We want these so we can figure out if anything is wrong with hearing sounds / terrain interaction.
     add_msg( m_debug,
-             _( "Avatar sound processing diagnostic: Checked:%i, Within minvol distance:%i, Within flood envelope:%i, Ambient Vol:%i mdB, Vol Threshold:%i mdB" ),
+             "Avatar sound processing diagnostic: Checked:%i, Within minvol distance:%i, Within flood envelope:%i, Ambient Vol:%i mdB, Vol Threshold:%i mdB",
              num_sounds_checked, num_sounds_in_minvol_dist, num_sound_in_envelope, ambient_vol, vol_threshold );
     if( loudest_vol > 0 ) {
         add_msg( m_debug,
-                 _( "Loudest Sound: Description:[%1s], Origin vol:%i dB at [%i:%i:%i], Minvol distance:%i, Floodfill radius:%i" ),
+                 "Loudest Sound: Description:[%1s], Origin vol:%i dB at [%i:%i:%i], Minvol distance:%i, Floodfill radius:%i",
                  loudest_sound_dummy.description, loudest_sound_dummy.volume, loudest_sound_dummy.origin.x(),
                  loudest_sound_dummy.origin.y(), loudest_sound_dummy.origin.z(), loudest_sound_minvol_radius,
                  loudest_sound_flood_radius );
         add_msg( m_debug,
-                 _( "Heard vol:%i mdB at [%i:%i:%i], Distance:%i, SDI from sound to Avatar:%i, with envelope escape vol in that SDI:%i mdB" ),
+                 "Heard vol:%i mdB at [%i:%i:%i], Distance:%i, SDI from sound to Avatar:%i, with envelope escape vol in that SDI:%i mdB",
                  loudest_vol, loc.x(), loc.y(), loc.z(), rl_dist( loc, loudest_sound_dummy.origin ),
                  loudest_sound_escape_dir, loudest_sound_escape_vol );
     }
@@ -2912,20 +2912,20 @@ void sounds::clear_floodfill_que( const bool &soundperf )
 
     if( !soundperf ) {
         add_msg( m_debug,
-                 _( "Attempted to floodfill %i total sounds. Flooding attempted on %i deafening, %i movement, %i from NPCs, %i from monsters, %i non-batch floods." ),
+                 "Attempted to floodfill %i total sounds. Flooding attempted on %i deafening, %i movement, %i from NPCs, %i from monsters, %i non-batch floods.",
                  map.m_sound_cache.sounds_this_turn, map.m_sound_cache.attempted_potential_deafening_sounds,
                  map.m_sound_cache.attempted_movement_sounds, map.m_sound_cache.attempted_NPC_sounds,
                  map.m_sound_cache.attempted_monster_sounds, map.m_sound_cache.attempted_non_batch_floodfills );
         add_msg( m_debug,
-                 _( "Batch flooded %i sounds from monsters and %i sounds from NPCs. %i sounds invalidated during batch flooding." ),
+                 "Batch flooded %i sounds from monsters and %i sounds from NPCs. %i sounds invalidated during batch flooding.",
                  map.m_sound_cache.batch_flooded_monster_sounds, map.m_sound_cache.batch_flooded_NPC_sounds,
                  map.m_sound_cache.invalidated_batch_sounds );
         add_msg( m_debug,
-                 _( "Caught %i sounds still in floodfill que. Cleared %i sound filter lists out of %i sound filter lists made." ),
+                 "Caught %i sounds still in floodfill que. Cleared %i sound filter lists out of %i sound filter lists made.",
                  sound_batch_floodfill_que.size(),
                  map.m_sound_cache.filtered_sound_lists_cleared, map.m_sound_cache.filtered_sound_lists_made );
         add_msg( m_debug,
-                 _( "Culled %i sounds this turn. Sounds vector size %i end of turn. Prior turn sound vector size %i" ),
+                 "Culled %i sounds this turn. Sounds vector size %i end of turn. Prior turn sound vector size %i",
                  map.m_sound_cache.sounds_culled_this_turn, sound_batch_floodfill_que.size(),
                  map.m_sound_cache.filtered_sound_lists_cleared, map.m_sound_cache.filtered_sound_lists_made );
     }


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #8205: debug-only messages in `src/sounds.cpp` were marked for gettext extraction and could appear in translation syncs. No related issue found via `gh search issues`.

## Describe the solution (The How)

Removed `_()` from `m_debug` diagnostics and commented debug snippets in `src/sounds.cpp`. Player-facing sound messages remain localizable.

## Describe alternatives you've considered

Leaving the strings for translators was rejected because they are diagnostics, not player-facing text.

## Testing

- `cmake --build --preset linux-full --target format` — `src/sounds.cpp` unchanged by formatter.
- `/usr/bin/xgettext ... src/sounds.cpp src/sounds.h` — sound debug diagnostics absent from the extracted POT; player-facing sound strings still present.
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles -- -j1` — build passed.
- `./out/build/linux-full/tests/cata_test-tiles '[sound]'` — 2 test cases passed.

## Additional context

Related PRs found by search: #8205, #7028.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked relevant PRs; no issue to close was found.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f2d9b54](https://github.com/cataclysmbn/Cataclysm-BN/commit/f2d9b5483c931528599a3d656d9e87b0518f4ea9) (fix(i18n): remove sound debug strings from translations) on 2026-06-03 11:35:00

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26879144286/artifacts/7382300535)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26879144286/artifacts/7383069879)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26879144286/artifacts/7382327674)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26879144286/artifacts/7382608960)
<!-- END artifact comment -->