### PR TITLE
fix: use offscreen SDL video for headless curses

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,6 +186,24 @@ struct arg_handler {
 };
 
 #if defined(CATA_SDL)
+#if defined(__linux__) && !defined(__ANDROID__) && !defined(TILES)
+auto use_offscreen_video_driver_for_headless_curses() -> void
+{
+    if( std::getenv( "SDL_VIDEO_DRIVER" ) != nullptr ||
+        std::getenv( "SDL_VIDEODRIVER" ) != nullptr ||
+        std::getenv( "DISPLAY" ) != nullptr ||
+        std::getenv( "WAYLAND_DISPLAY" ) != nullptr ) {
+        return;
+    }
+
+    if( SDL_SetHint( SDL_HINT_VIDEO_DRIVER, "offscreen" ) ) {
+        DebugLog( DL::Info, DC::Main ) << "SDL video driver set to offscreen for headless curses";
+    } else {
+        DebugLog( DL::Warn, DC::Main ) << "SDL video driver offscreen hint failed: " << SDL_GetError();
+    }
+}
+#endif
+
 auto init_sdl_platform( bool init_audio ) -> bool
 {
     auto init_flags = SDL_InitFlags{ SDL_INIT_VIDEO };
@@ -778,6 +796,9 @@ int main( int argc, char *argv[] )
     get_options().save();
     set_language(); // Have to set locale before initializing ncurses
 #if defined(CATA_SDL)
+#   if defined(__linux__) && !defined(__ANDROID__)
+    use_offscreen_video_driver_for_headless_curses();
+#   endif
     if( !init_sdl_platform( !test_mode ) ) {
         return 1;
     }


### PR DESCRIPTION
## Purpose of change (The Why)

Linux curses builds can fail `SDL_Init(SDL_INIT_VIDEO)` over SSH/headless unless SDL is pointed at a non-display video backend.

## Describe the solution (The How)

- In Linux curses only, set `SDL_HINT_VIDEO_DRIVER=offscreen` before SDL init when no display server or user-selected SDL video driver is present.
- Preserve user `SDL_VIDEO_DRIVER`/`SDL_VIDEODRIVER`, `DISPLAY`, and `WAYLAND_DISPLAY` choices.
- Leave lighting, visibility, and SDL_GPU paths unchanged.

## Related

- Follow-up to #9016.

## Testing

| before | after |
| - | - |
| <img width="1220" height="2712" alt="Screenshot_2026-06-08-12-25-50-083_com termux" src="https://github.com/user-attachments/assets/83c5b94e-b35f-4383-b185-2e1f664cb252" /> | <img width="1220" height="2712" alt="Screenshot_2026-06-08-12-48-38-603_com termux" src="https://github.com/user-attachments/assets/2155e1b5-8070-444f-a628-f3fd6ffd7a75" /> |


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [562fa85](https://github.com/cataclysmbn/Cataclysm-BN/commit/562fa8564091ba071d09829229d89ec6b90160f0) (fix: use offscreen SDL video for headless curses) on 2026-06-08 06:09:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27114743206/artifacts/7471534784)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27114743206/artifacts/7472096961)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27114743206/artifacts/7471634998)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27114743206/artifacts/7471854542)
<!-- END artifact comment -->