### PR TITLE
fix: make safe_reference and sounds thread-safe for worker mapgen

### DIFF
--- a/src/safe_reference.cpp
+++ b/src/safe_reference.cpp
@@ -17,6 +17,7 @@ bool save_and_quit = false;
 template<typename T>
 void safe_reference<T>::serialize_global( JsonOut &json )
 {
+    const std::lock_guard<std::mutex> guard( records_mutex );
     json.start_array();
     for( auto &it : records_by_id ) {
         //TODO!: better format
@@ -33,6 +34,7 @@ void safe_reference<T>::serialize_global( JsonOut &json )
 template<typename T>
 void safe_reference<T>::deserialize_global( const JsonArray &jsin )
 {
+    const std::lock_guard<std::mutex> guard( records_mutex );
     bool pair = false;
     safe_reference<T>::id_type id;
     for( const JsonValue val : jsin ) {
@@ -158,6 +160,7 @@ void serialize<item>( const safe_reference<item> &val, JsonOut &js );
 template<typename T>
 void safe_reference<T>::cleanup()
 {
+    const std::lock_guard<std::mutex> guard( records_mutex );
     std::set<record *> records;
     for( auto &rec : records_by_pointer ) {
         records.insert( rec.second );
@@ -181,6 +184,7 @@ void safe_reference<T>::register_load( T *obj, id_type id )
     if( id == ID_NONE ) {
         return;
     }
+    const std::lock_guard<std::mutex> guard( records_mutex );
     auto search = records_by_id.find( id );
     if( search != records_by_id.end() ) {
         search->second->target.p = obj;
@@ -194,6 +198,7 @@ void safe_reference<T>::register_load( T *obj, id_type id )
 template<typename T>
 auto safe_reference<T>::lookup_id( const T *obj ) -> safe_reference<T>::id_type
 {
+    const std::lock_guard<std::mutex> guard( records_mutex );
     auto search = records_by_pointer.find( obj );
     if( search != records_by_pointer.end() ) {
         if( search->second->id == ID_NONE ) {
@@ -207,6 +212,7 @@ auto safe_reference<T>::lookup_id( const T *obj ) -> safe_reference<T>::id_type
 template<typename T>
 void safe_reference<T>::mark_destroyed( T *obj )
 {
+    const std::lock_guard<std::mutex> guard( records_mutex );
     auto search = records_by_pointer.find( obj );
     if( search == records_by_pointer.end() ) {
         return;
@@ -217,6 +223,7 @@ void safe_reference<T>::mark_destroyed( T *obj )
 template<typename T>
 void safe_reference<T>::mark_deallocated( T *obj )
 {
+    const std::lock_guard<std::mutex> guard( records_mutex );
     auto search = records_by_pointer.find( obj );
     if( search == records_by_pointer.end() ) {
         return;

--- a/src/safe_reference.h
+++ b/src/safe_reference.h
@@ -112,12 +112,20 @@ class safe_reference
 
         inline static rbp_type records_by_pointer;
         inline static rbi_type records_by_id;
+        // Guards the structure of records_by_pointer / records_by_id (insert / erase /
+        // rehash). Worker-thread mapgen creates, merges and destroys items, which adds
+        // and removes records concurrently with the main thread. Individual record
+        // fields are not guarded by this: each item belongs to exactly one omt so two
+        // workers never touch the same record. Uncontended on the main thread, so the
+        // cost during normal gameplay is a single atomic CAS per lock/unlock.
+        inline static std::mutex records_mutex;
         // Atomic so that concurrent save_omt() workers can call serialize() without
         // racing on ID generation.  Reads/writes to individual record fields are safe
         // across workers because each item belongs to exactly one omt (distinct records).
         inline static std::atomic<uint32_t> next_id = 1;
 
         auto fill( T *obj ) -> void {
+            const std::lock_guard<std::mutex> guard( records_mutex );
             rbp_it search = records_by_pointer.find( obj );
             if( search != records_by_pointer.end() ) {
                 rec = search->second;
@@ -127,6 +135,7 @@ class safe_reference
             }
         }
         auto fill( id_type id ) -> void {
+            const std::lock_guard<std::mutex> guard( records_mutex );
             rbi_it search = records_by_id.find( id );
             if( search != records_by_id.end() ) {
                 rec = search->second;
@@ -162,6 +171,9 @@ class safe_reference
             if( rec == nullptr ) {
                 return;
             }
+            // resolve_redirects() above only follows pointers; the map erases below
+            // are the structural mutations that need the lock.
+            const std::lock_guard<std::mutex> guard( records_mutex );
             //Check if we're the last in-memory reference
             if( rec->mem_count == 1 ) {
                 if( base_id( rec->id ) == ID_NONE ) {
@@ -319,6 +331,7 @@ class safe_reference
          */
         static auto merge( T *primary, T *secondary ) -> void {
 
+            const std::lock_guard<std::mutex> guard( records_mutex );
             rbp_it sec_search = records_by_pointer.find( secondary );
 
             // The secondary doesn't have a record (i.e. there are no references

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -49,6 +49,7 @@
 #include "safemode_ui.h"
 #include "string_formatter.h"
 #include "string_id.h"
+#include "thread_pool.h"
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
@@ -1849,6 +1850,13 @@ static std::unordered_map<tripoint_bub_ms, sound_event> sound_markers;
 
 void sounds::sound( const sound_event &soundevent )
 {
+    // Worker-safe mapgen (e.g. a building collapse bash during background OMT
+    // generation) can reach this, but the sound system mutates the global player
+    // map's sound cache, which is not thread-safe and would be meaningless for an
+    // area still being generated. Drop sounds raised off the main thread.
+    if( is_pool_worker_thread() ) {
+        return;
+    }
     // Make a copy so that when our referenced sound event inevitably goes out of scope things dont explode.
     auto temp_se = soundevent;
     // Make sure our sound came from a valid inbounds location.


### PR DESCRIPTION
## Purpose of change (The Why)

Background/parallel map generation runs full mapgen on pool worker threads, but
some global, main-thread-only systems are reached from there, corrupting the
heap (`pointer being freed was not allocated`, `SIGSEGV`/`SIGABRT`):

- The `safe_reference` record maps (`records_by_pointer` / `records_by_id`) are
  mutated structurally (insert/erase/rehash) when items spawned during mapgen
  are merged/destroyed (`map::spawn_items` -> `add_item_or_charges` ->
  `merge_charges`).
- The global sound cache is mutated when `map::bash` (building collapse during
  mapgen) raises sounds via `sounds::sound`.

Note: the `cata_arena` and `cached_converter` (color cache) races were fixed
separately on `main`; this PR was rebased on top of those and now only covers
the remaining unsynchronized paths.

## Describe the solution (The How)

- Guard the `safe_reference` `records_by_pointer` / `records_by_id` maps with a
  mutex, locking every structural accessor (`fill`, `remove`, `merge`,
  `register_load`, `lookup_id`, `mark_destroyed`, `mark_deallocated`, `cleanup`,
  `serialize_global`, `deserialize_global`). This mirrors the existing pattern
  already used for `cache_reference::reference_map`. Locks are never nested, and
  hot read paths (`get`, `resolve_redirects`, ...) stay lock-free.
- Drop sounds raised on worker threads (`is_pool_worker_thread()`), matching the
  existing convention in `map.cpp` / `lightmap.cpp` / `map_extras.cpp`. Such
  sounds target the global player map and are meaningless for an area being
  generated.

## Describe alternatives you've considered

- A blanket lock around all of `safe_reference` (including read paths): rejected
  for unnecessary main-thread contention; only structural map mutations need it.
- Deferring item destruction to the main thread (as already done for submap
  destruction): heavier and unnecessary once the maps are synchronized.

## Testing

- `cmake --build out/build/osx-arm-slim --target cataclysm-bn-tiles -j 8` passes.
- The crash reproduced repeatedly during parallel mapgen before this change and
  no longer occurs after it.

## Additional context

`safe_reference<item>` lifecycle now takes an uncontended lock on the main
thread too (single atomic CAS), worth a profiling pass.

## Checklist

### Mandatory

- [ ] I wrote the PR title in conventional commit format.
- [ ] I ran the code formatter.
- [ ] I linked any relevant issues.

### Optional

- [x] This PR used AI assistance.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [89e8420](https://github.com/cataclysmbn/Cataclysm-BN/commit/89e8420885045061f524a2791174a4e33e395ab0) (fix: make safe_reference and sounds thread-safe for worker mapgen) on 2026-06-04 23:50:38

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26981697096/artifacts/7424585921)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26981697096/artifacts/7424622321)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26981697096/artifacts/7424492474)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26981697096/artifacts/7424220168)
<!-- END artifact comment -->