### PR TITLE
build: generate Lua docs before SDL startup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -804,7 +804,8 @@ int main( int argc, char *argv[] )
     }
 #endif
 #elif defined(CATA_SDL)
-    if( test_mode && !init_sdl_platform( false ) ) {
+    if( test_mode && lua_doc_output_path.empty() && lua_types_output_path.empty() &&
+        !init_sdl_platform( false ) ) {
         return 1;
     }
 #endif
@@ -830,8 +831,10 @@ int main( int argc, char *argv[] )
     }
 
 #if defined(CATA_SDL)
-    cata_gpu::init();
-    atexit( cata_gpu::shutdown );
+    if( lua_doc_output_path.empty() && lua_types_output_path.empty() ) {
+        cata_gpu::init();
+        atexit( cata_gpu::shutdown );
+    }
 #endif
 
 #if defined(TILES)
@@ -871,20 +874,6 @@ int main( int argc, char *argv[] )
         exit_handler( -999 );
     }
 
-    // Now we do the actual game.
-
-    game_ui::init_ui();
-
-    catacurses::curs_set( 0 ); // Invisible cursor here, because MAPBUFFER.load() is crash-prone
-
-#if !defined(_WIN32)
-    struct sigaction sigIntHandler;
-    sigIntHandler.sa_handler = signal_handler;
-    sigemptyset( &sigIntHandler.sa_mask );
-    sigIntHandler.sa_flags = 0;
-    sigaction( SIGINT, &sigIntHandler, nullptr );
-#endif
-
     DebugLog( DL::Info, DC::Main ) << "LAPI version: " << cata::get_lapi_version_string();
     cata::startup_lua_test();
 
@@ -912,6 +901,20 @@ int main( int argc, char *argv[] )
         }
         return 0;
     }
+
+    // Now we do the actual game.
+
+    game_ui::init_ui();
+
+    catacurses::curs_set( 0 ); // Invisible cursor here, because MAPBUFFER.load() is crash-prone
+
+#if !defined(_WIN32)
+    struct sigaction sigIntHandler;
+    sigIntHandler.sa_handler = signal_handler;
+    sigemptyset( &sigIntHandler.sa_mask );
+    sigIntHandler.sa_flags = 0;
+    sigaction( SIGINT, &sigIntHandler, nullptr );
+#endif
 
     prompt_select_lang_on_startup();
     replay_buffered_debugmsg_prompts();


### PR DESCRIPTION
## Purpose of change (The Why)

Fix docgen failing in CI over sdl init
Headless tiles builds should generate Lua docs without requiring an SDL video device.

## Describe the solution (The How)

- Skip tiles test-mode SDL video startup when only generating Lua docs/types.
- Skip GPU initialization for Lua docs/types.
- Run the existing Lua docs block before game UI setup.

## Testing

- `astyle --options=.astylerc --dry-run src/main.cpp`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `/usr/bin/cmake -E env --unset=LD_LIBRARY_PATH CATA_EXE=$PWD/out/build/linux-full/src/cataclysm-bn-tiles deno task docs:gen`
- `conventional-prs --input 'build: generate Lua docs before SDL startup'`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bc098fd](https://github.com/cataclysmbn/Cataclysm-BN/commit/bc098fd231271135902a102c99d36a182205c115) (build: generate Lua docs before SDL startup) on 2026-06-09 07:24:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27187249814/artifacts/7499893285)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27187249814/artifacts/7500655565)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27187249814/artifacts/7499890867)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27187249814/artifacts/7500268883)
<!-- END artifact comment -->