### PR TITLE
feat(UI): Extend batch crafting size limit

### DIFF
--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -5,8 +5,10 @@
 #include <cstdlib>
 #include <limits>
 
+#include "calendar.h"
 #include "character.h"
 #include "crafting.h"
+#include "crafting_gui.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "game_constants.h"
@@ -169,6 +171,38 @@ void craft_command::execute( const tripoint_bub_ms &new_loc )
                 return;
             }
             tool_selections.push_back( ts );
+        }
+    }
+
+    // Compute total volume of raw material inputs from the finalized selections.
+    {
+        const auto total_vol = [&]() {
+            auto acc = 0_ml;
+            for( const auto &sel : item_selections ) {
+                const auto &ic = sel.comp;
+                if( ic.type.is_null() ) {
+                    continue;
+                }
+                const auto cnt = ( ic.count > 0 ) ? ic.count * batch_size : std::abs( ic.count );
+                if( cnt <= 0 ) {
+                    continue;
+                }
+                const auto by_charges = item::count_by_charges( ic.type ) && ic.count > 0;
+                if( by_charges ) {
+                    const auto &ex = *item::spawn_temporary( ic.type, calendar::turn, cnt );
+                    acc += ex.volume();
+                } else {
+                    const auto &ex = *item::spawn_temporary( ic.type );
+                    acc += ex.volume() * cnt;
+                }
+            }
+            return acc;
+        }();
+        if( total_vol > 1000_liter ) {
+            if( !query_large_volume( total_vol ) ) {
+                volume_warning_canceled = true;
+                return;
+            }
         }
     }
 

--- a/src/craft_command.h
+++ b/src/craft_command.h
@@ -109,6 +109,10 @@ class craft_command
             return tool_selections;
         }
 
+        auto is_volume_warning_canceled() const -> bool {
+            return volume_warning_canceled;
+        }
+
     private:
         const recipe *rec = nullptr;
         int batch_size = 0;
@@ -128,6 +132,8 @@ class craft_command
 
         std::vector<comp_selection<item_comp>> item_selections;
         std::vector<comp_selection<tool_comp>> tool_selections;
