### PR TITLE
fix: make adjacent pit movement safe

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -49,6 +49,7 @@
 #include "npc.h"
 #include "options.h"
 #include "output.h"
+#include "utils/pit_trap_helpers.h"
 #include "player_activity.h"
 #include "projectile.h"
 #include "ranged.h"
@@ -260,7 +261,9 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
         attacking = true;
     }
 
-    if( !you.move_effects( attacking ) ) {
+    const auto skip_pit_escape = pit_trap_helpers::skips_pit_escape_check( m.tr_at( you.bub_pos() ),
+                                 m.tr_at( dest_loc ) );
+    if( !you.move_effects( attacking, skip_pit_escape ) ) {
         you.moves -= 100;
         return false;
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1817,7 +1817,12 @@ void static try_remove_webs( Character &c )
     }
 }
 
-bool Character::move_effects( bool attacking )
+auto Character::move_effects( const bool attacking ) -> bool
+{
+    return move_effects( attacking, false );
+}
+
+auto Character::move_effects( const bool attacking, const bool skip_pit_escape ) -> bool
 {
     if( has_effect( effect_downed ) ) {
         try_remove_downed( *this );
@@ -1848,7 +1853,7 @@ bool Character::move_effects( bool attacking )
 
     // Currently we only have one thing that forces movement if you succeed, should we get more
     // than this will need to be reworked to only have success effects if /all/ checks succeed
-    if( has_effect( effect_in_pit ) ) {
+    if( has_effect( effect_in_pit ) && !skip_pit_escape ) {
         /** @EFFECT_STR increases chance to escape pit */
 
         /** @EFFECT_DEX increases chance to escape pit, slightly */

--- a/src/character.h
+++ b/src/character.h
@@ -584,6 +584,7 @@ class Character : public Creature, public location_visitable<Character>
         /** Processes effects which may prevent the Character from moving (bear traps, crushed, etc.).
          *  Returns false if movement is stopped. */
         bool move_effects( bool attacking ) override;
+        auto move_effects( bool attacking, bool skip_pit_escape ) -> bool;
 
         void wait_effects();
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -157,6 +157,7 @@
 #include "path_info.h"
 #include "pathfinding.h"
 #include "pickup.h"
+#include "utils/pit_trap_helpers.h"
 #include "player.h"
 #include "player_activity.h"
 #include "point_float.h"
@@ -12053,6 +12054,9 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
     }
 
     const trap &tr = m.tr_at( dest_loc );
+    const auto regular_pit_move = pit_trap_helpers::is_regular_pit_destination_from_pit( m.tr_at(
+                                      u.bub_pos() ),
+                                  tr );
     if( !u.is_blind() || u.clairvoyance() < 1 || tr.can_see( dest_loc, u ) ) {
         const bool boardable = static_cast<bool>( m.veh_at( dest_loc ).part_with_feature( "BOARDABLE",
                                true ) );
@@ -12064,7 +12068,8 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
                     harmful_stuff.emplace_back( tr.name() );
                 }
             }
-        } else if( tr.can_see( dest_loc, u ) && !tr.is_benign() && !boardable ) {
+        } else if( tr.can_see( dest_loc, u ) && !tr.is_benign() && !boardable &&
+                   !regular_pit_move ) {
             harmful_stuff.emplace_back( tr.name() );
         }
 
@@ -12527,6 +12532,9 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
 
 auto game::place_player( const tripoint_bub_ms &dest_loc, const bool keep_grab ) -> point_rel_sm
 {
+    const auto regular_pit_move = pit_trap_helpers::is_regular_pit_destination_from_pit( m.tr_at(
+                                      u.bub_pos() ),
+                                  m.tr_at( dest_loc ) );
     const optional_vpart_position vp1 = m.veh_at( dest_loc );
     if( const std::optional<std::string> label = vp1.get_label() ) {
         add_msg( m_info, _( "Label here: %s" ), *label );
@@ -12762,10 +12770,12 @@ auto game::place_player( const tripoint_bub_ms &dest_loc, const bool keep_grab )
     // Traps!
     // Try to detect.
     character_funcs::search_surroundings( u );
-    if( u.is_mounted() ) {
-        m.creature_on_trap( *u.mounted_creature );
-    } else {
-        m.creature_on_trap( u );
+    if( !regular_pit_move ) {
+        if( u.is_mounted() ) {
+            m.creature_on_trap( *u.mounted_creature );
+        } else {
+            m.creature_on_trap( u );
+        }
     }
     // Drench the player if swimmable
     if( m.has_flag( "SWIMMABLE", u.bub_pos() ) &&

--- a/src/utils/pit_trap_helpers.cpp
+++ b/src/utils/pit_trap_helpers.cpp
@@ -1,0 +1,21 @@
+#include "utils/pit_trap_helpers.h"
+
+namespace pit_trap_helpers {
+
+auto is_pit_trap_type(const trap_id& id) -> bool {
+    return id == tr_pit || id == tr_spike_pit || id == tr_glass_pit;
+}
+
+auto is_same_pit_trap_type(const trap& from, const trap& to) -> bool {
+    return from.loadid == to.loadid && is_pit_trap_type(from.loadid);
+}
+
+auto is_regular_pit_destination_from_pit(const trap& from, const trap& to) -> bool {
+    return is_pit_trap_type(from.loadid) && to.loadid == tr_pit;
+}
+
+auto skips_pit_escape_check(const trap& from, const trap& to) -> bool {
+    return is_same_pit_trap_type(from, to) || is_regular_pit_destination_from_pit(from, to);
+}
+
+} // namespace pit_trap_helpers

--- a/src/utils/pit_trap_helpers.h
+++ b/src/utils/pit_trap_helpers.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "trap.h"
+
+namespace pit_trap_helpers {
+
+auto is_pit_trap_type(const trap_id& id) -> bool;
+auto is_same_pit_trap_type(const trap& from, const trap& to) -> bool;
+auto is_regular_pit_destination_from_pit(const trap& from, const trap& to) -> bool;
+auto skips_pit_escape_check(const trap& from, const trap& to) -> bool;
+
+} // namespace pit_trap_helpers

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -4,14 +4,116 @@
 #include <vector>
 
 #include "avatar.h"
+#include "avatar_action.h"
 #include "coordinates.h"
 #include "enums.h"
 #include "game.h"
 #include "game_constants.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "options_helpers.h"
 #include "state_helpers.h"
 #include "type_id.h"
+
+namespace
+{
+
+static const auto effect_in_pit = efftype_id( "in_pit" );
+static const auto skill_dodge = skill_id( "dodge" );
+
+struct adjacent_pit_move {
+    tripoint_bub_ms origin;
+    tripoint_bub_ms destination;
+};
+
+auto setup_adjacent_pit_move( const ter_id &origin_terrain,
+                              const ter_id &destination_terrain ) -> adjacent_pit_move
+{
+    clear_all_state();
+    auto &here = get_map();
+    const auto origin = tripoint_bub_ms( 60, 60, 0 );
+    const auto destination = origin + tripoint_rel_ms::east();
+
+    g->place_player( origin );
+    here.ter_set( origin, origin_terrain );
+    here.ter_set( destination, destination_terrain );
+    g->u.add_known_trap( origin, here.tr_at( origin ) );
+    g->u.add_known_trap( destination, here.tr_at( destination ) );
+    g->u.add_effect( effect_in_pit, 1_turns, bodypart_str_id::NULL_ID() );
+    g->u.str_cur = 0;
+    g->u.dex_cur = 0;
+    g->u.set_skill_level( skill_dodge, 0 );
+    g->u.moves = 1000;
+
+    return { .origin = origin, .destination = destination };
+}
+
+auto setup_adjacent_pit_move( const ter_id &terrain ) -> adjacent_pit_move
+{
+    return setup_adjacent_pit_move( terrain, terrain );
+}
+
+} // namespace
+
+TEST_CASE( "moving_between_adjacent_pit_traps" )
+{
+    SECTION( "regular pit movement skips warning, escape check, and repeated damage" ) {
+        const auto positions = setup_adjacent_pit_move( ter_id( "t_pit" ) );
+        const auto hp_before = g->u.get_hp();
+
+        CHECK( g->get_dangerous_tile( positions.destination ).empty() );
+        REQUIRE( avatar_action::move( g->u, get_map(), tripoint_rel_ms::east() ) );
+
+        CHECK( g->u.bub_pos() == positions.destination );
+        CHECK( g->u.get_hp() == hp_before );
+        CHECK( g->u.has_effect( effect_in_pit ) );
+    }
+
+    SECTION( "same spiked pit movement skips only the escape check" ) {
+        const auto positions = setup_adjacent_pit_move( ter_id( "t_pit_spiked" ) );
+        const auto dangerous_prompt = override_option( "DANGEROUS_TERRAIN_WARNING_PROMPT", "IGNORE" );
+        const auto hp_before = g->u.get_hp();
+
+        CHECK_FALSE( g->get_dangerous_tile( positions.destination ).empty() );
+        REQUIRE( avatar_action::move( g->u, get_map(), tripoint_rel_ms::east() ) );
+
+        CHECK( g->u.bub_pos() == positions.destination );
+        CHECK( g->u.get_hp() < hp_before );
+    }
+
+    SECTION( "same glass pit movement skips only the escape check" ) {
+        const auto positions = setup_adjacent_pit_move( ter_id( "t_pit_glass" ) );
+        const auto dangerous_prompt = override_option( "DANGEROUS_TERRAIN_WARNING_PROMPT", "IGNORE" );
+        const auto hp_before = g->u.get_hp();
+
+        CHECK_FALSE( g->get_dangerous_tile( positions.destination ).empty() );
+        REQUIRE( avatar_action::move( g->u, get_map(), tripoint_rel_ms::east() ) );
+
+        CHECK( g->u.bub_pos() == positions.destination );
+        CHECK( g->u.get_hp() < hp_before );
+    }
+
+    SECTION( "glass pit to regular pit skips warning, escape check, and repeated damage" ) {
+        const auto positions = setup_adjacent_pit_move( ter_id( "t_pit_glass" ), ter_id( "t_pit" ) );
+        const auto hp_before = g->u.get_hp();
+
+        CHECK( g->get_dangerous_tile( positions.destination ).empty() );
+        REQUIRE( avatar_action::move( g->u, get_map(), tripoint_rel_ms::east() ) );
+
+        CHECK( g->u.bub_pos() == positions.destination );
+        CHECK( g->u.get_hp() == hp_before );
+        CHECK( g->u.has_effect( effect_in_pit ) );
+    }
+
+    SECTION( "different pit trap movement remains dangerous" ) {
+        const auto positions = setup_adjacent_pit_move( ter_id( "t_pit" ) );
+        auto &here = get_map();
+        here.ter_set( positions.destination, ter_id( "t_pit_spiked" ) );
+        g->u.add_known_trap( positions.destination, here.tr_at( positions.destination ) );
+
+        CHECK_FALSE( g->get_dangerous_tile( positions.destination ).empty() );
+    }
+}
 
 TEST_CASE( "destroy_grabbed_furniture" )
 {


### PR DESCRIPTION
## Purpose of change (The Why)

Continues #9279. Moving between connected pit tiles should not repeatedly force a pit escape roll, and moving into a regular pit from another pit should not warn or apply another fall because that's annoying

## Describe the solution (The How)

- Skip the pit escape check when moving between the same pit trap type.
- Treat any pit-to-regular-pit move as safe from the warning prompt and repeated trap damage.
- Keep movement into damaging different pit traps dangerous.

## Additional context

See #9279.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-keywords-in-issues-and-pull-requests) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0ff21e0](https://github.com/cataclysmbn/Cataclysm-BN/commit/0ff21e0529f5a37d9f114e7f4813c24d3ee239e3) (fix: handle adjacent pit movement) on 2026-06-05 03:49:34

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26991862443/artifacts/7428232599)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26991862443/artifacts/7428234769)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26991862443/artifacts/7428072324)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/26991862443/artifacts/7427975642)
<!-- END artifact comment -->