### PR TITLE
fix: Monster Visibility Stale Check

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5195,6 +5195,31 @@ void game::mon_info_update( )
 {
     ZoneScoped;
 
+#if defined( CATA_SDL )
+    {
+        ZoneScopedN( "mon_info_update_visibility_refresh" );
+        const auto zlev = get_levz();
+        const auto minz = m.has_zlevels() ? -OVERMAP_DEPTH : zlev;
+        const auto maxz = m.has_zlevels() ? OVERMAP_HEIGHT : zlev;
+        const auto stale_gameplay_visibility = [&]() {
+            return std::ranges::any_of( std::views::iota( minz, maxz + 1 ), [this]( const auto z ) {
+                const auto &cache = m.get_cache_ref( z );
+                return cache.lightmap_dirty || cache.visibility_cache_dirty;
+            } );
+        };
+
+        if( stale_gameplay_visibility() ) {
+            m.build_map_cache( zlev );
+            if( stale_gameplay_visibility() ) {
+                m.update_visibility_cache( zlev );
+            }
+            if( stale_gameplay_visibility() ) {
+                return;
+            }
+        }
+    }
+#endif
+
     int newseen = 0;
     const auto iProxyDist = ( safe_mode_proximity <= 0 ) ? g_max_view_distance : safe_mode_proximity;
 


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #9339

## Describe the solution (The How)

Build monster visibility if visibility is stale

## Testing

Verified with non-debug night vision indoors and nighttime outdoors with various monster setups.

## Additional context

I'm concerned this is pointing at a larger issue but I'll keep poking around just in case. Seems fine so far.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0c0be65](https://github.com/cataclysmbn/Cataclysm-BN/commit/0c0be658c7585c6700cc3661fcdc36f8088bc23e) (Fix) on 2026-06-08 17:58:14

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27152435676/artifacts/7486860521)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27152435676/artifacts/7487857337)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27152435676/artifacts/7486922917)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27152435676/artifacts/7487389829)
<!-- END artifact comment -->