### PR TITLE
fix: bodytemp from clothing no longer has sharp reductions

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6306,8 +6306,17 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
 
         // Because we don't actually model insulation very well at the moment, clothes are oppressive in Summer
         // So we make them half as effective at making you uncomfortably hot as they are at making you not-cold
-        if( bp_conv >= BODYTEMP_HOT ) {
-            bp_conv -= clothing_warmth_adjustment / 2;
+        if( bp_conv >= BODYTEMP_NORM ) {
+            int bp_without_clothes = bp_conv - clothing_warmth_adjustment;
+            if( bp_without_clothes >= BODYTEMP_NORM ) {
+                // If the heat is above normal, clothes start to contribute less
+                bp_conv -= clothing_warmth_adjustment / 2;
+            } else {
+                // Do the same to any clothing that contributes to above normal
+                int clothes_to_norm = BODYTEMP_NORM - bp_without_clothes;
+                bp_conv -= ( clothing_warmth_adjustment - clothes_to_norm ) / 2;
+
+            }
         }
 
         // FINAL CALCULATION : Increments current body temperature towards convergent.


### PR DESCRIPTION
## Purpose of change (The Why)
Fixes issue caused by: #8259
Behold the following graphics from before the change in an ice lab ( floor -5 to be exact )
<img width="1920" height="1080" alt="Jun03::163513" src="https://github.com/user-attachments/assets/fee10142-0f07-4bb3-8148-869207cf4053" />
<img width="1920" height="1080" alt="Jun03::163518" src="https://github.com/user-attachments/assets/a6ebaba9-b985-4e00-b966-3dbfa1a2fbe3" />

I think it is fairly self explanitory
I turned on more things and I got COLDER

## Describe the solution (The How)
Previous math: `bp_conv -= clothing_warmth_adjustment / 2;`
This means in places like ice labs where I have hundreds of warmth from clothing there will be a sharp drop when reaching BODYTEMP_WARM
Now any temperature above gained from clothing BODYTEMP_NORM is halfed.

## Describe alternatives you've considered
Screm

## Testing
<img width="1920" height="1080" alt="Jun03::163934" src="https://github.com/user-attachments/assets/dab87ca7-2f1a-4bc5-b836-aec3cf710b83" />
<img width="1920" height="1080" alt="Jun03::163939" src="https://github.com/user-attachments/assets/576218e2-1ed6-4c60-95d5-33dacf3a46aa" />
<img width="1920" height="1080" alt="Jun03::163948" src="https://github.com/user-attachments/assets/825e84f6-5f94-48a9-aa9e-5ddc418f6ad8" />

Smooth temperature shifts afterwards

## Additional Context
I really should have ran the tests beforehand but I'll just hope

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3c1e033](https://github.com/cataclysmbn/Cataclysm-BN/commit/3c1e0336bbc5f74ab05172cadc491283db1446ac) (fix: bodytemp from clothing no longer has sharp reductions) on 2026-06-04 00:50:04

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26920323311/artifacts/7399549159)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26920323311/artifacts/7400097931)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26920323311/artifacts/7399520186)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26920323311/artifacts/7399755034)
<!-- END artifact comment -->