### PR TITLE
test: use offscreen SDL for headless test runs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,7 @@ class ui_adaptor;
 #   endif
 #   include <SDL3/SDL.h>
 #   include "compute/gpu_platform.h"
+#   include "platform/sdl_video.h"
 #endif
 #if defined(TILES)
 #   include <SDL3/SDL_main.h>
@@ -186,24 +187,6 @@ struct arg_handler {
 };
 
 #if defined(CATA_SDL)
-#if defined(__linux__) && !defined(__ANDROID__) && !defined(TILES)
-auto use_offscreen_video_driver_for_headless_curses() -> void
-{
-    if( std::getenv( "SDL_VIDEO_DRIVER" ) != nullptr ||
-        std::getenv( "SDL_VIDEODRIVER" ) != nullptr ||
-        std::getenv( "DISPLAY" ) != nullptr ||
-        std::getenv( "WAYLAND_DISPLAY" ) != nullptr ) {
-        return;
-    }
-
-    if( SDL_SetHint( SDL_HINT_VIDEO_DRIVER, "offscreen" ) ) {
-        DebugLog( DL::Info, DC::Main ) << "SDL video driver set to offscreen for headless curses";
-    } else {
-        DebugLog( DL::Warn, DC::Main ) << "SDL video driver offscreen hint failed: " << SDL_GetError();
-    }
-}
-#endif
-
 auto init_sdl_platform( bool init_audio ) -> bool
 {
     auto init_flags = SDL_InitFlags{ SDL_INIT_VIDEO };
@@ -796,9 +779,16 @@ int main( int argc, char *argv[] )
     get_options().save();
     set_language(); // Have to set locale before initializing ncurses
 #if defined(CATA_SDL)
-#   if defined(__linux__) && !defined(__ANDROID__)
-    use_offscreen_video_driver_for_headless_curses();
-#   endif
+    switch( use_offscreen_video_driver_for_headless_sdl() ) {
+        case offscreen_sdl_hint_result::applied:
+            DebugLog( DL::Info, DC::Main ) << "SDL video driver set to offscreen for headless curses";
+            break;
+        case offscreen_sdl_hint_result::failed:
+            DebugLog( DL::Warn, DC::Main ) << "SDL video driver offscreen hint failed: " << SDL_GetError();
+            break;
+        case offscreen_sdl_hint_result::skipped:
+            break;
+    }
     if( !init_sdl_platform( !test_mode ) ) {
         return 1;
     }

--- a/src/platform/sdl_video.cpp
+++ b/src/platform/sdl_video.cpp
@@ -1,0 +1,23 @@
+#include "platform/sdl_video.h"
+
+#if defined(CATA_SDL)
+
+#include <SDL3/SDL.h>
+#include <cstdlib>
+
+auto use_offscreen_video_driver_for_headless_sdl() -> offscreen_sdl_hint_result {
+#if defined(__linux__) && !defined(__ANDROID__)
+    if (std::getenv("SDL_VIDEO_DRIVER") != nullptr || std::getenv("SDL_VIDEODRIVER") != nullptr
+        || std::getenv("DISPLAY") != nullptr || std::getenv("WAYLAND_DISPLAY") != nullptr) {
+        return offscreen_sdl_hint_result::skipped;
+    }
+
+    return SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "offscreen")
+             ? offscreen_sdl_hint_result::applied
+             : offscreen_sdl_hint_result::failed;
+#else
+    return offscreen_sdl_hint_result::skipped;
+#endif
+}
+
+#endif

--- a/src/platform/sdl_video.h
+++ b/src/platform/sdl_video.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#if defined(CATA_SDL)
+
+enum class offscreen_sdl_hint_result {
+    skipped,
+    applied,
+    failed,
+};
+
+auto use_offscreen_video_driver_for_headless_sdl() -> offscreen_sdl_hint_result;
+
+#endif

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -67,6 +67,7 @@
 #   endif
 #   include "compute/gpu_platform.h"
 #   include "preload_config.h"
+#   include "platform/sdl_video.h"
 #   include <SDL3/SDL.h>
 #endif
 
@@ -81,6 +82,8 @@ bool s_sdl_platform_initialized = false;
 
 auto init_test_sdl_gpu() -> void
 {
+    use_offscreen_video_driver_for_headless_sdl();
+
     if( !SDL_Init( SDL_InitFlags{ SDL_INIT_VIDEO } ) ) {
         throw std::runtime_error( string_format( "SDL_Init failed: %s", SDL_GetError() ) );
     }


### PR DESCRIPTION
## Purpose of change (The Why)

Headless Linux test runs fail SDL video init unless the caller sets an offscreen driver.

Related: #9335

## Describe the solution (The How)

Share the headless SDL offscreen-driver hint helper between the curses executable and SDL tests.

## Testing

- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `env -u SDL_VIDEODRIVER -u SDL_VIDEO_DRIVER -u DISPLAY -u WAYLAND_DISPLAY ./out/build/linux-full/tests/cata_test-tiles "[lua]"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3bd9fa4](https://github.com/cataclysmbn/Cataclysm-BN/commit/3bd9fa472b29fc81bfd7b889ea1a95325d2a1c6b) (test: use offscreen SDL for headless test runs) on 2026-06-10 04:00:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27247352364/artifacts/7525285781)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27247352364/artifacts/7525363558)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27247352364/artifacts/7525053760)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27247352364/artifacts/7525247590)
<!-- END artifact comment -->