### PR TITLE
ci: recover nightly releases with existing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   VCPKG_BINARY_SOURCES: "default"
+  EXPECTED_NIGHTLY_ASSET_COUNT: 10
 
 jobs:
   metadata:
@@ -43,7 +44,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || fromJson(needs.metadata.outputs.count) > 0
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
-      release_already_exists: ${{ steps.tag_check.outputs.exists }}
+      tag_exists: ${{ steps.tag_check.outputs.exists }}
+      release_exists: ${{ steps.release_check.outputs.exists }}
+      upload_assets: ${{ steps.asset_check.outputs.upload_assets }}
 
     steps:
       - name: Check if there is existing git tag
@@ -53,6 +56,17 @@ jobs:
           tag: ${{ needs.metadata.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if release exists
+        id: release_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ needs.metadata.outputs.tag_name }}" --json tagName --jq .tagName > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/checkout@v4
 
@@ -66,6 +80,7 @@ jobs:
           tag_prefix: ""
 
       - name: Build Changelog
+        if: ${{ steps.release_check.outputs.exists == 'false' }}
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4.2.0
         with:
@@ -76,6 +91,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
+        if: ${{ steps.release_check.outputs.exists == 'false' }}
         id: create_release
         uses: softprops/action-gh-release@v2.0.2
         env:
@@ -89,16 +105,31 @@ jobs:
           draft: false
           prerelease: true
 
+      - name: Check release assets
+        id: asset_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          asset_count=$(gh release view "${{ needs.metadata.outputs.tag_name }}" --json assets --jq '.assets | length' 2>/dev/null || echo 0)
+          echo "asset_count=$asset_count" >> "$GITHUB_STEP_SUMMARY"
+          echo "asset_count=$asset_count" >> "$GITHUB_OUTPUT"
+
+          if [ "$asset_count" -lt "$EXPECTED_NIGHTLY_ASSET_COUNT" ]; then
+            echo "upload_assets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "upload_assets=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-translations:
     needs: [metadata, release]
-    if: ${{ needs.release.outputs.release_already_exists == 'false' }}
+    if: ${{ needs.release.outputs.upload_assets == 'true' }}
     uses: ./.github/workflows/build-translations.yml
     secrets:
       TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
   builds:
     needs: [metadata, release, build-translations]
-    if: ${{ needs.release.outputs.release_already_exists == 'false' }}
+    if: ${{ needs.release.outputs.upload_assets == 'true' }}
     uses: ./.github/workflows/build.yml
     with:
       version-label: ${{ needs.metadata.outputs.tag_name }}


### PR DESCRIPTION
## Purpose of change

Nightly Release failed when tag creation was blocked, and a manual tag recovery would make the workflow skip builds because tag existence was treated as release completion.

Failed run: https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27113086227

## Describe the solution

- Track tag existence, release existence, and asset completeness separately.
- Create missing releases even when the tag already exists.
- Re-run release asset uploads when a nightly release has fewer than the expected assets.

## Testing

- `actionlint .github/workflows/release.yml`
- `conventional-prs --input 'ci: recover nightly releases with existing tags'`

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [8cb49b5](https://github.com/cataclysmbn/Cataclysm-BN/commit/8cb49b55cb0a01bff47b9747a09fcb552bee9775) (ci: recover nightly releases with existing tags) on 2026-06-09 03:12:44

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27178938771/artifacts/7496925616)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27178938771/artifacts/7497396548)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27178938771/artifacts/7496940613)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27178938771/artifacts/7497208940)
<!-- END artifact comment -->