### PR TITLE
fix: typo in inactive grenade launcher turret description, add `looks like` for inactive 50cal turret

### DIFF
--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -804,7 +804,7 @@
     "id": "bot_turret_mark19",
     "type": "TOOL",
     "name": { "str": "inactive autonomous grenade launcher milspec turret" },
-    "description": "This is an inactive grenade launcher milspec turret.  Using this item involves loading the unit with the factory-loaded .50 BMG rounds in your inventory (if you wish to divide your ammunition, set aside whatever .50 BMG rounds you do NOT want to give the turret) turning it on, and placing it on the ground, where it will attach itself.  If programmed successfully the turret will then identify you as a friendly, and attack all enemies with its gun.",
+    "description": "This is an inactive grenade launcher milspec turret.  Using this item involves loading the unit with the factory-loaded 40x53mm grenades in your inventory (if you wish to divide your ammunition, set aside whatever 40x53mm grenades you do NOT want to give the turret) turning it on, and placing it on the ground, where it will attach itself.  If programmed successfully the turret will then identify you as a friendly, and attack all enemies with its grenade launcher.",
     "weight": "120 kg",
     "volume": "40 L",
     "price": "5 kUSD",

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -791,6 +791,7 @@
     "material": [ "steel", "plastic" ],
     "symbol": ";",
     "color": "green",
+    "looks_like": "bot_antimateriel",
     "use_action": {
       "type": "place_monster",
       "monster_id": "mon_turret_antimateriel",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The description for the inactive grenade launcher turret incorrectly states that the turret uses .50 cal rounds instead. Also, the inactive 50cal turret lacks a sprite.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Changes the description to mention 40x53mm grenades instead, and gives a looks_like to the inactive 50cal turret to the obseleted m2hb turret cause they use the same sprite.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
50 cal grenades????
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c92eac8](https://github.com/cataclysmbn/Cataclysm-BN/commit/c92eac875253487129f5419e08fc715a68d7bc3e) (Update inactive_bots.json) on 2026-06-07 06:53:43

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27084225068/artifacts/7461229983)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27084225068/artifacts/7461520089)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27084225068/artifacts/7461233863)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27084225068/artifacts/7461350417)
<!-- END artifact comment -->