### PR TITLE
fix: remove mandatory backfire from engine start

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1137,16 +1137,6 @@ bool vehicle::start_engine( const int e )
     if( einfo.engine_backfire_threshold() ) {
         if( ( 1 - dmg ) < einfo.engine_backfire_threshold() && one_in( einfo.engine_backfire_freq() ) ) {
             backfire( e );
-        } else {
-            sound_event se;
-            se.origin = pos;
-            se.volume = std::min( 135, std::max( start_moves, 85 ) );
-            se.category = sounds::sound_t::movement;
-            se.movement_noise = true;
-            se.description = string_format( _( "the %s bang as it starts" ), eng.name() );
-            se.id = "vehicle";
-            se.variant = "engine_bangs_start";
-            sounds::sound( se );
         }
     }
 


### PR DESCRIPTION
Engines that could backfire always backfired when starting, this was just not being noticed until the sound change made sounds mean something.

## Describe the solution (The How)

Engines that could backfire would check for a backfire at start. If this failed they would make a loud bang anyway. Which wasn't the start noise because there's an explicit call for engine start noise below this at the bottom of the engine start function. Also the false backfire was very loud at 135 db even with a dinky engine. 

## Describe alternatives you've considered

Making engines cause 135 db bangs at every startup, alerting zombies for miles.

## Testing

Spawned fresh car. Drove about. No 135db banging startup from a brand new car. However the startup volume is pretty low. This is true while driving too, road noise is pretty much non-existent if I'm reading this correctly. But that's another issue.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a843a5f](https://github.com/cataclysmbn/Cataclysm-BN/commit/a843a5fe03f82ea2c90848de21d2538eb0aa0bd9) (remove backfire from engine start) on 2026-06-05 19:00:21

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27031294015/artifacts/7443450618)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27031294015/artifacts/7444243672)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27031294015/artifacts/7443563257)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27031294015/artifacts/7443737849)
<!-- END artifact comment -->