### PR TITLE
fix: make "s"mashing at a vehicle actually damage the vehicle part aimed

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -728,6 +728,7 @@ void map::add_vehicle_to_cache( vehicle *veh )
         // DANGER: Unlike what you think where you can just use vpr.has_flag( VPFLAG_NOCOLLIDE )
         // THAT DOES NOT WORK DO NOT TRY AND CHANGE THIS MESS
         if( !ch.veh_cached_parts.contains( p ) ||
+            ch.veh_cached_parts[p].first != veh ||
             ( !veh->part_info( vpr.part_index() ).has_flag( VPFLAG_NOCOLLIDE ) ) ) {
             ch.veh_cached_parts[p] = std::make_pair( veh,  static_cast<int>( vpr.part_index() ) );
         }
@@ -4739,7 +4740,7 @@ bash_results map::bash_vehicle( const tripoint_bub_ms &p, const bash_params &par
     bash_results result;
     // Smash vehicle if present
     if( const optional_vpart_position vp = veh_at( p ) ) {
-        vp->vehicle().damage( vp->part_index(), params.strength, DT_BASH );
+        vp->vehicle().damage( vp->part_index(), params.strength, DT_BASH, true );
         if( !params.silent ) {
             sound_event se;
             se.origin = p;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -728,7 +728,6 @@ void map::add_vehicle_to_cache( vehicle *veh )
         // DANGER: Unlike what you think where you can just use vpr.has_flag( VPFLAG_NOCOLLIDE )
         // THAT DOES NOT WORK DO NOT TRY AND CHANGE THIS MESS
         if( !ch.veh_cached_parts.contains( p ) ||
-            ch.veh_cached_parts[p].first != veh ||
             ( !veh->part_info( vpr.part_index() ).has_flag( VPFLAG_NOCOLLIDE ) ) ) {
             ch.veh_cached_parts[p] = std::make_pair( veh,  static_cast<int>( vpr.part_index() ) );
         }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
fixes #9293 and made smashing vehicles fun again

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
fixed vehicle parts to take damage when deliberately smashed, even if they lack the OBSTACLE flag (e.g., bare frames). I also fixed cache update condition so that Stale cache entries from destroyed/removed vehicles no longer prevent a different vehicle's parts from being cached.

## Describe alternatives you've considered

I'd thought of waiting for https://github.com/cataclysmbn/Cataclysm-BN/pull/9292 to implement a fix for #9293 as one of its refactors.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
1. create a strong enough character
2. spawn in a weapon with big bash damage (like a sledge hammer)
3. spawn in a vehicle as test subject
4. "s"mash at one of its part
5. watch as scrap fly

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
str 10 character, wielding a sledgehammer, smashing at a bubble car
<img width="1919" height="1078" alt="image" src="https://github.com/user-attachments/assets/72e3f10a-81b6-4394-b97e-9f1a3eec3f80" />


## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [98cad8a](https://github.com/cataclysmbn/Cataclysm-BN/commit/98cad8a2a68af2e37dd33499e5262991c07c1b36) (Removed the potential breakage of nocollide) on 2026-06-08 00:21:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27107826583/artifacts/7468985262)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27107826583/artifacts/7469277790)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27107826583/artifacts/7468985274)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27107826583/artifacts/7469117090)
<!-- END artifact comment -->