### PR TITLE
fix: silent throw/bow ammunition was creating sonic booms

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1180,10 +1180,14 @@ static int calc_gun_volume( const item &gun )
     int noise = parent.type->gun->loudness;
     // Check the ammo data first so that subsonic ammo is suppressable by gun mods.
     if( gun.ammo_data() ) {
-        noise += gun.ammo_data()->ammo->loudness;
-        // Speed of sound at sea level is around 343 meters per second.
-        if( gun.ammo_data()->ammo->speed > 342 ) {
-            noise = std::max( 120, noise );
+        // if ammo loudness is explicitly set to 0, it should always be quiet. Speed gets used strangely
+        // in too many ammo types and we shouldn't trust that it is always true speed.
+        if ( gun.ammo_data()->ammo->loudness > 0) {
+            noise += gun.ammo_data()->ammo->loudness;
+            // Speed of sound at sea level is around 343 meters per second.
+            if( gun.ammo_data()->ammo->speed > 342 ) {
+                noise = std::max( 120, noise );
+            }
         }
     }
     for( const auto mod : parent.gunmods() ) {


### PR DESCRIPTION
## Purpose of change (The Why)

Keep silent ammo silent, don't trust the speed setting

Resolves #9276 

## Describe the solution (The How)

If ammo loudness is explicitly 0, treat it as silent ammo no matter the speed

## Describe alternatives you've considered

Sling shots cause sonic booms until all the zombies get annoyed

## Testing

Waiting for experimental build since I can't compile on this computer

## Additional context

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.