### PR TITLE
fix: synchronize arena cleanup

### DIFF
--- a/src/cata_arena.h
+++ b/src/cata_arena.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <unordered_map>
+#include <mutex>
 #include <set>
+#include <unordered_map>
 
 #include "safe_reference.h"
 
@@ -10,6 +11,7 @@ class cata_arena
 {
     private:
         std::set<T *> pending_deletion;
+        std::mutex pending_deletion_mutex;
 
         static cata_arena<T> &get_instance() {
             // Heap-allocated and never deleted — intentional. This avoids the static
@@ -22,19 +24,25 @@ class cata_arena
         }
 
         void mark_for_destruction_internal( T *alloc ) {
-            pending_deletion.insert( alloc );
+            auto lk = std::lock_guard( pending_deletion_mutex );
             safe_reference<T>::mark_destroyed( alloc );
             cache_reference<T>::mark_destroyed( alloc );
+            pending_deletion.insert( alloc );
         }
 
         bool cleanup_internal() {
-            if( pending_deletion.empty() ) {
-                return false;
+            auto dcopy = std::set<T *> {};
+            {
+                auto lk = std::lock_guard( pending_deletion_mutex );
+                if( pending_deletion.empty() ) {
+                    return false;
+                }
+                dcopy.swap( pending_deletion );
+                for( T * const &p : dcopy ) {
+                    safe_reference<T>::mark_deallocated( p );
+                }
             }
-            std::set<T *> dcopy = std::set<T *>( pending_deletion );
-            pending_deletion.clear();
             for( T * const &p : dcopy ) {
-                safe_reference<T>::mark_deallocated( p );
                 delete p;
             }
             return true;

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -607,8 +607,7 @@ bool mapbuffer::preload_omt( const tripoint_abs_omt &omt_addr )
                                               "preload_omt: submap %d,%d,%d already loaded; keeping in-memory version",
                                               pos.x(), pos.y(), pos.z() );
             // Do NOT let sm destruct here on the worker thread.  Submap/item destruction
-            // touches safe_reference<T>::records_by_pointer, cache_reference<T>::reference_map,
-            // and cata_arena<T>::pending_deletion — all unsynchronised global statics.
+            // touches safe_reference<T>::records_by_pointer, which remains main-thread-only.
             // Defer to drain_pending_submap_destroy(), called on the main thread after join.
             if( sm ) {
                 auto lk = std::lock_guard( pending_destroy_mutex_ );

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -138,9 +138,9 @@ class mapbuffer
          * version already existed.  Must be called on the main thread after all
          * preload_omt() futures have been joined.
          *
-         * safe_reference<T>, cache_reference<T>, and cata_arena<T> all rely on
-         * unsynchronised global statics; destructing submaps (and their items) on
-         * worker threads would race on those statics.  preload_omt() defers such
+         * safe_reference<T> relies on unsynchronised global statics; destructing
+         * submaps (and their items) on worker threads would race on those statics.
+         * preload_omt() defers such
          * destruction here instead of letting it happen on the worker.
          */
         auto drain_pending_submap_destroy() -> void;
@@ -177,8 +177,8 @@ class mapbuffer
 
         /// Submaps that preload_omt() could not add (duplicate already in memory).
         /// Their destruction is deferred here and drained on the main thread via
-        /// drain_pending_submap_destroy() to avoid racing on the global statics
-        /// inside safe_reference<T>, cache_reference<T>, and cata_arena<T>.
+        /// drain_pending_submap_destroy() to avoid racing on safe_reference<T>
+        /// global statics.
         mutable std::mutex pending_destroy_mutex_;
         std::vector<std::unique_ptr<submap>> pending_destroy_submaps_;
 

--- a/src/submap_load_manager.cpp
+++ b/src/submap_load_manager.cpp
@@ -888,7 +888,7 @@ void submap_load_manager::update()
     TracyPlot( "New Sim OMT Z Preload Attempts", static_cast<int64_t>( preloaded_zlevels ) );
 
     // Drain duplicate submaps created by concurrent preload_omt workers.
-    // Must happen on the main thread (safe_reference / cata_arena not thread-safe).
+    // Must happen on the main thread (safe_reference remains main-thread-only).
     {
         auto drained_dims = std::set<std::string> {};
         std::ranges::transform( new_omts, std::inserter( drained_dims, drained_dims.end() ),

--- a/src/thread_pool.h
+++ b/src/thread_pool.h
@@ -31,15 +31,14 @@
  *
  *   safe_reference<T>  — records_by_pointer / records_by_id are NOT mutex-protected.
  *     next_id is std::atomic (safe for concurrent serialize() calls from save workers).
- *     All other safe_reference operations (fill, remove, register_load, mark_destroyed,
- *     mark_deallocated, cleanup) must run on the main thread only.
+ *     Direct safe_reference operations other than serialize() must run on the main thread only.
+ *     cata_arena serializes its own mark_destroyed()/mark_deallocated() calls.
  *
- *   cata_arena<T>      — pending_deletion is NOT mutex-protected.
- *     mark_for_destruction() and cleanup() must run on the main thread only.
+ *   cata_arena<T>      — pending_deletion is mutex-protected.
+ *     mark_for_destruction() can overlap cleanup(), which drains outside the lock.
  *
  * In practice:
- *   • Submaps must not be destroyed on worker threads (destructor calls mark_for_destruction
- *     and safe_reference::mark_destroyed).  Use mapbuffer::drain_pending_submap_destroy()
+ *   • Submaps must not be destroyed on worker threads.  Use mapbuffer::drain_pending_submap_destroy()
  *     on the main thread after joining all preload_omt() futures.
  *   • Submap deserialisation IS safe from workers because
  *     active_item_cache constructs cache_reference objects, which are now mutex-guarded.

--- a/tests/cata_arena_test.cpp
+++ b/tests/cata_arena_test.cpp
@@ -1,0 +1,55 @@
+#include "catch/catch.hpp"
+
+#include <atomic>
+#include <ranges>
+#include <thread>
+#include <vector>
+
+#include "cata_arena.h"
+#include "item.h"
+
+TEST_CASE( "item arena cleanup tolerates concurrent destruction", "[arena]" )
+{
+    constexpr auto worker_count = 8;
+    constexpr auto items_per_worker = 5000;
+
+    while( cata_arena<item>::cleanup() ) {}
+
+    auto ready = std::atomic<int> { 0 };
+    auto finished = std::atomic<int> { 0 };
+    auto start = std::atomic<bool> { false };
+    auto workers = std::vector<std::thread> {};
+
+    for( const auto worker_index : std::views::iota( 0, worker_count ) ) {
+        workers.emplace_back( [&ready, &finished, &start, worker_index, items_per_worker]() {
+            ready.fetch_add( 1, std::memory_order_release );
+            while( !start.load( std::memory_order_acquire ) ) {
+                std::this_thread::yield();
+            }
+            for( const auto item_index : std::views::iota( 0, items_per_worker ) ) {
+                cata_arena<item>::mark_for_destruction( new item() );
+                if( ( item_index + worker_index ) % 8 == 0 ) {
+                    std::this_thread::yield();
+                }
+            }
+            finished.fetch_add( 1, std::memory_order_release );
+        } );
+    }
+
+    while( ready.load( std::memory_order_acquire ) != worker_count ) {
+        std::this_thread::yield();
+    }
+    start.store( true, std::memory_order_release );
+
+    while( finished.load( std::memory_order_acquire ) != worker_count ) {
+        cata_arena<item>::cleanup();
+        std::this_thread::yield();
+    }
+
+    for( auto &worker : workers ) {
+        worker.join();
+    }
+    while( cata_arena<item>::cleanup() ) {}
+
+    SUCCEED( "concurrent item destruction and arena cleanup completed" );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9153

Lazy OMT workers can destroy newly generated items while the main thread drains `cata_arena<item>`, racing on `pending_deletion` and corrupting its `std::set`.

Related: #9265 addresses data vars cache locking, not this arena queue.

## Describe the solution (The How)

Guard `cata_arena<T>::pending_deletion` with a mutex, swap/copy work under lock, and delete objects after releasing the lock.

## Describe alternatives you've considered

Avoided disabling lazy OMT workers; the unsafe shared arena queue is synchronized directly.

## Testing

- `cmake --build --preset linux-full --target format`
- Pre-fix: `./out/build/linux-full/tests/cata_test-tiles "[arena]"` reproduced SIGSEGV in `std::set<item*>::insert` from `cata_arena<item>::mark_for_destruction_internal`.
- Post-fix: `./out/build/linux-full/tests/cata_test-tiles "[arena]"` passes.
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`

## Additional context

The new regression test stresses concurrent item destruction and arena cleanup.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0b7fb90](https://github.com/cataclysmbn/Cataclysm-BN/commit/0b7fb909b270128b6933439c05617989968353d3) (fix: synchronize arena cleanup) on 2026-06-04 12:06:17

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26947687346/artifacts/7410596779)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26947687346/artifacts/7410658386)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26947687346/artifacts/7410259582)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26947687346/artifacts/7410164131)
<!-- END artifact comment -->