### PR TITLE
fix: remove minimums from artifact assign values

### DIFF
--- a/src/artifact.cpp
+++ b/src/artifact.cpp
@@ -1152,8 +1152,8 @@ void it_artifact_tool::deserialize( const JsonObject &jo )
             materials.emplace_back( id );
         }
     }
-    assign( jo, "volume", volume, false, 1_ml );
-    assign( jo, "weight", weight, false, 1_gram );
+    assign( jo, "volume", volume, false );
+    assign( jo, "weight", weight, false );
     melee[DT_BASH] = jo.get_int( "melee_dam" );
     melee[DT_CUT] = jo.get_int( "melee_cut" );
     m_to_hit = jo.get_int( "m_to_hit" );
@@ -1262,8 +1262,8 @@ void it_artifact_armor::deserialize( const JsonObject &jo )
             materials.emplace_back( id );
         }
     }
-    assign( jo, "volume", volume, false, 1_ml );
-    assign( jo, "weight", weight, false, 1_gram );
+    assign( jo, "volume", volume, false );
+    assign( jo, "weight", weight, false );
     melee[DT_BASH] = jo.get_int( "melee_dam" );
     melee[DT_CUT] = jo.get_int( "melee_cut" );
     m_to_hit = jo.get_int( "m_to_hit" );
@@ -1278,7 +1278,7 @@ void it_artifact_armor::deserialize( const JsonObject &jo )
     armor->thickness = jo.get_int( "material_thickness" );
     armor->env_resist = jo.get_int( "env_resist" );
     armor->warmth = jo.get_int( "warmth" );
-    assign( jo, "storage", armor->storage, false, 1_ml );
+    assign( jo, "storage", armor->storage, false );
 
     for( const int entry : jo.get_array( "effects_worn" ) ) {
         artifact->effects_worn.push_back( static_cast<art_effect_passive>( entry ) );


### PR DESCRIPTION
## Purpose of change (The Why)
Followup to the previous artifact assign PRs
Fixes out of bounds artifact error

## Describe the solution (The How)
Remove artifact minimum values

## Describe alternatives you've considered
Make it much more clear the differences between all of them, as I assumed foolishly that that was the default value

## Testing
It compiles

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [03fb413](https://github.com/cataclysmbn/Cataclysm-BN/commit/03fb413e529c32e2fe2498e4f9c752c126f502db) (fix: remove minimums from artifact assign values) on 2026-06-08 00:30:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27108337820/artifacts/7469139856)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27108337820/artifacts/7469372414)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27108337820/artifacts/7469153922)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27108337820/artifacts/7469260778)
<!-- END artifact comment -->