### PR TITLE
fix: keep canned vehicle ingredients fresh when crafting

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <string>
 #include <utility>
@@ -1090,6 +1091,21 @@ void item::inherit_flags( const std::vector<item *> &parents, const recipe &maki
     }
 }
 
+static auto component_relative_rot( const item *component ) -> double
+{
+    return component != nullptr && component->goes_bad() ? component->get_relative_rot() : 0.0;
+}
+
+static auto highest_component_relative_rot( const std::vector<item *> &components ) -> double
+{
+    namespace ranges = std::ranges;
+    using namespace std::views;
+    if( components.empty() ) {
+        return 0.0;
+    }
+    return ranges::max( components | transform( component_relative_rot ) );
+}
+
 void complete_craft( Character &who, item &craft )
 {
     if( !craft.is_craft() ) {
@@ -1105,16 +1121,7 @@ void complete_craft( Character &who, item &craft )
     for( detached_ptr<item> &it : used ) {
         used_items.push_back( &*it );
     }
-    // Makes it so that crafting inherits the components' rot instead of the vehicle cargo age, whatever that means
-    double relative_rot = 0.0;
-    for( const item *comp : used_items ) {
-        if( comp->goes_bad() ) {
-            const double comp_rot = comp->get_relative_rot();
-            if( comp_rot > relative_rot ) {
-                relative_rot = comp_rot;
-            }
-        }
-    }
+    const auto relative_rot = highest_component_relative_rot( used_items );
     const bool ignore_component = making.has_flag( "NUTRIENT_OVERRIDE" );
 
     // Set up the new item, and assign an inventory letter if available

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9605,6 +9605,13 @@ int item::get_remaining_capacity_for_id( const itype_id &liquid, bool allow_buck
     return rem_cap;
 }
 
+auto item::preserve_freshness_when_unsealed() -> void
+{
+    if( goes_bad() && is_in_preserving_container() ) {
+        mark_rot_checked_now();
+    }
+}
+
 detached_ptr<item> item::use_amount( detached_ptr<item> &&self, const itype_id &it, int &quantity,
                                      std::vector<detached_ptr<item>> &used,
                                      const std::function<bool( const item & )> &filter )
@@ -9614,6 +9621,7 @@ detached_ptr<item> item::use_amount( detached_ptr<item> &&self, const itype_id &
 
     self->remove_items_with( [&]( detached_ptr<item> &&a ) {
         if( quantity > 0  && a->typeId() == it && filter( *a ) ) {
+            a->preserve_freshness_when_unsealed();
             used.push_back( std::move( a ) );
             quantity--;
             return VisitResponse::SKIP;
@@ -9752,6 +9760,9 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
 
 
     auto handle_item = [&qty, &used, &pos, &what]( detached_ptr<item> &&e ) {
+        if( e->typeId() == what ) {
+            e->preserve_freshness_when_unsealed();
+        }
         if( e->is_tool() ) {
             if( e->typeId() == what || ( what == itype_UPS && e->has_flag( flag_IS_UPS ) ) ) {
                 int ups_eff_mult = e->type->tool->ups_eff_mult;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -825,11 +825,18 @@ void item::set_damage( int qty )
     damage_ = std::max( std::min( qty, max_damage() ), min_damage() );
 }
 
+auto item::prepare_for_location_removal() -> void
+{
+    if( goes_bad() && is_in_preserving_container() ) {
+        mark_rot_checked_now();
+    }
+}
+
 detached_ptr<item> item::split( int qty )
 {
     const bool split_from_preserving_container = goes_bad() && is_in_preserving_container();
     if( split_from_preserving_container ) {
-        mark_rot_checked_now();
+        prepare_for_location_removal();
     }
     if( qty <= 0 || !count_by_charges() || qty >= charges ) {
         return detach();
@@ -872,9 +879,7 @@ bool item::attempt_detach( std::function < detached_ptr<item>( detached_ptr<item
     if( is_null() ) {
         return false;
     }
-    if( goes_bad() && is_in_preserving_container() ) {
-        mark_rot_checked_now();
-    }
+    prepare_for_location_removal();
     if( count_by_charges() ) {
         return attempt_split( 0, cb );
     }
@@ -886,7 +891,7 @@ bool item::attempt_split( int qty,
 {
     const bool split_from_preserving_container = goes_bad() && is_in_preserving_container();
     if( split_from_preserving_container ) {
-        mark_rot_checked_now();
+        prepare_for_location_removal();
     }
     const bool split_needs_rot_actualization = goes_bad() && has_position() &&
             !split_from_preserving_container;
@@ -9605,13 +9610,6 @@ int item::get_remaining_capacity_for_id( const itype_id &liquid, bool allow_buck
     return rem_cap;
 }
 
-auto item::preserve_freshness_when_unsealed() -> void
-{
-    if( goes_bad() && is_in_preserving_container() ) {
-        mark_rot_checked_now();
-    }
-}
-
 detached_ptr<item> item::use_amount( detached_ptr<item> &&self, const itype_id &it, int &quantity,
                                      std::vector<detached_ptr<item>> &used,
                                      const std::function<bool( const item & )> &filter )
@@ -9621,7 +9619,6 @@ detached_ptr<item> item::use_amount( detached_ptr<item> &&self, const itype_id &
 
     self->remove_items_with( [&]( detached_ptr<item> &&a ) {
         if( quantity > 0  && a->typeId() == it && filter( *a ) ) {
-            a->preserve_freshness_when_unsealed();
             used.push_back( std::move( a ) );
             quantity--;
             return VisitResponse::SKIP;
@@ -9760,9 +9757,6 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
 
 
     auto handle_item = [&qty, &used, &pos, &what]( detached_ptr<item> &&e ) {
-        if( e->typeId() == what ) {
-            e->preserve_freshness_when_unsealed();
-        }
         if( e->is_tool() ) {
             if( e->typeId() == what || ( what == itype_UPS && e->has_flag( flag_IS_UPS ) ) ) {
                 int ups_eff_mult = e->type->tool->ups_eff_mult;

--- a/src/item.h
+++ b/src/item.h
@@ -2429,6 +2429,7 @@ class item : public location_visitable<item>, public game_object<item>
                 bool seals, temperature_flag flag, const weather_manager &weather_generator );
         auto is_in_preserving_container() const -> bool;
         auto mark_rot_checked_now() -> void;
+        auto preserve_freshness_when_unsealed() -> void;
 
         /** Helper for checking reloadability. **/
         bool is_reloadable_helper( const itype_id &ammo, bool now ) const;

--- a/src/item.h
+++ b/src/item.h
@@ -396,6 +396,12 @@ class item : public location_visitable<item>, public game_object<item>
          */
         detached_ptr<item> split( int qty );
 
+        /**
+         * Update state before removing the item from its current location.
+         * This must run while @ref loc or @ref saved_loc still identifies the old location.
+         */
+        auto prepare_for_location_removal() -> void;
+
         virtual bool attempt_detach( std::function < detached_ptr<item>( detached_ptr<item> && ) > )
         override;
 
@@ -2429,7 +2435,6 @@ class item : public location_visitable<item>, public game_object<item>
                 bool seals, temperature_flag flag, const weather_manager &weather_generator );
         auto is_in_preserving_container() const -> bool;
         auto mark_rot_checked_now() -> void;
-        auto preserve_freshness_when_unsealed() -> void;
 
         /** Helper for checking reloadability. **/
         bool is_reloadable_helper( const itype_id &ammo, bool now ) const;

--- a/src/location_vector.cpp
+++ b/src/location_vector.cpp
@@ -231,6 +231,7 @@ typename location_vector<T>::iterator location_vector<T>::erase( typename
     }
     T *subject = *it;
     typename std::vector<T *>::iterator ret = contents.erase( it.it );
+    subject->prepare_for_location_removal();
     subject->remove_location();
 
     detached_ptr<T> local;
@@ -394,6 +395,7 @@ typename std::vector<detached_ptr<T>> location_vector<T>::clear()
     }
     std::vector<detached_ptr<T>> ret;
     for( item * const &i : contents ) {
+        i->prepare_for_location_removal();
         i->remove_location();
         ret.push_back( detached_ptr( i ) );
     }
@@ -412,6 +414,7 @@ void location_vector<T>::remove_with( std::function < detached_ptr<T>( detached_
     for( auto it = contents.begin(); it != contents.end(); ) {
         item &as_item = **it;
         location<T> *saved_loc = ( *it )->loc;
+        ( *it )->prepare_for_location_removal();
         ( *it )->remove_location();
         ( *it )->saved_loc = saved_loc;
         detached_ptr<T> original( *it );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -265,6 +265,26 @@ TEST_CASE( "Preserving containers stop contained food rot" )
         REQUIRE( removed.size() == 1 );
         CHECK( removed.front()->get_rot() == 0_turns );
     }
+
+    SECTION( "split preserved charges start fresh when opened" ) {
+        prepare_map_storage_test();
+
+        auto sealed_can = item::in_its_container( item::spawn( "sauce_red" ) );
+        item &food = sealed_can->contents.front();
+        REQUIRE( food.count_by_charges() );
+
+        calendar::turn += 20_days;
+
+        auto removed = detached_ptr<item>();
+        REQUIRE( food.attempt_split( 3, [&removed]( detached_ptr<item> &&it ) {
+            removed = std::move( it );
+            return detached_ptr<item>();
+        } ) );
+
+        REQUIRE( removed );
+        CHECK( removed->charges == 3 );
+        CHECK( removed->get_rot() == 0_turns );
+    }
 }
 
 TEST_CASE( "Items rot away" )

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -57,6 +57,7 @@ static auto make_storage( const vpart_id &storage_part,
     const auto part_index = veh->install_part( tripoint_mnt_veh::zero(), storage_part, true );
     REQUIRE( part_index >= 0 );
     veh->part( part_index ).enabled = enabled;
+    here.add_vehicle_to_cache( veh );
     here.build_map_cache( vehicle_pos.z(), true );
 
     return { .veh = veh, .part_index = part_index, .pos = vehicle_pos };
@@ -67,6 +68,13 @@ static auto add_sashimi_to_vehicle_part( vehicle &veh, const int part_index ) ->
     auto sashimi = item::spawn( "sashimi" );
     REQUIRE( sashimi->goes_bad() );
     REQUIRE_FALSE( veh.add_item( part_index, std::move( sashimi ) ) );
+}
+
+static auto add_canned_red_sauce_to_vehicle_part( vehicle &veh, const int part_index ) -> void
+{
+    auto sauce = item::in_its_container( item::spawn( "sauce_red" ) );
+    REQUIRE( sauce->goes_bad_after_opening( true ) );
+    REQUIRE_FALSE( veh.add_item( part_index, std::move( sauce ) ) );
 }
 
 static auto move_to_inventory_with_attempt_detach( item &stored ) -> item * // *NOPAD*
@@ -383,6 +391,26 @@ TEST_CASE( "Vehicle storage temperature controls food rot" )
         process_storage_for( 25_hours );
 
         CHECK( fixture.veh->get_items( fixture.part_index ).empty() );
+    }
+
+    SECTION( "preserved food in vehicle cargo is fresh when opened for crafting" ) {
+        auto fixture = make_storage( vpart_id( "box" ), true );
+        add_canned_red_sauce_to_vehicle_part( *fixture.veh, fixture.part_index );
+
+        calendar::turn += 20_days;
+
+        auto cargo = get_map().veh_at( fixture.pos ).part_with_feature( "CARGO", true );
+        REQUIRE( cargo.has_value() );
+        REQUIRE( static_cast<int>( cargo->part_index() ) == fixture.part_index );
+
+        auto quantity = 1;
+        auto components = get_map().use_amount( fixture.pos, PICKUP_RANGE, itype_id( "sauce_red" ),
+                                                quantity, return_true<item> );
+
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+        CHECK( components.front()->get_rot() == 0_turns );
+        CHECK( !components.front()->rotten() );
     }
 }
 

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -218,6 +218,53 @@ TEST_CASE( "Preserving containers stop contained food rot" )
 
         CHECK( removed->get_rot() > 0_turns );
     }
+
+    SECTION( "directly removed food starts fresh when opened" ) {
+        prepare_map_storage_test();
+
+        auto sealed_jar = item::in_container( itype_id( "jar_glass_sealed" ),
+                                              item::spawn( "meat_cooked" ) );
+        item &food = sealed_jar->contents.front();
+
+        calendar::turn += 20_days;
+
+        auto removed = sealed_jar->contents.remove_top( &food );
+
+        REQUIRE( removed );
+        CHECK( removed->get_rot() == 0_turns );
+    }
+
+    SECTION( "filtered removed food starts fresh when opened" ) {
+        prepare_map_storage_test();
+
+        auto sealed_jar = item::in_container( itype_id( "jar_glass_sealed" ),
+                                              item::spawn( "meat_cooked" ) );
+
+        calendar::turn += 20_days;
+
+        auto removed = detached_ptr<item>();
+        sealed_jar->contents.remove_top_items_with( [&removed]( detached_ptr<item> &&it ) {
+            removed = std::move( it );
+            return detached_ptr<item>();
+        } );
+
+        REQUIRE( removed );
+        CHECK( removed->get_rot() == 0_turns );
+    }
+
+    SECTION( "cleared preserved food starts fresh when opened" ) {
+        prepare_map_storage_test();
+
+        auto sealed_jar = item::in_container( itype_id( "jar_glass_sealed" ),
+                                              item::spawn( "meat_cooked" ) );
+
+        calendar::turn += 20_days;
+
+        auto removed = sealed_jar->contents.clear_items();
+
+        REQUIRE( removed.size() == 1 );
+        CHECK( removed.front()->get_rot() == 0_turns );
+    }
 }
 
 TEST_CASE( "Items rot away" )


### PR DESCRIPTION
## Purpose of change (The Why)

close #9380
Follow-up to #9322: canned ingredients pulled from vehicle cargo could inherit room-temperature rot when opened for crafting.

## Describe the solution (The How)

- Centralize preserved-content freshness reset in the item location-removal hook.
- Cover direct preserved-content removal paths and charge splits.
- Keep crafted food freshness based on consumed components via a small helper.

## Testing

- `cmake --build out/build/linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `SDL_VIDEODRIVER=offscreen ./out/build/linux-full/tests/cata_test-tiles "Preserving containers stop contained food rot"`
- `SDL_VIDEODRIVER=offscreen ./out/build/linux-full/tests/cata_test-tiles "Vehicle storage temperature controls food rot"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3e77c0d](https://github.com/cataclysmbn/Cataclysm-BN/commit/3e77c0df78814f893c3ff0eb047e34de47ed6991) (fix: centralize preserved food removal freshness) on 2026-06-10 05:03:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27250514320/artifacts/7526377195)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27250514320/artifacts/7526657497)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27250514320/artifacts/7526642207)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27250514320/artifacts/7526722567)
<!-- END artifact comment -->