### PR TITLE
fix: make 0 loudness ammo be quiet even if supersonic

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1180,7 +1180,7 @@ static int calc_gun_volume( const item &gun )
     int noise = parent.type->gun->loudness;
     // Check the ammo data first so that subsonic ammo is suppressable by gun mods. However due to legacy ammo types and
     // default speeds, allow ammo that is explicitly set to 0 to still be quiet.
-    if( gun.ammo_data() && gun.amm_data()->ammo->loundess > 0) {
+    if( gun.ammo_data() && gun.amm_data()->ammo->loudness > 0) {
         noise += gun.ammo_data()->ammo->loudness;
         // Speed of sound at sea level is around 343 meters per second.
         if( gun.ammo_data()->ammo->speed > 342 ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1180,7 +1180,7 @@ static int calc_gun_volume( const item &gun )
     int noise = parent.type->gun->loudness;
     // Check the ammo data first so that subsonic ammo is suppressable by gun mods. However due to legacy ammo types and
     // default speeds, allow ammo that is explicitly set to 0 to still be quiet.
-    if( gun.ammo_data() && gun.amm_data()->ammo->loudness > 0) {
+    if( gun.ammo_data() && gun.amm_data()->ammo->loudness > 0 ) {
         noise += gun.ammo_data()->ammo->loudness;
         // Speed of sound at sea level is around 343 meters per second.
         if( gun.ammo_data()->ammo->speed > 342 ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1180,7 +1180,7 @@ static int calc_gun_volume( const item &gun )
     int noise = parent.type->gun->loudness;
     // Check the ammo data first so that subsonic ammo is suppressable by gun mods. However due to legacy ammo types and
     // default speeds, allow ammo that is explicitly set to 0 to still be quiet.
-    if( gun.ammo_data() && gun.amm_data()->ammo->loudness > 0 ) {
+    if( gun.ammo_data() && gun.ammo_data()->ammo->loudness > 0 ) {
         noise += gun.ammo_data()->ammo->loudness;
         // Speed of sound at sea level is around 343 meters per second.
         if( gun.ammo_data()->ammo->speed > 342 ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1178,8 +1178,9 @@ static int calc_gun_volume( const item &gun )
     // If our ammo is subsonic, loudness mods from the gun and gunmods can reduce noise freely.
     // If the ammo is not subsonic, loudness cannot be reduced below 120 as the bullet will make a sonic boom.
     int noise = parent.type->gun->loudness;
-    // Check the ammo data first so that subsonic ammo is suppressable by gun mods.
-    if( gun.ammo_data() ) {
+    // Check the ammo data first so that subsonic ammo is suppressable by gun mods. However due to legacy ammo types and
+    // default speeds, allow ammo that is explicitly set to 0 to still be quiet.
+    if( gun.ammo_data() && gun.amm_data()->ammo->loundess > 0) {
         noise += gun.ammo_data()->ammo->loudness;
         // Speed of sound at sea level is around 343 meters per second.
         if( gun.ammo_data()->ammo->speed > 342 ) {
@@ -1189,7 +1190,6 @@ static int calc_gun_volume( const item &gun )
     for( const auto mod : parent.gunmods() ) {
         noise += mod->type->gunmod->loudness;
     }
-
 
     noise = std::max( noise, 0 );
     return noise;


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9276 

## Describe the solution (The How)

If loudness was 0, explicitly let that ammo be quiet even if it's a sonic boom 

## Describe alternatives you've considered

Getting into why the default speed for some projectiles is 3x the speed of sound,
nerfing that to a reasonable level
trying to figure out all things that work off speed and how the values need to change 


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [00d86bb](https://github.com/cataclysmbn/Cataclysm-BN/commit/00d86bb815a42f97fb43eba999dc869ff79a780b) (fix other typo) on 2026-06-05 01:40:43

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26987902315/artifacts/7426427508)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26987902315/artifacts/7426834040)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26987902315/artifacts/7426386504)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26987902315/artifacts/7426863994)
<!-- END artifact comment -->