### PR TITLE
fix: harden crash handler for worker-thread and macOS crashes

### DIFF
--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -4,6 +4,7 @@
 #if defined(BACKTRACE)
 
 #include <atomic>
+#include <chrono>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
@@ -12,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <typeinfo>
 
 #if defined(_WIN32)
@@ -21,6 +23,10 @@
 #include <dbghelp.h>
 #endif
 
+#if defined(__APPLE__) && defined(TILES) && !defined(__ANDROID__)
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 #include "debug.h"
 #include "get_version.h"
 #include "path_info.h"
@@ -28,9 +34,117 @@
 // signal handlers are expected to have C linkage, and only use the
 // common subset of C & C++
 
-#if defined(_WIN32)
 // Ensures only the first crash path (exception filter or signal handler) logs and dumps.
-static std::atomic_flag g_crash_logged{};
+namespace
+{
+
+// Only the first crashing thread runs the handler; the rest wait on it.
+auto g_crash_logged = std::atomic_flag {};
+// Set after the report is on disk (before the dialog), so the watchdog stands
+// down and never auto-dismisses a dialog the user is still reading.
+auto g_crash_report_durable = std::atomic_bool { false };
+// Set after the dialog closes, so duplicate crashing threads do not terminate
+// the process while the dialog is still up.
+auto g_crash_handling_complete = std::atomic_bool { false };
+// Captured on the first (main-thread) init_crash_handlers() call; used on
+// non-Apple platforms to only drive the GUI from the main thread.
+auto g_main_thread_id = std::thread::id {};
+auto g_main_thread_id_set = std::atomic_flag {};
+// Bound on the non-interactive phase (log flush + stack trace) before giving up.
+constexpr auto crash_handler_timeout = std::chrono::seconds { 30 };
+constexpr auto crash_handler_wait_step = std::chrono::milliseconds { 10 };
+
+// std::signal( sig, SIG_DFL ) trips -Wold-style-cast because SIG_DFL expands to
+// a C-style cast; keep the suppression in one place.
+auto reset_signal_to_default( int sig ) -> void
+{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+    std::signal( sig, SIG_DFL );
+#pragma GCC diagnostic pop
+}
+
+// No deadline: the first handler may be showing a dialog that blocks for the
+// user. If it instead hangs before the report is durable, the watchdog exits the
+// whole process, which unblocks this wait too.
+auto wait_for_crash_handling_completion() -> void
+{
+    while( !g_crash_handling_complete.load( std::memory_order_acquire ) ) {
+        std::this_thread::sleep_for( crash_handler_wait_step );
+    }
+}
+
+auto write_crash_log_file( const std::string &crash_log_file,
+                           const std::string &log_text ) -> void
+{
+    auto *file = fopen( crash_log_file.c_str(), "w" );
+    if( file ) {
+        fwrite( log_text.data(), 1, log_text.size(), file );
+        fclose( file );
+    }
+}
+
+// Forcibly terminate if the non-interactive phase (log flush + stack trace) hangs
+// or re-crashes - likely when the crash itself was caused by heap corruption.
+// Stands down once the report is durable so it never kills the crash dialog.
+auto start_crash_handling_watchdog() -> void
+{
+    try {
+        auto watchdog = std::thread( []() {
+            std::this_thread::sleep_for( crash_handler_timeout );
+            if( !g_crash_report_durable.load( std::memory_order_acquire ) ) {
+                std::_Exit( EXIT_FAILURE );
+            }
+        } );
+        watchdog.detach();
+    } catch( ... ) {
+        // Best effort: if the watchdog thread cannot be started (e.g. the
+        // allocator is wedged) we still proceed; the duplicate-thread wait and
+        // the re-raise below bound the damage.
+    }
+}
+
+#if defined(TILES) && !defined(__ANDROID__)
+auto show_crash_dialog( const std::string &crash_log_file,
+                        const std::string &header_text,
+                        std::ostringstream &log_text ) -> void
+{
+#if defined(__APPLE__)
+    // SDL's message box marshals onto the main run loop, which deadlocks when a
+    // worker thread crashes while the main thread is blocked (e.g. waiting on the
+    // job that crashed). CFUserNotificationDisplayAlert spins its own run loop on
+    // the calling thread, so it works from any thread and any main-thread state.
+    static_cast<void>( crash_log_file );
+    static_cast<void>( log_text );
+    auto *message = CFStringCreateWithCString( nullptr, header_text.c_str(),
+                    kCFStringEncodingUTF8 );
+    auto response = CFOptionFlags{ 0 };
+    CFUserNotificationDisplayAlert( 0, kCFUserNotificationStopAlertLevel,
+                                    nullptr, nullptr, nullptr,
+                                    CFSTR( "Error" ), message, nullptr,
+                                    nullptr, nullptr, &response );
+    if( message ) {
+        CFRelease( message );
+    }
+#else
+    // On other platforms only the main thread may safely drive the GUI.
+    if( std::this_thread::get_id() != g_main_thread_id ) {
+        return;
+    }
+    if( SDL_ShowSimpleMessageBox( SDL_MESSAGEBOX_ERROR, "Error",
+                                  header_text.c_str(), nullptr ) != 0 ) {
+        log_text << "Error creating SDL message box: " << SDL_GetError() << '\n';
+        write_crash_log_file( crash_log_file, log_text.str() );
+    }
+#endif
+}
+#endif
+
+} // namespace
+
+#if defined(_WIN32)
 // Set by windows_exception_filter; used by dump_to() and debug_write_backtrace().
 static EXCEPTION_POINTERS *g_exception_info = nullptr;
 #endif
