### PR TITLE
revert: input drain during world processing

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2302,15 +2302,6 @@ bool game::do_turn()
         Pathfinding::clear_d_maps();
     }
 
-    // Drain the OS input buffer so key-repeat events generated during world
-    // processing don't accumulate and drive movement after key release.  Keep
-    // input while activity or auto-move interruption checks are active, so
-    // pause/menu keys can still stop long-running actions.
-    if( !u.activity && !u.has_destination() ) {
-        ZoneScopedN( "do_turn_pump_events" );
-        inp_mngr.pump_events();
-    }
-
     return false;
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves [#9245](https://github.com/cataclysmbn/Cataclysm-BN/issues/9245)

## Describe the solution (The How)

Revert the PR https://github.com/cataclysmbn/Cataclysm-BN/pull/9017/changes
I don't think I could easily adjust the solution from that PR to cover everything needed,
so reverting until I figure out another solution, possibly an Autorun? Better input handling?

## Describe alternatives you've considered

Could wait until we implement a better solution.. but I'd rather just revert as I didn't see issues pop up for the previous behavior.

## Testing

Set pain to 200, broke both legs, verified the previous behavior was back. It is.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [ ] I have committed the output of `deno task semantic`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4e6bb9f](https://github.com/cataclysmbn/Cataclysm-BN/commit/4e6bb9f77d4b06006a5aa4f02b6912831c516bb4) (revert 9017) on 2026-06-09 10:51:38

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27196972531/artifacts/7504021219)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27196972531/artifacts/7504967251)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27196972531/artifacts/7504019312)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27196972531/artifacts/7504534233)
<!-- END artifact comment -->