### PR TITLE
fix: overstuffing vehicles no longer gives detached ptr error

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6249,7 +6249,9 @@ detached_ptr<item> vehicle::add_charges( int part, detached_ptr<item> &&itm )
     itm_copy->charges = amount;
     itm->charges -= amount;
     detached_ptr<item> remaining = add_item( part, std::move( itm_copy ) );
-    itm->charges += remaining->charges;
+    if( remaining ) {
+        itm->charges += remaining->charges;
+    }
     return itm->charges > 0 ? std::move( itm ) : detached_ptr<item>();
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #3713
closes: #4773

## Describe the solution (The How)
Check the remaining for existing
I stupidly assumed it was itm that was the issue when I tried fixing before

## Describe alternatives you've considered
Dont do this and forever be pestered on detached pointer errors

## Testing
Stuffing 200 blueberries in a seat properly works

## Additional context
I EXPLODE

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3442639](https://github.com/cataclysmbn/Cataclysm-BN/commit/3442639e774e9511f3d1ac41517890106dcdbb1b) (fix: overstuffing vehicles no longer gives detached ptr error) on 2026-06-07 20:32:46

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27102369382/artifacts/7467279232)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27102369382/artifacts/7467570209)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27102369382/artifacts/7467255666)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27102369382/artifacts/7467388804)
<!-- END artifact comment -->