### PR TITLE
fix: check for `inbounds` when monsters process sounds

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -2173,8 +2173,8 @@ void sounds::process_sounds()
     // Monsters ignore movement sounds from their own faction, a bit omiscient but it simplifies things.
     for( monster &critter : g->all_monsters() ) {
 
-        // Monster is deaf, skip. We also skip hallucinations.
-        if( !critter.can_hear() || critter.is_hallucination() ) {
+        // Monster is deaf, skip. We also skip hallucinations and monsters not loaded in.
+        if( !critter.can_hear() || critter.is_hallucination() || !map.inbounds( critter.bub_pos() ) ) {
             continue;
         }
         sound_filter_key filter_key;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fix for random sound crashes provided by @Retagin who was currently busy with another PR.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In sounds.cpp, `sounds::process_sounds` now also skips over monsters that aren't inbounds, in addition to deaf and hallucinatory ones.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

I'm gonna have to keep dicking around with it until I'm reasonably sure I've tested enough in my playthrough save that the random crash is truly gone for real now. Random crashes are such a pain in the dick...

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c33bd17](https://github.com/cataclysmbn/Cataclysm-BN/commit/c33bd175dc9dd48380d9499fc9df404f76d03687) (fix: check for `inbounds` when monsters process sounds) on 2026-06-06 02:31:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27048794115/artifacts/7449974524)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27048794115/artifacts/7450291128)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27048794115/artifacts/7450105957)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27048794115/artifacts/7450120343)
<!-- END artifact comment -->