### PR TITLE
fix: dirty transparancy cache when field decays within reality bubble

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5460,7 +5460,7 @@ void game::world_tick()
                 auto has_fire = false;
                 if( sm_ptr->field_count > 0 ) {
                     ZoneScopedN( "wtd_process_fields" );
-                    has_fire = process_fields_in_submap( *sm_ptr, pos_sm, mb );
+                    has_fire = process_fields_in_submap( dim, *sm_ptr, pos_sm, mb );
                 }
                 sm_ptr->last_touched = calendar::turn;
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1763,8 +1763,8 @@ auto process_fields_in_submap( const std::string &dim, submap &sm,
                 ++it;
             }
 
-            if( in_bubble && dirty_transparency_cache ) {                
-                map.set_transparency_cache_dirty( abs_to_bub( project_to<coords::ms>( pos ) )  );
+            if( in_bubble && dirty_transparency_cache ) {
+                map.set_transparency_cache_dirty( abs_to_bub( project_to<coords::ms>( pos ) ) );
                 map.set_seen_cache_dirty( abs_to_bub( project_to<coords::ms>( pos ) ) );
             }
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1103,7 +1103,7 @@ static const std::array<point, 8> eight_dirs_sm = {{
     }
 };
 
-auto process_fields_in_submap( submap &sm,
+auto process_fields_in_submap( const std::string &dim, submap &sm,
                                const tripoint_abs_sm &pos,
                                mapbuffer &mb ) -> bool
 {
@@ -1112,8 +1112,10 @@ auto process_fields_in_submap( submap &sm,
         return false;
     }
 
-    auto has_fire = false;
+    map &map = get_map();
+    const auto in_bubble = submap_loader.is_properly_requested( dim, pos );
 
+    auto has_fire = false;
     // Snapshot before iterating: wandering-field spread can push_back to sm.field_cache
     // within the same submap (line ~1742), which would invalidate the range iterators.
     // Newly-added entries are newborn (age 0) and skip all effects anyway, so processing
@@ -1122,6 +1124,8 @@ auto process_fields_in_submap( submap &sm,
     std::ranges::for_each( field_positions, [&]( const point_sm_ms & local ) {
         auto &curfield = sm.get_field( local );
 
+        bool dirty_transparency_cache = false;
+
         if( !curfield.displayed_field_type() ) {
             return;
         }
@@ -1129,14 +1133,19 @@ auto process_fields_in_submap( submap &sm,
         for( auto it = curfield.begin(); it != curfield.end(); ) {
             auto &cur = it->second;
 
+            auto cur_fd_type_id = cur.get_field_type();
+
             // Dead entries — clean up.
             if( !cur.is_field_alive() ) {
                 --sm.field_count;
+                if( !cur_fd_type_id->get_transparent( cur.get_field_intensity() - 1 ) ) {
+                    dirty_transparency_cache = true;
+                }
                 curfield.remove_field( it++ );
                 continue;
             }
 
-            auto cur_fd_type_id = cur.get_field_type();
+            dirty_transparency_cache |= cur_fd_type_id->dirty_transparency_cache;
 
             // Track fire before the newborn suppression below.
             if( cur_fd_type_id.obj().has_fire ) {
@@ -1753,6 +1762,12 @@ auto process_fields_in_submap( submap &sm,
             } else {
                 ++it;
             }
+
+            if( in_bubble && dirty_transparency_cache ) {                
+                map.set_transparency_cache_dirty( abs_to_bub( project_to<coords::ms>( pos ) )  );
+                map.set_seen_cache_dirty( abs_to_bub( project_to<coords::ms>( pos ) ) );
+            }
+
         } // end field-entry loop
     } );
 

--- a/src/submap_fields.h
+++ b/src/submap_fields.h
@@ -34,7 +34,7 @@ void create_burnproducts( std::vector<detached_ptr<item>> &out, const item &fuel
  * Known omissions (render-context-dependent):
  *   • Vehicle fire damage      (TODO: requires coordinate translation).
  *   • NPC complaints / scent   (player-centric, handled by creature_in_field).
- *   • Transparency cache flush (handled on next in-bubble load).
+ *   • Transparency cache flush (handled on next in-bubble load, unless already within bubble).
  *   • Monster spawning         (TODO: deferred to submap spawn system).
  *   • Fungal haze spreading    (TODO: requires fungal_effects with map context).
  *   • Item detonation in fire  (TODO: explosion creation needs map).
@@ -42,6 +42,6 @@ void create_burnproducts( std::vector<detached_ptr<item>> &out, const item &fuel
  * @return  true if any fire field remains alive after processing.
  *          world_tick() uses this to request adjacent submap loading.
  */
-auto process_fields_in_submap( submap &sm,
+auto process_fields_in_submap( const std::string &dim, submap &sm,
                                const tripoint_abs_sm &pos,
                                mapbuffer &mb ) -> bool;

--- a/tests/simulation_test.cpp
+++ b/tests/simulation_test.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 
+#include "avatar.h"
 #include "cached_options.h"
 #include "cata_utility.h"
 #include "coordinates.h"
@@ -62,7 +63,8 @@ TEST_CASE( "fire_processes_in_loaded_submap_outside_bubble", "[simulation][field
     plant_fire( *sm, fire_pt );
     REQUIRE( sm->get_field( fire_pt ).find_field( fd_fire ) != nullptr );
 
-    process_fields_in_submap( *sm, FAR_SM_POS, MAPBUFFER );
+    auto &dummy = get_avatar();
+    process_fields_in_submap( dummy.get_dimension(), *sm, FAR_SM_POS, MAPBUFFER );
 
     const auto *fire = sm->get_field( fire_pt ).find_field( fd_fire );
     REQUIRE( fire != nullptr );
@@ -145,7 +147,7 @@ TEST_CASE( "fire_isolated_between_dimensions", "[simulation][field][dimension]" 
     }
 
     // Process only the secondary dimension.
-    process_fields_in_submap( *dim_sm, FAR_SM_POS, dim );
+    process_fields_in_submap( TEST_DIM_ID, *dim_sm, FAR_SM_POS, dim );
 
     // Fire in the secondary dimension must have aged (processing occurred).
     const auto *dim_fire = dim_sm->get_field( fire_pt ).find_field( fd_fire );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Currently, if a thick smoke field is spawned, it will update the transparancy cache to block vision
However, when this thick smoke field decays into regular smoke, it will still be opaque
even when the smoke field dissipates and the tile no longer has a field on it, the tile will remain opaque until something else updates the transparancy cache

this applies to every opaque field

which is both not great and really goddamn annoying

process_fields_in_submap used to dirty the cache in this instance but that was removed in the map data overhaul pr
the reason for removal is presumably related to fire submap related shenanigans? as process_fields_in_submap can now be called on submaps outside of the reality bubble to process fire spread and the likes, and we probably dont care about the transparancy cache for submaps outside of the reality bubble

however we do still need to care about dirtying transparency for submaps within the reality bubble, otherwise we get this issue

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

process_fields_in_submap now dirties the transparancy cache, but only if the submap in question is within the reality bubble

## Testing

Fired a raufoss round in a field, passed a few turns and observed the tiles with thick smoke on them now actually turn transparent when they become regular smoke

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a570d95](https://github.com/cataclysmbn/Cataclysm-BN/commit/a570d9514f4e045287890d740cbd9c5589ddf9cf) (style(autofix.ci): automated formatting) on 2026-06-04 05:11:30

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26929931652/artifacts/7402934701)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26929931652/artifacts/7403349821)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26929931652/artifacts/7402923525)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26929931652/artifacts/7403039459)
<!-- END artifact comment -->