### PR TITLE
fix: ranged weapons with low sound and extreme speeds no longer cause extreme volume

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1184,7 +1184,7 @@ static int calc_gun_volume( const item &gun )
         // Speed of sound at sea level is around 343 meters per second.
         // While it would be ideal to be based on speed of sound
         // EVERYTHING flies faster then the speed of sound so using that to force loud sounds makes little sense in the current state of affairs
-        noise = std::min( 140, noise );
+        noise = std::min( 191, noise );
     }
     for( const auto mod : parent.gunmods() ) {
         noise += mod->type->gunmod->loudness;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1184,7 +1184,8 @@ static int calc_gun_volume( const item &gun )
         // Speed of sound at sea level is around 343 meters per second.
         // While it would be ideal to be based on speed of sound
         // EVERYTHING flies faster then the speed of sound so using that to force loud sounds makes little sense in the current state of affairs
-        // NOTE: If speed gets more standardized, this is a better spot for a cap then below
+        // NOTE: If supersonic ever gets implented, use it here 
+        noise = std::max( 160, noise );
     }
     for( const auto mod : parent.gunmods() ) {
         noise += mod->type->gunmod->loudness;
@@ -1192,7 +1193,7 @@ static int calc_gun_volume( const item &gun )
 
 
     // Cap it like it gets capped when making a sound
-    noise = std::max( std::min( 191, noise ), 0 );
+    noise = std::max( noise, 0 );
     return noise;
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1184,8 +1184,8 @@ static int calc_gun_volume( const item &gun )
         // Speed of sound at sea level is around 343 meters per second.
         // While it would be ideal to be based on speed of sound
         // EVERYTHING flies faster then the speed of sound so using that to force loud sounds makes little sense in the current state of affairs
-        // NOTE: If supersonic ever gets implented, use it here
-        noise = std::max( 160, noise );
+        // NOTE: If supersonic ever gets implented, use it here 
+        noise = std::min( 160, noise );
     }
     for( const auto mod : parent.gunmods() ) {
         noise += mod->type->gunmod->loudness;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1182,9 +1182,9 @@ static int calc_gun_volume( const item &gun )
     if( gun.ammo_data() ) {
         noise += gun.ammo_data()->ammo->loudness;
         // Speed of sound at sea level is around 343 meters per second.
-        if( gun.ammo_data()->ammo->speed > 342 ) {
-            noise = std::min( 120, noise );
-        }
+        // While it would be ideal to be based on speed of sound
+        // EVERYTHING flies faster then the speed of sound so using that to force loud sounds makes little sense in the current state of affairs
+        noise = std::min( 140, noise );
     }
     for( const auto mod : parent.gunmods() ) {
         noise += mod->type->gunmod->loudness;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1184,14 +1184,15 @@ static int calc_gun_volume( const item &gun )
         // Speed of sound at sea level is around 343 meters per second.
         // While it would be ideal to be based on speed of sound
         // EVERYTHING flies faster then the speed of sound so using that to force loud sounds makes little sense in the current state of affairs
-        noise = std::min( 191, noise );
+        // NOTE: If speed gets more standardized, this is a better spot for a cap then below
     }
     for( const auto mod : parent.gunmods() ) {
         noise += mod->type->gunmod->loudness;
     }
 
 
-    noise = std::max( noise, 0 );
+    // Cap it like it gets capped when making a sound
+    noise = std::max( std::min( 191, noise ), 0 );
     return noise;
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1183,7 +1183,7 @@ static int calc_gun_volume( const item &gun )
         noise += gun.ammo_data()->ammo->loudness;
         // Speed of sound at sea level is around 343 meters per second.
         if( gun.ammo_data()->ammo->speed > 342 ) {
-            noise = std::max( 120, noise );
+            noise = std::min( 120, noise );
         }
     }
     for( const auto mod : parent.gunmods() ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1184,7 +1184,7 @@ static int calc_gun_volume( const item &gun )
         // Speed of sound at sea level is around 343 meters per second.
         // While it would be ideal to be based on speed of sound
         // EVERYTHING flies faster then the speed of sound so using that to force loud sounds makes little sense in the current state of affairs
-        // NOTE: If supersonic ever gets implented, use it here 
+        // NOTE: If supersonic ever gets implented, use it here
         noise = std::min( 160, noise );
     }
     for( const auto mod : parent.gunmods() ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1184,7 +1184,7 @@ static int calc_gun_volume( const item &gun )
         // Speed of sound at sea level is around 343 meters per second.
         // While it would be ideal to be based on speed of sound
         // EVERYTHING flies faster then the speed of sound so using that to force loud sounds makes little sense in the current state of affairs
-        // NOTE: If supersonic ever gets implented, use it here 
+        // NOTE: If supersonic ever gets implented, use it here
         noise = std::max( 160, noise );
     }
     for( const auto mod : parent.gunmods() ) {


### PR DESCRIPTION
## Purpose of change (The Why)
fixes #9276

## Describe the solution (The How)
std::max to std::min in gun volume
~~Assume the point of it was that no gun should be able to exceed 120 decibels, not that all high speed guns do~~
Retagin has confirmed that *ideally* it would be capped at 100 for subsonic and 140 for sonic
But due to everything exceeding that I'm capping everything at 191 like elsewhere it is presented ( which I hope is right )

## Describe alternatives you've considered
Figure out why slings think they are going at the speed of sound?

## Testing
Throwing stuff is quiet
Guns are still LOUD

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [05a931c](https://github.com/cataclysmbn/Cataclysm-BN/commit/05a931c6118a6f39b8ab087a461678f76bf7c436) (style(autofix.ci): automated formatting) on 2026-06-05 03:33:32

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26991203556/artifacts/7427878311)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26991203556/artifacts/7427917234)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26991203556/artifacts/7427650180)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26991203556/artifacts/7427855839)
<!-- END artifact comment -->