### PR TITLE
feat(balance): add a recipe for sawing 40x53mm cases into 40x46mm cases

### DIFF
--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -873,5 +873,20 @@
     "tools": [ [ [ "hydraulic_press", 10 ] ], [ [ "forging_standard", 1, "LIST" ] ] ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 6 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "40x46mm_casing",
+    "id_suffix": "resize",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_COMPONENTS",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "skills_required": [ "gun", 3 ],
+    "time": "3 m",
+    "batch_time_factors": [ 80, 5 ],
+    "book_learn": [ [ "manual_launcher", 5 ], [ "recipe_bullets", 3 ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "DRILL", "level": 2 }, { "id": "CASING_PRESSING", "level": 2 } ],
+    "components": [ [ [ "40x53mm_casing", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This follows up on an idea I brought up in https://github.com/cataclysmbn/Cataclysm-BN/pull/8006 but left out since 40x46mm casings were a drunken shitshow prior to https://github.com/cataclysmbn/Cataclysm-BN/pull/9277

Also in a sense follows up on https://github.com/cataclysmbn/Cataclysm-BN/pull/9154 via giving players more options if they insist on sticking with 40x46mm instead of finding/making an upgrade kit, such as if they main underbarrel launchers which can't currently be upgraded to 40x53mm.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Adds a recipe for sawing a 40x53mm casing down to be used as a 40x46mm casing. Same general idea of "make shorter go boom" though I suppose realistically 40x53mm cases will lack the hi-low pressure thingy inside them, so seemed sketchy enough to warrant a separate PR.

## Describe alternatives you've considered

Not doing this because unrealistic.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Ported changes to playthrough build and load-tested.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [deb6722](https://github.com/cataclysmbn/Cataclysm-BN/commit/deb67228b0354e9ed1f1173c2eb63136deba583d) (feat(balance): add a recipe for sawing 40x53mm cases into 40x46mm cases) on 2026-06-06 18:11:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27068643118/artifacts/7456322545)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27068643118/artifacts/7456597385)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27068643118/artifacts/7456328657)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27068643118/artifacts/7456438384)
<!-- END artifact comment -->