### PR TITLE
feat(UI): add repeated dangerous terrain warning option

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12056,7 +12056,8 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
     if( !u.is_blind() || u.clairvoyance() < 1 || tr.can_see( dest_loc, u ) ) {
         const auto boardable = static_cast<bool>( m.veh_at( dest_loc ).part_with_feature( "BOARDABLE",
                                true ) );
-        const auto already_in_same_trap = m.tr_at( u.bub_pos() ).loadid == tr.loadid;
+        const auto repeat_warning = get_option<bool>( "REPEAT_DANGEROUS_TERRAIN_WARNINGS" );
+        const auto already_in_same_trap = !repeat_warning && m.tr_at( u.bub_pos() ).loadid == tr.loadid;
         // HACK: Hack for now, later ledge should stop being a trap
         // Note: in non-z-level mode, ledges obey different rules and so should be handled as regular traps
         if( tr.loadid == tr_ledge && m.has_zlevels() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12054,8 +12054,9 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
 
     const trap &tr = m.tr_at( dest_loc );
     if( !u.is_blind() || u.clairvoyance() < 1 || tr.can_see( dest_loc, u ) ) {
-        const bool boardable = static_cast<bool>( m.veh_at( dest_loc ).part_with_feature( "BOARDABLE",
+        const auto boardable = static_cast<bool>( m.veh_at( dest_loc ).part_with_feature( "BOARDABLE",
                                true ) );
+        const auto already_in_same_trap = m.tr_at( u.bub_pos() ).loadid == tr.loadid;
         // HACK: Hack for now, later ledge should stop being a trap
         // Note: in non-z-level mode, ledges obey different rules and so should be handled as regular traps
         if( tr.loadid == tr_ledge && m.has_zlevels() ) {
@@ -12064,7 +12065,8 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
                     harmful_stuff.emplace_back( tr.name() );
                 }
             }
-        } else if( tr.can_see( dest_loc, u ) && !tr.is_benign() && !boardable ) {
+        } else if( tr.can_see( dest_loc, u ) && !tr.is_benign() && !boardable &&
+                   !already_in_same_trap ) {
             harmful_stuff.emplace_back( tr.name() );
         }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1377,6 +1377,12 @@ void options_manager::add_options_general()
     "ALWAYS"
        );
 
+    add( "REPEAT_DANGEROUS_TERRAIN_WARNINGS", general,
+         translate_marker( "Repeat dangerous terrain warnings" ),
+         translate_marker( "If false, moving from a visible trap into the same trap type will not show another dangerous terrain warning.  Moving into a different trap type, such as from a pit to a spiked pit, is still warned." ),
+         true
+       );
+
     add_empty_line();
 
     add( "SAFEMODE", general, translate_marker( "Safe mode" ),

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -10,6 +10,7 @@
 #include "game_constants.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "options_helpers.h"
 #include "state_helpers.h"
 #include "type_id.h"
 
@@ -49,7 +50,7 @@ TEST_CASE( "place_player_can_safely_move_multiple_submaps" )
     CHECK( get_map().check_submap_active_item_consistency().empty() );
 }
 
-TEST_CASE( "dangerous_pit_warning_ignores_same_pit" )
+TEST_CASE( "dangerous_pit_warning_repeat_option" )
 {
     clear_all_state();
     auto &here = get_map();
@@ -66,11 +67,20 @@ TEST_CASE( "dangerous_pit_warning_ignores_same_pit" )
     CHECK( g->is_dangerous_tile( pit_pos ) );
 
     here.ter_set( player_pos, pit );
-    CHECK_FALSE( g->is_dangerous_tile( pit_pos ) );
 
-    here.ter_set( pit_pos, spiked_pit );
-    g->u.add_known_trap( pit_pos, here.tr_at( pit_pos ) );
-    CHECK( g->is_dangerous_tile( pit_pos ) );
+    SECTION( "same trap warnings repeat when enabled" ) {
+        const auto repeat_warning = override_option( "REPEAT_DANGEROUS_TERRAIN_WARNINGS", "true" );
+        CHECK( g->is_dangerous_tile( pit_pos ) );
+    }
+
+    SECTION( "same trap warnings are skipped when disabled" ) {
+        const auto repeat_warning = override_option( "REPEAT_DANGEROUS_TERRAIN_WARNINGS", "false" );
+        CHECK_FALSE( g->is_dangerous_tile( pit_pos ) );
+
+        here.ter_set( pit_pos, spiked_pit );
+        g->u.add_known_trap( pit_pos, here.tr_at( pit_pos ) );
+        CHECK( g->is_dangerous_tile( pit_pos ) );
+    }
 }
 
 static std::ostream &operator<<( std::ostream &os, const ter_id &tid )

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -49,6 +49,30 @@ TEST_CASE( "place_player_can_safely_move_multiple_submaps" )
     CHECK( get_map().check_submap_active_item_consistency().empty() );
 }
 
+TEST_CASE( "dangerous_pit_warning_ignores_same_pit" )
+{
+    clear_all_state();
+    auto &here = get_map();
+    const auto player_pos = tripoint_bub_ms( 60, 60, 0 );
+    const auto pit_pos = player_pos + tripoint_rel_ms::east();
+    const auto floor = ter_str_id( "t_floor" );
+    const auto pit = ter_str_id( "t_pit" );
+    const auto spiked_pit = ter_str_id( "t_pit_spiked" );
+
+    here.ter_set( player_pos, floor );
+    here.ter_set( pit_pos, pit );
+    g->u.setpos( player_pos );
+    g->u.add_known_trap( pit_pos, here.tr_at( pit_pos ) );
+    CHECK( g->is_dangerous_tile( pit_pos ) );
+
+    here.ter_set( player_pos, pit );
+    CHECK_FALSE( g->is_dangerous_tile( pit_pos ) );
+
+    here.ter_set( pit_pos, spiked_pit );
+    g->u.add_known_trap( pit_pos, here.tr_at( pit_pos ) );
+    CHECK( g->is_dangerous_tile( pit_pos ) );
+}
+
 static std::ostream &operator<<( std::ostream &os, const ter_id &tid )
 {
     os << tid.id().c_str();


### PR DESCRIPTION
## Purpose of change (The Why)

Moving from one pit tile into another known pit tile repeatedly asks `Really step into pit?`, even though the player is already standing in the same hazard. For damaging traps like spiked pits, some players may still want repeated warnings.

## Describe the solution (The How)

Add `Repeat dangerous terrain warnings` next to the existing dangerous terrain warning option. When disabled, moving from a visible trap into the same trap type skips the repeated dangerous terrain warning. Moving into a different trap type, such as pit to spiked pit, still warns.

The option defaults to enabled so existing safety behavior remains unchanged unless the player opts out.

## Describe alternatives you've considered

Originally suppressed matching trap warnings unconditionally, but kept it option-gated so repeatedly triggering damaging traps can still be warned normally by default.

## Testing

- `cmake --build --preset linux-full --target format`
  - Expected: formatter completes without changing touched files.
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
  - Expected: game and test targets build.
- `./out/build/linux-full/tests/cata_test-tiles "dangerous_pit_warning_repeat_option"`
  - Expected: entering a known pit from floor remains dangerous, same-trap warnings repeat when the option is enabled, same-trap warnings are skipped when disabled, and pit-to-spiked-pit remains dangerous.
  - Result: passed, 5 assertions.

## Additional context

Added a regression test covering both option states.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7142fab](https://github.com/cataclysmbn/Cataclysm-BN/commit/7142fab41cf55b0759dba175255055232a4e7bbe) (feat: add repeated dangerous terrain warning option) on 2026-06-04 18:26:37

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26967884768/artifacts/7418889784)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26967884768/artifacts/7419380250)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26967884768/artifacts/7418623950)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26967884768/artifacts/7418862919)
<!-- END artifact comment -->