### PR TITLE
build: avoid GCC 16 vehicle hash ICE

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5814,11 +5814,9 @@ void traverse( StartPoint &start,
     using tvr = traverse_visitor_result;
     constexpr bool IsConst = std::is_const_v<StartPoint>;
     struct hash {
-        const std::hash<char> char_hash = std::hash<char>();
-        const std::hash<size_t> ptr_hash = std::hash<size_t>();
         auto operator()( const vehicle_or_grid<IsConst> &elem ) const {
-            return char_hash( static_cast<char>( elem.type ) ) ^
-                   ptr_hash(
+            return std::hash<char>{}( static_cast<char>( elem.type ) ) ^
+                   std::hash<size_t>{}(
                        // Because only one of pointers is not nullptr, binary OR would get value of set pointer.
                        reinterpret_cast<size_t>( elem.veh ) | reinterpret_cast<size_t>( elem.grid )
                    );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5815,8 +5815,8 @@ void traverse( StartPoint &start,
     constexpr bool IsConst = std::is_const_v<StartPoint>;
     struct hash {
         auto operator()( const vehicle_or_grid<IsConst> &elem ) const {
-            return std::hash<char>{}( static_cast<char>( elem.type ) ) ^
-                   std::hash<size_t>{}(
+            return std::hash<char> {}( static_cast<char>( elem.type ) ) ^
+                   std::hash<size_t> {}(
                        // Because only one of pointers is not nullptr, binary OR would get value of set pointer.
                        reinterpret_cast<size_t>( elem.veh ) | reinterpret_cast<size_t>( elem.grid )
                    );


### PR DESCRIPTION
## Purpose of change (The Why)

Avoids an MSYS2 UCRT64 GCC 16.1.0 internal compiler error while compiling
`src/vehicle.cpp`, in `distribution_graph::traverse`.

## Describe the solution (The How)

Make the local `unordered_set` hash functor stateless. The hash result is
unchanged; `std::hash` is constructed at the call site instead of stored as
`const` members.

## Describe alternatives you've considered

Leaving the code unchanged would keep MSYS2 UCRT64 GCC 16.1.0 unable to build
this translation unit locally. This change keeps the behavior the same and only
adjusts the hash functor shape.

## Testing

- Built `cataclysm-bn-tiles` locally with MSYS2 UCRT64 GCC 16.1.0.

## Additional context

This was found while doing a local Windows/MSYS2 UCRT64 build.

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [ ] I ran the code formatter.
- [ ] I linked any relevant issues using github keyword syntax like `closes #1234` in Summary of the PR so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit in the Linux kernel format.
- [x] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [x] If documentation for this feature or process does not exist, please write it.
  - [x] If the change alters versions of software required to build or work with the game, please document it.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ea89bd8](https://github.com/cataclysmbn/Cataclysm-BN/commit/ea89bd877b7cd14c09583a6a7358a866d979486f) (style(autofix.ci): automated formatting) on 2026-06-04 13:12:54

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26953068514/artifacts/7412103823)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26953068514)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26953068514)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26953068514)
<!-- END artifact comment -->