### PR TITLE
feat: sanity-check migration of stackable items

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -2643,6 +2643,8 @@ namespace charge_removal_blacklist
 {
 const std::set<itype_id> &get();
 void load( const JsonObject &jo );
+void defer( item *, int );
+void split_deferred();
 void reset();
 } // namespace charge_removal_blacklist
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8171,6 +8171,8 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle, const bool 
         }
     }
     reset_vehicle_cache( );
+
+    charge_removal_blacklist::split_deferred();
 }
 
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -376,6 +376,8 @@ auto game::unserialize( std::istream &fin ) -> bool
         inp_mngr.pump_events();
         Messages::deserialize( data );
 
+        charge_removal_blacklist::split_deferred();
+
     } catch( const JsonError &jsonerr ) {
         debugmsg( "Bad save json\n%s", jsonerr.c_str() );
         return false;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -77,6 +77,7 @@
 #include "lru_cache.h"
 #include "magic.h"
 #include "magic_teleporter_list.h"
+#include "map.h"
 #include "map_memory.h"
 #include "mapdata.h"
 #include "mattack_common.h"
@@ -2492,6 +2493,72 @@ void reset()
 {
     removal_list.clear();
 }
+static std::vector<std::tuple<item *, int>> split_defer;
+void defer( item *it, int cnt )
+{
+    split_defer.push_back( std::make_tuple( it, cnt ) );
+}
+
+void split_deferred()
+{
+    auto &m = get_map();
+
+    for( const auto& [it, cnt] : split_defer ) {
+        const auto pos = it->position();
+        for( auto n = 0; n < cnt; n++ ) {
+            auto tmp = item::spawn( *it );
+
+            /* Handle Vehicle */
+            const auto vp = m.veh_at( pos );
+            if( vp.has_value() ) {
+                const auto vpid = vp->part_index();
+                const auto stk = vp->vehicle().get_items( vpid );
+                if( std::ranges::contains( stk, it ) ) {
+                    tmp = vp->vehicle().add_item( vpid, std::move( tmp ) );
+                }
+                if( !tmp ) {
+                    continue;
+                }
+            }
+
+            /* Handle Player  */
+            {
+                auto &u = get_avatar();
+                if( u.has_item( *it ) ) {
+                    tmp = u.i_add_or_drop( std::move( tmp ) );
+                }
+                if( !tmp ) {
+                    continue;
+                }
+            }
+
+            /* Handle NPCs */
+            {
+                const auto npc_vec = get_overmapbuffer( m.get_bound_dimension() ).get_overmap_npcs();
+                for( const auto &p : npc_vec ) {
+                    if( p->has_item( *it ) ) {
+                        tmp = p->i_add_or_drop( std::move( tmp ) );
+                    }
+                    if( !tmp ) {
+                        break;
+                    }
+                }
+                if( !tmp ) {
+                    continue;
+                }
+            }
+
+            /* drop on map */
+            tmp = m.add_item_or_charges( pos, std::move( tmp ) );
+
+            if( tmp ) {
+                debugmsg( "failed to split charges to items: %s", it->type_name( 1 ) );
+            }
+        }
+    }
+    split_defer.clear();
+}
+
 } // namespace charge_removal_blacklist
 
 namespace to_cbc_migration
@@ -2810,11 +2877,15 @@ void item::io( Archive &archive )
     if( charges != 0 && !type->can_have_charges() ) {
         // Types that are known to have charges, but should not have them.
         // We fix it here, but it's expected from bugged saves and does not require a message.
-        if( !charge_removal_blacklist::get().contains( type->get_id() ) ) {
-            debugmsg( "Item %s was loaded with charges, but can not have any!", type->get_id() );
-        }
+        const auto to_split = charges - 1;
         charges = 0;
         curammo = nullptr;
+
+        if( !charge_removal_blacklist::get().contains( type->get_id() ) ) {
+            debugmsg( "Item %s was loaded with charges, but can not have any!", type->get_id() );
+        } else if( to_split > 0 ) {
+            charge_removal_blacklist::defer( this, to_split );
+        }
     }
 
     // Relic check. Kinda late, but that's how relics have to be


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This splits off another now-unrelated feature from https://github.com/cataclysmbn/Cataclysm-BN/pull/8859 which was needed when my initial solution to invulnerable quarterpanels was to make sheet metal no longer stackable, but now this is just a standalone improvement to charge removal blacklist behavior.

Entirely done by @Usagirei, I'm just moving this to its own PR. Co-auth retained in commit.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In item.h, add defintions for `defer` and `split_deferred` to `charge_removal_blacklist` namespace.
2. In map.cpp, added a call to `charge_removal_blacklist::split_deferred` to `map::load`.
3. In savegame.cpp, added a call to `charge_removal_blacklist::split_deferred` to `game::unserialize`.
4. In savegame_json.cpp, added map.h to includes and added function defintions for `defer` and `split_deferred` to `charge_removal_blacklist` namespace.
5. Also in savegame_json.cpp, `item::io` updated to also do its part to split up stacks that have been migrated to charge removal blacklist.

## Describe alternatives you've considered

Keeping it in the PR. It's no longer essential since we're adding damagable stackables instead plus the risks of that feature mean it might hold it up for a while anyway.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned a stack of 10 sheet metal.
3. Saved, temporarily removed stackable from sheet metal and added it to charge blacklist.
4. Loaded, it correctly converts into 10 individual sheet metals instead of leaving only a single one like it used to.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2c57cb9](https://github.com/cataclysmbn/Cataclysm-BN/commit/2c57cb94aa13508249f605b5fda05729425e429b) (feat: sanity-check migration of stackable items) on 2026-06-05 01:35:52

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26985694379/artifacts/7426124642)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26985694379/artifacts/7426090054)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26985694379/artifacts/7425744539)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26985694379/artifacts/7426245398)
<!-- END artifact comment -->