### PR TITLE
feat(balance): Reduce electric engine volume, sonic boom potential based on vehicle speed.

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4459,10 +4459,11 @@ void vehicle::noise_and_smoke( int load, time_duration time )
             double cur_stress = load / 1000.0 * max_stress;
             // idle stress = 1.0 resulting in nominal working engine noise = engine_noise_factor()
             // and preventing noise = 0
-            const bool electric_engine = part_info(p).fuel_type == fuel_type_battery;
+            const bool electric_engine = part_info( p ).fuel_type == fuel_type_battery;
             cur_stress = std::max( cur_stress, 1.0 );
             // Reduce the relative volume of electric engines as there is not literal explosions occouring inside.
-            double part_noise = cur_stress * part_info( p ).engine_noise_factor() * ((electric_engine) ? 0.1 : 1.0 );
+            double part_noise = cur_stress * part_info( p ).engine_noise_factor() * ( (
+                                    electric_engine ) ? 0.1 : 1.0 );
 
             if( part_info( p ).has_flag( "E_COMBUSTION" ) ) {
                 combustion = true;
@@ -4506,7 +4507,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
     // noise = std::max( noise, std::fabs( velocity / 224.0 ) );
     // Cap engine noise to avoid deafening. Deafening can occour at or above 140dBspl.
     noise = std::min( noise, 139.0 );
-    if ( velocity >= 34300 ) {
+    if( velocity >= 34300 ) {
         // Sonic boom.
         noise = 180;
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4459,8 +4459,10 @@ void vehicle::noise_and_smoke( int load, time_duration time )
             double cur_stress = load / 1000.0 * max_stress;
             // idle stress = 1.0 resulting in nominal working engine noise = engine_noise_factor()
             // and preventing noise = 0
+            const bool electric_engine = part_info(p).fuel_type == fuel_type_battery;
             cur_stress = std::max( cur_stress, 1.0 );
-            double part_noise = cur_stress * part_info( p ).engine_noise_factor();
+            // Reduce the relative volume of electric engines as there is not literal explosions occouring inside.
+            double part_noise = cur_stress * part_info( p ).engine_noise_factor() * ((electric_engine) ? 0.1 : 1.0 );
 
             if( part_info( p ).has_flag( "E_COMBUSTION" ) ) {
                 combustion = true;
@@ -4500,10 +4502,14 @@ void vehicle::noise_and_smoke( int load, time_duration time )
     if( is_flying && has_part( VPFLAG_ROTOR ) ) {
         noise *= 2;
     }
+    // Speed alone wont generate much noise unless the vehicle is traveling faster than the speed of sound.
+    // noise = std::max( noise, std::fabs( velocity / 224.0 ) );
     // Cap engine noise to avoid deafening. Deafening can occour at or above 140dBspl.
     noise = std::min( noise, 139.0 );
-    // Even a vehicle with engines off will make noise traveling at high speeds
-    noise = std::max( noise, std::fabs( velocity / 224.0 ) );
+    if ( velocity >= 34300 ) {
+        // Sonic boom.
+        noise = 180;
+    }
     int lvl = 0;
     if( one_in( 4 ) && rng( 0, 30 ) < noise ) {
         while( noise > sounds[lvl].second ) {


### PR DESCRIPTION
## Purpose of change (The Why)

dB volume of electric engines is frequently comparable or nearly identical to volume output of combustion engines.
Overall volume of vehicle based on speed not properly scaled to the dB system

## Describe the solution (The How)

Apply noise modifier to engines that use bateries as fuel of *0.1.

Remove prior volume based on speed setting. Most of the perceived volume from an objects speed is due to the air currents coming off the vehicles backdraft, which is negligible compared to engine noise.

If vehicle goes faster than the speed of sound, set noise volume to 180dB to approximate sonic boom.

## Describe alternatives you've considered

## Testing

Forced vern shultz to ride around at high speeds in a motorized electric shopping cart to confirm volume. 

## Additional context

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [aa413bc](https://github.com/cataclysmbn/Cataclysm-BN/commit/aa413bc2e1fb15a0b6f81339ba8649be5f03c8aa) (style(autofix.ci): automated formatting) on 2026-06-04 07:36:19

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26934870272/artifacts/7404564599)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26934870272/artifacts/7405240884)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26934870272/artifacts/7404668235)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26934870272/artifacts/7404839465)
<!-- END artifact comment -->