### PR TITLE
fix(UI): preserve android force fullscreen preference

### DIFF
--- a/android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -26,6 +26,7 @@ import android.os.Handler;
 import android.os.LocaleList;
 import android.os.Message;
 import android.os.ParcelFileDescriptor;
+import android.preference.PreferenceManager;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.SparseArray;
@@ -926,9 +927,14 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                         } else {
                             int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
                             window.getDecorView().setSystemUiVisibility(flags);
-                            window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-                            window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                            SDLActivity.mFullscreenModeActive = false;
+                            Context appContext = context.getApplicationContext();
+                            boolean forceFullscreen =
+                                    PreferenceManager.getDefaultSharedPreferences(appContext).getBoolean("Force fullscreen", false);
+                            window.addFlags(forceFullscreen ? WindowManager.LayoutParams.FLAG_FULLSCREEN :
+                                            WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                            window.clearFlags(forceFullscreen ? WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN :
+                                              WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                            SDLActivity.mFullscreenModeActive = forceFullscreen;
                         }
                         if (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */) {
                             window.getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
@@ -2227,4 +2233,3 @@ class SDLClipboardHandler implements
         SDLActivity.onNativeClipboardChanged();
     }
 }
-


### PR DESCRIPTION
## Purpose of change (The Why)

- fixes #9172

Android fullscreen mode could be cleared after SDL changed the window style, even when the player had enabled the Android `Force fullscreen` startup option.

## Describe the solution (The How)

When SDL applies the visible window style, the Android activity now checks the stored `Force fullscreen` preference before updating window flags.

If the preference is enabled, the activity keeps `FLAG_FULLSCREEN`, clears `FLAG_FORCE_NOT_FULLSCREEN`, and keeps `mFullscreenModeActive` true. If it is disabled, the previous non-fullscreen behavior is preserved.

## Describe alternatives you've considered

Leaving SDL's default visible-window behavior unchanged would keep clearing fullscreen despite the user preference.

## Testing

- Ran `git diff --check upstream/main...HEAD`.
- Built Android `arm64-v8a` debug APK successfully with `assembleStableDebug`.
- Manually installed and verified the fix on an Android arm64 device.

Before, the status bar stayed visible and reduced the game area:

![Before fullscreen fix](https://raw.githubusercontent.com/marojiro/Cataclysm-BN/pr-assets/9172-fullscreen/pr-assets/9172-fullscreen/BEFORE.jpg)

After, the game uses fullscreen correctly:

![After fullscreen fix](https://raw.githubusercontent.com/marojiro/Cataclysm-BN/pr-assets/9172-fullscreen/pr-assets/9172-fullscreen/AFTER.jpg)

## Additional context

This PR used AI assistance from gpt-5.5 xhigh.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style) / style check where applicable (`git diff --check`; no project Java formatter was found).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6771940](https://github.com/cataclysmbn/Cataclysm-BN/commit/677194050a374be22210009e982b4e0bf029cae5) (fix(android): preserve force fullscreen preference) on 2026-06-06 14:56:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27064132265/artifacts/7454973778)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27064132265/artifacts/7455246571)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27064132265/artifacts/7454984154)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27064132265/artifacts/7455092746)
<!-- END artifact comment -->