### PR TITLE
fix: add locks to data vars array cache

### DIFF
--- a/src/data_vars_cvt.h
+++ b/src/data_vars_cvt.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <shared_mutex>
 #include <sstream>
 #include <iomanip>
 #include <list>
@@ -67,6 +68,7 @@ struct cached_converter {
     private:
         Inner _conv;
 
+        static inline std::shared_mutex listlock;
         static inline std::list<std::pair<key_type, value_type>> _list;
         static inline std::unordered_map<key_type, typename decltype( _list )::iterator> _map;
 
@@ -121,6 +123,7 @@ struct cached_converter {
         }
 
         static void cache_put( const key_type &key, const value_type &value )  {
+            std::unique_lock lock( listlock );
             const auto it = _map.find( key );
             _list.push_front( {key, value} );
             if( it != _map.end() ) {
@@ -137,6 +140,7 @@ struct cached_converter {
         }
 
         static const value_type &cache_get( const key_type &key ) {
+            std::shared_lock lock( listlock );
             const auto it = _map.find( key );
             if( it == _map.end() ) {
                 throw std::range_error( "Invalid key" );
@@ -146,15 +150,18 @@ struct cached_converter {
         }
 
         static bool cache_contains( const key_type &key ) {
+            std::shared_lock lock( listlock );
             return _map.contains( key );
         }
 
         static void cache_clear() {
+            std::unique_lock lock( listlock );
             _list.clear();
             _map.clear();
         }
 
         static  size_t cache_size() {
+            std::shared_lock lock( listlock );
             return _map.size();
         }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Work on the myriad "crash in city issues"
May be related to:
https://github.com/cataclysmbn/Cataclysm-BN/issues/9249, https://github.com/cataclysmbn/Cataclysm-BN/issues/9248, https://github.com/cataclysmbn/Cataclysm-BN/issues/9227, https://github.com/cataclysmbn/Cataclysm-BN/issues/9153

## Describe the solution (The How)
Adds locks to data var cached sets to prevent double assign segfault

## Describe alternatives you've considered
None

## Testing
Vehicles crash significantly less
I am still investigating the following segfault:
[trace.txt](https://github.com/user-attachments/files/28583613/trace.txt)
Segfault fixed by: #9269 
Which has a nearly identical cause interaction but is rarer

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [8478204](https://github.com/cataclysmbn/Cataclysm-BN/commit/847820401ef016a8dad7ef2f7b46db9322afb76e) (fix: add locks to data vars array cache) on 2026-06-04 07:19:02

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26934418190/artifacts/7404978819)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26934418190/artifacts/7405069160)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26934418190/artifacts/7404698952)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26934418190/artifacts/7404623494)
<!-- END artifact comment -->