### PR TITLE
build: prefer local external dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ endif()
 option(LUA_DOCS_ON_BUILD "Generate Lua reference/annotations after building cataclysm-bn-tiles (requires deno)." ${LUA_DOCS_DEFAULT})
 option(CATA_CLANG_TIDY_PLUGIN "Build Cata's custom clang-tidy plugin" "OFF")
 option(USE_TRACY "Use Tracy profiler" "OFF")
+set(TRACY_VERSION "" CACHE STRING "Tracy version to fetch when source fallback is used")
+option(TRACY_ON_DEMAND "Enable Tracy on-demand profiler connection" "ON")
+option(TRACY_ONLY_IPV4 "Use IPv4 only for Tracy profiler connections" "OFF")
 set(CATA_CLANG_TIDY_INCLUDE_DIR "" CACHE STRING
         "Path to internal clang-tidy headers required for plugin (e.g. ClangTidy.h)")
 set(CATA_CHECK_CLANG_TIDY "" CACHE STRING "Path to check_clang_tidy.py for plugin tests")
@@ -331,59 +334,80 @@ find_package(Threads REQUIRED)
 
 if (USE_TRACY)
 
-    if (NOT TRACY_VERSION)
-        if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-            set(TRACY_VERSION 6d1deb5640ed11da01995fb1791115cfebe54dbf)
-        else()
-            set(TRACY_VERSION v0.10)
+    find_package(Tracy CONFIG QUIET)
+
+    if (TARGET Tracy::TracyClient AND NOT TARGET TracyClient)
+        add_library(TracyClient INTERFACE IMPORTED)
+        target_link_libraries(TracyClient INTERFACE Tracy::TracyClient)
+        get_target_property(CATA_TRACY_INCLUDE_DIRS Tracy::TracyClient INTERFACE_INCLUDE_DIRECTORIES)
+        foreach (CATA_TRACY_INCLUDE_DIR ${CATA_TRACY_INCLUDE_DIRS})
+            if (EXISTS "${CATA_TRACY_INCLUDE_DIR}/tracy/tracy/Tracy.hpp")
+                target_include_directories(TracyClient INTERFACE "${CATA_TRACY_INCLUDE_DIR}/tracy")
+            endif ()
+        endforeach ()
+        unset(CATA_TRACY_INCLUDE_DIRS)
+        unset(CATA_TRACY_INCLUDE_DIR)
+        target_compile_definitions(TracyClient INTERFACE TRACY_ENABLE)
+        if (TRACY_ON_DEMAND)
+            target_compile_definitions(TracyClient INTERFACE TRACY_ON_DEMAND)
+        endif ()
+        if (TRACY_ONLY_IPV4)
+            target_compile_definitions(TracyClient INTERFACE TRACY_ONLY_IPV4)
+        endif ()
+        message(STATUS "Using installed Tracy")
+    endif ()
+
+    if (NOT TARGET TracyClient)
+        if (NOT TRACY_VERSION)
+            if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+                set(TRACY_VERSION 6d1deb5640ed11da01995fb1791115cfebe54dbf)
+            else()
+                set(TRACY_VERSION v0.10)
+            endif()
+            message(STATUS "Using tracy version: ${TRACY_VERSION}")
         endif()
-        message(STATUS "Using tracy version: ${TRACY_VERSION}")
-    endif()
 
-    FetchContent_Declare(
-        tracy
-        GIT_REPOSITORY https://github.com/wolfpld/tracy.git
-        GIT_TAG "${TRACY_VERSION}"
-        GIT_PROGRESS TRUE)
+        message(STATUS "Installing Tracy from Source")
+        FetchContent_Declare(
+            tracy
+            GIT_REPOSITORY https://github.com/wolfpld/tracy.git
+            GIT_TAG "${TRACY_VERSION}"
+            GIT_PROGRESS TRUE)
 
-    FetchContent_MakeAvailable(tracy)
-    set_target_properties(TracyClient PROPERTIES TRACY_ENABLE ON TRACY_ON_DEMAND ON)
+        FetchContent_MakeAvailable(tracy)
+        set_target_properties(TracyClient PROPERTIES TRACY_ENABLE ON TRACY_ON_DEMAND ${TRACY_ON_DEMAND})
 
