### PR TITLE
ci: use clang-format 22 in autofix

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -36,9 +36,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends astyle cmake ninja-build gettext ccache ca-certificates wget gnupg
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x ./llvm.sh
-          sudo ./llvm.sh "$LLVM_VERSION"
+          wget -qO "$RUNNER_TEMP/llvm.sh" https://apt.llvm.org/llvm.sh
+          chmod +x "$RUNNER_TEMP/llvm.sh"
+          sudo "$RUNNER_TEMP/llvm.sh" "$LLVM_VERSION"
           sudo apt-get install -y --no-install-recommends "clang-format-$LLVM_VERSION"
           "/usr/bin/clang-format-$LLVM_VERSION" --version
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -32,10 +32,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - env: { DEBIAN_FRONTEND: noninteractive }
+      - env: { DEBIAN_FRONTEND: noninteractive, LLVM_VERSION: "22" }
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends astyle clang-format cmake ninja-build gettext ccache
+          sudo apt-get install -y --no-install-recommends astyle cmake ninja-build gettext ccache ca-certificates wget gnupg
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x ./llvm.sh
+          sudo ./llvm.sh "$LLVM_VERSION"
+          sudo apt-get install -y --no-install-recommends "clang-format-$LLVM_VERSION"
+          "/usr/bin/clang-format-$LLVM_VERSION" --version
 
       - uses: denoland/setup-deno@v2
         with: { cache: true }
@@ -47,7 +52,7 @@ jobs:
           key: deno-${{ hashFiles('deno.lock') }}
 
       - name: configure cmake for formatting
-        run: cmake --preset lint
+        run: cmake --preset lint -DCLANG_FORMAT_EXECUTABLE=/usr/bin/clang-format-22
 
       - name: format C++ files
         run: cmake --build build --target format

