### PR TITLE
fix: external vehicle parts location name fix

### DIFF
--- a/data/json/vehicleparts/balloons.json
+++ b/data/json/vehicleparts/balloons.json
@@ -34,7 +34,7 @@
     "copy-from": "airship_balloon",
     "type": "vehicle_part",
     "name": "external airship balloon",
-    "location": "structural",
+    "location": "structure",
     "//": "Overhead, so don't affect movement but don't board.",
     "extend": { "flags": [ "PROTUSION", "EXTENDABLE", "AISLE", "ROOF", "NOCOLLIDE", "NOCOLLIDEBELOW" ] }
   }

--- a/data/json/vehicleparts/jets.json
+++ b/data/json/vehicleparts/jets.json
@@ -25,7 +25,7 @@
     "copy-from": "jet_thruster",
     "type": "vehicle_part",
     "name": "external jet thruster",
-    "location": "structural",
+    "location": "structure",
     "extend": { "flags": [ "PROTUSION", "EXTENDABLE", "AISLE", "ROOF", "NOCOLLIDE", "NOCOLLIDEBELOW" ] }
   },
   {

--- a/data/json/vehicleparts/wings.json
+++ b/data/json/vehicleparts/wings.json
@@ -46,7 +46,7 @@
     "copy-from": "wing_metal",
     "type": "vehicle_part",
     "name": "external metal wing",
-    "location": "structural",
+    "location": "structure",
     "extend": { "flags": [ "PROTUSION", "EXTENDABLE", "BOARDABLE", "SEAT_REQUIRES_BALANCE" ] }
   },
   {
@@ -54,7 +54,7 @@
     "copy-from": "lit_wing_metal",
     "type": "vehicle_part",
     "name": "external metal wing with lights",
-    "location": "structural",
+    "location": "structure",
     "extend": { "flags": [ "PROTUSION", "EXTENDABLE", "BOARDABLE", "SEAT_REQUIRES_BALANCE" ] }
   },
   {
@@ -178,7 +178,7 @@
     "copy-from": "wing_wood",
     "type": "vehicle_part",
     "name": "external wooden wing",
-    "location": "structural",
+    "location": "structure",
     "extend": { "flags": [ "PROTUSION", "EXTENDABLE", "BOARDABLE", "SEAT_REQUIRES_BALANCE" ] }
   },
   {
@@ -186,7 +186,7 @@
     "copy-from": "lit_wing_wood",
     "type": "vehicle_part",
     "name": "external wooden wing with lights",
-    "location": "structural",
+    "location": "structure",
     "extend": { "flags": [ "PROTUSION", "EXTENDABLE", "BOARDABLE", "SEAT_REQUIRES_BALANCE" ] }
   },
   {
@@ -310,7 +310,7 @@
     "copy-from": "wing_carbon",
     "type": "vehicle_part",
     "name": "external carbon wing",
-    "location": "structural",
+    "location": "structure",
     "extend": { "flags": [ "PROTUSION", "EXTENDABLE", "BOARDABLE", "SEAT_REQUIRES_BALANCE" ] }
   },
   {
@@ -318,7 +318,7 @@
     "copy-from": "lit_wing_carbon",
     "type": "vehicle_part",
     "name": "external carbon wing with lights",
-    "location": "structural",
+    "location": "structure",
     "extend": { "flags": [ "PROTUSION", "EXTENDABLE", "BOARDABLE", "SEAT_REQUIRES_BALANCE" ] }
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)
While scrungling #9292 found some typos

## Describe the solution (The How)
Destroy the typo so it can continue

## Describe alternatives you've considered
None

## Testing
Structure is what is used in code

## Additional context
Weh

## Checklist
### Mandatory
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [01d4f76](https://github.com/cataclysmbn/Cataclysm-BN/commit/01d4f768e446ea516f0e13e1004becb6ad9a55b9) (fix: external balloon wing and jet location fix) on 2026-06-09 06:00:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27184373354/artifacts/7498824095)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27184373354/artifacts/7499380445)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27184373354/artifacts/7499300502)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27184373354/artifacts/7499111077)
<!-- END artifact comment -->