### PR TITLE
fix: increase some drug effects durations

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -821,7 +821,6 @@
     "quench": -5,
     "stim": -10,
     "healthy": -1,
-    "fun": 15,
     "addiction_potential": 5,
     "flags": [ "NO_INGEST" ],
     "use_action": {

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -457,7 +457,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You snort a bump of coke.",
-      "effects": [ { "id": "cocaine_high", "duration": "60 minutes" } ],
+      "effects": [ { "id": "cocaine_high", "duration": "300 minutes" } ],
       "stat_adjustments": { "hunger": -10 }
     }
   },
@@ -550,9 +550,9 @@
       "type": "consume_drug",
       "activation_message": "You smoke your crack rocks.  Mother would be proud.",
       "effects": [
-        { "id": "cocaine_high", "duration": "10 minutes" },
-        { "id": "cocaine_high", "duration": "10 minutes" },
-        { "id": "cocaine_high", "duration": "10 minutes" }
+        { "id": "cocaine_high", "duration": "100 minutes" },
+        { "id": "cocaine_high", "duration": "100 minutes" },
+        { "id": "cocaine_high", "duration": "100 minutes" }
       ],
       "stat_adjustments": { "hunger": -10 },
       "fields_produced": { "fd_cracksmoke": 2 },
@@ -831,7 +831,7 @@
       "smoking_duration": 4,
       "do_weed_msg": true,
       "charges_needed": { "fire": 1 },
-      "effects": [ { "id": "weed_high", "duration": "15 s" }, { "id": "pkill1", "duration": "12 m" } ],
+      "effects": [ { "id": "weed_high", "duration": "90 m" }, { "id": "pkill1", "duration": "12 m" } ],
       "fields_produced": { "fd_weedsmoke": 2 }
     }
   },
@@ -862,7 +862,7 @@
       "charges_needed": { "fire": 1 },
       "do_weed_msg": true,
       "effects": [
-        { "id": "weed_high", "duration": "15 s" },
+        { "id": "weed_high", "duration": "120 m" },
         { "id": "cig", "duration": "15 s" },
         { "id": "pkill1", "duration": "12 m" }
       ],
@@ -1498,7 +1498,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You smoke some weed.  Good stuff, man!",
-      "effects": [ { "id": "weed_high", "duration": 90 }, { "id": "pkill1", "duration": 360 } ],
+      "effects": [ { "id": "weed_high", "duration": 5400 }, { "id": "pkill1", "duration": 360 } ],
       "stat_adjustments": { "hunger": 4, "thirst": 6 },
       "fields_produced": { "fd_weedsmoke": 2 },
       "charges_needed": { "fire": 1 },

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1497,7 +1497,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You smoke some weed.  Good stuff, man!",
-      "effects": [ { "id": "weed_high", "duration": 5400 }, { "id": "pkill1", "duration": 360 } ],
+      "effects": [ { "id": "weed_high", "duration": "90 m" }, { "id": "pkill1", "duration": "6 m" } ],
       "stat_adjustments": { "hunger": 4, "thirst": 6 },
       "fields_produced": { "fd_weedsmoke": 2 },
       "charges_needed": { "fire": 1 },

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -821,6 +821,7 @@
     "quench": -5,
     "stim": -10,
     "healthy": -1,
+    "fun": 15,
     "addiction_potential": 5,
     "flags": [ "NO_INGEST" ],
     "use_action": {


### PR DESCRIPTION
I changed it to DDA 0.E because it just felt like the right value, they aren't good for your brain cells but they are enjoyable after all
<img width="991" height="427" alt="image" src="https://github.com/user-attachments/assets/f03b9c34-6749-458f-89f8-b9d1329f2422" />

Edit: since the joint missing the fun field was normal, but the "high" duration was still extremely short, here's the new PR text

With the consume system, Heroin makes you "high" for ~7 hours, to match somewhat realistic (although still shorter) values for the other drugs:
Cocaine: 5 hours
Crack: 5 hours
Blunt: 2 hours (uses x2 marijuana, won't make you twice as long high but could still be increased a bit)
Joint: 1.5 hours (puffing once makes you high for that long, but extinguishing it makes it unusable, so this can't be exploited)
Marijuana: 1.5 hours

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [233b05b](https://github.com/cataclysmbn/Cataclysm-BN/commit/233b05b2ba82f1c6003abe4bb201d12888c33867) (Apply suggestion from @chaosvolt) on 2026-06-04 20:59:07

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26975837689/artifacts/7421682888)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26975837689/artifacts/7422562447)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26975837689/artifacts/7422490625)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26975837689/artifacts/7422038520)
<!-- END artifact comment -->