### PR TITLE
feat(balance): bandaid hovercraft repulsor cost fix

### DIFF
--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -223,7 +223,7 @@
     "name": { "str": "portal generator" },
     "description": "This is a rare, bizarre, and arcane device of an otherworldly nature.  It's giving you a headache just looking at it.  It is covered in alien markings.",
     "weight": "1133 g",
-    "volume": "500 ml",
+    "volume": "2500 ml",
     "price": "6600 USD",
     "price_postapoc": "10 USD",
     "to_hit": -1,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Repulsor takes 50 nanomaterial, 8 superalloy, 8 plutonium cells, and 3 portal generators. Apparently, portal generator can be printed for 10 nanomaterial as printing costs is just 5 per 250ml volume.

## Describe the solution (The How)

Increase volume of portal generator from 500ml to 2500ml thus increasing nanomaterial cost of one repulsor from 80 to 200 (when printing portal generators).

## Describe alternatives you've considered

Give each item in nanofab templates a manually defined cost. Apparently it was already proposed and met with mixed reactions.

## Testing

Loaded via mod, printed one portal generator, verified that both display price and amount of nanomaterial used is correct and that the item prints.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bfbfd87](https://github.com/cataclysmbn/Cataclysm-BN/commit/bfbfd873ccf1e43db8573a52f202ea95b63d6829) (balance: bandaid hovercraft repulsor cost fix) on 2026-06-07 14:42:50

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27094198829/artifacts/7464688245)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27094198829/artifacts/7464991192)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27094198829/artifacts/7464690410)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27094198829/artifacts/7464833159)
<!-- END artifact comment -->