### PR TITLE
test(mods): check default mods by default

### DIFF
--- a/docs/en/dev/reference/cli_options.md
+++ b/docs/en/dev/reference/cli_options.md
@@ -41,6 +41,10 @@ Checks the BN json files.
 
 Checks the json files belonging to default or specified BN mods.
 
+### `--check-all-mods`
+
+Checks the json files belonging to all non-obsolete BN mods.
+
 ### `--dump-stats <what> [mode = TSV] [opts…]`
 
 Dumps item stats.

--- a/docs/en/dev/reference/cli_options.md
+++ b/docs/en/dev/reference/cli_options.md
@@ -39,7 +39,7 @@ Checks the BN json files.
 
 ### `--check-mods [mods…]`
 
-Checks the json files belonging to BN mods.
+Checks the json files belonging to default or specified BN mods.
 
 ### `--dump-stats <what> [mode = TSV] [opts…]`
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1030,15 +1030,13 @@ bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opt
         to_check.emplace( id );
     }
 
-    // If no specific mods specified check all non-obsolete mods
+    // If no specific mods specified check mods enabled for newly created worlds.
     if( to_check.empty() ) {
-        for( const mod_id &mod : world_generator->get_mod_manager().all_mods() ) {
-            if( !mod->obsolete ) {
-                to_check.emplace( mod );
-            }
+        for( const mod_id &mod : world_generator->get_mod_manager().get_default_mods() ) {
+            to_check.emplace( mod );
         }
     }
-    // If no mods are available then test core data only
+    // If no default mods are available then test core data only
     if( to_check.empty() ) {
         to_check.emplace( mod_management::get_default_core_content_pack() );
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1006,7 +1006,8 @@ void init::load_world_modfiles( loading_ui &ui, const world *world,
     load_and_finalize_packs( ui, _( "Loading files" ), mods );
 }
 
-bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opts )
+auto init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opts,
+                                  const check_mods_mode mode ) -> bool
 {
     const dependency_tree &tree = world_generator->get_mod_manager().get_tree();
 
@@ -1030,13 +1031,20 @@ bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opt
         to_check.emplace( id );
     }
 
