### PR TITLE
feat(balance): add recipes for some more magazines

### DIFF
--- a/data/json/recipes/weapon/magazines.json
+++ b/data/json/recipes/weapon/magazines.json
@@ -529,6 +529,58 @@
     "components": [ [ [ "plastic_chunk", 5 ] ] ]
   },
   {
+    "result": "glock40mag",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "skill_used": "computer",
+    "difficulty": 3,
+    "skills_required": [ [ "fabrication", 2 ] ],
+    "time": "3 m",
+    "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ], [ "textbook_anarch", 3 ], [ "reference_fabrication1", 3 ] ],
+    "using": [ [ "3d_printing_standard", 3 ] ],
+    "components": [ [ [ "plastic_chunk", 3 ] ] ]
+  },
+  {
+    "result": "glock40bigmag",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "skill_used": "computer",
+    "difficulty": 3,
+    "skills_required": [ [ "fabrication", 2 ] ],
+    "time": "5 m",
+    "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ], [ "textbook_anarch", 3 ], [ "reference_fabrication1", 3 ] ],
+    "using": [ [ "3d_printing_standard", 5 ] ],
+    "components": [ [ [ "plastic_chunk", 4 ] ] ]
+  },
+  {
+    "result": "saiga10mag",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "skill_used": "computer",
+    "difficulty": 4,
+    "skills_required": [ [ "fabrication", 3 ] ],
+    "time": "5 m",
+    "book_learn": [ [ "textbook_computer", 4 ], [ "advanced_electronics", 4 ], [ "textbook_anarch", 4 ], [ "reference_fabrication1", 3 ] ],
+    "using": [ [ "3d_printing_standard", 5 ] ],
+    "components": [ [ [ "plastic_chunk", 5 ] ] ]
+  },
+  {
+    "result": "saiga410mag_10rd",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "skill_used": "computer",
+    "difficulty": 4,
+    "skills_required": [ [ "fabrication", 3 ] ],
+    "time": "5 m",
+    "book_learn": [ [ "textbook_computer", 4 ], [ "advanced_electronics", 4 ], [ "textbook_anarch", 4 ], [ "reference_fabrication1", 3 ] ],
+    "using": [ [ "3d_printing_standard", 5 ] ],
+    "components": [ [ [ "plastic_chunk", 5 ] ] ]
+  },
+  {
     "result": "carbonmag_223",
     "type": "recipe",
     "category": "CC_WEAPON",
@@ -767,6 +819,21 @@
     "components": [ [ [ "scrap", 4 ] ] ]
   },
   {
+    "result": "falmag",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "autolearn": false,
+    "skill_used": "fabrication",
+    "book_learn": [ [ "mag_guns", 3 ] ],
+    "difficulty": 3,
+    "time": "120 m",
+    "reversible": true,
+    "decomp_learn": 3,
+    "using": [ [ "magazine_standard", 5 ] ],
+    "components": [ [ [ "scrap", 5 ] ] ]
+  },
+  {
     "result": "g3mag",
     "type": "recipe",
     "category": "CC_WEAPON",
@@ -855,6 +922,21 @@
     "decomp_learn": 3,
     "using": [ [ "magazine_standard", 5 ] ],
     "components": [ [ [ "scrap", 10 ] ] ]
+  },
+  {
+    "result": "m1911mag",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "autolearn": false,
+    "skill_used": "fabrication",
+    "book_learn": [ [ "mag_guns", 3 ] ],
+    "difficulty": 3,
+    "time": "60 m",
+    "reversible": true,
+    "decomp_learn": 3,
+    "using": [ [ "magazine_standard", 5 ] ],
+    "components": [ [ [ "scrap", 2 ] ] ]
   },
   {
     "result": "usp45mag",
@@ -1247,6 +1329,21 @@
     "components": [ [ [ "scrap", 3 ] ] ]
   },
   {
+    "result": "m9mag",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "autolearn": false,
+    "skill_used": "fabrication",
+    "book_learn": [ [ "mag_guns", 3 ] ],
+    "difficulty": 3,
+    "time": "60 m",
+    "reversible": true,
+    "decomp_learn": 3,
+    "using": [ [ "magazine_standard", 5 ] ],
+    "components": [ [ [ "scrap", 3 ] ] ]
+  },
+  {
     "result": "m9bigmag",
     "type": "recipe",
     "category": "CC_WEAPON",
@@ -1590,6 +1687,21 @@
     "decomp_learn": 3,
     "using": [ [ "magazine_standard", 5 ] ],
     "components": [ [ [ "scrap", 2 ] ] ]
+  },
+  {
+    "result": "gatlingdrum240",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "autolearn": false,
+    "skill_used": "fabrication",
+    "book_learn": [ [ "mag_guns", 5 ] ],
+    "difficulty": 5,
+    "time": "120 m",
+    "reversible": true,
+    "decomp_learn": 3,
+    "using": [ [ "magazine_standard", 25 ] ],
+    "components": [ [ [ "steel_standard", 8, "LIST" ] ], [ [ "cartridgebrass", 2000 ] ] ]
   },
   {
     "result": "22_speedloader8",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This adds some recipes for basic magazines that were absent.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Adds an FAL magazine recipe.
2. Adds a recipe for standard M9 magazines, bit weird that only extended mags were allowed.
3. Added recipes for 15 and 22 round .40 S&W Glock mags.
4. Added recipe for M1911 magazines.
5. Added recipe for gatling drums.
6. Added recipes for 10-round Saiga-12 and Saiga-410 mags.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Ported to playthrough build and load-tested.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Things I should do in the future:
1. Audit recipe skill levels so makeshift mags still have a purpose.
2. Check for plastic mags made out of the wrong materials.
3. Add some use of `magazine_standard` to the 3D-printed recipes and a small amount of scrap metal.
4. Possibly add small-metal version of aluminum so aluminum mags like the G3 magazine can be made out of the correct material, or just be lazy and use whole big-ass ingots?

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3c0c949](https://github.com/cataclysmbn/Cataclysm-BN/commit/3c0c9494f3cde6029a803fd23fa6ae3fc25f7943) (feat(balance): add recipes for some more magazines) on 2026-06-06 16:58:44

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27067386995/artifacts/7455950649)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27067386995/artifacts/7456140968)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27067386995/artifacts/7455956999)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27067386995/artifacts/7456083348)
<!-- END artifact comment -->