### PR TITLE
fix: apply shaped ammo trail effects

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4846,14 +4846,7 @@ void map::shoot( const tripoint_bub_ms &origin, const tripoint_bub_ms &p, projec
         dam = 0;
     }
 
-    for( const ammo_effect_str_id &ae_id : proj.get_ammo_effects() ) {
-        const ammo_effect &ae = *ae_id;
-        if( ae.trail_field_type ) {
-            if( x_in_y( ae.trail_chance, 100 ) ) {
-                add_field( p, ae.trail_field_type, rng( ae.trail_intensity_min, ae.trail_intensity_max ) );
-            }
-        }
-    }
+    apply_ammo_trail_effects( p, proj.get_ammo_effects(), 1.0 );
 
     // Check fields?
     const field_entry *fieldhit = get_field( p, fd_web );

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -98,6 +98,20 @@ void projectile::load( JsonObject &jo )
     jo.read( "proj_effects", proj_effects );
 }
 
+auto apply_ammo_trail_effects( const tripoint_bub_ms &p,
+                               const std::set<ammo_effect_str_id> &effects,
+                               const double chance_multiplier ) -> void
+{
+    map &here = get_map();
+    for( const auto &ae_id : effects ) {
+        const auto &ae = *ae_id;
+        const auto adjusted_chance = std::clamp( ae.trail_chance * chance_multiplier, 0.0, 100.0 );
+        if( ae.trail_field_type && x_in_y( adjusted_chance, 100.0 ) ) {
+            here.add_field( p, ae.trail_field_type, rng( ae.trail_intensity_min, ae.trail_intensity_max ) );
+        }
+    }
+}
+
 void apply_ammo_effects( const tripoint_bub_ms &p, const std::set<ammo_effect_str_id> &effects,
                          Creature *source )
 {

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -90,6 +90,9 @@ struct dealt_projectile_attack {
     bool suppress_damage_message = false;
 };
 
+auto apply_ammo_trail_effects( const tripoint_bub_ms &p,
+                               const std::set<ammo_effect_str_id> &effects,
+                               double chance_multiplier ) -> void;
 void apply_ammo_effects( const tripoint_bub_ms &p, const std::set<ammo_effect_str_id> &effects,
                          Creature *source );
 // Legacy. TODO: Remove

--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -129,6 +129,10 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
 
     draw_cone_aoe( origin, final_coverage );
 
+    for( const auto &[point, coverage] : final_coverage ) {
+        apply_ammo_trail_effects( point, proj.get_ammo_effects(), coverage );
+    }
+
     // Here and not above because we want the animation first
     // Terrain will be shown damaged, but having it in unknown state would complicate timing the animation
     for( const auto &[point, coverage] : final_coverage ) {

--- a/tests/ranged_aoe_test.cpp
+++ b/tests/ranged_aoe_test.cpp
@@ -9,6 +9,7 @@
 
 #include "ballistics.h"
 #include "dispersion.h"
+#include "field_type.h"
 #include "shape.h"
 #include "shape_impl.h"
 #include "map.h"
@@ -213,6 +214,31 @@ TEST_CASE( "expected shape coverage through windows", "[shape]" )
     CHECK( cov[origin + 2 * point_east] == Approx( 0.25 ) );
     CHECK( cov[origin + 3 * point_east] == Approx( 0.25 ) );
     CHECK( cov[origin + 4 * point_east] == Approx( 0.25 ) );
+}
+
+TEST_CASE( "shaped attacks apply trail ammo effects", "[ranged][projectile]" )
+{
+    clear_all_state();
+
+    map &here = get_map();
+    auto &attacker = get_player_character();
+    const auto origin = tripoint_bub_ms( 60, 60, 0 );
+    const auto target = origin + 5 * point_east;
+    attacker.set_body();
+    attacker.setpos( origin );
+
+    const auto shape_factory = cone_factory( 15_degrees, 6.0 );
+    const auto attack_shape = shape_factory.create( rl_vec3d( origin ), rl_vec3d( target ) );
+    auto proj = projectile {};
+    proj.speed = 1000;
+    proj.range = 6;
+    proj.impact.add_damage( DT_HEAT, 1 );
+    proj.add_effect( ammo_effect_str_id( "LASER" ) );
+
+    ranged::execute_shaped_attack( *attack_shape, proj, attacker, nullptr );
+
+    CHECK( here.get_field( origin + point_east, fd_laser ) != nullptr );
+    CHECK( here.get_field( origin + 2 * point_east, fd_laser ) != nullptr );
 }
 
 TEST_CASE( "character using birdshot against another character", "[ranged]" )


### PR DESCRIPTION
## Purpose of change (The Why)

close #9179

Dragon's breath shells use shaped AoE plus `STREAM`, but shaped AoE did not apply ammo trail effects, so the cone dealt damage without leaving the intended fire trail.

Related search: no duplicate Cataclysm-BN PRs found for dragon breath/shaped ammo trail.

## Describe the solution (The How)

- Move ammo trail field application into `apply_ammo_trail_effects()`.
- Reuse it from `map::shoot()` and shaped AoE execution.
- Scale shaped trail chance by shape coverage.
- Add a regression test for shaped ammo trail effects.

## Testing

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/2e9e9cfd-80d8-4a0a-9731-3a1765c29a01" />

load shotgun with dragon's breath shell and confirm that it works

## Additional context

Root cause was duplicated projectile/trail handling between normal projectile traversal and shaped AoE traversal.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [049fe00](https://github.com/cataclysmbn/Cataclysm-BN/commit/049fe00e98e5b64bbf007f1deda9fdf2100ccdf3) (fix: apply shaped ammo trail effects) on 2026-06-04 16:51:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26962390214/artifacts/7416463427)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26962390214/artifacts/7417107900)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26962390214/artifacts/7416359721)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26962390214/artifacts/7416459562)
<!-- END artifact comment -->