### PR TITLE
fix: Use texture streaming for dynamic atlas generation

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1150,7 +1150,7 @@ bool tileset_loader::copy_surface_to_dynamic_atlas(
         point( surf->w / sprite_width, surf->h / sprite_height )
     );
 
-    auto [st_tex, st_surf, st_sub_rect] =
+    auto [_, st_surf, st_sub_rect] =
         ts.texture_atlas()->get_staging_area( sprite_width, sprite_height );
 
     SDL_SetSurfaceBlendMode( surf.get(), SDL_BLENDMODE_NONE );
@@ -1173,23 +1173,11 @@ bool tileset_loader::copy_surface_to_dynamic_atlas(
         SDL_BlitSurface( surf.get(), &src_rect, st_surf, &st_sub_rect );
 
         const auto surf_hash = get_surface_hash( st_surf, nullptr );
-        const auto existing = ts.tileset_atlas->id_search( surf_hash );
 
-        atlas_texture atl_tex;
-        if( existing.has_value() ) {
-            atl_tex = existing.value();
-        } else {
-            atl_tex = ts.tileset_atlas->allocate_sprite( sprite_width, sprite_height );
-            ts.tileset_atlas->id_assign( surf_hash, atl_tex );
-
-            SDL_UpdateTexture( st_tex, nullptr, st_surf->pixels, st_surf->pitch );
-            SDL_SetRenderTarget( renderer.get(), atl_tex.first.get() );
-            {
-                const SDL_FRect fsrc{ float( st_sub_rect.x ), float( st_sub_rect.y ), float( st_sub_rect.w ), float( st_sub_rect.h ) };
-                const SDL_FRect fdst{ float( atl_tex.second.x ), float( atl_tex.second.y ), float( atl_tex.second.w ), float( atl_tex.second.h ) };
-                SDL_RenderTexture( renderer.get(), st_tex, &fsrc, &fdst );
-            }
-        }
+        auto atl_tex = ts.tileset_atlas->get_or_create_sprite( sprite_width, sprite_height, surf_hash, [&](SDL_Surface* sprSurf, const SDL_Rect* sprRect) {
+                const SDL_Rect srcRect{ ( st_sub_rect.x ), ( st_sub_rect.y ), ( st_sub_rect.w ), ( st_sub_rect.h ) };
+                SDL_BlitSurface( st_surf, &srcRect, sprSurf, sprRect );
+            });
 
         const auto tex_key = tileset_lookup_key{ index, TILESET_NO_MASK, tileset_fx_type::none, TILESET_NO_COLOR, TILESET_NO_WARP, point_zero };
         auto &[at_tex, at_rect] = atl_tex;
@@ -1684,23 +1672,14 @@ texture_result tileset::get_or_default( const int sprite_index,
         apply_color_filter( st_surf, st_sub_rect_final, st_surf, final_src_rect, color_pixel_copy );
 
         auto surf_hash = get_surface_hash( st_surf, &st_sub_rect_final );
-        auto existing = tileset_atlas->id_search( surf_hash );
 
-        atlas_texture atl_tex;
-        if( existing.has_value() ) {
-            atl_tex = std::move( existing.value() );
-        } else {
-            atl_tex = tileset_atlas->allocate_sprite( final_w, final_h );
-            tileset_atlas->id_assign( surf_hash, atl_tex );
-
-            SDL_UpdateTexture( st_tex, nullptr, st_surf->pixels, st_surf->pitch );
-            SDL_SetRenderTarget( rp, atl_tex.first.get() );
-            {
-                const SDL_FRect fsrc{ float( st_sub_rect_final.x ), float( st_sub_rect_final.y ), float( st_sub_rect_final.w ), float( st_sub_rect_final.h ) };
-                const SDL_FRect fdst{ float( atl_tex.second.x ), float( atl_tex.second.y ), float( atl_tex.second.w ), float( atl_tex.second.h ) };
-                SDL_RenderTexture( rp, st_tex, &fsrc, &fdst );
-            }
-        }
+        const auto atl_tex = tileset_atlas->get_or_create_sprite(
+            final_w, final_h, surf_hash, [&](SDL_Surface* sprSurf, const SDL_Rect* sprRect) {
+                const SDL_Rect
+                    srcRect{(st_sub_rect_final.x), (st_sub_rect_final.y), (st_sub_rect_final.w),
+                            (st_sub_rect_final.h)};
+                SDL_BlitSurface(st_surf, &srcRect, sprSurf, sprRect);
+            });
 
         sdl_restore_render_state( rp, state );
         auto &[at_tex, at_rect] = atl_tex;
@@ -6407,18 +6386,17 @@ void tileset_loader::ensure_default_item_highlight()
         return;
     }
 #if defined(DYNAMIC_ATLAS)
-    const Uint8 highlight_alpha = 127;
+    constexpr Uint8 highlight_alpha = 127;
 
     int index = offset;
 
-    const SDL_Surface_Ptr surface = create_surface_32( ts.tile_width, ts.tile_height );
-    assert( surface );
-    throwErrorIf( !SDL_FillSurfaceRect( surface.get(), nullptr,
-                                        SDL_MapRGBA( SDL_GetPixelFormatDetails( surface->format ), nullptr, 0, 0, 127,
-                                                highlight_alpha ) ), "SDL_FillSurfaceRect failed" );
-
-    auto [tex, rect] = ts.tileset_atlas->allocate_sprite( ts.tile_width, ts.tile_height );
-    SDL_UpdateTexture( tex.get(), &rect, surface->pixels, surface->pitch );
+    auto [tex, rect] = ts.tileset_atlas->create_sprite(
+        ts.tile_width, ts.tile_height, std::nullopt, [&](SDL_Surface* sprSurf, const SDL_Rect* sprRect) {
+            const auto col = SDL_MapRGBA(
+                SDL_GetPixelFormatDetails(sdl_color_pixel_format), nullptr, 0, 0, 127,
+                highlight_alpha);
+            SDL_FillSurfaceRect(sprSurf, sprRect, col);
+        });
 
     ts.tile_ids[ITEM_HIGHLIGHT].sprite.fg.add( std::vector<int>( {index} ), 1 );
     ts.tile_lookup.emplace( tileset_lookup_key{

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1174,10 +1174,11 @@ bool tileset_loader::copy_surface_to_dynamic_atlas(
 
         const auto surf_hash = get_surface_hash( st_surf, nullptr );
 
-        auto atl_tex = ts.tileset_atlas->get_or_create_sprite( sprite_width, sprite_height, surf_hash, [&](SDL_Surface* dstSurf, const SDL_Rect* dstRect) {
-                const SDL_Rect srcRect{ ( st_sub_rect.x ), ( st_sub_rect.y ), ( st_sub_rect.w ), ( st_sub_rect.h ) };
-                SDL_BlitSurface( st_surf, &srcRect, dstSurf, dstRect );
-            });
+        auto atl_tex = ts.tileset_atlas->get_or_create_sprite( sprite_width, sprite_height,
+        surf_hash, [&]( SDL_Surface * dstSurf, const SDL_Rect * dstRect ) {
+            const SDL_Rect srcRect{ ( st_sub_rect.x ), ( st_sub_rect.y ), ( st_sub_rect.w ), ( st_sub_rect.h ) };
+            SDL_BlitSurface( st_surf, &srcRect, dstSurf, dstRect );
+        } );
 
         const auto tex_key = tileset_lookup_key{ index, TILESET_NO_MASK, tileset_fx_type::none, TILESET_NO_COLOR, TILESET_NO_WARP, point_zero };
         auto &[at_tex, at_rect] = atl_tex;
@@ -1674,12 +1675,12 @@ texture_result tileset::get_or_default( const int sprite_index,
         auto surf_hash = get_surface_hash( st_surf, &st_sub_rect_final );
 
         const auto atl_tex = tileset_atlas->get_or_create_sprite(
-            final_w, final_h, surf_hash, [&](SDL_Surface* dstSurf, const SDL_Rect* dstRect) {
-                const SDL_Rect
-                    srcRect{(st_sub_rect_final.x), (st_sub_rect_final.y), (st_sub_rect_final.w),
-                            (st_sub_rect_final.h)};
-                SDL_BlitSurface(st_surf, &srcRect, dstSurf, dstRect);
-            });
+        final_w, final_h, surf_hash, [&]( SDL_Surface * dstSurf, const SDL_Rect * dstRect ) {
+            const SDL_Rect
+            srcRect{( st_sub_rect_final.x ), ( st_sub_rect_final.y ), ( st_sub_rect_final.w ),
+                    ( st_sub_rect_final.h )};
+            SDL_BlitSurface( st_surf, &srcRect, dstSurf, dstRect );
+        } );
 
         sdl_restore_render_state( rp, state );
         auto &[at_tex, at_rect] = atl_tex;
@@ -6391,12 +6392,13 @@ void tileset_loader::ensure_default_item_highlight()
     int index = offset;
 
     auto [tex, rect] = ts.tileset_atlas->create_sprite(
-        ts.tile_width, ts.tile_height, std::nullopt, [&](SDL_Surface* dstSurf, const SDL_Rect* dstRect) {
-            const auto col = SDL_MapRGBA(
-                SDL_GetPixelFormatDetails(sdl_color_pixel_format), nullptr, 0, 0, 127,
-                highlight_alpha);
-            SDL_FillSurfaceRect(dstSurf, dstRect, col);
-        });
+                           ts.tile_width, ts.tile_height, std::nullopt, [&]( SDL_Surface * dstSurf,
+    const SDL_Rect * dstRect ) {
+        const auto col = SDL_MapRGBA(
+                             SDL_GetPixelFormatDetails( sdl_color_pixel_format ), nullptr, 0, 0, 127,
+                             highlight_alpha );
+        SDL_FillSurfaceRect( dstSurf, dstRect, col );
+    } );
 
     ts.tile_ids[ITEM_HIGHLIGHT].sprite.fg.add( std::vector<int>( {index} ), 1 );
     ts.tile_lookup.emplace( tileset_lookup_key{

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1174,9 +1174,9 @@ bool tileset_loader::copy_surface_to_dynamic_atlas(
 
         const auto surf_hash = get_surface_hash( st_surf, nullptr );
 
-        auto atl_tex = ts.tileset_atlas->get_or_create_sprite( sprite_width, sprite_height, surf_hash, [&](SDL_Surface* sprSurf, const SDL_Rect* sprRect) {
+        auto atl_tex = ts.tileset_atlas->get_or_create_sprite( sprite_width, sprite_height, surf_hash, [&](SDL_Surface* dstSurf, const SDL_Rect* dstRect) {
                 const SDL_Rect srcRect{ ( st_sub_rect.x ), ( st_sub_rect.y ), ( st_sub_rect.w ), ( st_sub_rect.h ) };
-                SDL_BlitSurface( st_surf, &srcRect, sprSurf, sprRect );
+                SDL_BlitSurface( st_surf, &srcRect, dstSurf, dstRect );
             });
 
         const auto tex_key = tileset_lookup_key{ index, TILESET_NO_MASK, tileset_fx_type::none, TILESET_NO_COLOR, TILESET_NO_WARP, point_zero };
@@ -1674,11 +1674,11 @@ texture_result tileset::get_or_default( const int sprite_index,
         auto surf_hash = get_surface_hash( st_surf, &st_sub_rect_final );
 
         const auto atl_tex = tileset_atlas->get_or_create_sprite(
-            final_w, final_h, surf_hash, [&](SDL_Surface* sprSurf, const SDL_Rect* sprRect) {
+            final_w, final_h, surf_hash, [&](SDL_Surface* dstSurf, const SDL_Rect* dstRect) {
                 const SDL_Rect
                     srcRect{(st_sub_rect_final.x), (st_sub_rect_final.y), (st_sub_rect_final.w),
                             (st_sub_rect_final.h)};
-                SDL_BlitSurface(st_surf, &srcRect, sprSurf, sprRect);
+                SDL_BlitSurface(st_surf, &srcRect, dstSurf, dstRect);
             });
 
         sdl_restore_render_state( rp, state );
@@ -6391,11 +6391,11 @@ void tileset_loader::ensure_default_item_highlight()
     int index = offset;
 
     auto [tex, rect] = ts.tileset_atlas->create_sprite(
-        ts.tile_width, ts.tile_height, std::nullopt, [&](SDL_Surface* sprSurf, const SDL_Rect* sprRect) {
+        ts.tile_width, ts.tile_height, std::nullopt, [&](SDL_Surface* dstSurf, const SDL_Rect* dstRect) {
             const auto col = SDL_MapRGBA(
                 SDL_GetPixelFormatDetails(sdl_color_pixel_format), nullptr, 0, 0, 127,
                 highlight_alpha);
-            SDL_FillSurfaceRect(sprSurf, sprRect, col);
+            SDL_FillSurfaceRect(dstSurf, dstRect, col);
         });
 
     ts.tile_ids[ITEM_HIGHLIGHT].sprite.fg.add( std::vector<int>( {index} ), 1 );

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -159,19 +159,19 @@ auto dynamic_atlas::find_sprite( const size_t id ) -> std::optional<atlas_textur
 
 void dynamic_atlas::readback_load()
 {
+    const auto &r = get_sdl_renderer();
+    const auto state = sdl_save_render_state(r.get());
     for( auto &it : sheets ) {
         if( it.dirty ) {
-            const auto &r = get_sdl_renderer();
-            const auto prev_rt = SDL_GetRenderTarget( r.get() );
-            SDL_SetRenderTarget( r.get(), it.texture.get() );
-
+            auto tmpTex = CreateTexture( r, sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET, it.atlas_width, it.atlas_height );
+            SDL_SetRenderTarget( r.get(), tmpTex.get() );
+            SDL_RenderTexture( r.get(), it.texture.get(), nullptr, nullptr);
             // SDL3: SDL_RenderReadPixels returns a new surface owned by us.
             it.readback.reset( SDL_RenderReadPixels( r.get(), nullptr ) );
-
-            SDL_SetRenderTarget( r.get(), prev_rt );
             it.dirty = false;
         }
     }
+    sdl_restore_render_state(r.get(), state);
 }
 
 void dynamic_atlas::readback_clear()
@@ -236,9 +236,10 @@ atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h 
         return atlas_texture{tex, r2};
     };
 
-    for( const auto &s : sheets ) {
+    for( auto &s : sheets ) {
         auto p = s.packer->pack( w, h );
         if( p.has_value() ) {
+            s.dirty = true;
             return get_texture( s.texture, p.value(), w, h );
         }
     }
@@ -274,16 +275,6 @@ atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h 
     SDL_SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
     SDL_SetTextureScaleMode( tex, SDL_SCALEMODE_NEAREST );
 
-    {
-        const auto state = sdl_save_render_state( r.get() );
-
-        SDL_SetRenderTarget( r.get(), tex );
-        SetRenderDrawColor( r, 255, 255, 255, 0 );
-        SDL_RenderClear( r.get() );
-
-        sdl_restore_render_state( r.get(), state );
-    }
-
     auto s = sprite_sheet{
         SDL_Texture_Ptr( tex ),
         std::move( packer ),
@@ -292,8 +283,7 @@ atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h 
         nullptr,
         true
     };
-    auto &entry = sheets.emplace_back( std::move( s ) );
-    entry.dirty = true;
+    const auto &entry = sheets.emplace_back( std::move( s ) );
 
     const auto rect = entry.packer->pack( w, h );
 
@@ -302,7 +292,6 @@ atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h 
 
 void dynamic_atlas::readback_dump( const std::string &s ) const
 {
-
     int i = 0;
     for( auto &q : sheets ) {
         auto name = std::format( "{}/tile_dump_{}.png", s, i++ );

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -160,18 +160,19 @@ auto dynamic_atlas::find_sprite( const size_t id ) -> std::optional<atlas_textur
 void dynamic_atlas::readback_load()
 {
     const auto &r = get_sdl_renderer();
-    const auto state = sdl_save_render_state(r.get());
+    const auto state = sdl_save_render_state( r.get() );
     for( auto &it : sheets ) {
         if( it.dirty ) {
-            auto tmpTex = CreateTexture( r, sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET, it.atlas_width, it.atlas_height );
+            auto tmpTex = CreateTexture( r, sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET, it.atlas_width,
+                                         it.atlas_height );
             SDL_SetRenderTarget( r.get(), tmpTex.get() );
-            SDL_RenderTexture( r.get(), it.texture.get(), nullptr, nullptr);
+            SDL_RenderTexture( r.get(), it.texture.get(), nullptr, nullptr );
             // SDL3: SDL_RenderReadPixels returns a new surface owned by us.
             it.readback.reset( SDL_RenderReadPixels( r.get(), nullptr ) );
             it.dirty = false;
         }
     }
-    sdl_restore_render_state(r.get(), state);
+    sdl_restore_render_state( r.get(), state );
 }
 
 void dynamic_atlas::readback_clear()
@@ -197,29 +198,32 @@ auto dynamic_atlas::readback_find( const texture &tex ) -> std::tuple<bool, SDL_
 }
 
 auto dynamic_atlas::get_or_create_sprite(
-    const int w, const int h, const std::optional<size_t>& id, const sprite_callback& cb)
-    -> atlas_texture {
-    const auto existing = id.has_value() ? find_sprite(id.value()) : std::nullopt;
-    if (existing.has_value()) { return existing.value(); }
-    return create_sprite(w, h, id, cb);
+    const int w, const int h, const std::optional<size_t> &id, const sprite_callback &cb )
+- > atlas_texture
+{
+    const auto existing = id.has_value() ? find_sprite( id.value() ) : std::nullopt;
+    if( existing.has_value() ) { return existing.value(); }
+    return create_sprite( w, h, id, cb );
 }
 
-auto dynamic_atlas::create_sprite(const int w, const int h, const std::optional<size_t>& id, const sprite_callback& blitFn)
-    -> atlas_texture {
+auto dynamic_atlas::create_sprite( const int w, const int h, const std::optional<size_t> &id,
+                                   const sprite_callback &blitFn )
+- > atlas_texture
+{
     // TODO: Update sprite instead of allocating a new one if ID already exists?
-    auto atl_tex = allocate_sprite_internal(w, h);
-    if ( id.has_value() && !this->assign_id_internal(id.value(), atl_tex) ) {
-        debugmsg("Duplicate sprite ID in atlas: %x", id.value());
+    auto atl_tex = allocate_sprite_internal( w, h );
+    if( id.has_value() && !this->assign_id_internal( id.value(), atl_tex ) ) {
+        debugmsg( "Duplicate sprite ID in atlas: %x", id.value() );
     }
     auto& [tex, rect] = atl_tex;
 
-    SDL_Surface* tmpSurf{};
-    if (SDL_LockTextureToSurface(tex.get(), &rect, &tmpSurf)) {
+    SDL_Surface *tmpSurf{};
+    if( SDL_LockTextureToSurface( tex.get(), &rect, &tmpSurf ) ) {
         const auto tmpRect = SDL_Rect{0, 0, w, h};
-        blitFn(tmpSurf, &tmpRect);
-        SDL_UnlockTexture(tex.get());
+        blitFn( tmpSurf, &tmpRect );
+        SDL_UnlockTexture( tex.get() );
     } else {
-        debugmsg("Failed to lock dynamic atlas texture for writing.");
+        debugmsg( "Failed to lock dynamic atlas texture for writing." );
     }
 
     return atl_tex;

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -199,7 +199,7 @@ auto dynamic_atlas::readback_find( const texture &tex ) -> std::tuple<bool, SDL_
 
 auto dynamic_atlas::get_or_create_sprite(
     const int w, const int h, const std::optional<size_t> &id, const sprite_callback &cb )
-- > atlas_texture
+-> atlas_texture
 {
     const auto existing = id.has_value() ? find_sprite( id.value() ) : std::nullopt;
     if( existing.has_value() ) { return existing.value(); }
@@ -208,7 +208,7 @@ auto dynamic_atlas::get_or_create_sprite(
 
 auto dynamic_atlas::create_sprite( const int w, const int h, const std::optional<size_t> &id,
                                    const sprite_callback &blitFn )
-- > atlas_texture
+-> atlas_texture
 {
     // TODO: Update sprite instead of allocating a new one if ID already exists?
     auto atl_tex = allocate_sprite_internal( w, h );

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -198,17 +198,21 @@ auto dynamic_atlas::readback_find( const texture &tex ) -> std::tuple<bool, SDL_
 }
 
 auto dynamic_atlas::get_or_create_sprite(
-    const int w, const int h, const std::optional<size_t> &id, const sprite_callback &cb )
-- > atlas_texture
+    const int w, const int h,
+    const std::optional<size_t> &id,
+    const sprite_callback &cb ) -> atlas_texture
 {
     const auto existing = id.has_value() ? find_sprite( id.value() ) : std::nullopt;
-    if( existing.has_value() ) { return existing.value(); }
+    if( existing.has_value() ) {
+        return existing.value();
+    }
     return create_sprite( w, h, id, cb );
 }
 
-auto dynamic_atlas::create_sprite( const int w, const int h, const std::optional<size_t> &id,
-                                   const sprite_callback &blitFn )
-- > atlas_texture
+auto dynamic_atlas::create_sprite(
+    const int w, const int h,
+    const std::optional<size_t> &id,
+    const sprite_callback &blitFn ) -> atlas_texture
 {
     // TODO: Update sprite instead of allocating a new one if ID already exists?
     auto atl_tex = allocate_sprite_internal( w, h );

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -14,6 +14,8 @@
 #include "sdl_utils.h"
 #include "sdltiles.h"
 
+#define dbg(x) DebugLogFL((x),DC::SDL)
+
 detail::texture_packer::~texture_packer() = default;
 
 template<typename T>
@@ -129,9 +131,8 @@ auto dynamic_atlas::get_staging_area(
                             SDL_Rect{0, 0, width, height} );
 }
 
-auto dynamic_atlas::id_assign( const size_t id, const atlas_texture &tex ) -> bool
+auto dynamic_atlas::assign_id_internal( const size_t id, const atlas_texture &tex ) -> bool
 {
-
     const auto it = std::ranges::find_if( sheets, [&]( const sprite_sheet & s ) {
         return s.texture.get() == std::get<0>( tex ).get();
     } );
@@ -144,7 +145,7 @@ auto dynamic_atlas::id_assign( const size_t id, const atlas_texture &tex ) -> bo
     return ok;
 }
 
-auto dynamic_atlas::id_search( const size_t id ) -> std::optional<atlas_texture>
+auto dynamic_atlas::find_sprite( const size_t id ) -> std::optional<atlas_texture>
 {
     const auto it = sprite_ids.find( id );
     if( it == sprite_ids.end() ) {
@@ -195,7 +196,36 @@ auto dynamic_atlas::readback_find( const texture &tex ) -> std::tuple<bool, SDL_
     } );
 }
 
-atlas_texture dynamic_atlas::allocate_sprite( const int w, const int h )
+auto dynamic_atlas::get_or_create_sprite(
+    const int w, const int h, const std::optional<size_t>& id, const sprite_callback& cb)
+    -> atlas_texture {
+    const auto existing = id.has_value() ? find_sprite(id.value()) : std::nullopt;
+    if (existing.has_value()) { return existing.value(); }
+    return create_sprite(w, h, id, cb);
+}
+
+auto dynamic_atlas::create_sprite(const int w, const int h, const std::optional<size_t>& id, const sprite_callback& blitFn)
+    -> atlas_texture {
+    // TODO: Update sprite instead of allocating a new one if ID already exists?
+    auto atl_tex = allocate_sprite_internal(w, h);
+    if ( id.has_value() && !this->assign_id_internal(id.value(), atl_tex) ) {
+        debugmsg("Duplicate sprite ID in atlas: %x", id.value());
+    }
+    auto& [tex, rect] = atl_tex;
+
+    SDL_Surface* tmpSurf{};
+    if (SDL_LockTextureToSurface(tex.get(), &rect, &tmpSurf)) {
+        const auto tmpRect = SDL_Rect{0, 0, w, h};
+        blitFn(tmpSurf, &tmpRect);
+        SDL_UnlockTexture(tex.get());
+    } else {
+        debugmsg("Failed to lock dynamic atlas texture for writing.");
+    }
+
+    return atl_tex;
+}
+
+atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h )
 {
     constexpr auto get_texture = []( const SDL_Texture_SharedPtr & tex, const SDL_Rect & r,
     const int actual_w, const int actual_h ) {
@@ -239,7 +269,7 @@ atlas_texture dynamic_atlas::allocate_sprite( const int w, const int h )
 
     assert( w <= tex_width && h <= tex_height );
 
-    const auto tex = SDL_CreateTexture( r.get(), sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET,
+    const auto tex = SDL_CreateTexture( r.get(), sdl_color_pixel_format, SDL_TEXTUREACCESS_STREAMING,
                                         tex_width, tex_height );
     SDL_SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
     SDL_SetTextureScaleMode( tex, SDL_SCALEMODE_NEAREST );

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -199,7 +199,7 @@ auto dynamic_atlas::readback_find( const texture &tex ) -> std::tuple<bool, SDL_
 
 auto dynamic_atlas::get_or_create_sprite(
     const int w, const int h, const std::optional<size_t> &id, const sprite_callback &cb )
--> atlas_texture
+- > atlas_texture
 {
     const auto existing = id.has_value() ? find_sprite( id.value() ) : std::nullopt;
     if( existing.has_value() ) { return existing.value(); }
@@ -208,7 +208,7 @@ auto dynamic_atlas::get_or_create_sprite(
 
 auto dynamic_atlas::create_sprite( const int w, const int h, const std::optional<size_t> &id,
                                    const sprite_callback &blitFn )
--> atlas_texture
+- > atlas_texture
 {
     // TODO: Update sprite instead of allocating a new one if ID already exists?
     auto atl_tex = allocate_sprite_internal( w, h );

--- a/src/dynamic_atlas.h
+++ b/src/dynamic_atlas.h
@@ -39,7 +39,7 @@ class dynamic_atlas
             SDL_Surface_Ptr readback;
             bool dirty;
         };
-        using sprite_callback = std::function<void(SDL_Surface*, const SDL_Rect*)>;
+        using sprite_callback = std::function<void( SDL_Surface *, const SDL_Rect * )>;
 
         dynamic_atlas()
             : max_atlas_width( 0 ), max_atlas_height( 0 ), hint_sprite_width( 0 ), hint_sprite_height( 0 ) {}
@@ -47,8 +47,10 @@ class dynamic_atlas
             : max_atlas_width( w ), max_atlas_height( h ), hint_sprite_width( sw ), hint_sprite_height( sh ) {}
 
         auto find_sprite( size_t id ) -> std::optional<atlas_texture>;
-        auto create_sprite( int w, int h, const std::optional<size_t>& id, const sprite_callback& ) -> atlas_texture;
-        auto get_or_create_sprite( int w, int h, const std::optional<size_t>& id, const sprite_callback& ) -> atlas_texture;
+        auto create_sprite( int w, int h, const std::optional<size_t> &id,
+                            const sprite_callback & ) -> atlas_texture;
+        auto get_or_create_sprite( int w, int h, const std::optional<size_t> &id,
+                                   const sprite_callback & ) -> atlas_texture;
         void clear();
 
         void readback_load();

--- a/src/dynamic_atlas.h
+++ b/src/dynamic_atlas.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <optional>
 #include <vector>
+#include <functional>
 
 #include "sdl_wrappers.h"
 
@@ -38,13 +39,16 @@ class dynamic_atlas
             SDL_Surface_Ptr readback;
             bool dirty;
         };
+        using sprite_callback = std::function<void(SDL_Surface*, const SDL_Rect*)>;
 
         dynamic_atlas()
             : max_atlas_width( 0 ), max_atlas_height( 0 ), hint_sprite_width( 0 ), hint_sprite_height( 0 ) {}
         dynamic_atlas( const int w, const int h, const int sw = 0, const int sh = 0 )
             : max_atlas_width( w ), max_atlas_height( h ), hint_sprite_width( sw ), hint_sprite_height( sh ) {}
 
-        auto allocate_sprite( int w, int h ) -> atlas_texture;
+        auto find_sprite( size_t id ) -> std::optional<atlas_texture>;
+        auto create_sprite( int w, int h, const std::optional<size_t>& id, const sprite_callback& ) -> atlas_texture;
+        auto get_or_create_sprite( int w, int h, const std::optional<size_t>& id, const sprite_callback& ) -> atlas_texture;
         void clear();
 
         void readback_load();
@@ -58,9 +62,9 @@ class dynamic_atlas
         auto begin() const { return sheets.begin(); }
         auto end() const { return sheets.end(); }
 
-        auto id_assign( size_t id, const atlas_texture &tex ) -> bool;
-        auto id_search( size_t id ) -> std::optional<atlas_texture>;
     private:
+        auto assign_id_internal( size_t id, const atlas_texture &tex ) -> bool;
+        auto allocate_sprite_internal( int w, int h ) -> atlas_texture;
         std::vector<sprite_sheet> sheets;
         std::unordered_map<size_t, std::pair<int, SDL_Rect>> sprite_ids;
         SDL_Surface_Ptr staging_surf;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Resolve issue with SDL3 `gpu` renderer backend and calling `SDL_RenderTexture` in a loop thousands of times causing memory usage to explode, until either the system crashes or the process is killed

<img width="241" height="189" alt="image" src="https://github.com/user-attachments/assets/61a3fb72-a92f-41a5-9606-9bbab5d31822" />

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Use Texture streaming for atlas building instead of render to texture.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

:fire::computer::boom: 

## Testing

* Set Rendering backend to `gpu` in options
* Restart game
* Load / Start a save with UndeadPeople Tileset and its 10000 tiles `normal_items.png`
* Memory usage doesn't go up by 32+GB
* No visual glitches / missing tiles
* Dumping tile atlas still work
* Repeat and ensure the other renderer types still work as expected

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

* Atlas texture is no longer a valid render target, as its now created with streaming flags
* Staging texture is still a valid render target

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6bdc1c7](https://github.com/cataclysmbn/Cataclysm-BN/commit/6bdc1c726c76249eb9ff8c80f77060d1d2d34380) (ffs) on 2026-06-08 11:01:14

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27128948148/artifacts/7476845216)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27128948148/artifacts/7477824695)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27128948148/artifacts/7476825338)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27128948148/artifacts/7477314099)
<!-- END artifact comment -->