--- a/src/compute/gpu_lm.cpp
+++ b/src/compute/gpu_lm.cpp
@@ -1034,8 +1034,8 @@ auto ensure_uint_shift_scratch(
 // ---------------------------------------------------------------------------
 
 auto make_source(
-    int const x, int const y, int const zlev, float const luminance,
-    uint32_t const flags = 0u) -> GpuLightSource {
+    int const x, int const y, int const zlev, float const luminance, uint32_t const flags = 0u)
+    -> GpuLightSource {
     return GpuLightSource{
         .x = x,
         .y = y,
@@ -1194,8 +1194,8 @@ auto make_source_stats(std::vector<light_source_kind> const& kinds) -> source_co
 
 auto upsert_source(
     std::vector<GpuLightSource>& sources, std::unordered_map<std::size_t, std::size_t>& indices,
-    std::size_t const source_slot, tripoint_bub_ms const& pos,
-    float const luminance) -> std::size_t {
+    std::size_t const source_slot, tripoint_bub_ms const& pos, float const luminance)
+    -> std::size_t {
     auto const [iter, inserted] = indices.emplace(source_slot, sources.size());
     if (inserted) {
         sources.push_back(make_source(pos.x(), pos.y(), pos.z(), luminance));
@@ -1484,8 +1484,8 @@ auto append_source(
 }
 
 auto add_item_sources(
-    source_accumulator& acc, tripoint_bub_ms const& pos,
-    location_vector<item> const& items) -> void {
+    source_accumulator& acc, tripoint_bub_ms const& pos, location_vector<item> const& items)
+    -> void {
     for (auto const& itm : items) {
         auto luminance = 0.0f;
         auto width = 0_degrees;
@@ -1671,8 +1671,8 @@ auto vehicle_light_color(vpart_reference const& part) -> std::optional<uint32_t>
 }
 
 auto append_vehicle_source(
-    source_accumulator& acc, GpuLightSource const& source,
-    std::optional<uint32_t> const color_rgb) -> void {
+    source_accumulator& acc, GpuLightSource const& source, std::optional<uint32_t> const color_rgb)
+    -> void {
     append_source(acc, source, light_source_kind::vehicle);
     add_colored_source({
         .acc = acc,
@@ -1822,8 +1822,8 @@ auto add_monster_sources(source_accumulator& acc) -> void {
 }
 
 auto collect_sources(
-    map const& m, std::vector<int> const& dirty_levels,
-    bool const collect_colored_sources) -> source_collection {
+    map const& m, std::vector<int> const& dirty_levels, bool const collect_colored_sources)
+    -> source_collection {
     if (dirty_levels.empty()) { return {}; }
 
     auto const& lc0 = m.get_cache_ref(dirty_levels.front());
@@ -1867,8 +1867,8 @@ auto source_is_on_dirty_level(std::vector<int> const& dirty_levels, int const zl
 }
 
 auto write_source_map_to_level_caches(
-    map const& m, std::vector<int> const& dirty_levels,
-    std::vector<GpuLightSource> const& sources) -> void {
+    map const& m, std::vector<int> const& dirty_levels, std::vector<GpuLightSource> const& sources)
+    -> void {
     for (int const z : dirty_levels) {
         auto& lc = const_cast<level_cache&>(m.get_cache_ref(z));
         std::ranges::fill(lc.sm, 0.0f);
@@ -2105,8 +2105,8 @@ auto sorted_unique(std::vector<int> levels) -> std::vector<int> {
 }
 
 auto make_seen_download_levels(
-    run_gpu_lighting_params const& p, bool const seen_was_valid,
-    std::vector<int> const& all_levels) -> std::vector<int> {
+    run_gpu_lighting_params const& p, bool const seen_was_valid, std::vector<int> const& all_levels)
+    -> std::vector<int> {
     if (!seen_was_valid) { return all_levels; }
 
     auto levels = std::vector<int>{};
@@ -2170,8 +2170,8 @@ auto make_z_level_ranges(std::vector<int> const& levels) -> std::vector<z_level_
 }
 
 auto make_visibility_dispatch_plan(
-    std::vector<int> const& levels, int const cache_xy,
-    int const total_z_count) -> visibility_dispatch_plan {
+    std::vector<int> const& levels, int const cache_xy, int const total_z_count)
+    -> visibility_dispatch_plan {
     auto fallback = visibility_dispatch_plan{
         .z_start_idx = 0,
         .z_count = total_z_count,
@@ -2328,8 +2328,8 @@ auto pack_char_cache_uint(
 }
 
 auto pack_vehicle_obscured_cache_uint(
-    map const& m, std::vector<int> const& levels, int const cache_xy,
-    std::vector<uint32_t>& out) -> void {
+    map const& m, std::vector<int> const& levels, int const cache_xy, std::vector<uint32_t>& out)
+    -> void {
     out.resize(levels.size() * static_cast<std::size_t>(cache_xy));
     auto level_index = std::size_t{0};
     for (auto const z : levels) {
@@ -4494,8 +4494,8 @@ auto begin_gpu_sight_pairs(SDL_GPUDevice* const device, begin_gpu_sight_pairs_pa
 }
 
 auto finish_gpu_sight_pairs(
-    SDL_GPUDevice* const device, gpu_sight_pairs_work const& work,
-    std::vector<uint32_t>& results) -> bool {
+    SDL_GPUDevice* const device, gpu_sight_pairs_work const& work, std::vector<uint32_t>& results)
+    -> bool {
     ZoneScopedN("finish_gpu_sight_pairs");
 
     if (work.id == 0) {

--- a/src/compute/gpu_lm.h
+++ b/src/compute/gpu_lm.h
@@ -340,8 +340,8 @@ auto resident_lighting_ready_for_sight_pairs(resident_sight_pair_inputs_params c
 auto begin_gpu_sight_pairs(SDL_GPUDevice* device, begin_gpu_sight_pairs_params const& p)
     -> gpu_sight_pairs_work;
 auto finish_gpu_sight_pairs(
-    SDL_GPUDevice* device, gpu_sight_pairs_work const& work,
-    std::vector<uint32_t>& results) -> bool;
+    SDL_GPUDevice* device, gpu_sight_pairs_work const& work, std::vector<uint32_t>& results)
+    -> bool;
 auto run_gpu_sight_pairs(SDL_GPUDevice* device, run_gpu_sight_pairs_params const& p) -> bool;
 
 // Release all GPU pipeline objects owned by the lm module.

--- a/src/compute/gpu_platform.cpp
+++ b/src/compute/gpu_platform.cpp
@@ -435,8 +435,8 @@ auto select_shader_format(SDL_GPUShaderFormat const formats)
 }
 
 auto probe_shader(
-    SDL_GPUDevice* const device, SDL_GPUShaderFormat const fmt,
-    std::string_view const ext) -> void {
+    SDL_GPUDevice* const device, SDL_GPUShaderFormat const fmt, std::string_view const ext)
+    -> void {
     auto const path = PATH_INFO::shaders() + "test_compute" + std::string{ext};
     auto const blob = read_file_bytes(path);
     if (blob.empty()) {

--- a/src/compute/gpu_transparency.cpp
+++ b/src/compute/gpu_transparency.cpp
@@ -303,8 +303,8 @@ auto gather_transparency_refs(map const& m, int const zlev)
 }
 
 auto prepare_transparency_inputs(
-    std::span<transparency_submap_ref const> refs,
-    std::vector<transparency_submap_in>& out) -> void {
+    std::span<transparency_submap_ref const> refs, std::vector<transparency_submap_in>& out)
+    -> void {
     out.clear();
     out.reserve(refs.size());
 

--- a/src/compute/gpu_transparency.h
+++ b/src/compute/gpu_transparency.h
@@ -93,8 +93,8 @@ auto gather_transparency_refs(map const& m, int zlev) -> std::vector<transparenc
 // Reads ter/furn/field/outside_cache data from each ref.sm and writes one
 // transparency_submap_in per ref into out (clearing it first).
 auto prepare_transparency_inputs(
-    std::span<transparency_submap_ref const> refs,
-    std::vector<transparency_submap_in>& out) -> void;
+    std::span<transparency_submap_ref const> refs, std::vector<transparency_submap_in>& out)
+    -> void;
 
 struct transparency_output_target {
     SDL_GPUBuffer* buffer = nullptr;


### PR DESCRIPTION
## Purpose of change (The Why)

Autofix CI used outdated Ubuntu 24 default `clang-format` 18, which format differently from local clang-format 22.

## Describe the solution (The How)

- Install clang-format 22 from apt.llvm.org in autofix CI.
- Configure CMake formatting with `/usr/bin/clang-format-22`.
- Apply clang-format 22 output to affected compute files.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9bceaaa](https://github.com/cataclysmbn/Cataclysm-BN/commit/9bceaaacd71dc628c6916e62324ff11e1169ec5f) (ci: keep llvm installer out of workspace) on 2026-06-09 01:04:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27122869788/artifacts/7495689506)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27122869788/artifacts/7495872102)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27122869788/artifacts/7495613965)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27122869788/artifacts/7495956228)
<!-- END artifact comment -->