### PR TITLE
fix: avoid vehicle z shift during submap rotation

### DIFF
--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -28,6 +28,7 @@
 #include "options_helpers.h"
 #include "overmapbuffer.h"
 #include "state_helpers.h"
+#include "submap.h"
 #include "type_id.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
@@ -568,6 +569,39 @@ static void test_coord_translate( units::angle dir, const tripoint_mnt_veh &pivo
     tdir.advance( p.x() - pivot.x() );
     q.x() = tdir.dx() + tdir.ortho_dx( p.y() - pivot.y() );
     q.y() = tdir.dy() + tdir.ortho_dy( p.y() - pivot.y() );
+}
+
+TEST_CASE( "rotating_submap_with_vehicle_on_ramp_does_not_shift_vehicle_z",
+           "[vehicle][submap][mapgen][9249]" )
+{
+    clear_all_state();
+
+    auto &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+
+    const auto vehicle_origin = tripoint_bub_ms( SEEX * 2 + 1, SEEY * 2 + 1, 0 );
+    const auto projected_vehicle_origin = project_remain<coords::sm>( bub_to_abs( vehicle_origin ) );
+    auto rotated_vehicle = std::make_unique<vehicle>( vproto_id( "shopping_cart" ), 0, 0 );
+    rotated_vehicle->abs_sm_pos = projected_vehicle_origin.quotient_tripoint;
+    rotated_vehicle->sm_ms_pos = projected_vehicle_origin.remainder;
+    rotated_vehicle->attach();
+
+    const auto expected_position = rotated_vehicle->sm_ms_pos.rotate( 1, { SEEX, SEEY } );
+    const auto rotated_origin = abs_to_bub( project_combine( rotated_vehicle->abs_sm_pos,
+                                            expected_position ) );
+    here.ter_set( rotated_origin, ter_id( "t_ramp_up_high" ) );
+    here.invalidate_map_cache( rotated_origin.z() );
+    here.build_map_cache( rotated_origin.z(), true );
+    auto generated_submap = submap( rotated_vehicle->abs_sm_pos, here.get_bound_dimension() );
+    generated_submap.vehicles.push_back( std::move( rotated_vehicle ) );
+
+    const auto debug_msg = capture_debugmsg_during( [&]() { generated_submap.rotate( 1 ); } );
+
+    INFO( debug_msg );
+    CHECK( debug_msg.empty() );
+    REQUIRE( !generated_submap.vehicles.empty() );
+    CHECK( generated_submap.vehicles.front()->sm_ms_pos == expected_position );
+    CHECK( generated_submap.vehicles.front()->turn_dir == 90_degrees );
 }
 
 TEST_CASE( "check_vehicle_rotation_against_old", "[.]" )


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9249

Rotating mapgen submaps can rotate vehicles before `map::rotate()` updates each vehicle's absolute submap position. Vehicles on ramp terrain could try to shift z-levels during that raw submap rotation and touch the wrong/missing source submap.

Related search: issue #9249 found; no matching open PRs found.

## Describe the solution (The How)

Allow vehicle facing refresh to update part positions and ramp offsets without moving the vehicle between z-level submaps. Use that mode from `submap::rotate()` so raw submap rotation keeps the rotated vehicle state but defers z-level ownership movement.

## Describe alternatives you've considered

Suppressing vehicle rotation during mapgen was not used because vehicles still need rotated facing and positions.

## Testing

- `astyle --options=.astylerc src/vehicle.h src/vehicle.cpp src/submap.cpp tests/vehicle_test.cpp`
- Red before fix: `./out/build/linux-full/tests/cata_test-tiles "rotating_submap_with_vehicle_on_ramp_does_not_shift_vehicle_z"` failed with `shift_vehicle [Shopping Cart] failed could not find vehicle`.
- After fix: `./out/build/linux-full/tests/cata_test-tiles "rotating_submap_with_vehicle_on_ramp_does_not_shift_vehicle_z"` passed.
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles` passed.

## Additional context

None.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [be3d1cb](https://github.com/cataclysmbn/Cataclysm-BN/commit/be3d1cb06e2bac078112d2b80c7137f00a88a9f1) (test: cover rotated vehicle mapgen crash) on 2026-06-26 14:24:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28239162868/artifacts/7906991442)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28239162868)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28239162868/artifacts/7906993745)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28239162868/artifacts/7906775962)
<!-- END artifact comment -->