### PR TITLE
fix(UI): prevent item action menu hotkeys falsely denying usable items

### DIFF
--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -4,6 +4,7 @@
 #include <iterator>
 #include <list>
 #include <memory>
+#include <optional>
 #include <set>
 #include <tuple>
 #include <unordered_set>
@@ -50,28 +51,6 @@ static char key_bound_to( const input_context &ctxt, const item_action_id &act )
     auto keys = ctxt.keys_bound_to( act );
     return keys.empty() ? '\0' : keys[0];
 }
-
-class actmenu_cb : public uilist_callback
-{
-    private:
-        const action_map am;
-    public:
-        actmenu_cb( const action_map &acm ) : am( acm ) { }
-        ~actmenu_cb() override = default;
-
-        bool key( const input_context &ctxt, const input_event &event, int /*idx*/,
-                  uilist * /*menu*/ ) override {
-            const std::string &action = ctxt.input_to_action( event );
-            // Don't write a message if unknown command was sent
-            // Only when an inexistent tool was selected
-            const auto itemless_action = am.find( action );
-            if( itemless_action != am.end() ) {
-                popup( _( "You do not have an item that can perform this action." ) );
-                return true;
-            }
-            return false;
-        }
-};
 
 item_action_generator::item_action_generator() = default;
 
@@ -255,12 +234,15 @@ void game::item_action_menu()
     kmenu.text = _( "Execute which action?" );
     kmenu.input_category = "ITEM_ACTIONS";
     input_context ctxt( "ITEM_ACTIONS" );
+    // Register every action in both contexts so rows show their bound hotkeys and
+    // the in-menu keybinding overlay can still list/rebind them. A pressed key
+    // resolves to its registered action rather than the row hotkey, so the
+    // post-query loop dispatches those by action id via UILIST_ADDITIONAL.
     for( const auto &id : item_actions ) {
         ctxt.register_action( id.first, id.second.name );
         kmenu.additional_actions.emplace_back( id.first, id.second.name );
     }
-    actmenu_cb callback( item_actions );
-    kmenu.callback = &callback;
+    kmenu.allow_additional = true;
     int num = 0;
 
     const auto assigned_action = [&iactions]( const item_action_id & action ) {
@@ -326,15 +308,27 @@ void game::item_action_menu()
         num++;
     }
 