+
+        bool volume_warning_canceled = false;
 
         /** Checks if tools we selected in a previous call to execute() are still available. */
         std::vector<comp_selection<item_comp>> check_item_components_missing(

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -384,10 +384,12 @@ bool Character::has_morale_to_craft() const
 void Character::craft( const tripoint_bub_ms &loc )
 {
     const recipe *resume_rec = nullptr;
-    int resume_batch = 0;
+    int resume_bs = 0;
+    bool resume_was_batch = false;
     while( true ) {
         int batch_size = 0;
-        const recipe *rec = select_crafting_recipe( batch_size, *this, resume_rec, resume_batch );
+        bool this_was_batch = false;
+        const recipe *rec = select_crafting_recipe( batch_size, *this, resume_rec, resume_bs, resume_was_batch, &this_was_batch );
         if( !rec ) {
             return;
         }
@@ -398,7 +400,8 @@ void Character::craft( const tripoint_bub_ms &loc )
         if( last_craft->is_volume_warning_canceled() ) {
             *last_craft = craft_command();
             resume_rec = rec;
-            resume_batch = batch_size;
+            resume_bs = batch_size;
+            resume_was_batch = this_was_batch;
             continue;
         }
         return;
@@ -417,10 +420,12 @@ void Character::recraft( const tripoint_bub_ms &loc )
 void Character::long_craft( const tripoint_bub_ms &loc )
 {
     const recipe *resume_rec = nullptr;
-    int resume_batch = 0;
+    int resume_bs = 0;
+    bool resume_was_batch = false;
     while( true ) {
         int batch_size = 0;
-        const recipe *rec = select_crafting_recipe( batch_size, *this, resume_rec, resume_batch );
+        bool this_was_batch = false;
+        const recipe *rec = select_crafting_recipe( batch_size, *this, resume_rec, resume_bs, resume_was_batch, &this_was_batch );
         if( !rec ) {
             return;
         }
@@ -431,7 +436,8 @@ void Character::long_craft( const tripoint_bub_ms &loc )
         if( last_craft->is_volume_warning_canceled() ) {
             *last_craft = craft_command();
             resume_rec = rec;
-            resume_batch = batch_size;
+            resume_bs = batch_size;
+            resume_was_batch = this_was_batch;
             continue;
         }
         return;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -383,12 +383,25 @@ bool Character::has_morale_to_craft() const
 
 void Character::craft( const tripoint_bub_ms &loc )
 {
-    int batch_size = 0;
-    const recipe *rec = select_crafting_recipe( batch_size, *this );
-    if( rec ) {
-        if( crafting_allowed( *this, *rec ) ) {
-            make_craft( rec->ident(), batch_size, loc );
+    const recipe *resume_rec = nullptr;
+    int resume_batch = 0;
+    while( true ) {
+        int batch_size = 0;
+        const recipe *rec = select_crafting_recipe( batch_size, *this, resume_rec, resume_batch );
+        if( !rec ) {
+            return;
         }
+        if( !crafting_allowed( *this, *rec ) ) {
+            return;
+        }
+        make_craft( rec->ident(), batch_size, loc );
+        if( last_craft->is_volume_warning_canceled() ) {
+            *last_craft = craft_command();
+            resume_rec = rec;
+            resume_batch = batch_size;
+            continue;
+        }
+        return;
     }
 }
 
@@ -403,12 +416,25 @@ void Character::recraft( const tripoint_bub_ms &loc )
 
 void Character::long_craft( const tripoint_bub_ms &loc )
 {
-    int batch_size = 0;
-    const recipe *rec = select_crafting_recipe( batch_size, *this );
-    if( rec ) {
-        if( crafting_allowed( *this, *rec ) ) {
-            make_all_craft( rec->ident(), batch_size, loc );
+    const recipe *resume_rec = nullptr;
+    int resume_batch = 0;
+    while( true ) {
+        int batch_size = 0;
+        const recipe *rec = select_crafting_recipe( batch_size, *this, resume_rec, resume_batch );
+        if( !rec ) {
+            return;
         }
+        if( !crafting_allowed( *this, *rec ) ) {
+            return;
+        }
+        make_all_craft( rec->ident(), batch_size, loc );
+        if( last_craft->is_volume_warning_canceled() ) {
+            *last_craft = craft_command();
+            resume_rec = rec;
+            resume_batch = batch_size;
+            continue;
+        }
+        return;
     }
 }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1377,9 +1377,19 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
         } else if( action == "PAGE_UP" ) {
             recipe_info_scroll -= scroll_recipe_info_lines;
             item_info_scroll -= scroll_recipe_info_lines;
+            if( batch ) {
+                line = std::max( 0, line - 50 );
+                }
         } else if( action == "PAGE_DOWN" ) {
             recipe_info_scroll += scroll_recipe_info_lines;
             item_info_scroll += scroll_recipe_info_lines;
+            if( batch ) {
+                if ( line == 0 ) {
+                line = std::min( static_cast<int>( current.size() - 1 ), line + 49 );
+                } else {
+                line = std::min( static_cast<int>( current.size() - 1 ), line + 50 );
+                }
+            }
         } else if( action == "LEFT" ) {
             if( batch || !filterstring.empty() ) {
                 continue;

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -664,7 +664,9 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
 
 const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter,
                                        const recipe *resume_recipe,
-                                       int resume_batch_size )
+                                       int resume_batch_size,
+                                       bool resume_batch_mode,
+                                       bool *selected_in_batch )
 {
     struct {
         const recipe *recp = nullptr;
@@ -866,7 +868,31 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter,
 
     const recipe *resume_rec = resume_recipe;
     int resume_bs = resume_batch_size;
-    bool resume_batch = ( resume_bs > 1 );
+    bool resume_batch = resume_batch_mode;
+
+    if( resume_rec && resume_batch ) {
+        batch = true;
+        chosen = resume_rec;
+    }
+
+    if( resume_rec && !resume_batch ) {
+        const std::string &cat = resume_rec->category;
+        auto it = std::find( craft_cat_list.begin(), craft_cat_list.end(), cat );
+        if( it != craft_cat_list.end() ) {
+            size_t max = craft_cat_list.size();
+            for( size_t i = 0; i < max; ++i ) {
+                if( tab.cur() == cat ) break;
+                tab.next();
+            }
+            subtab = list_circularizer<std::string>( craft_subcat_list[tab.cur()] );
+            // force subtab to ALL so the recipe is guaranteed to be in the built list for search
+            size_t smax = craft_subcat_list[tab.cur()].size();
+            for( size_t j = 0; j < smax; ++j ) {
+                if( subtab.cur() == "CSC_ALL" ) break;
+                subtab.next();
+            }
+        }
+    }
 
     const inventory &crafting_inv = crafter.crafting_inventory();
     const std::vector<npc *> helpers = character_funcs::get_crafting_helpers( crafter );
@@ -1318,28 +1344,17 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter,
             }
 
             if( resume_rec != nullptr ) {
-                int rcp_idx = 0;
-                bool found = false;
-                for( const recipe *const rcp : current ) {
-                    if( rcp == resume_rec ) {
-                        line = rcp_idx;
-                        found = true;
-                        break;
-                    }
-                    ++rcp_idx;
-                }
-                if( found && resume_batch && resume_bs > 0 ) {
-                    batch = true;
-                    batch_line = line;
-                    chosen = current[line];
-                    current.clear();
-                    available.clear();
-                    for( int i = 1; i <= 250; i++ ) {
-                        current.push_back( chosen );
-                        available.emplace_back( crafter, chosen, i,
-                                                available_recipes.contains( *chosen ) );
-                    }
+                if( resume_batch ) {
                     line = std::max( 0, std::min( 249, resume_bs - 1 ) );
+                } else {
+                    int rcp_idx = 0;
+                    for( const recipe *const rcp : current ) {
+                        if( rcp == resume_rec ) {
+                            line = rcp_idx;
+                            break;
+                        }
+                        ++rcp_idx;
+                    }
                 }
                 resume_rec = nullptr;
                 resume_batch = false;
@@ -1472,6 +1487,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter,
             } else {
                 chosen = current[line];
                 batch_size_out = ( batch ) ? line + 1 : 1;
+                if( selected_in_batch ) *selected_in_batch = batch;
                 done = true;
                 if( highlight_unread_recipes && available_recipes.contains( *chosen ) ) {
                     uistate.read_recipes.insert( chosen->ident() );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -38,6 +38,7 @@
 #include "npc.h"
 #include "options.h"
 #include "player_activity.h"
+#include "units_utility.h"
 #include "mod_manager.h"
 #include "output.h"
 #include "player.h"
@@ -661,7 +662,9 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
     return ctxt;
 }
 
-const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
+const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter,
+                                       const recipe *resume_recipe,
+                                       int resume_batch_size )
 {
     struct {
         const recipe *recp = nullptr;
@@ -860,6 +863,10 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
     int num_recipe = 0;
     int batch_line = 0;
     const recipe *chosen = nullptr;
+
+    const recipe *resume_rec = resume_recipe;
+    int resume_bs = resume_batch_size;
+    bool resume_batch = ( resume_bs > 1 );
 
     const inventory &crafting_inv = crafter.crafting_inventory();
     const std::vector<npc *> helpers = character_funcs::get_crafting_helpers( crafter );
@@ -1308,6 +1315,34 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
                     }
                     ++rcp_idx;
                 }
+            }
+
+            if( resume_rec != nullptr ) {
+                int rcp_idx = 0;
+                bool found = false;
+                for( const recipe *const rcp : current ) {
+                    if( rcp == resume_rec ) {
+                        line = rcp_idx;
+                        found = true;
+                        break;
+                    }
+                    ++rcp_idx;
+                }
+                if( found && resume_batch && resume_bs > 0 ) {
+                    batch = true;
+                    batch_line = line;
+                    chosen = current[line];
+                    current.clear();
+                    available.clear();
+                    for( int i = 1; i <= 250; i++ ) {
+                        current.push_back( chosen );
+                        available.emplace_back( crafter, chosen, i,
+                                                available_recipes.contains( *chosen ) );
+                    }
+                    line = std::max( 0, std::min( 249, resume_bs - 1 ) );
+                }
+                resume_rec = nullptr;
+                resume_batch = false;
             }
         }
         keepline = false;
@@ -2020,4 +2055,16 @@ bool lcmatch_any( const std::vector< std::vector<T> > &list_of_list, const std::
         }
     }
     return false;
+}
+
+auto query_large_volume( units::volume total_volume ) -> bool
+{
+    const int ml = units::to_milliliter<int>( total_volume );
+    const double user_vol = convert_volume( ml );
+    const double user_thresh = convert_volume( 1000000 );
+    const char *unit = volume_units_abbr();
+    const std::string msg = string_format(
+        _( "The volume of the inputs for this recipe is <color_red>%.2f %s</color> / %.0f %s and may be too large to work on.\n\nContinue?" ),
+        user_vol, unit, user_thresh, unit );
+    return query_yn( msg );
 }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1091,7 +1091,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
 
             if( batch ) {
                 current.clear();
-                for( int i = 1; i <= 50; i++ ) {
+                for( int i = 1; i <= 1000; i++ ) {
                     current.push_back( chosen );
                     available.emplace_back( crafter, chosen, i,
                                             available_recipes.contains( *chosen ) );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2080,7 +2080,7 @@ auto query_large_volume( units::volume total_volume ) -> bool
     const double user_thresh = convert_volume( 1000000 );
     const char *unit = volume_units_abbr();
     const std::string msg = string_format(
-        _( "The volume of the inputs for this recipe is <color_red>%.2f %s</color> / %.0f %s and may be too large to work on.\n\nContinue?" ),
+        _( "The volume of the components of this recipe is <color_red>%.2f %s of %.0f %s</color> which may be too large to work on.\n\nContinue?" ),
         user_vol, unit, user_thresh, unit );
     return query_yn( msg );
 }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1091,7 +1091,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
 
             if( batch ) {
                 current.clear();
-                for( int i = 1; i <= 1000; i++ ) {
+                for( int i = 1; i <= 250; i++ ) {
                     current.push_back( chosen );
                     available.emplace_back( crafter, chosen, i,
                                             available_recipes.contains( *chosen ) );

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -8,7 +8,9 @@ class JsonObject;
 
 const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter,
                                        const recipe *resume_recipe = nullptr,
-                                       int resume_batch_size = 0 );
+                                       int resume_batch_size = 0,
+                                       bool resume_batch_mode = false,
+                                       bool *selected_in_batch = nullptr );
 
 void load_recipe_category( const JsonObject &jsobj );
 void reset_recipe_categories();

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -1,12 +1,18 @@
 #pragma once
 
+#include "units.h"
+
 class Character;
 class recipe;
 class JsonObject;
 
-const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter );
+const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter,
+                                       const recipe *resume_recipe = nullptr,
+                                       int resume_batch_size = 0 );
 
 void load_recipe_category( const JsonObject &jsobj );
 void reset_recipe_categories();
+
+auto query_large_volume( units::volume total_volume ) -> bool;
 
 


### PR DESCRIPTION
Related: #5634
> The usage of crafting like 500 times is more important, if you ask me.

<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Spamming crafting activities for 50 batches of stuff one at a time was frustrating for liquids which had to be told what container to be poured into each time they concluded.

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Extend the maximum amount of batches that can be put into one crafting activity.

Also maximizes batch time savings.

Warns if the combined components are too voluminous.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Suffering.

## Testing

Compiled, played with the scrolling.

Crafted the max amount of stuff.

Tried to craft recipe with oversized components, got warning message box.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

To make it less painful to scroll the batch size entries, PG_DOWN / PG_UP will scroll by batches of 50.

https://github.com/user-attachments/assets/bfca1cf7-ee71-4d7e-a67e-ed15c9f17a04

This PR used AI assistance from qwen3.6-35b-a3b-uncensored-wasserstein aider and AI development from grok-4.3 Grok Build

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b4de22d](https://github.com/cataclysmbn/Cataclysm-BN/commit/b4de22d8fd23892b70ed0f3e2894e77c444a6a54) (revise warning text) on 2026-06-14 11:32:11

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27495943753/artifacts/7620452713)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27495943753/artifacts/7620419467)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27495943753/artifacts/7620181477)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27495943753/artifacts/7620200792)
<!-- END artifact comment -->