-    if(NOT MSVC)
-        target_compile_options(TracyClient PRIVATE "-Wno-everything")
-    endif()
-    if (NOT DYNAMIC_LINKING)
-        set_target_properties(TracyClient PROPERTIES TRACY_STATIC ON)
+        if(NOT MSVC)
+            target_compile_options(TracyClient PRIVATE "-Wno-everything")
+        endif()
+        if (NOT DYNAMIC_LINKING)
+            set_target_properties(TracyClient PROPERTIES TRACY_STATIC ON)
+        endif ()
     endif ()
 endif ()
 
 # Check for build types and libraries
 if (CATA_SDL)
     message(STATUS "Searching for SDL3 library --")
-    if (NOT CMAKE_FIND_PACKAGE_PREFER_CONFIG)
-        if (NOT BUILD_SDL3)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-            # ^^ Use sdl3-config.cmake provided by the system or VCPKG
-            find_package(SDL3 CONFIG)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
+    if (NOT BUILD_SDL3)
+        find_package(SDL3 CONFIG QUIET)
+    endif ()
+    if (NOT (SDL3_FOUND OR TARGET SDL3::SDL3 OR TARGET SDL3::SDL3-static))
+        message("Installing SDL3 from Source")
+        set(SDL_TEST_LIBRARY OFF)
+        SET(SDL_SHARED ON)
+        # Install via FetchContent
+        FetchContent_Declare(
+                SDL3
+                URL https://github.com/libsdl-org/SDL/archive/refs/tags/release-3.4.8.tar.gz
+                EXCLUDE_FROM_ALL
+        )
+        FetchContent_MakeAvailable(SDL3)
+        if (DYNAMIC_LINKING)
+            install(TARGETS SDL3-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
         endif ()
-        if(NOT SDL3_FOUND)
-            message("Installing SDL3 from Source")
-            set(SDL_TEST_LIBRARY OFF)
-            SET(SDL_SHARED ON)
-            # Install via FetchContent
-            FetchContent_Declare(
-                    SDL3
-                    URL https://github.com/libsdl-org/SDL/archive/refs/tags/release-3.4.8.tar.gz
-                    EXCLUDE_FROM_ALL
-            )
-            FetchContent_MakeAvailable(SDL3)
-            if (DYNAMIC_LINKING)
-                install(TARGETS SDL3-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
-            endif ()
-        else()
-            message("Using system SDL3")
-        endif()
+    else()
+        message("Using installed SDL3")
     endif()
     if (NOT (SDL3_FOUND OR TARGET SDL3::SDL3 OR TARGET SDL3::SDL3-static))
         message(FATAL_ERROR
@@ -601,29 +625,24 @@ endif()
 if (TILES)
     # Find SDL3_ttf & SDL3_image for tile rendering
     message(STATUS "Searching for SDL3_ttf library --")
-    if (NOT CMAKE_FIND_PACKAGE_PREFER_CONFIG)
-        if (NOT BUILD_SDL3)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-            # ^^ Use sdl3_ttf-config.cmake provided by the system or VCPKG
-            find_package(SDL3_ttf CONFIG)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
+    if (NOT BUILD_SDL3)
+        find_package(SDL3_ttf CONFIG QUIET)
+    endif ()
+    if (NOT (SDL3_ttf_FOUND OR TARGET SDL3_ttf::SDL3_ttf OR TARGET SDL3_ttf::SDL3_ttf-static))
+        message("Installing SDL3_ttf from Source")
+        set(SDLTTF_PLUTOSVG OFF)
+        # Install via FetchContent
+        FetchContent_Declare(
+                SDL3_TTF
+                URL https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-3.2.2.tar.gz
+                EXCLUDE_FROM_ALL
+        )
+        FetchContent_MakeAvailable(SDL3_TTF)
+        if (DYNAMIC_LINKING)
+            install(TARGETS SDL3_ttf-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
         endif ()
-        if(NOT SDL3_ttf_FOUND)
-            message("Installing SDL3_ttf from Source")
-            set(SDLTTF_PLUTOSVG OFF)
-            # Install via FetchContent
-            FetchContent_Declare(
-                    SDL3_TTF
-                    URL https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-3.2.2.tar.gz
-                    EXCLUDE_FROM_ALL
-            )
-            FetchContent_MakeAvailable(SDL3_TTF)
-            if (DYNAMIC_LINKING)
-                install(TARGETS SDL3_ttf-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
-            endif ()
-        else()
-            message("Using system SDL3_ttf")
-        endif()
+    else()
+        message("Using installed SDL3_ttf")
     endif()
     if (NOT (SDL3_ttf_FOUND OR TARGET SDL3_ttf::SDL3_ttf OR TARGET SDL3_ttf::SDL3_ttf-static))
         message(FATAL_ERROR
@@ -634,30 +653,25 @@ if (TILES)
     endif ()
 
     message(STATUS "Searching for SDL3_image library --")
-    if (NOT CMAKE_FIND_PACKAGE_PREFER_CONFIG)
-        if (NOT BUILD_SDL3)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-            # ^^ Use sdl3_image-config.cmake provided by the system or VCPKG
-            find_package(SDL3_image CONFIG)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
+    if (NOT BUILD_SDL3)
+        find_package(SDL3_image CONFIG QUIET)
+    endif ()
+    if (NOT (SDL3_image_FOUND OR TARGET SDL3_image::SDL3_image OR TARGET SDL3_image::SDL3_image-static))
+        message("Installing SDL3_image from Source")
+        set(SDLIMAGE_JXL ON)
+        set(SDLIMAGE_PNG_LIBPNG ON)
+        # Install via FetchContent
+        FetchContent_Declare(
+                SDL3_IMAGE
+                URL https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-3.4.4.tar.gz
+                EXCLUDE_FROM_ALL
+        )
+        FetchContent_MakeAvailable(SDL3_IMAGE)
+        if (DYNAMIC_LINKING)
+            install(TARGETS SDL3_image-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
         endif ()
-        if(NOT SDL3_image_FOUND)
-            message("Installing SDL3_image from Source")
-            set(SDLIMAGE_JXL ON)
-            set(SDLIMAGE_PNG_LIBPNG ON)
-            # Install via FetchContent
-            FetchContent_Declare(
-                    SDL3_IMAGE
-                    URL https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-3.4.4.tar.gz
-                    EXCLUDE_FROM_ALL
-            )
-            FetchContent_MakeAvailable(SDL3_IMAGE)
-            if (DYNAMIC_LINKING)
-                install(TARGETS SDL3_image-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
-            endif ()
-        else()
-            message("Using system SDL3_image")
-        endif()
+    else()
+        message("Using installed SDL3_image")
     endif()
     if (NOT (SDL3_image_FOUND OR TARGET SDL3_image::SDL3_image OR TARGET SDL3_image::SDL3_image-static))
         message(FATAL_ERROR
@@ -696,28 +710,23 @@ if (SOUND)
 
     # Sound requires SDL_mixer library
     message(STATUS "Searching for SDL3_mixer library --")
-    if (NOT CMAKE_FIND_PACKAGE_PREFER_CONFIG)
-        if (NOT BUILD_SDL3)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-            # ^^ Use sdl3_mixer-config.cmake provided by the system or VCPKG
-            find_package(SDL3_mixer CONFIG)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
+    if (NOT BUILD_SDL3)
+        find_package(SDL3_mixer CONFIG QUIET)
+    endif ()
+    if (NOT (SDL3_mixer_FOUND OR TARGET SDL3_mixer::SDL3_mixer OR TARGET SDL3_mixer::SDL3_mixer-static))
+        message("Installing SDL3_mixer from Source")
+        # Install via FetchContent
+        FetchContent_Declare(
+                SDL3_MIXER
+                URL https://github.com/libsdl-org/SDL_mixer/archive/refs/tags/release-3.2.0.tar.gz
+                EXCLUDE_FROM_ALL
+        )
+        FetchContent_MakeAvailable(SDL3_MIXER )
+        if (DYNAMIC_LINKING)
+            install(TARGETS SDL3_mixer-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
         endif ()
-        if(NOT SDL3_mixer_FOUND)
-            message("Installing SDL3_mixer from Source")
-            # Install via FetchContent
-            FetchContent_Declare(
-                    SDL3_MIXER
-                    URL https://github.com/libsdl-org/SDL_mixer/archive/refs/tags/release-3.2.0.tar.gz
-                    EXCLUDE_FROM_ALL
-            )
-            FetchContent_MakeAvailable(SDL3_MIXER )
-            if (DYNAMIC_LINKING)
-                install(TARGETS SDL3_mixer-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
-            endif ()
-        else()
-            message("Using system SDL3_mixer")
-        endif()
+    else()
+        message("Using installed SDL3_mixer")
     endif()
     if (NOT (SDL3_mixer_FOUND OR TARGET SDL3_mixer::SDL3_mixer OR TARGET SDL3_mixer::SDL3_mixer-static))
         message(FATAL_ERROR
@@ -730,67 +739,81 @@ endif ()
 if (BACKTRACE)
     add_definitions(-DBACKTRACE)
     if (LIBBACKTRACE AND NOT MSVC)
-        message(STATUS "Integrating libbacktrace build using ExternalProject")
+        find_path(CATA_LIBBACKTRACE_INCLUDE_DIR NAMES backtrace.h)
+        find_library(CATA_LIBBACKTRACE_LIBRARY NAMES backtrace libbacktrace)
+        mark_as_advanced(CATA_LIBBACKTRACE_INCLUDE_DIR CATA_LIBBACKTRACE_LIBRARY)
 
-        set(LIBBACKTRACE_GIT_REPO https://github.com/ianlancetaylor/libbacktrace.git)
-        set(LIBBACKTRACE_GIT_TAG master)
+        if (CATA_LIBBACKTRACE_INCLUDE_DIR AND CATA_LIBBACKTRACE_LIBRARY)
+            message(STATUS "Using installed libbacktrace: ${CATA_LIBBACKTRACE_LIBRARY}")
+            add_library(backtrace UNKNOWN IMPORTED)
+            set_target_properties(backtrace
+                PROPERTIES
+                    IMPORTED_LOCATION "${CATA_LIBBACKTRACE_LIBRARY}"
+                    INTERFACE_INCLUDE_DIRECTORIES "${CATA_LIBBACKTRACE_INCLUDE_DIR}"
+            )
+        else ()
+            message(STATUS "Installing libbacktrace from Source")
 
-        set(LIBBACKTRACE_INSTALL_DIR "${CMAKE_BINARY_DIR}/libbacktrace/install")
-        SET(LIBBACKTRACE_LIBRARY "${LIBBACKTRACE_INSTALL_DIR}/lib/libbacktrace.a")
+            set(LIBBACKTRACE_GIT_REPO https://github.com/ianlancetaylor/libbacktrace.git)
+            set(LIBBACKTRACE_GIT_TAG master)
 
-        include(ProcessorCount)
-        ProcessorCount(NCPU)
-        if(NCPU EQUAL 0)
-            set(NCPU 1)
-        endif()
+            set(LIBBACKTRACE_INSTALL_DIR "${CMAKE_BINARY_DIR}/libbacktrace/install")
+            SET(LIBBACKTRACE_LIBRARY "${LIBBACKTRACE_INSTALL_DIR}/lib/libbacktrace.a")
 
-        # Set up ccache for libbacktrace if available
-        if (CCACHE_FOUND AND CATA_CCACHE AND CMAKE_C_COMPILER_LAUNCHER)
-            # Join compiler launcher and compiler into a single string for configure
-            set(LIBBACKTRACE_CC_LIST "${CMAKE_C_COMPILER_LAUNCHER}" "${CMAKE_C_COMPILER}")
-            set(LIBBACKTRACE_CXX_LIST "${CMAKE_CXX_COMPILER_LAUNCHER}" "${CMAKE_CXX_COMPILER}")
-            list(JOIN LIBBACKTRACE_CC_LIST " " LIBBACKTRACE_CC)
-            list(JOIN LIBBACKTRACE_CXX_LIST " " LIBBACKTRACE_CXX)
-        else()
-            set(LIBBACKTRACE_CC "${CMAKE_C_COMPILER}")
-            set(LIBBACKTRACE_CXX "${CMAKE_CXX_COMPILER}")
-        endif()
+            include(ProcessorCount)
+            ProcessorCount(NCPU)
+            if(NCPU EQUAL 0)
+                set(NCPU 1)
+            endif()
 
-        ExternalProject_Add(
-            libbacktrace_external
-            GIT_REPOSITORY ${LIBBACKTRACE_GIT_REPO}
-            GIT_TAG ${LIBBACKTRACE_GIT_TAG}
-            GIT_SHALLOW TRUE
+            # Set up ccache for libbacktrace if available
+            if (CCACHE_FOUND AND CATA_CCACHE AND CMAKE_C_COMPILER_LAUNCHER)
+                # Join compiler launcher and compiler into a single string for configure
+                set(LIBBACKTRACE_CC_LIST "${CMAKE_C_COMPILER_LAUNCHER}" "${CMAKE_C_COMPILER}")
+                set(LIBBACKTRACE_CXX_LIST "${CMAKE_CXX_COMPILER_LAUNCHER}" "${CMAKE_CXX_COMPILER}")
+                list(JOIN LIBBACKTRACE_CC_LIST " " LIBBACKTRACE_CC)
+                list(JOIN LIBBACKTRACE_CXX_LIST " " LIBBACKTRACE_CXX)
+            else()
+                set(LIBBACKTRACE_CC "${CMAKE_C_COMPILER}")
+                set(LIBBACKTRACE_CXX "${CMAKE_CXX_COMPILER}")
+            endif()
 
-            SOURCE_DIR "${CMAKE_BINARY_DIR}/libbacktrace/src"
-            BINARY_DIR "${CMAKE_BINARY_DIR}/libbacktrace/build"
+            ExternalProject_Add(
+                libbacktrace_external
+                GIT_REPOSITORY ${LIBBACKTRACE_GIT_REPO}
+                GIT_TAG ${LIBBACKTRACE_GIT_TAG}
+                GIT_SHALLOW TRUE
 
-            CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env
-                CC=${LIBBACKTRACE_CC}
-                CXX=${LIBBACKTRACE_CXX}
-                <SOURCE_DIR>/configure
-                --prefix=${LIBBACKTRACE_INSTALL_DIR}
+                SOURCE_DIR "${CMAKE_BINARY_DIR}/libbacktrace/src"
+                BINARY_DIR "${CMAKE_BINARY_DIR}/libbacktrace/build"
 
-            BUILD_COMMAND make -j${NCPU}
+                CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env
+                    CC=${LIBBACKTRACE_CC}
+                    CXX=${LIBBACKTRACE_CXX}
+                    <SOURCE_DIR>/configure
+                    --prefix=${LIBBACKTRACE_INSTALL_DIR}
 
-            INSTALL_COMMAND make install
+                BUILD_COMMAND make -j${NCPU}
 
-            INSTALL_DIR ${LIBBACKTRACE_INSTALL_DIR}
-            BUILD_BYPRODUCTS ${LIBBACKTRACE_LIBRARY}
+                INSTALL_COMMAND make install
 
-            UPDATE_DISCONNECTED 1
-        )
+                INSTALL_DIR ${LIBBACKTRACE_INSTALL_DIR}
+                BUILD_BYPRODUCTS ${LIBBACKTRACE_LIBRARY}
 
-        add_library(backtrace SHARED IMPORTED)
-        set_target_properties(backtrace
-            PROPERTIES IMPORTED_LOCATION ${LIBBACKTRACE_LIBRARY}
-        )
-        # Hack to make it work, otherwise INTERFACE_INCLUDE_DIRECTORIES will not be propagated
-        file(MAKE_DIRECTORY "${LIBBACKTRACE_INSTALL_DIR}/include")
-        target_include_directories(backtrace INTERFACE
-            "${LIBBACKTRACE_INSTALL_DIR}/include"
-        )
-        add_dependencies(backtrace libbacktrace_external)
+                UPDATE_DISCONNECTED 1
+            )
+
+            add_library(backtrace UNKNOWN IMPORTED)
+            set_target_properties(backtrace
+                PROPERTIES IMPORTED_LOCATION ${LIBBACKTRACE_LIBRARY}
+            )
+            # Hack to make it work, otherwise INTERFACE_INCLUDE_DIRECTORIES will not be propagated
+            file(MAKE_DIRECTORY "${LIBBACKTRACE_INSTALL_DIR}/include")
+            target_include_directories(backtrace INTERFACE
+                "${LIBBACKTRACE_INSTALL_DIR}/include"
+            )
+            add_dependencies(backtrace libbacktrace_external)
+        endif ()
     endif ()
     if (LIBBACKTRACE)
         add_definitions(-DLIBBACKTRACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,25 +389,30 @@ endif ()
 # Check for build types and libraries
 if (CATA_SDL)
     message(STATUS "Searching for SDL3 library --")
-    if (NOT BUILD_SDL3)
-        find_package(SDL3 CONFIG QUIET)
-    endif ()
-    if (NOT (SDL3_FOUND OR TARGET SDL3::SDL3 OR TARGET SDL3::SDL3-static))
-        message("Installing SDL3 from Source")
-        set(SDL_TEST_LIBRARY OFF)
-        SET(SDL_SHARED ON)
-        # Install via FetchContent
-        FetchContent_Declare(
-                SDL3
-                URL https://github.com/libsdl-org/SDL/archive/refs/tags/release-3.4.8.tar.gz
-                EXCLUDE_FROM_ALL
-        )
-        FetchContent_MakeAvailable(SDL3)
-        if (DYNAMIC_LINKING)
-            install(TARGETS SDL3-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
+    if (NOT CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+        if (NOT BUILD_SDL3)
+            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+            # ^^ Use sdl3-config.cmake provided by the system or VCPKG
+            find_package(SDL3 CONFIG)
+            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
         endif ()
-    else()
-        message("Using installed SDL3")
+        if(NOT SDL3_FOUND)
+            message("Installing SDL3 from Source")
+            set(SDL_TEST_LIBRARY OFF)
+            SET(SDL_SHARED ON)
+            # Install via FetchContent
+            FetchContent_Declare(
+                    SDL3
+                    URL https://github.com/libsdl-org/SDL/archive/refs/tags/release-3.4.8.tar.gz
+                    EXCLUDE_FROM_ALL
+            )
+            FetchContent_MakeAvailable(SDL3)
+            if (DYNAMIC_LINKING)
+                install(TARGETS SDL3-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
+            endif ()
+        else()
+            message("Using system SDL3")
+        endif()
     endif()
     if (NOT (SDL3_FOUND OR TARGET SDL3::SDL3 OR TARGET SDL3::SDL3-static))
         message(FATAL_ERROR
@@ -625,24 +630,29 @@ endif()
 if (TILES)
     # Find SDL3_ttf & SDL3_image for tile rendering
     message(STATUS "Searching for SDL3_ttf library --")
-    if (NOT BUILD_SDL3)
-        find_package(SDL3_ttf CONFIG QUIET)
-    endif ()
-    if (NOT (SDL3_ttf_FOUND OR TARGET SDL3_ttf::SDL3_ttf OR TARGET SDL3_ttf::SDL3_ttf-static))
-        message("Installing SDL3_ttf from Source")
-        set(SDLTTF_PLUTOSVG OFF)
-        # Install via FetchContent
-        FetchContent_Declare(
-                SDL3_TTF
-                URL https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-3.2.2.tar.gz
-                EXCLUDE_FROM_ALL
-        )
-        FetchContent_MakeAvailable(SDL3_TTF)
-        if (DYNAMIC_LINKING)
-            install(TARGETS SDL3_ttf-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
+    if (NOT CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+        if (NOT BUILD_SDL3)
+            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+            # ^^ Use sdl3_ttf-config.cmake provided by the system or VCPKG
+            find_package(SDL3_ttf CONFIG)
+            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
         endif ()
-    else()
-        message("Using installed SDL3_ttf")
+        if(NOT SDL3_ttf_FOUND)
+            message("Installing SDL3_ttf from Source")
+            set(SDLTTF_PLUTOSVG OFF)
+            # Install via FetchContent
+            FetchContent_Declare(
+                    SDL3_TTF
+                    URL https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-3.2.2.tar.gz
+                    EXCLUDE_FROM_ALL
+            )
+            FetchContent_MakeAvailable(SDL3_TTF)
+            if (DYNAMIC_LINKING)
+                install(TARGETS SDL3_ttf-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
+            endif ()
+        else()
+            message("Using system SDL3_ttf")
+        endif()
     endif()
     if (NOT (SDL3_ttf_FOUND OR TARGET SDL3_ttf::SDL3_ttf OR TARGET SDL3_ttf::SDL3_ttf-static))
         message(FATAL_ERROR
@@ -653,25 +663,30 @@ if (TILES)
     endif ()
 
     message(STATUS "Searching for SDL3_image library --")
-    if (NOT BUILD_SDL3)
-        find_package(SDL3_image CONFIG QUIET)
-    endif ()
-    if (NOT (SDL3_image_FOUND OR TARGET SDL3_image::SDL3_image OR TARGET SDL3_image::SDL3_image-static))
-        message("Installing SDL3_image from Source")
-        set(SDLIMAGE_JXL ON)
-        set(SDLIMAGE_PNG_LIBPNG ON)
-        # Install via FetchContent
-        FetchContent_Declare(
-                SDL3_IMAGE
-                URL https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-3.4.4.tar.gz
-                EXCLUDE_FROM_ALL
-        )
-        FetchContent_MakeAvailable(SDL3_IMAGE)
-        if (DYNAMIC_LINKING)
-            install(TARGETS SDL3_image-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
+    if (NOT CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+        if (NOT BUILD_SDL3)
+            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+            # ^^ Use sdl3_image-config.cmake provided by the system or VCPKG
+            find_package(SDL3_image CONFIG)
+            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
         endif ()
-    else()
-        message("Using installed SDL3_image")
+        if(NOT SDL3_image_FOUND)
+            message("Installing SDL3_image from Source")
+            set(SDLIMAGE_JXL ON)
+            set(SDLIMAGE_PNG_LIBPNG ON)
+            # Install via FetchContent
+            FetchContent_Declare(
+                    SDL3_IMAGE
+                    URL https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-3.4.4.tar.gz
+                    EXCLUDE_FROM_ALL
+            )
+            FetchContent_MakeAvailable(SDL3_IMAGE)
+            if (DYNAMIC_LINKING)
+                install(TARGETS SDL3_image-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
+            endif ()
+        else()
+            message("Using system SDL3_image")
+        endif()
     endif()
     if (NOT (SDL3_image_FOUND OR TARGET SDL3_image::SDL3_image OR TARGET SDL3_image::SDL3_image-static))
         message(FATAL_ERROR
@@ -710,23 +725,28 @@ if (SOUND)
 
     # Sound requires SDL_mixer library
     message(STATUS "Searching for SDL3_mixer library --")
-    if (NOT BUILD_SDL3)
-        find_package(SDL3_mixer CONFIG QUIET)
-    endif ()
-    if (NOT (SDL3_mixer_FOUND OR TARGET SDL3_mixer::SDL3_mixer OR TARGET SDL3_mixer::SDL3_mixer-static))
-        message("Installing SDL3_mixer from Source")
-        # Install via FetchContent
-        FetchContent_Declare(
-                SDL3_MIXER
-                URL https://github.com/libsdl-org/SDL_mixer/archive/refs/tags/release-3.2.0.tar.gz
-                EXCLUDE_FROM_ALL
-        )
-        FetchContent_MakeAvailable(SDL3_MIXER )
-        if (DYNAMIC_LINKING)
-            install(TARGETS SDL3_mixer-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
+    if (NOT CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+        if (NOT BUILD_SDL3)
+            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+            # ^^ Use sdl3_mixer-config.cmake provided by the system or VCPKG
+            find_package(SDL3_mixer CONFIG)
+            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
         endif ()
-    else()
-        message("Using installed SDL3_mixer")
+        if(NOT SDL3_mixer_FOUND)
+            message("Installing SDL3_mixer from Source")
+            # Install via FetchContent
+            FetchContent_Declare(
+                    SDL3_MIXER
+                    URL https://github.com/libsdl-org/SDL_mixer/archive/refs/tags/release-3.2.0.tar.gz
+                    EXCLUDE_FROM_ALL
+            )
+            FetchContent_MakeAvailable(SDL3_MIXER )
+            if (DYNAMIC_LINKING)
+                install(TARGETS SDL3_mixer-shared DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
+            endif ()
+        else()
+            message("Using system SDL3_mixer")
+        endif()
     endif()
     if (NOT (SDL3_mixer_FOUND OR TARGET SDL3_mixer::SDL3_mixer OR TARGET SDL3_mixer::SDL3_mixer-static))
         message(FATAL_ERROR

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -536,7 +536,7 @@ much faster.
 
 [libbacktrace]: https://github.com/ianlancetaylor/libbacktrace
 
-Installed external dependencies are preferred before downloading source fallbacks. Set
+Supported installed external dependencies are preferred before downloading source fallbacks. Set
 `CMAKE_PREFIX_PATH` to a local prefix such as `$HOME/.local` to use locally installed packages.
 
 - USE_TRACY=`<boolean>`

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -536,6 +536,9 @@ much faster.
 
 [libbacktrace]: https://github.com/ianlancetaylor/libbacktrace
 
+Installed external dependencies are preferred before downloading source fallbacks. Set
+`CMAKE_PREFIX_PATH` to a local prefix such as `$HOME/.local` to use locally installed packages.
+
 - USE_TRACY=`<boolean>`
 
 Use tracy profiler. See [Profiling with tracy](../tracy.md) for more information.


### PR DESCRIPTION
## Purpose of change (The Why)

Reduce repeated source downloads for local builds by preferring installed external dependencies before source fallbacks.

## Describe the solution (The How)

- Use direct `find_package(... CONFIG QUIET)` checks for installed Tracy and SDL3 modules before source fallbacks.
- Use direct `find_path`/`find_library` checks for installed libbacktrace before ExternalProject fallback.
- Document `CMAKE_PREFIX_PATH` usage for local prefixes.

## Testing

- `cmake -S . -B out/build/local-libbacktrace-test -G Ninja -DTILES=OFF -DSOUND=OFF -DUSE_TRACY=OFF -DLIBBACKTRACE=ON -DCMAKE_PREFIX_PATH=/home/scarf/.local/share/zrythm`
- `cmake -S . -B out/build/libbacktrace-fallback-test -G Ninja -DTILES=OFF -DCURSES=OFF -DSOUND=OFF -DUSE_TRACY=OFF -DLIBBACKTRACE=ON -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_IGNORE_PREFIX_PATH=/home/scarf/.local/share/zrythm`
- `cmake --preset linux-full -DCMAKE_PREFIX_PATH=/home/scarf/.local/share/zrythm`
- `cmake --build --preset linux-full --target cata_shaders --parallel 10`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles --parallel 10`

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [x] I ran the code formatter.
- [x] I linked any relevant issues using github keyword syntax like `closes #1234` in Summary of the PR so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit in the Linux kernel format.
- [x] This is a PR that modifies build process or code organization.
  - [x] I documented the changes in the appropriate location in the `docs/` folder.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [04bf54d](https://github.com/cataclysmbn/Cataclysm-BN/commit/04bf54d4e7264fbd98398ab7cb7a9f0df5bb8363) (build: restore SDL package fallback guard) on 2026-06-09 20:17:47

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27228423331/artifacts/7518427826)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27228423331/artifacts/7518581922)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27228423331/artifacts/7517984693)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27228423331/artifacts/7517977944)
<!-- END artifact comment -->