### PR TITLE
fix: guard sound cache bounds

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -457,7 +457,15 @@ void map::cull_heard_sounds()
 // Fear nothing but the consequences of your own poor decisions.
 void map::flood_fill_sound( const sound_event soundevent, const int zlev )
 {
+    if( !inbounds_z( zlev ) ) {
+        return;
+    }
+
     const auto &map_cache = get_cache( zlev );
+    if( !map_cache.inbounds( soundevent.origin.xy() ) ) {
+        return;
+    }
+
     const auto &absorption_cache = map_cache.absorption_cache;
     const auto &outside_cache = map_cache.outside_cache;
     const auto &wall_present = map_cache.sound_wall_cache;
@@ -940,6 +948,9 @@ void map::batch_flood_fill_sounds()
                 // We still floodfill these sounds out later, just when we get to the right z-level.
                 continue;
             } else if( flooded_sound.volume < 7 ) {
+                num_invalidated_sounds++;
+                continue;
+            } else if( !map_cache.inbounds( flooded_sound.origin.xy() ) ) {
                 num_invalidated_sounds++;
                 continue;
             } else {
@@ -2164,6 +2175,14 @@ void sounds::process_sounds()
     // Monsters just go to the loudest thing they hear, so we run through that here.
     // Monsters ignore movement sounds from their own faction, a bit omiscient but it simplifies things.
     for( monster &critter : g->all_monsters() ) {
+        const auto &critterloc = critter.bub_pos();
+        if( !critter.is_simulated() || !map.inbounds( critterloc ) ) {
+            continue;
+        }
+        const auto &level_cache = map.get_cache_ref( critterloc.z() );
+        if( !level_cache.inbounds( critterloc.xy() ) ) {
+            continue;
+        }
 
         // Monster is deaf, skip. We also skip hallucinations.
         if( !critter.can_hear() || critter.is_hallucination() ) {
@@ -2185,8 +2204,6 @@ void sounds::process_sounds()
         const bool player_ally = critter.friendly != 0;
         filter_key.horde_monster = !player_ally && !fears_enemy_sounds && filter_key.noise_angers;
         const auto &horde_monster = filter_key.horde_monster;
-
-        const auto &critterloc = critter.bub_pos();
 
         // Check to see if there is a matching filtered list, or if our list list empty.
         if( !filtered_sounds.contains( filter_key ) || filtered_sounds.empty() ) {
@@ -2224,7 +2241,6 @@ void sounds::process_sounds()
         const short critter_vol_threshold = std::max( ( critter_ambient_vol -
                                             ( goodhearing ? 2000 : 1000 ) ), 1000 );
 
-        const auto &level_cache = map.get_cache_ref( critterloc.z() );
         const short critter_t_absorb = level_cache.absorption_cache[level_cache.idx( critterloc.x(),
                                                         critterloc.y() )];
         const bool critter_indoors = !level_cache.outside_cache[level_cache.idx( critterloc.x(),

--- a/tests/sound_mechanics_test.cpp
+++ b/tests/sound_mechanics_test.cpp
@@ -2,10 +2,15 @@
 
 #include <array>
 #include <cstdint>
+#include <string>
 #include <unordered_set>
 
+#include "debug.h"
 #include "map.h"
+#include "map_helpers.h"
+#include "monster.h"
 #include "sounds.h"
+#include "state_helpers.h"
 
 namespace
 {
@@ -60,4 +65,58 @@ TEST_CASE( "sound_filter_key_distinguishes_noise_fear", "[sound]" )
     filter_keys.insert( fears_noise );
 
     CHECK( filter_keys.size() == 2 );
+}
+
+TEST_CASE( "flood_fill_sound_skips_out_of_cache_origins", "[sound][cache]" )
+{
+    clear_all_state();
+    auto &here = get_map();
+    const auto &level_cache = here.get_cache_ref( 0 );
+    const auto invalid_origin = tripoint_bub_ms( -1, 60, 0 );
+    auto out_of_cache_sound = sound_event{
+        .volume = 80,
+        .origin = invalid_origin,
+        .category = sounds::sound_t::alarm,
+        .description = "out of cache regression sound"
+    };
+
+    REQUIRE_FALSE( level_cache.inbounds( invalid_origin.xy() ) );
+
+    const auto debug_msg = capture_debugmsg_during( [&]() {
+        here.flood_fill_sound( out_of_cache_sound, invalid_origin.z() );
+    } );
+
+    CHECK( debug_msg.empty() );
+    CHECK( here.m_sound_cache.sound_instances.empty() );
+}
+
+TEST_CASE( "process_sounds_skips_out_of_cache_monsters", "[sound][cache]" )
+{
+    clear_all_state();
+    auto &here = get_map();
+    const auto &level_cache = here.get_cache_ref( 0 );
+    auto source_sound = sound_event{
+        .volume = 80,
+        .origin = tripoint_bub_ms( 60, 60, 0 ),
+        .category = sounds::sound_t::alarm,
+        .description = "monster cache regression sound"
+    };
+    auto cache = sound_instance_cache( source_sound, get_flood_dist_enum( source_sound.volume ),
+                                       get_flood_radius_by_enum( get_flood_dist_enum( source_sound.volume ) ) );
+    cache.terrain_sound_absorbtion_at_source = level_cache.absorption_cache[level_cache.idx(
+                source_sound.origin.x(), source_sound.origin.y() )];
+    here.m_sound_cache.sound_instances.push_back( cache );
+
+    auto &critter = spawn_test_monster( "mon_zombie", tripoint_bub_ms( 60, 61, 0 ) );
+    const auto invalid_critter_pos = tripoint_bub_ms( level_cache.cache_x, 60, 0 );
+    critter.setpos( invalid_critter_pos );
+
+    REQUIRE_FALSE( level_cache.inbounds( invalid_critter_pos.xy() ) );
+
+    const auto debug_msg = capture_debugmsg_during( [&]() {
+        sounds::process_sounds();
+    } );
+
+    CHECK( debug_msg.empty() );
+    CHECK( here.m_sound_cache.sound_instances.front().heard_by_monsters );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9256

Sound caches could be indexed with out-of-cache coordinates after the sound overhaul, producing crashes/debug spam such as impossible escape volume messages. This also covers the sound-related duplicate context reported under #9249 without closing the original mapgen crash report there.

## Describe the solution (The How)

- Skip direct flood-fill sound origins that are outside the level cache before indexing cache vectors.
- Invalidate batched sound origins that are outside the active level cache before flood filling.
- Skip monsters that are not simulated or not safe to index into the level cache before sound AI processing.

## Describe alternatives you've considered

Broader sound propagation changes were avoided; valid in-cache sound propagation is unchanged.

## Testing

- `cmake --build --preset linux-full --target cata_test-tiles`
- Red before fix: `./out/build/linux-full/tests/cata_test-tiles "flood_fill_sound_skips_out_of_cache_origins,process_sounds_skips_out_of_cache_monsters"` failed because `flood_fill_sound_skips_out_of_cache_origins` added a cache for an out-of-cache origin.
- After fix: `./out/build/linux-full/tests/cata_test-tiles "flood_fill_sound_skips_out_of_cache_origins,process_sounds_skips_out_of_cache_monsters"` passed, 7 assertions in 2 test cases.
- `cmake --build out/build/linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`

## Additional context

Related search found #9256 and #9249; no matching open PRs were found for sound cache bounds / impossible escape volume.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [36ad54b](https://github.com/cataclysmbn/Cataclysm-BN/commit/36ad54b7f46b63d862f5ba6057c1a0060418de5f) (fix: guard sound cache bounds) on 2026-06-04 02:04:13

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26923266265/artifacts/7400559231)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26923266265/artifacts/7401097510)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26923266265/artifacts/7400579025)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26923266265/artifacts/7400769204)
<!-- END artifact comment -->