@@ -61,21 +175,22 @@ extern "C" {
 
     static void log_crash( const char *type, const char *msg )
     {
-        // This implementation is not technically async-signal-safe for many
-        // reasons, including the memory allocations and the SDL message box.
-        // But it should usually work in practice, unless for example the
-        // program segfaults inside malloc.
+        if( g_crash_logged.test_and_set( std::memory_order_acq_rel ) ) {
+            wait_for_crash_handling_completion();
+            return;
+        }
 
-        // Flush the debug log before writing the crash report so that any
-        // messages written just before the crash are on disk.
-        flush_debug_log();
+        // This implementation is not technically async-signal-safe because it
+        // allocates and collects a backtrace. Write a minimal file first so a
+        // later failure still leaves a crash report on disk. This is best
+        // effort: building the report below already allocates, so a crash with a
+        // sufficiently corrupted heap may still take down this write itself.
 
-        const std::string crash_log_file = PATH_INFO::crash();
+        const auto crash_log_file = PATH_INFO::crash();
 #if defined(_WIN32)
-        const std::string minidump_file = crash_log_file + ".dmp";
-        dump_to( minidump_file.c_str() );
+        const auto minidump_file = crash_log_file + ".dmp";
 #endif
-        std::ostringstream log_text;
+        auto log_text = std::ostringstream {};
 #if defined(__ANDROID__)
         // At this point, Android JVM is already doomed
         // No further UI interaction (including the SDL message box)
@@ -93,46 +208,50 @@ extern "C" {
                  << "\nVERSION: " << getVersionString()
                  << "\nTYPE: " << type
                  << "\nMESSAGE: " << msg;
-#if defined(TILES)
-        if( SDL_ShowSimpleMessageBox( SDL_MESSAGEBOX_ERROR, "Error",
-                                      log_text.str().c_str(), nullptr ) != 0 ) {
-            log_text << "Error creating SDL message box: " << SDL_GetError() << '\n';
-        }
 #endif
+        const auto header_text = log_text.str();
+        write_crash_log_file( crash_log_file,
+                              header_text +
+                              "\nSTACK TRACE:\nStack trace collection has not completed.\n" );
+
+        // From here on every step can hang or re-crash on a corrupted heap, so
+        // arm the watchdog now that a crash report already exists on disk.
+        start_crash_handling_watchdog();
+
+        // Flush the debug log after creating the crash report so that a hang
+        // here does not prevent crash.log from existing.
+        flush_debug_log();
+
+#if defined(_WIN32)
+        dump_to( minidump_file.c_str() );
 #endif
+
         log_text << "\nSTACK TRACE:\n";
         debug_write_backtrace( log_text );
+        write_crash_log_file( crash_log_file, log_text.str() );
         std::cerr << log_text.str();
-        FILE *file = fopen( crash_log_file.c_str(), "w" );
-        if( file ) {
-            fwrite( log_text.str().data(), 1, log_text.str().size(), file );
-            fclose( file );
-        }
+
+        // The report is now durable: tell the watchdog to stand down so the
+        // dialog below can block for the user without being auto-dismissed.
+        g_crash_report_durable.store( true, std::memory_order_release );
+
+#if defined(TILES) && !defined(__ANDROID__)
+        show_crash_dialog( crash_log_file, header_text, log_text );
+#endif
 #if defined(__ANDROID__)
         // Create a placeholder dummy file "config/crash.log.prompt"
         // to let the app show a dialog box at next start
-        file = fopen( ( crash_log_file + ".prompt" ).c_str(), "w" );
+        auto *file = fopen( ( crash_log_file + ".prompt" ).c_str(), "w" );
         if( file ) {
             fwrite( "0", 1, 1, file );
             fclose( file );
         }
 #endif
+        g_crash_handling_complete.store( true, std::memory_order_release );
     }
 
     static void signal_handler( int sig )
     {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-        signal( sig, SIG_DFL );
-#pragma GCC diagnostic pop
-#if defined(_WIN32)
-        if( g_crash_logged.test_and_set() ) {
-            raise( sig );
-            return;
-        }
-#endif
         const char *msg;
         switch( sig ) {
             case SIGSEGV:
@@ -144,29 +263,32 @@ extern "C" {
             case SIGABRT:
                 msg = "SIGABRT: Abnormal termination";
                 break;
+#if defined(SIGBUS)
+            case SIGBUS:
+                msg = "SIGBUS: Bus error";
+                break;
+#endif
             case SIGFPE:
                 msg = "SIGFPE: Arithmetical error";
                 break;
+#if defined(SIGTRAP)
+            case SIGTRAP:
+                msg = "SIGTRAP: Trace trap";
+                break;
+#endif
             default:
                 return;
         }
         log_crash( "Signal", msg );
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-        std::signal( SIGABRT, SIG_DFL );
-#pragma GCC diagnostic pop
-        abort();
+        reset_signal_to_default( sig );
+        std::raise( sig );
+        std::_Exit( EXIT_FAILURE );
     }
 } // extern "C"
 
 #if defined(_WIN32)
 static LONG WINAPI windows_exception_filter( EXCEPTION_POINTERS *exception_info )
 {
-    if( g_crash_logged.test_and_set() ) {
-        return EXCEPTION_CONTINUE_SEARCH;
-    }
     g_exception_info = exception_info;
     set_crash_exception_context( exception_info ? exception_info->ContextRecord : nullptr );
     const char *msg = "Unknown exception";
@@ -198,7 +320,8 @@ static LONG WINAPI windows_exception_filter( EXCEPTION_POINTERS *exception_info 
 
 [[noreturn]] static void crash_terminate_handler()
 {
-    // TODO: thread-safety?
+    // log_crash() is guarded by g_crash_logged, so concurrent terminations are
+    // serialized: the first one dumps while the rest wait and then abort.
     const char *type;
     const char *msg;
     try {
@@ -213,29 +336,24 @@ static LONG WINAPI windows_exception_filter( EXCEPTION_POINTERS *exception_info 
         msg = e.what();
         // call here to avoid `msg = e.what()` going out of scope
         log_crash( type, msg );
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-        std::signal( SIGABRT, SIG_DFL );
-#pragma GCC diagnostic pop
+        reset_signal_to_default( SIGABRT );
         abort();
     } catch( ... ) {
         type = "Unknown exception";
         msg = "Not derived from std::exception";
     }
     log_crash( type, msg );
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-    std::signal( SIGABRT, SIG_DFL );
-#pragma GCC diagnostic pop
+    reset_signal_to_default( SIGABRT );
     abort();
 }
 
 void init_crash_handlers()
 {
+    // The first caller is main() on the main thread, before any worker threads
+    // are spawned; thread_pool workers re-invoke this and must not clobber it.
+    if( !g_main_thread_id_set.test_and_set( std::memory_order_acq_rel ) ) {
+        g_main_thread_id = std::this_thread::get_id();
+    }
 #if defined(_WIN32)
     // On Windows, SIGSEGV/SIGILL/SIGFPE are translated from SEH hardware exceptions
     // by the CRT via a Vectored Exception Handler (VEH). Registering C signal handlers
@@ -247,7 +365,14 @@ void init_crash_handlers()
     SetUnhandledExceptionFilter( windows_exception_filter );
 #else
     for( auto sig : {
-             SIGSEGV, SIGILL, SIGABRT, SIGFPE
+             SIGSEGV, SIGILL, SIGABRT,
+#if defined(SIGBUS)
+             SIGBUS,
+#endif
+#if defined(SIGTRAP)
+             SIGTRAP,
+#endif
+             SIGFPE
          } ) {
         std::signal( sig, signal_handler );
     }


### PR DESCRIPTION
## Purpose of change (The Why)
The crash handler was unreliable, especially on macOS and for crashes on worker
threads:
- `crash.log` was sometimes not created at all, or created with only a
  placeholder and no stack trace.
- The SDL crash dialog was shown *before* the log was written, so a hang or a
  second crashing thread could kill the process before the report was on disk.
- `SIGBUS` and `SIGTRAP` (both seen on macOS) were not handled.
- Showing the SDL message box from a worker thread deadlocks on macOS (Cocoa
  `dispatch_sync` onto a stalled main run loop), leaving the game hung with no
  dialog.
- The handler could return without deterministically terminating.
## Describe the solution (The How)
- Register `SIGBUS`/`SIGTRAP` on non-Windows platforms.
- Write a minimal `crash.log` (header + placeholder) immediately, then flush the
  debug log and collect the stack trace, then rewrite the full report — so a
  later hang still leaves a report on disk.
- Add a cross-platform once-only crash guard; duplicate crashing threads wait for
  the first handler instead of racing it.
- Add a watchdog that force-exits if the non-interactive phase (log flush + stack
  symbolization) hangs; it stands down once the report is durable so it never
  auto-dismisses the dialog.
- Show the dialog only after the log is durable. On macOS use
  `CFUserNotificationDisplayAlert`, which runs its own run loop and works from any
  thread; other platforms keep the SDL dialog, restricted to the main thread.
- After acknowledgment, restore the default handler for the original signal,
  re-raise it, and `_Exit(EXIT_FAILURE)` as a fallback for deterministic
  termination.
## Describe alternatives you've considered
- Only showing the SDL dialog from the main thread: rejected because
  worker-thread crashes would then silently exit with no dialog.
- Marshalling the message onto the main thread's event queue for next pump:
  unreliable during a crash when the main loop isn't pumping.
## Testing
- `cmake --build out/build/osx-arm-slim --target cataclysm-bn-tiles -j 8` passes.
- Reproduced crashes on pool worker threads; verified `crash.log` is persisted
  with a full stack trace and the crash dialog appears (instead of hanging or
  exiting silently).
## Additional context
Surfaced while debugging heap corruption during parallel mapgen; the underlying
data race is fixed separately. This PR only makes the crash reporter reliable.
## Checklist
### Mandatory
- [ ] I wrote the PR title in conventional commit format.
- [ ] I ran the code formatter.
- [ ] I linked any relevant issues.
### Optional
- [x] This PR used AI assistance.
  - [ ] I added an `Assisted-by:` trailer to every AI-assisted commit.
- [x] This is a PR that modifies build process or code organization.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ddc94e0](https://github.com/cataclysmbn/Cataclysm-BN/commit/ddc94e04d697251f0f7c8331f7d459ed4656c16b) (fix: harden crash handler for worker-thread and macOS crashes) on 2026-06-10 10:17:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27264689904/artifacts/7531634899)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27264689904/artifacts/7532403409)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27264689904/artifacts/7531605877)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27264689904/artifacts/7532126737)
<!-- END artifact comment -->