-    kmenu.query();
-    if( kmenu.ret < 0 || kmenu.ret >= static_cast<int>( iactions.size() ) ) {
+    std::optional<item_action_id> action;
+    do {
+        kmenu.query();
+        if( kmenu.ret >= 0 && kmenu.ret < static_cast<int>( iactions.size() ) ) {
+            action = std::get<0>( menu_items[kmenu.ret] );
+        } else if( kmenu.ret == UILIST_ADDITIONAL ) {
+            if( assigned_action( kmenu.ret_act ) ) {
+                action = kmenu.ret_act;
+            } else {
+                popup( _( "You do not have an item that can perform this action." ) );
+            }
+        }
+    } while( kmenu.ret == UILIST_ADDITIONAL && !action );
+
+    if( !action ) {
         return;
     }
 
-    const item_action_id action = std::get<0>( menu_items[kmenu.ret] );
-    item *it = iactions[action];
+    item *it = iactions[*action];
 
-    u.invoke_item( it, action );
+    u.invoke_item( it, *action );
 
     u.inv_restack( );
     u.inv_unsort();


### PR DESCRIPTION
## Purpose of change (The Why)

closes #5247 

Pressing a bound hotkey in the `%` / Shift+5 item-action quick menu if you pressed f for Start a Fire quickly you would get the message *"You do not have an item that can perform this action."* every time you used the hotkey, this applied for any other action within the item-action quick menu such as sewing.

The issue was being caused by the item action menu treating the same key in two different ways. For example if the player went to start a fire with f after opening the item action menu they would expect that they would be able to quickly start a fire, however in the code f was also being bound to a special action called firestarter. So when the player pressed f the game would treat that as the player wants the firestarter action key and would trigger the fallback path and display the You do not have an item that can perform this action message as the game code is assuming the player doesn't have the item down that path.

## Describe the solution (The How)
  - Keep every item-action registered in both the input context and the menu's
    `additional_actions` (unchanged from before): rows keep showing their bound keys and
    the in-menu `?` keybinding overlay still lists them.
  - Set `allow_additional` on the menu and drop the old `actmenu_cb` callback entirely.
    A pressed action key now comes back from `uilist::query()` as `UILIST_ADDITIONAL`
    with `ret_act` naming the action — the same uilist mechanism `editmap.cpp` already uses.
  - A post-query loop dispatches it: if some carried item can perform the action it is
    invoked directly, otherwise the "You do not have an item…" popup shows and the menu
    re-opens.
  - Net −6 lines vs main: the false denial is gone, and an available action whose row is
    hidden by an active list filter now executes instead of being denied.

## Describe alternatives you've considered

- De-registration (implemented first, then replaced): register only the
  *unavailable* actions as the menu's additional actions, so an available action's key is no
  longer recognized as a command and falls through to uilist's normal row-hotkey (ANY_INPUT)
  path. This has the side effect of hiding any available actions from the ? key bindings menu in the item actions menu
- Callback routing (second iteration, also replaced): keep an action→row map and have the
  menu callback select the action's row from inside the key handler. Worked, but it
  re-implemented what uilist's `allow_additional` / `UILIST_ADDITIONAL` mechanism already
  provides, copied two maps every time the menu opened, and silently swallowed the hotkey
  when an active filter hid the action's row.

## Testing

The following Tests have been done to ensure no issues

- Builds clean (curses `cata_test` + tiles, gcc and clang). Full curses suite passes
- Final implementation re-verified by manual testing in the Linux tiles build: f lights a fire; f without a firestarter shows the denial popup and the menu stays open afterwards; arrows+Enter unchanged; `?` overlay unchanged
- Manual Testing in the Tiles Windows Build shows that the fix works as expected (re-verified on the final implementation using the CI artifact built from this PR's squashed commit; menu hotkeys, navigation, and every key combination tried behaved as expected)
- Wield a lighter (f) + carry a sewing kit with thread (s). % > / > type sew > Enter (hides firestarter) → press f. The fire action now executes even while its row is filtered out (on main this was a false denial; in the earlier iteration it was a silent no-op).
- Testing the fix. Lighter usable, % > f > prompted for Light Where?. And % > f with no firestarter > correct denial popup.
- Bionic pseudo-items. Active Integrated Toolset (bio_tools): % shows interleaved toolset actions; press w (repair_metal) on a damaged metal item > routes correctly. However, In testing this exposed an already existing bug with bionic toolsets where debug messages will fire. "Attempted to resolve invalid safe reference" and "Lost tool for used long repair". I verified that this existed outside of my PR by testing with the 5/31 nightly build and the 6/4 nightly build. The behavior is in both those builds.
- Depleted tool. Firestarter with 0 charges > % > f > correct denial (no false-select/wrong-invoke).
- Pseudo unusable. Toolset present but power-drained > w > correct denial.
- Rapid double-f > second keypress lands in the sub-prompt, not a closed menu; no double-invoke/crash.
- The ? Keybindings menu does show a lot of repetition in keybinding types IE. Drink, Activate, Eat, Lightup. This behavior is present in the 06-05 nightly build that doesn't contain this PR.
- Opened as many menus and used as many commands as I could think of, no difference in experience between this PR and 06-05 nightly.
- Reviewer note: this input path can't be covered headlessly, `uilist::query()` bails in `test_mode`. 

## Additional context

- Note to the reviewer: I have checked everything I can think of to make sure these changes are safe, I don't think i've missed anything and i've checked both windows and linux builds. 

## Checklist

### Mandatory

- [x] PR title in conventional commit format.
- [x] Ran the code formatter (astyle).
- [x] Linked relevant issues

### Optional

- [x] This PR used AI assistance.
  - [x] Added an `Assisted-by:` trailer to the commit (Linux-kernel format).