-    // If no specific mods specified check mods enabled for newly created worlds.
     if( to_check.empty() ) {
-        for( const mod_id &mod : world_generator->get_mod_manager().get_default_mods() ) {
-            to_check.emplace( mod );
+        if( mode == check_mods_mode::all_mods ) {
+            for( const mod_id &mod : world_generator->get_mod_manager().all_mods() ) {
+                if( !mod->obsolete ) {
+                    to_check.emplace( mod );
+                }
+            }
+        } else {
+            for( const mod_id &mod : world_generator->get_mod_manager().get_default_mods() ) {
+                to_check.emplace( mod );
+            }
         }
     }
-    // If no default mods are available then test core data only
+    // If no mode-selected mods are available then test core data only
     if( to_check.empty() ) {
         to_check.emplace( mod_management::get_default_core_content_pack() );
     }

--- a/src/init.h
+++ b/src/init.h
@@ -208,15 +208,22 @@ void load_world_modfiles( loading_ui &ui, const world *world, const std::string 
  */
 void load_soundpack_files( const std::string &soundpack_path );
 
+enum class check_mods_mode {
+    default_mods,
+    all_mods,
+};
+
 /**
  * Check mods for errors.
  *
  * Does so by individually loading & finalizing each mod with all its dependencies.
  * @param ui structure for load progress display
- * @param opts check specific mods (or all if empty)
+ * @param opts check specific mods (or mode-selected mods if empty)
+ * @param mode which mods to check when opts is empty
  * @return whether all mods were successfully loaded and had no errors
  */
-bool check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opts );
+auto check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opts,
+                            check_mods_mode mode ) -> bool;
 
 } // namespace init
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -265,7 +265,7 @@ int main( int argc, char *argv[] )
                 },
                 {
                     "--check-mods", "[mods…]",
-                    "Checks the json files belonging to BN mods",
+                    "Checks the json files belonging to default or specified BN mods",
                     section_default,
                     [&check_mods, &opts]( int n, const char *params[] ) -> int {
                         check_mods = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,6 +197,7 @@ int main( int argc, char *argv[] )
     int seed = time( nullptr );
     bool verifyexit = false;
     bool check_mods = false;
+    auto check_mods_mode = init::check_mods_mode::default_mods;
     std::filesystem::path lua_doc_output_path;
     std::filesystem::path lua_types_output_path;
     std::string dump;
@@ -238,7 +239,7 @@ int main( int argc, char *argv[] )
         const char *section_default = nullptr;
         const char *section_map_sharing = "Map sharing";
         const char *section_user_directory = "User directories";
-        const std::array<arg_handler, 15> first_pass_arguments = {{
+        const std::array<arg_handler, 16> first_pass_arguments = {{
                 {
                     "--seed", "<string of letters and or numbers>",
                     "Sets the random number generator's seed value",
@@ -274,6 +275,17 @@ int main( int argc, char *argv[] )
                         {
                             opts.emplace_back( params[ i ] );
                         }
+                        return 0;
+                    }
+                },
+                {
+                    "--check-all-mods", nullptr,
+                    "Checks the json files belonging to all non-obsolete BN mods",
+                    section_default,
+                    [&check_mods, &check_mods_mode]( int, const char ** ) -> int {
+                        check_mods = true;
+                        check_mods_mode = init::check_mods_mode::all_mods;
+                        test_mode = true;
                         return 0;
                     }
                 },
@@ -761,7 +773,7 @@ int main( int argc, char *argv[] )
             init_colors();
             loading_ui ui( false );
             const std::vector<mod_id> mods( opts.begin(), opts.end() );
-            if( init::check_mods_for_errors( ui, mods ) ) {
+            if( init::check_mods_for_errors( ui, mods, check_mods_mode ) ) {
                 exit( 0 );
             } else {
                 exit( 1 );


### PR DESCRIPTION
## Purpose of change (The Why)

`--check-mods` is slow because it tests **all** mods

Related follow-up: https://github.com/cataclysmbn/Cataclysm-BN/pull/9143

## Describe the solution (The How)

Use the world creation default mod list when `--check-mods` is run without explicit mods. Explicit mod arguments such as `--check-mods aftershock bn` keep the existing behavior.

Add `--check-all-mods` for the previous exhaustive non-obsolete mod check workflow. CI all-mods tests are unchanged; `.github/workflows/matrix.yml` still loads the `get_all_mods.py` list through `cata_test`.

Updated the generated CLI option reference.

## Describe alternatives you've considered

Kept the exhaustive workflow under `--check-all-mods` instead of requiring maintainers to list every mod manually.

## Testing

- `cmake --build out/build/linux-full --target format`
- `cmake --build out/build/linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `/usr/bin/time -f 'default check-mods elapsed=%e user=%U sys=%S maxrss=%M' out/build/linux-full/src/cataclysm-bn-tiles --userdir /tmp/cbn-review-check-default-user --check-mods`
  - Exit 0, checked 12 default mods, elapsed 97.43s.
- `/usr/bin/time -f 'explicit check-mods elapsed=%e user=%U sys=%S maxrss=%M' out/build/linux-full/src/cataclysm-bn-tiles --userdir /tmp/cbn-review-check-explicit-user --check-mods aftershock bn`
  - Exit 0, checked exactly Aftershock and Bright Nights, elapsed 18.76s.
- `/usr/bin/time -f 'all check-mods elapsed=%e user=%U sys=%S maxrss=%M' out/build/linux-full/src/cataclysm-bn-tiles --userdir /tmp/cbn-review-check-all-user --check-all-mods`
  - Exit 0, checked 66 non-obsolete in-repo mods, elapsed 520.67s.

Reviewer suggestion: run `--check-mods` with a custom user default mod list and verify only those defaults are checked.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked relevant prior PR context; no matching issue was found.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6945101](https://github.com/cataclysmbn/Cataclysm-BN/commit/6945101c57a94282cab50f57f8d3de55f90601f4) (feat(mods): add exhaustive mod check option) on 2026-06-04 05:09:01

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26929775469/artifacts/7402906859)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26929775469/artifacts/7403325897)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26929775469/artifacts/7402852935)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26929775469/artifacts/7402978448)
<!-- END artifact comment -->