### PR TITLE
fix: make changing speed on driving not pass time if cruise control on

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1323,8 +1323,8 @@ void vehicle::pldrive( Character &driver, tripoint_rel_veh p )
             cruise_thrust( -p.y() * thr_amount );
         } else {
             thrust( -p.y() );
+            driver.moves -= action_time_scale::vehicle_control_cost( driver, 100 );
         }
-        driver.moves -= action_time_scale::vehicle_control_cost( driver, 100 );
     }
 
     // TODO: Actually check if we're on land on water (or disable water-skidding)

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1323,7 +1323,6 @@ void vehicle::pldrive( Character &driver, tripoint_rel_veh p )
             cruise_thrust( -p.y() * thr_amount );
         } else {
             thrust( -p.y() );
-            driver.moves -= action_time_scale::vehicle_control_cost( driver, 100 );
         }
     }
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1323,6 +1323,7 @@ void vehicle::pldrive( Character &driver, tripoint_rel_veh p )
             cruise_thrust( -p.y() * thr_amount );
         } else {
             thrust( -p.y() );
+            driver.moves -= action_time_scale::vehicle_control_cost( driver, 100 );
         }
     }
 

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -339,7 +339,7 @@ TEST_CASE( "vehicle control scale modifies throttle move cost", "[vehicle][speed
     const auto origin = tripoint_bub_ms( 60, 60, 0 );
     auto *veh_ptr = get_map().add_vehicle( vproto_id( "bicycle" ), origin, 0_degrees, 0, 0 );
     REQUIRE( veh_ptr != nullptr );
-    
+
     veh_ptr->cruise_on = false;
     veh_ptr->pldrive( you, tripoint_rel_veh{ 0, 1, 0 } );
 

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -339,10 +339,28 @@ TEST_CASE( "vehicle control scale modifies throttle move cost", "[vehicle][speed
     const auto origin = tripoint_bub_ms( 60, 60, 0 );
     auto *veh_ptr = get_map().add_vehicle( vproto_id( "bicycle" ), origin, 0_degrees, 0, 0 );
     REQUIRE( veh_ptr != nullptr );
-
+    
+    veh_ptr->cruise_on = false;
     veh_ptr->pldrive( you, tripoint_rel_veh{ 0, 1, 0 } );
 
     CHECK( you.get_moves() == -25 );
+}
+
+TEST_CASE( "vehicle speed control free in cruise mode", "[vehicle][speed]" )
+{
+    clear_all_state();
+
+    auto &you = get_avatar();
+    you.set_moves( 25 );
+
+    const auto origin = tripoint_bub_ms( 60, 60, 0 );
+    auto *veh_ptr = get_map().add_vehicle( vproto_id( "bicycle" ), origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    veh_ptr->cruise_on = true;
+    veh_ptr->pldrive( you, tripoint_rel_veh{ 0, 1, 0 } );
+
+    CHECK( you.get_moves() == 25 );
 }
 
 TEST_CASE( "horde_spawns_skip_owned_vehicle_tiles", "[horde][vehicle][monster]" )


### PR DESCRIPTION
## Purpose of change (The Why)

changing speed would make time pass

## Describe the solution (The How)

make it not pass

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3d279c6](https://github.com/cataclysmbn/Cataclysm-BN/commit/3d279c65bfa85db11838da5e59bceff69e41ab83) (style(autofix.ci): automated formatting) on 2026-06-09 04:04:07

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27179648955/artifacts/7497218722)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27179648955/artifacts/7497717424)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27179648955/artifacts/7497240833)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27179648955/artifacts/7497403010)
<!-- END artifact comment -->