### PR TITLE
feat(balance): reduce backfire volume

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1506,7 +1506,7 @@ void vehicle::backfire( const int e ) const
     const auto pos = bub_part_location( engines[e] );
     sound_event se;
     se.origin = pos;
-    se.volume = 100 + rng(0,20) + rng(0,20);
+    se.volume = 100 + rng( 0, 20 ) + rng( 0, 20 );
     se.category = sounds::sound_t::movement;
     se.movement_noise = true;
     se.description = string_format( _( "a loud BANG! from the %s" ), // NOLINT(cata-text-style)

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1506,7 +1506,7 @@ void vehicle::backfire( const int e ) const
     const auto pos = bub_part_location( engines[e] );
     sound_event se;
     se.origin = pos;
-    se.volume = std::min( 160, 40 + power / 10000 );
+    se.volume = 100 + rng(0,20) + rng(0,20);
     se.category = sounds::sound_t::movement;
     se.movement_noise = true;
     se.description = string_format( _( "a loud BANG! from the %s" ), // NOLINT(cata-text-style)


### PR DESCRIPTION
Backfires are way loud and quickly will hit the max of 140 because they are based on engine power which is not reasonable. A more powerful engine should backfire at less damage and will backfire more, but those values are already part of the engine part definition files.

Gave backfires a bit of a range of volume because backfires are like that.

## Purpose of change (The Why)

Backfires are basically hitting the max of 140db with all engines, and that's a really loud backfire.

## Describe the solution (The How)

Make backfires volume independent of the engine power.

## Describe alternatives you've considered

Tuning every engine type differently to change how often backfires occur
## Checklist

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3cf974f](https://github.com/cataclysmbn/Cataclysm-BN/commit/3cf974f16f317f2038cd4e715c5f72d4bf3aa267) (style(autofix.ci): automated formatting) on 2026-06-05 19:33:53

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27032982618/artifacts/7444160913)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27032982618/artifacts/7444882495)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27032982618/artifacts/7444097093)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27032982618/artifacts/7444473222)
<!-- END artifact comment -->