### PR TITLE
feat(balance): remove guilt from killing child zombie

### DIFF
--- a/data/json/monsters/zed_burned.json
+++ b/data/json/monsters/zed_burned.json
@@ -31,19 +31,7 @@
     "harvest": "zombie",
     "death_function": [ "SMOKEBURST", "NORMAL" ],
     "upgrades": { "half_life": 14, "into_group": "GROUP_CHILD_ZOMBIE_UPGRADE" },
-    "flags": [
-      "SEES",
-      "HEARS",
-      "STUMBLES",
-      "POISON",
-      "GRABS",
-      "NO_BREATHE",
-      "REVIVES",
-      "REVIVES_HEALTHY",
-      "NO_NECRO",
-      "GUILT",
-      "CLIMBS"
-    ]
+    "flags": [ "SEES", "HEARS", "STUMBLES", "POISON", "GRABS", "NO_BREATHE", "REVIVES", "REVIVES_HEALTHY", "NO_NECRO", "CLIMBS" ]
   },
   {
     "id": "mon_zombie_fiend",

--- a/data/json/monsters/zed_children.json
+++ b/data/json/monsters/zed_children.json
@@ -65,7 +65,7 @@
     "burn_into": "mon_zombie_child_scorched",
     "fungalize_into": "mon_zombie_child_fungus",
     "upgrades": { "half_life": 14, "into_group": "GROUP_CHILD_ZOMBIE_UPGRADE" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "BLEED", "POISON", "GUILT", "NO_BREATHE", "REVIVES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "BLEED", "POISON", "NO_BREATHE", "REVIVES" ]
   },
   {
     "id": "mon_zombie_creepy",
@@ -131,8 +131,7 @@
     "death_function": [ "NORMAL" ],
     "burn_into": "mon_zombie_child_scorched",
     "fungalize_into": "mon_zombie_child_fungus",
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BLEED", "GUILT", "BASHES", "POISON", "NO_BREATHE", "REVIVES" ],
-    "//": "GUILT because it still looks enough like a child to evoke pity"
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BLEED", "BASHES", "POISON", "NO_BREATHE", "REVIVES" ]
   },
   {
     "id": "mon_zombie_snotgobbler",
@@ -165,8 +164,7 @@
     "death_function": [ "BOOMER" ],
     "burn_into": "mon_zombie_child_scorched",
     "fungalize_into": "mon_zombie_child_fungus",
-    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BLEED", "GUILT", "POISON", "NO_BREATHE", "REVIVES" ],
-    "//": "GUILT because it still looks enough like a child to evoke pity"
+    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BLEED", "POISON", "NO_BREATHE", "REVIVES" ]
   },
   {
     "id": "mon_zombie_sproglodyte",
@@ -234,7 +232,6 @@
     "death_function": [ "NORMAL" ],
     "burn_into": "mon_zombie_child_scorched",
     "fungalize_into": "mon_zombie_child_fungus",
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BLEED", "GUILT", "POISON", "NO_BREATHE", "REVIVES", "HARDTOSHOOT" ],
-    "//": "GUILT because it still looks enough like a child to evoke pity"
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BLEED", "POISON", "NO_BREATHE", "REVIVES", "HARDTOSHOOT" ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

getting guilt from killing zombie children is silly, like you were happily killing zombies and ferals which look even closer to actual human anyways

## Describe the solution (The How)

remove the GUILT flags from child zombie and its variants

## Additional context

<img width="50%" alt="Chicken_Jockey" src="https://github.com/user-attachments/assets/d63da05c-50f5-454d-96df-7a10b755a7a9" />

CHICKEN JOCKEY

## Checklist


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional


- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f3b5953](https://github.com/cataclysmbn/Cataclysm-BN/commit/f3b59535c62f8d8c893e2bf4175bb958efe5bc6c) (fix: remove child zombie guilt morale) on 2026-06-07 03:10:36

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27079761406/artifacts/7459846628)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27079761406/artifacts/7460132970)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27079761406/artifacts/7459859768)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27079761406/artifacts/7459942496)
<!-- END artifact comment -->