### PR TITLE
fix: made sure fresh ingredients in a vehicle part produce fresh food

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1104,7 +1104,16 @@ void complete_craft( Character &who, item &craft )
     for( detached_ptr<item> &it : used ) {
         used_items.push_back( &*it );
     }
-    const double relative_rot = craft.get_relative_rot();
+    // Makes it so that crafting inherits the components' rot instead of the vehicle cargo age, whatever that means
+    double relative_rot = 0.0;
+    for( const item *comp : used_items ) {
+        if( comp->goes_bad() ) {
+            const double comp_rot = comp->get_relative_rot();
+            if( comp_rot > relative_rot ) {
+                relative_rot = comp_rot;
+            }
+        }
+    }
     const bool ignore_component = making.has_flag( "NUTRIENT_OVERRIDE" );
 
     // Set up the new item, and assign an inventory letter if available


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
resolves #9254 and allows you to craft fresh food from fresh ingredients as expected

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
It fixes the crafted food freshness by making sure crafted food takes after the "freshness" of the ingredients instead of some arcane values like... the age of the vehicle part the ingredients is located at.

## Describe alternatives you've considered

Perhaps enjoying your freshly rotten cooked dish?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
1. Change day to a few days after start
2. Spawn an RV or any vehicle that has a kitchen unit and storage
3. Spawn in food and place in vehicle storage (and get to a high enough cooking skill)
4. Craft food from the ingredients
5. Marvel at the new freshness of the food!

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Fresh food crafted from fresh ingredients a few days after start!
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/933f958d-9035-4cdb-8c1c-f7a4f1a335ab" />
<img width="1919" height="1078" alt="image" src="https://github.com/user-attachments/assets/cd78a801-c25e-4176-9c04-67b0e3b5d594" />

Rotten food crafted from rotten ingredients!
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/1caf9421-84ec-4f00-9345-21022678b32d" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7f3f914](https://github.com/cataclysmbn/Cataclysm-BN/commit/7f3f9142af239abb61d2b4e63611ad08b82711b4) (Merge branch 'main' into freshly-produced-food) on 2026-06-07 18:05:17

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27098685983/artifacts/7466093961)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27098685983/artifacts/7466397914)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27098685983/artifacts/7466118478)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27098685983/artifacts/7466192543)
<!-- END artifact comment -->