### PR TITLE
feat: Tileset defined tint / painting improvements

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2562,6 +2562,14 @@ const color_tint_pair *tileset::get_tint( const std::string &tint_id )
     return nullptr;
 }
 
+bool tileset::try_get_tint(const std::string& tint_id, color_tint_pair& tint) {
+    if( tints.contains( tint_id ) ) {
+        tint = tints[tint_id];
+        return true;
+    }
+    return false;
+}
+
 void tileset_loader::process_variations_after_loading( weighted_int_list<std::vector<int>> &vs )
 {
     // loop through all of the variations

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1252,17 +1252,17 @@ static void apply_surf_blend_effect(
             }
             case tint_blend_mode::subtract: {
                 col = RGBColor{
-                    static_cast<uint8_t>(std::max<int>(base.r - (255 - target.r), 0)),
-                    static_cast<uint8_t>(std::max<int>(base.g - (255 - target.g), 0)),
-                    static_cast<uint8_t>(std::max<int>(base.b - (255 - target.b), 0)),
+                    static_cast<uint8_t>( std::max<int>( base.r - ( 255 - target.r ), 0 ) ),
+                    static_cast<uint8_t>( std::max<int>( base.g - ( 255 - target.g ), 0 ) ),
+                    static_cast<uint8_t>( std::max<int>( base.b - ( 255 - target.b ), 0 ) ),
                     base.a};
                 break;
             }
             case tint_blend_mode::multiply: {
                 col = RGBColor{
-                    static_cast<uint8_t>(base.r * target.r / 256),
-                    static_cast<uint8_t>(base.g * target.g / 256),
-                    static_cast<uint8_t>(base.b * target.b / 256),
+                    static_cast<uint8_t>( base.r *target.r / 256 ),
+                    static_cast<uint8_t>( base.g *target.g / 256 ),
+                    static_cast<uint8_t>( base.b *target.b / 256 ),
                     base.a};
                 break;
             }
@@ -1270,9 +1270,9 @@ static void apply_surf_blend_effect(
                 // A truely accurate normal blend would use the alpha from the target, but that'd be
                 // useless here.
                 col = RGBColor{
-                    static_cast<uint8_t>(ilerp<uint16_t, uint8_t>(base.r, target.r, target.a)),
-                    static_cast<uint8_t>(ilerp<uint16_t, uint8_t>(base.g, target.g, target.a)),
-                    static_cast<uint8_t>(ilerp<uint16_t, uint8_t>(base.b, target.b, target.a)),
+                    static_cast<uint8_t>( ilerp<uint16_t, uint8_t>( base.r, target.r, target.a ) ),
+                    static_cast<uint8_t>( ilerp<uint16_t, uint8_t>( base.g, target.g, target.a ) ),
+                    static_cast<uint8_t>( ilerp<uint16_t, uint8_t>( base.b, target.b, target.a ) ),
                     base.a};
                 break;
             }
@@ -2569,7 +2569,8 @@ const color_tint_pair *tileset::get_tint( const std::string &tint_id )
     return nullptr;
 }
 
-bool tileset::try_get_tint(const std::string& tint_id, color_tint_pair& tint) {
+bool tileset::try_get_tint( const std::string &tint_id, color_tint_pair &tint )
+{
     if( tints.contains( tint_id ) ) {
         tint = tints[tint_id];
         return true;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1247,26 +1247,33 @@ static void apply_surf_blend_effect(
                     static_cast<uint8_t>( std::min<int>( base.r + target.r, 255 ) ),
                     static_cast<uint8_t>( std::min<int>( base.g + target.g, 255 ) ),
                     static_cast<uint8_t>( std::min<int>( base.b + target.b, 255 ) ),
-                    static_cast<uint8_t>( std::min<int>( base.a + target.a, 255 ) ) };
+                    base.a };
                 break;
             }
             case tint_blend_mode::subtract: {
-                col = RGBColor{ static_cast<uint8_t>( std::max<int>( base.r - ( 255 - target.r ), 0 ) ),
-                                static_cast<uint8_t>( std::max<int>( base.g - ( 255 - target.g ), 0 ) ),
-                                static_cast<uint8_t>( std::max<int>( base.b - ( 255 - target.b ), 0 ) ), base.a };
+                col = RGBColor{
+                    static_cast<uint8_t>(std::max<int>(base.r - (255 - target.r), 0)),
+                    static_cast<uint8_t>(std::max<int>(base.g - (255 - target.g), 0)),
+                    static_cast<uint8_t>(std::max<int>(base.b - (255 - target.b), 0)),
+                    base.a};
                 break;
             }
             case tint_blend_mode::multiply: {
-                col = RGBColor{ static_cast<uint8_t>( base.r *target.r / 256 ),
-                                static_cast<uint8_t>( base.g *target.g / 256 ),
-                                static_cast<uint8_t>( base.b *target.b / 256 ), base.a };
+                col = RGBColor{
+                    static_cast<uint8_t>(base.r * target.r / 256),
+                    static_cast<uint8_t>(base.g * target.g / 256),
+                    static_cast<uint8_t>(base.b * target.b / 256),
+                    base.a};
                 break;
             }
             case tint_blend_mode::normal: {
-                // A truely accurate normal blend would use the alpha from the target, but that'd be useless here.
-                col = RGBColor{ static_cast<uint8_t>( ilerp<uint16_t, uint8_t>( base.r, target.r, target.a ) ),
-                                static_cast<uint8_t>( ilerp<uint16_t, uint8_t>( base.g, target.g, target.a ) ),
-                                static_cast<uint8_t>( ilerp<uint16_t, uint8_t>( base.b, target.b, target.a ) ), base.a };
+                // A truely accurate normal blend would use the alpha from the target, but that'd be
+                // useless here.
+                col = RGBColor{
+                    static_cast<uint8_t>(ilerp<uint16_t, uint8_t>(base.r, target.r, target.a)),
+                    static_cast<uint8_t>(ilerp<uint16_t, uint8_t>(base.g, target.g, target.a)),
+                    static_cast<uint8_t>(ilerp<uint16_t, uint8_t>(base.b, target.b, target.a)),
+                    base.a};
                 break;
             }
             case tint_blend_mode::divide: {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -515,7 +515,7 @@ class tileset
         std::pair<std::string, bool> get_tint_controller( const std::string &tint_type );
 
         const color_tint_pair *get_tint( const std::string &tint_id );
-        bool try_get_tint( const std::string &tint_id, color_tint_pair& tint );
+        bool try_get_tint( const std::string &tint_id, color_tint_pair &tint );
 };
 
 class tileset_loader
@@ -898,35 +898,35 @@ class cata_tiles
 
         bool draw_block( const tripoint_bub_ms &p, SDL_Color color, int scale );
 
-        auto get_overmap_color(overmapbuffer& o, const tripoint_abs_omt& p) const
-            -> color_tint_pair;
-        auto get_terrain_color(const ter_t& t, const map& m, const tripoint_bub_ms& p) const
-            -> color_tint_pair;
-        auto get_furniture_color(const furn_t& f, const map& m, const tripoint_bub_ms& p) const
-            -> color_tint_pair;
-        auto get_graffiti_color(const map& m, const tripoint_bub_ms& p) const -> color_tint_pair;
-        auto get_trap_color(const trap& tr, const map& map, tripoint_bub_ms tripoint) const
-            -> color_tint_pair;
-        auto get_field_color(const field& f, const map& m, const tripoint_bub_ms& p) const
-            -> color_tint_pair;
-        auto get_item_color(const item& i, const map& m, const tripoint_bub_ms& p) const
-            -> color_tint_pair;
+        auto get_overmap_color( overmapbuffer &o, const tripoint_abs_omt &p ) const
+        -> color_tint_pair;
+        auto get_terrain_color( const ter_t &t, const map &m, const tripoint_bub_ms &p ) const
+        -> color_tint_pair;
+        auto get_furniture_color( const furn_t &f, const map &m, const tripoint_bub_ms &p ) const
+        -> color_tint_pair;
+        auto get_graffiti_color( const map &m, const tripoint_bub_ms &p ) const -> color_tint_pair;
+        auto get_trap_color( const trap &tr, const map &map, tripoint_bub_ms tripoint ) const
+        -> color_tint_pair;
+        auto get_field_color( const field &f, const map &m, const tripoint_bub_ms &p ) const
+        -> color_tint_pair;
+        auto get_item_color( const item &i, const map &m, const tripoint_bub_ms &p ) const
+        -> color_tint_pair;
         auto get_vpart_color(
-            const optional_vpart_position& vp, const map& m, const tripoint_bub_ms& p,
-            bool use_roof = false) const -> color_tint_pair;
-        auto get_monster_color(const monster& mon, const map& m, const tripoint_bub_ms& p) const
-            -> color_tint_pair;
-        auto get_character_color(const Character& ch, const map& m, const tripoint_bub_ms& p) const
-            -> color_tint_pair;
+            const optional_vpart_position &vp, const map &m, const tripoint_bub_ms &p,
+            bool use_roof = false ) const -> color_tint_pair;
+        auto get_monster_color( const monster &mon, const map &m, const tripoint_bub_ms &p ) const
+        -> color_tint_pair;
+        auto get_character_color( const Character &ch, const map &m, const tripoint_bub_ms &p ) const
+        -> color_tint_pair;
         auto get_effect_color(
-            const effect& eff, const Character& c, const map& m, const tripoint_bub_ms& p) const
-            -> color_tint_pair;
+            const effect &eff, const Character &c, const map &m, const tripoint_bub_ms &p ) const
+        -> color_tint_pair;
         auto get_bionic_color(
-            const bionic& bio, const Character& c, const map& m, const tripoint_bub_ms& p) const
-            -> color_tint_pair;
+            const bionic &bio, const Character &c, const map &m, const tripoint_bub_ms &p ) const
+        -> color_tint_pair;
         auto get_mutation_color(
-            const mutation& mut, const Character& c, const map& m, const tripoint_bub_ms& p) const
-            -> color_tint_pair;
+            const mutation &mut, const Character &c, const map &m, const tripoint_bub_ms &p ) const
+        -> color_tint_pair;
 
         bool draw_terrain( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                            const bool ( &invisible )[5], int z_drop );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -275,7 +275,7 @@ constexpr int TILESET_NO_MASK = -1;
 constexpr SDL_Color TILESET_NO_COLOR = {0, 0, 0, 0};
 
 struct tint_config {
-    SDL_Color color;
+    SDL_Color color = TILESET_NO_COLOR;
     tint_blend_mode blend_mode = tint_blend_mode::tint;
     float contrast = 1.0f;    // 1.0 = no change, absent = skip
     float saturation = 1.0f;  // 1.0 = no change, absent = skip
@@ -515,6 +515,7 @@ class tileset
         std::pair<std::string, bool> get_tint_controller( const std::string &tint_type );
 
         const color_tint_pair *get_tint( const std::string &tint_id );
+        bool try_get_tint( const std::string &tint_id, color_tint_pair& tint );
 };
 
 class tileset_loader
@@ -897,39 +898,35 @@ class cata_tiles
 
         bool draw_block( const tripoint_bub_ms &p, SDL_Color color, int scale );
 
-        static auto get_overmap_color( const overmapbuffer &o,
-                                       const tripoint_abs_omt &p ) -> color_tint_pair;
-        static auto get_terrain_color( const ter_t &t, const map &m,
-                                       const tripoint_bub_ms &p ) -> color_tint_pair;
-        static auto get_furniture_color( const furn_t &f, const map &m,
-                                         const tripoint_bub_ms &p ) -> color_tint_pair;
-        static auto get_graffiti_color( const map &m, const tripoint_bub_ms &p ) -> color_tint_pair;
-        static auto get_trap_color( const trap &tr, const map &map,
-                                    tripoint_bub_ms tripoint ) -> color_tint_pair;
-        static auto get_field_color( const field &f, const map &m,
-                                     const tripoint_bub_ms &p ) -> color_tint_pair;
-        auto get_item_color( const item &i, const map &m, const tripoint_bub_ms &p ) -> color_tint_pair;
-        auto get_item_color( const item &i ) -> color_tint_pair;
-        static auto get_vpart_color(
-            const optional_vpart_position &vp, const map &m, const tripoint_bub_ms &p,
-            const bool use_roof = false ) -> color_tint_pair;
-        static auto get_monster_color(
-            const monster &mon, const map &m, const tripoint_bub_ms &p ) -> color_tint_pair;
-        static auto get_character_color(
-            const Character &ch, const map &m, const tripoint_bub_ms &p ) -> color_tint_pair;
+        auto get_overmap_color(overmapbuffer& o, const tripoint_abs_omt& p) const
+            -> color_tint_pair;
+        auto get_terrain_color(const ter_t& t, const map& m, const tripoint_bub_ms& p) const
+            -> color_tint_pair;
+        auto get_furniture_color(const furn_t& f, const map& m, const tripoint_bub_ms& p) const
+            -> color_tint_pair;
+        auto get_graffiti_color(const map& m, const tripoint_bub_ms& p) const -> color_tint_pair;
+        auto get_trap_color(const trap& tr, const map& map, tripoint_bub_ms tripoint) const
+            -> color_tint_pair;
+        auto get_field_color(const field& f, const map& m, const tripoint_bub_ms& p) const
+            -> color_tint_pair;
+        auto get_item_color(const item& i, const map& m, const tripoint_bub_ms& p) const
+            -> color_tint_pair;
+        auto get_vpart_color(
+            const optional_vpart_position& vp, const map& m, const tripoint_bub_ms& p,
+            bool use_roof = false) const -> color_tint_pair;
+        auto get_monster_color(const monster& mon, const map& m, const tripoint_bub_ms& p) const
+            -> color_tint_pair;
+        auto get_character_color(const Character& ch, const map& m, const tripoint_bub_ms& p) const
+            -> color_tint_pair;
         auto get_effect_color(
-            const effect &eff, const Character &c, const map &m, const tripoint_bub_ms &p ) -> color_tint_pair;
-        auto get_effect_color(
-            const effect &eff, const Character &c ) -> color_tint_pair;
+            const effect& eff, const Character& c, const map& m, const tripoint_bub_ms& p) const
+            -> color_tint_pair;
         auto get_bionic_color(
-            const bionic &bio, const Character &c, const map &m, const tripoint_bub_ms &p )-> color_tint_pair;
-        auto get_bionic_color(
-            const bionic &bio, const Character &c )-> color_tint_pair;
+            const bionic& bio, const Character& c, const map& m, const tripoint_bub_ms& p) const
+            -> color_tint_pair;
         auto get_mutation_color(
-            const mutation &mut, const Character &c, const map &m,
-            const tripoint_bub_ms &p )-> color_tint_pair;
-        auto get_mutation_color(
-            const mutation &mut, const Character &c )-> color_tint_pair;
+            const mutation& mut, const Character& c, const map& m, const tripoint_bub_ms& p) const
+            -> color_tint_pair;
 
         bool draw_terrain( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                            const bool ( &invisible )[5], int z_drop );

--- a/src/cata_tiles_color.cpp
+++ b/src/cata_tiles_color.cpp
@@ -10,192 +10,277 @@
 #include "vehicle.h"
 #include "vehicle_part.h"
 #include "vpart_position.h"
+#include "omdata.h"
 
 static constexpr RGBColor RGB_NO_COLOR = TILESET_NO_COLOR;
 
+namespace {
+
 struct blend_mode_cvt {
-    bool operator()( const std::string &str, tint_blend_mode &res ) const {
-        res = string_to_tint_blend_mode( str );
+    bool operator()(const std::string& str, tint_blend_mode& res) const {
+        res = string_to_tint_blend_mode(str);
         return true;
     }
 };
 
-static std::optional<color_tint_pair> tint_from_data_vars( const data_vars::data_set &i )
-{
-    if( i.contains( TINT_COLOR_VAR_NAME ) || i.contains( TINT_COLOR_FG_VAR_NAME ) ||
-        i.contains( TINT_COLOR_BG_VAR_NAME ) ) {
+template<typename T>
+struct tint_helper {};
 
-        const auto col = i.get<RGBColor>( TINT_COLOR_VAR_NAME, RGB_NO_COLOR );
-        const auto col_bg = i.get<RGBColor>( TINT_COLOR_BG_VAR_NAME, col );
-        const auto col_fg = i.get<RGBColor>( TINT_COLOR_FG_VAR_NAME, col );
-
-        tint_config bg_tint{};
-        tint_config fg_tint{};
-
-        const auto blend_mode = i.get<tint_blend_mode, blend_mode_cvt>( TINT_MODE_VAR_NAME,
-                                tint_blend_mode::tint );
-        const auto saturation = i.get<float>( TINT_SATURATION_VAR_NAME, 1.0f );
-        const auto contrast = i.get<float>( TINT_CONTRAST_VAR_NAME, 1.0f );
-        const auto brightness = i.get<float>( TINT_BRIGHTNESS_VAR_NAME, 1.0f );
-
-        if( col_bg != RGB_NO_COLOR ) {
-            bg_tint.color = col_bg;
-            bg_tint.blend_mode = blend_mode;
-            bg_tint.saturation = saturation;
-            bg_tint.contrast = contrast;
-            bg_tint.brightness = brightness;
-        }
-
-        if( col_fg != RGB_NO_COLOR ) {
-            fg_tint.color = col_fg;
-            fg_tint.blend_mode = blend_mode;
-            fg_tint.saturation = saturation;
-            fg_tint.contrast = contrast;
-            fg_tint.brightness = brightness;
-        }
-
-        return std::make_pair( bg_tint, fg_tint );
+template <> struct tint_helper<item> {
+    static auto get_flags(const item& t) {
+        return std::ranges::transform_view(t.get_flags(), [](auto& v) { return v.str(); });
     }
-    return std::nullopt;
+    static auto& get_typestr(const item& t) { return t.typeId().str(); }
+};
+
+template<>
+struct tint_helper<ter_t> {
+    static auto& get_flags(const ter_t& t) { return t.get_flags(); }
+    static auto& get_typestr(const ter_t& t) { return t.id.str(); }
+};
+
+template<>
+struct tint_helper<furn_t> {
+    static auto& get_flags(const furn_t& t) { return t.get_flags(); }
+    static auto& get_typestr(const furn_t& t) { return t.id.str(); }
+};
+
+template<>
+struct tint_helper<vehicle_part> {
+    static auto& get_flags(const vehicle_part& t) { return t.info().get_flags(); }
+    static auto& get_typestr(const vehicle_part& t) { return t.info().get_id().str(); }
+};
+
+template<>
+struct tint_helper<monster> {
+    static auto& get_typestr(const monster& t) { return t.type->id.str(); }
+};
+
+template <> struct tint_helper<bionic> {
+    static auto get_flags(const bionic& t) {
+        return std::ranges::transform_view(t.id->flags, [](auto& v) { return v.str(); });
+    }
+    static auto& get_typestr(const bionic& t) { return t.id.str(); }
+};
+
+template<>
+struct tint_helper<effect> {
+    static auto& get_typestr(const effect& t) { return t.get_id().str(); }
+};
+
+template<>
+struct tint_helper<oter_t> {
+    static auto& get_typestr(const oter_t& t) { return t.id.str(); }
+};
+
+template<typename T>
+color_tint_pair tint_from_tileset(
+    const std::unique_ptr<tileset>& tileset_ptr,
+    const T& v,
+    const color_tint_pair& defVal = {}) {
+    using helper = tint_helper<T>;
+
+    color_tint_pair tint = defVal;
+
+    if constexpr (requires { helper::get_flags(v); }) {
+        for (const auto& flag : helper::get_flags(v)) {
+            if (tileset_ptr->try_get_tint(flag, tint)) {
+                return tint;
+            }
+        }
+    }
+
+    if constexpr (requires { helper::get_typestr(v); }) {
+        if (tileset_ptr->try_get_tint(helper::get_typestr(v), tint)) {
+            return tint;
+        }
+    }
+
+    return tint;
 }
 
-auto cata_tiles::get_overmap_color(
-    const overmapbuffer &, const tripoint_abs_omt & ) -> color_tint_pair
+color_tint_pair tint_from_data_vars(const data_vars::data_set& i, const color_tint_pair& defVal = {})
 {
-    return { std::nullopt, std::nullopt };
+    auto [bg_tint, fg_tint] = defVal;
+
+    if (!std::ranges::any_of(i, [](auto& f) { return f.first.starts_with(TINT_VAR_PREFIX); })) {
+        return defVal;
+    }
+
+    constexpr blend_mode_cvt blendCvt{};
+
+    auto color = RGB_NO_COLOR;
+    auto scl = 0.0f;
+    auto blend = tint_blend_mode::tint;
+
+    {
+        if (i.try_get(TINT_COLOR_BG_VAR_NAME, color)
+            || i.try_get(TINT_COLOR_VAR_NAME, color)) {
+            bg_tint.color = color;
+        }
+        if (i.try_get(TINT_MODE_BG_VAR_NAME, blend, blendCvt)
+            || i.try_get(TINT_MODE_VAR_NAME, blend, blendCvt)) {
+            bg_tint.blend_mode = blend;
+        }
+        if (i.try_get(TINT_SATURATION_BG_VAR_NAME, scl)
+            || i.try_get(TINT_SATURATION_VAR_NAME, scl)) {
+            bg_tint.saturation = scl;
+        }
+        if (i.try_get(TINT_CONTRAST_BG_VAR_NAME, scl)
+            || i.try_get(TINT_CONTRAST_VAR_NAME, scl)) {
+            bg_tint.contrast = scl;
+        }
+        if (i.try_get(TINT_BRIGHTNESS_BG_VAR_NAME, scl)
+            || i.try_get(TINT_BRIGHTNESS_VAR_NAME, scl)) {
+            bg_tint.brightness = scl;
+        }
+    }
+
+    {
+        if (i.try_get(TINT_COLOR_FG_VAR_NAME, color)
+            || i.try_get(TINT_COLOR_VAR_NAME, color)) {
+            fg_tint.color = color;
+        }
+        if (i.try_get(TINT_MODE_FG_VAR_NAME, blend, blendCvt)
+            || i.try_get(TINT_MODE_VAR_NAME, blend, blendCvt)) {
+            fg_tint.blend_mode = blend;
+        }
+        if (i.try_get(TINT_SATURATION_FG_VAR_NAME, scl)
+            || i.try_get(TINT_SATURATION_VAR_NAME, scl)) {
+            fg_tint.saturation = scl;
+        }
+        if (i.try_get(TINT_CONTRAST_FG_VAR_NAME, scl)
+            || i.try_get(TINT_CONTRAST_VAR_NAME, scl)) {
+            fg_tint.contrast = scl;
+        }
+        if (i.try_get(TINT_BRIGHTNESS_FG_VAR_NAME, scl)
+            || i.try_get(TINT_BRIGHTNESS_VAR_NAME, scl)) {
+            fg_tint.brightness = scl;
+        }
+    }
+
+    return color_tint_pair{bg_tint, fg_tint};
+}
+
+} // namespace
+
+auto cata_tiles::get_overmap_color(
+    overmapbuffer & o, const tripoint_abs_omt & p) const -> color_tint_pair
+{
+    const oter_t oter = o.ter(p).obj();
+    return tint_from_tileset(tileset_ptr, oter);
 }
 
 auto cata_tiles::get_terrain_color(
-    const ter_t &, const map &m, const tripoint_bub_ms &p ) -> color_tint_pair
+    const ter_t & t, const map &m, const tripoint_bub_ms &p ) const -> color_tint_pair
 {
-    const auto vars = m.ter_vars( p );
-    if( vars != nullptr ) {
-        const auto ivar_color = tint_from_data_vars( *vars );
-        if( ivar_color.has_value() ) {
-            return ivar_color.value();
-        }
+    auto tint = tint_from_tileset(tileset_ptr, t);
+
+    const auto vars = m.ter_vars(p);
+    if (vars != nullptr) {
+        return tint_from_data_vars( *vars , tint );
     }
-    return { std::nullopt, std::nullopt };
+
+    return tint;
 }
 
 auto cata_tiles::get_furniture_color(
-    const furn_t &, const map &m, const tripoint_bub_ms &p ) -> color_tint_pair
+    const furn_t & f, const map &m, const tripoint_bub_ms &p ) const -> color_tint_pair
 {
-    const auto vars = m.furn_vars( p );
-    if( vars != nullptr ) {
-        const auto ivar_color = tint_from_data_vars( *vars );
-        if( ivar_color.has_value() ) {
-            return ivar_color.value();
-        }
+    auto tint = tint_from_tileset(tileset_ptr, f);
+
+    const auto vars = m.furn_vars(p);
+    if (vars != nullptr) {
+        return tint_from_data_vars( *vars , tint );
     }
-    return { std::nullopt, std::nullopt };
+
+    return tint;
 }
 
 auto cata_tiles::get_graffiti_color(
-    const map &, const tripoint_bub_ms & )-> color_tint_pair
+    const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    return { std::nullopt, std::nullopt };
+    return color_tint_pair{};
 }
 
 auto cata_tiles::get_trap_color(
-    const trap &, const map &, tripoint_bub_ms ) -> color_tint_pair
+    const trap & tr, const map &, tripoint_bub_ms ) const -> color_tint_pair
 {
-    return { std::nullopt, std::nullopt };
+    return tint_from_tileset(tileset_ptr, tr);
 }
 
 auto cata_tiles::get_field_color(
-    const field &, const map &, const tripoint_bub_ms & ) -> color_tint_pair
+    const field & f, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    return { std::nullopt, std::nullopt };
+    return tint_from_tileset(tileset_ptr, f);
 }
 
 auto cata_tiles::get_item_color(
-    const item &i, const map &, const tripoint_bub_ms & ) -> color_tint_pair
+    const item &i, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    const auto ivar_color = tint_from_data_vars( i.item_vars() );
-    if( ivar_color.has_value() ) {
-        return ivar_color.value();
-    }
-
-    const auto &data = i.get_flags();
-    for( const flag_id &flag : data ) {
-        const color_tint_pair *tint = tileset_ptr->get_tint( flag.str() );
-        if( tint != nullptr ) {
-            return *tint;
-        }
-    }
-
-    const color_tint_pair *tint = tileset_ptr->get_tint( i.typeId().str() );
-    if( tint != nullptr ) {
-        return *tint;
-    }
-
-    return { std::nullopt, std::nullopt };
+    const auto tint = tint_from_tileset(tileset_ptr, i);
+    return tint_from_data_vars( i.item_vars(), tint );
 }
 
 auto cata_tiles::get_vpart_color(
     const optional_vpart_position &vp, const map &, const tripoint_bub_ms &,
-    const bool use_roof )-> color_tint_pair
+    const bool use_roof ) const -> color_tint_pair
 {
-    if( vp.has_value() ) {
-        if( use_roof ) {
-            auto &veh = vp->vehicle();
-            const auto part_idx = veh.roof_at_part( vp->part_index() );
-            if( part_idx != -1 ) {
-                auto [bg, fg] = veh.part( part_idx ).get_color();
-                return {bg, fg};
-            }
+    color_tint_pair tint{};
+    if( !vp.has_value() ) {
+        return tint;
+    }
+
+    vehicle_part* vpp = nullptr;
+    if (use_roof) {
+        auto& veh = vp->vehicle();
+        const auto part_idx = veh.roof_at_part(vp->part_index());
+        if (part_idx != -1) {
+            vpp = &veh.part(part_idx);
         }
+    } else {
         const auto part_ref = vp.part_displayed();
-        if( part_ref ) {
-            auto [bg, fg] = part_ref->part().get_color();
-            return {bg, fg};
+        if (part_ref) {
+            vpp = &part_ref->part();
         }
     }
-    return { std::nullopt, std::nullopt };
+
+    if (vpp == nullptr) {
+        return tint;
+    }
+
+    tint = tint_from_tileset(tileset_ptr, *vpp);
+    auto [bg, fg] = vpp->get_color();
+    std::tie(tint.first.color, tint.second.color) = std::make_pair(bg, fg);
+    return tint;
 }
 
 auto cata_tiles::get_monster_color(
-    const monster &, const map &, const tripoint_bub_ms & ) -> color_tint_pair
+    const monster & mon, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    return { std::nullopt, std::nullopt };
+    return tint_from_tileset(tileset_ptr, mon);
 }
 
 auto cata_tiles::get_character_color(
-    const Character &, const map &, const tripoint_bub_ms & ) -> color_tint_pair
+    const Character &, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    return { std::nullopt, std::nullopt };
+    return color_tint_pair{};
 }
 
 auto cata_tiles::get_effect_color(
-    const effect &eff, const Character &, const map &, const tripoint_bub_ms & ) -> color_tint_pair
+    const effect &eff, const Character &, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    const color_tint_pair *tint = tileset_ptr->get_tint( eff.get_id().str() );
-    if( tint != nullptr ) {
-        return *tint;
-    }
-    return { std::nullopt, std::nullopt };
+    return tint_from_tileset(tileset_ptr, eff);
 }
 
 auto cata_tiles::get_bionic_color(
-    const bionic &bio, const Character &, const map &, const tripoint_bub_ms & )-> color_tint_pair
+    const bionic &bio, const Character &, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    const auto &data = bio.id.obj();
-    for( const flag_id &flag : data.flags ) {
-        const color_tint_pair *tint = tileset_ptr->get_tint( flag.str() );
-        if( tint != nullptr ) {
-            return *tint;
-        }
-    }
-    const color_tint_pair *tint = tileset_ptr->get_tint( bio.id.str() );
-    if( tint != nullptr ) {
-        return *tint;
-    }
-    return { std::nullopt, std::nullopt };
+    return tint_from_tileset(tileset_ptr, bio);
 }
 
 auto cata_tiles::get_mutation_color(
-    const mutation &mut, const Character &c, const map &, const tripoint_bub_ms & )-> color_tint_pair
+    const mutation &mut, const Character &c, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
     const mutation_branch &mut_branch = mut.first.obj();
     std::string fallback_color;

--- a/src/cata_tiles_color.cpp
+++ b/src/cata_tiles_color.cpp
@@ -14,11 +14,12 @@
 
 static constexpr RGBColor RGB_NO_COLOR = TILESET_NO_COLOR;
 
-namespace {
+namespace
+{
 
 struct blend_mode_cvt {
-    bool operator()(const std::string& str, tint_blend_mode& res) const {
-        res = string_to_tint_blend_mode(str);
+    bool operator()( const std::string &str, tint_blend_mode &res ) const {
+        res = string_to_tint_blend_mode( str );
         return true;
     }
 };
@@ -27,71 +28,72 @@ template<typename T>
 struct tint_helper {};
 
 template <> struct tint_helper<item> {
-    static auto get_flags(const item& t) {
-        return std::ranges::transform_view(t.get_flags(), [](auto& v) { return v.str(); });
+    static auto get_flags( const item &t ) {
+        return std::ranges::transform_view( t.get_flags(), []( auto & v ) { return v.str(); } );
     }
-    static auto& get_typestr(const item& t) { return t.typeId().str(); }
+    static auto &get_typestr( const item &t ) { return t.typeId().str(); }
 };
 
 template<>
 struct tint_helper<ter_t> {
-    static auto& get_flags(const ter_t& t) { return t.get_flags(); }
-    static auto& get_typestr(const ter_t& t) { return t.id.str(); }
+    static auto &get_flags( const ter_t &t ) { return t.get_flags(); }
+    static auto &get_typestr( const ter_t &t ) { return t.id.str(); }
 };
 
 template<>
 struct tint_helper<furn_t> {
-    static auto& get_flags(const furn_t& t) { return t.get_flags(); }
-    static auto& get_typestr(const furn_t& t) { return t.id.str(); }
+    static auto &get_flags( const furn_t &t ) { return t.get_flags(); }
+    static auto &get_typestr( const furn_t &t ) { return t.id.str(); }
 };
 
 template<>
 struct tint_helper<vehicle_part> {
-    static auto& get_flags(const vehicle_part& t) { return t.info().get_flags(); }
-    static auto& get_typestr(const vehicle_part& t) { return t.info().get_id().str(); }
+    static auto &get_flags( const vehicle_part &t ) { return t.info().get_flags(); }
+    static auto &get_typestr( const vehicle_part &t ) { return t.info().get_id().str(); }
 };
 
 template<>
 struct tint_helper<monster> {
-    static auto& get_typestr(const monster& t) { return t.type->id.str(); }
+    static auto &get_typestr( const monster &t ) { return t.type->id.str(); }
 };
 
 template <> struct tint_helper<bionic> {
-    static auto get_flags(const bionic& t) {
-        return std::ranges::transform_view(t.id->flags, [](auto& v) { return v.str(); });
+    static auto get_flags( const bionic &t ) {
+        return std::ranges::transform_view( t.id->flags, []( auto & v ) { return v.str(); } );
     }
-    static auto& get_typestr(const bionic& t) { return t.id.str(); }
+    static auto &get_typestr( const bionic &t ) { return t.id.str(); }
 };
 
 template<>
 struct tint_helper<effect> {
-    static auto& get_typestr(const effect& t) { return t.get_id().str(); }
+    static auto &get_typestr( const effect &t ) { return t.get_id().str(); }
 };
 
 template<>
 struct tint_helper<oter_t> {
-    static auto& get_typestr(const oter_t& t) { return t.id.str(); }
+    static auto &get_typestr( const oter_t &t ) { return t.id.str(); }
 };
 
 template<typename T>
 color_tint_pair tint_from_tileset(
-    const std::unique_ptr<tileset>& tileset_ptr,
-    const T& v,
-    const color_tint_pair& defVal = {}) {
+    const std::unique_ptr<tileset> &tileset_ptr,
+    const T &v,
+    const color_tint_pair &defVal = {} )
+{
     using helper = tint_helper<T>;
 
     color_tint_pair tint = defVal;
 
-    if constexpr (requires { helper::get_flags(v); }) {
-        for (const auto& flag : helper::get_flags(v)) {
-            if (tileset_ptr->try_get_tint(flag, tint)) {
+    if constexpr( requires { helper::get_flags( v ); } ) {
+        for( const auto &flag : helper::get_flags( v ) ) {
+            if( tileset_ptr->try_get_tint( flag, tint ) ) {
                 return tint;
             }
         }
     }
 
-    if constexpr (requires { helper::get_typestr(v); }) {
-        if (tileset_ptr->try_get_tint(helper::get_typestr(v), tint)) {
+    if constexpr( requires { helper::get_typestr( v ); } ) {
+        if( tileset_ptr->try_get_tint( helper::get_typestr( v ), tint ) ) {
             return tint;
         }
     }
@@ -99,11 +101,11 @@ color_tint_pair tint_from_tileset(
     return tint;
 }
 
-color_tint_pair tint_from_data_vars(const data_vars::data_set& i, const color_tint_pair& defVal = {})
+color_tint_pair tint_from_data_vars( const data_vars::data_set &i, const color_tint_pair &defVal = {} )
 {
     auto [bg_tint, fg_tint] = defVal;
 
-    if (!std::ranges::any_of(i, [](auto& f) { return f.first.starts_with(TINT_VAR_PREFIX); })) {
+    if( !std::ranges::any_of( i, []( auto & f ) { return f.first.starts_with( TINT_VAR_PREFIX ); } ) ) {
         return defVal;
     }
 
@@ -114,47 +116,47 @@ color_tint_pair tint_from_data_vars(const data_vars::data_set& i, const color_ti
     auto blend = tint_blend_mode::tint;
 
     {
-        if (i.try_get(TINT_COLOR_BG_VAR_NAME, color)
-            || i.try_get(TINT_COLOR_VAR_NAME, color)) {
+        if( i.try_get( TINT_COLOR_BG_VAR_NAME, color )
+            || i.try_get( TINT_COLOR_VAR_NAME, color ) ) {
             bg_tint.color = color;
         }
-        if (i.try_get(TINT_MODE_BG_VAR_NAME, blend, blendCvt)
-            || i.try_get(TINT_MODE_VAR_NAME, blend, blendCvt)) {
+        if( i.try_get( TINT_MODE_BG_VAR_NAME, blend, blendCvt )
+            || i.try_get( TINT_MODE_VAR_NAME, blend, blendCvt ) ) {
             bg_tint.blend_mode = blend;
         }
-        if (i.try_get(TINT_SATURATION_BG_VAR_NAME, scl)
-            || i.try_get(TINT_SATURATION_VAR_NAME, scl)) {
+        if( i.try_get( TINT_SATURATION_BG_VAR_NAME, scl )
+            || i.try_get( TINT_SATURATION_VAR_NAME, scl ) ) {
             bg_tint.saturation = scl;
         }
-        if (i.try_get(TINT_CONTRAST_BG_VAR_NAME, scl)
-            || i.try_get(TINT_CONTRAST_VAR_NAME, scl)) {
+        if( i.try_get( TINT_CONTRAST_BG_VAR_NAME, scl )
+            || i.try_get( TINT_CONTRAST_VAR_NAME, scl ) ) {
             bg_tint.contrast = scl;
         }
-        if (i.try_get(TINT_BRIGHTNESS_BG_VAR_NAME, scl)
-            || i.try_get(TINT_BRIGHTNESS_VAR_NAME, scl)) {
+        if( i.try_get( TINT_BRIGHTNESS_BG_VAR_NAME, scl )
+            || i.try_get( TINT_BRIGHTNESS_VAR_NAME, scl ) ) {
             bg_tint.brightness = scl;
         }
     }
 
     {
-        if (i.try_get(TINT_COLOR_FG_VAR_NAME, color)
-            || i.try_get(TINT_COLOR_VAR_NAME, color)) {
+        if( i.try_get( TINT_COLOR_FG_VAR_NAME, color )
+            || i.try_get( TINT_COLOR_VAR_NAME, color ) ) {
             fg_tint.color = color;
         }
-        if (i.try_get(TINT_MODE_FG_VAR_NAME, blend, blendCvt)
-            || i.try_get(TINT_MODE_VAR_NAME, blend, blendCvt)) {
+        if( i.try_get( TINT_MODE_FG_VAR_NAME, blend, blendCvt )
+            || i.try_get( TINT_MODE_VAR_NAME, blend, blendCvt ) ) {
             fg_tint.blend_mode = blend;
         }
-        if (i.try_get(TINT_SATURATION_FG_VAR_NAME, scl)
-            || i.try_get(TINT_SATURATION_VAR_NAME, scl)) {
+        if( i.try_get( TINT_SATURATION_FG_VAR_NAME, scl )
+            || i.try_get( TINT_SATURATION_VAR_NAME, scl ) ) {
             fg_tint.saturation = scl;
         }
-        if (i.try_get(TINT_CONTRAST_FG_VAR_NAME, scl)
-            || i.try_get(TINT_CONTRAST_VAR_NAME, scl)) {
+        if( i.try_get( TINT_CONTRAST_FG_VAR_NAME, scl )
+            || i.try_get( TINT_CONTRAST_VAR_NAME, scl ) ) {
             fg_tint.contrast = scl;
         }
-        if (i.try_get(TINT_BRIGHTNESS_FG_VAR_NAME, scl)
-            || i.try_get(TINT_BRIGHTNESS_VAR_NAME, scl)) {
+        if( i.try_get( TINT_BRIGHTNESS_FG_VAR_NAME, scl )
+            || i.try_get( TINT_BRIGHTNESS_VAR_NAME, scl ) ) {
             fg_tint.brightness = scl;
         }
     }
@@ -165,33 +167,33 @@ color_tint_pair tint_from_data_vars(const data_vars::data_set& i, const color_ti
 } // namespace
 
 auto cata_tiles::get_overmap_color(
-    overmapbuffer & o, const tripoint_abs_omt & p) const -> color_tint_pair
+    overmapbuffer &o, const tripoint_abs_omt &p ) const -> color_tint_pair
 {
-    const oter_t oter = o.ter(p).obj();
-    return tint_from_tileset(tileset_ptr, oter);
+    const oter_t oter = o.ter( p ).obj();
+    return tint_from_tileset( tileset_ptr, oter );
 }
 
 auto cata_tiles::get_terrain_color(
-    const ter_t & t, const map &m, const tripoint_bub_ms &p ) const -> color_tint_pair
+    const ter_t &t, const map &m, const tripoint_bub_ms &p ) const -> color_tint_pair
 {
-    auto tint = tint_from_tileset(tileset_ptr, t);
+    auto tint = tint_from_tileset( tileset_ptr, t );
 
-    const auto vars = m.ter_vars(p);
-    if (vars != nullptr) {
-        return tint_from_data_vars( *vars , tint );
+    const auto vars = m.ter_vars( p );
+    if( vars != nullptr ) {
+        return tint_from_data_vars( *vars, tint );
     }
 
     return tint;
 }
 
 auto cata_tiles::get_furniture_color(
-    const furn_t & f, const map &m, const tripoint_bub_ms &p ) const -> color_tint_pair
+    const furn_t &f, const map &m, const tripoint_bub_ms &p ) const -> color_tint_pair
 {
-    auto tint = tint_from_tileset(tileset_ptr, f);
+    auto tint = tint_from_tileset( tileset_ptr, f );
 
-    const auto vars = m.furn_vars(p);
-    if (vars != nullptr) {
-        return tint_from_data_vars( *vars , tint );
+    const auto vars = m.furn_vars( p );
+    if( vars != nullptr ) {
+        return tint_from_data_vars( *vars, tint );
     }
 
     return tint;
@@ -204,21 +206,21 @@ auto cata_tiles::get_graffiti_color(
 }
 
 auto cata_tiles::get_trap_color(
-    const trap & tr, const map &, tripoint_bub_ms ) const -> color_tint_pair
+    const trap &tr, const map &, tripoint_bub_ms ) const -> color_tint_pair
 {
-    return tint_from_tileset(tileset_ptr, tr);
+    return tint_from_tileset( tileset_ptr, tr );
 }
 
 auto cata_tiles::get_field_color(
-    const field & f, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
+    const field &f, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    return tint_from_tileset(tileset_ptr, f);
+    return tint_from_tileset( tileset_ptr, f );
 }
 
 auto cata_tiles::get_item_color(
     const item &i, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    const auto tint = tint_from_tileset(tileset_ptr, i);
+    const auto tint = tint_from_tileset( tileset_ptr, i );
     return tint_from_data_vars( i.item_vars(), tint );
 }
 
@@ -231,34 +233,34 @@ auto cata_tiles::get_vpart_color(
         return tint;
     }
 
-    vehicle_part* vpp = nullptr;
-    if (use_roof) {
-        auto& veh = vp->vehicle();
-        const auto part_idx = veh.roof_at_part(vp->part_index());
-        if (part_idx != -1) {
-            vpp = &veh.part(part_idx);
+    vehicle_part *vpp = nullptr;
+    if( use_roof ) {
+        auto &veh = vp->vehicle();
+        const auto part_idx = veh.roof_at_part( vp->part_index() );
+        if( part_idx != -1 ) {
+            vpp = &veh.part( part_idx );
         }
     } else {
         const auto part_ref = vp.part_displayed();
-        if (part_ref) {
+        if( part_ref ) {
             vpp = &part_ref->part();
         }
     }
 
-    if (vpp == nullptr) {
+    if( vpp == nullptr ) {
         return tint;
     }
 
-    tint = tint_from_tileset(tileset_ptr, *vpp);
+    tint = tint_from_tileset( tileset_ptr, *vpp );
     auto [bg, fg] = vpp->get_color();
-    std::tie(tint.first.color, tint.second.color) = std::make_pair(bg, fg);
+    std::tie( tint.first.color, tint.second.color ) = std::make_pair( bg, fg );
     return tint;
 }
 
 auto cata_tiles::get_monster_color(
-    const monster & mon, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
+    const monster &mon, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    return tint_from_tileset(tileset_ptr, mon);
+    return tint_from_tileset( tileset_ptr, mon );
 }
 
 auto cata_tiles::get_character_color(
@@ -268,19 +270,22 @@ auto cata_tiles::get_character_color(
 }
 
 auto cata_tiles::get_effect_color(
-    const effect &eff, const Character &, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
+    const effect &eff, const Character &, const map &,
+    const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    return tint_from_tileset(tileset_ptr, eff);
+    return tint_from_tileset( tileset_ptr, eff );
 }
 
 auto cata_tiles::get_bionic_color(
-    const bionic &bio, const Character &, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
+    const bionic &bio, const Character &, const map &,
+    const tripoint_bub_ms & ) const -> color_tint_pair
 {
-    return tint_from_tileset(tileset_ptr, bio);
+    return tint_from_tileset( tileset_ptr, bio );
 }
 
 auto cata_tiles::get_mutation_color(
-    const mutation &mut, const Character &c, const map &, const tripoint_bub_ms & ) const -> color_tint_pair
+    const mutation &mut, const Character &c, const map &,
+    const tripoint_bub_ms & ) const -> color_tint_pair
 {
     const mutation_branch &mut_branch = mut.first.obj();
     std::string fallback_color;

--- a/src/item.h
+++ b/src/item.h
@@ -114,13 +114,27 @@ static const std::string source_p1_name = "source_" + p1_name;
 static const std::string source_p2_name = "source_" + p2_name;
 static const tripoint_abs_ms tripoint_abs_ms_min( tripoint_min );
 
+static const std::string TINT_VAR_PREFIX( "tint_" );
+
 static const std::string TINT_COLOR_VAR_NAME( "tint_color" );
 static const std::string TINT_COLOR_FG_VAR_NAME( "tint_color_fg" );
 static const std::string TINT_COLOR_BG_VAR_NAME( "tint_color_bg" );
+
 static const std::string TINT_MODE_VAR_NAME( "tint_blend_mode" );
+static const std::string TINT_MODE_FG_VAR_NAME( "tint_blend_mode_fg" );
+static const std::string TINT_MODE_BG_VAR_NAME( "tint_blend_mode_bg" );
+
 static const std::string TINT_SATURATION_VAR_NAME( "tint_saturation" );
+static const std::string TINT_SATURATION_FG_VAR_NAME( "tint_saturation_fg" );
+static const std::string TINT_SATURATION_BG_VAR_NAME( "tint_saturation_bg" );
+
 static const std::string TINT_CONTRAST_VAR_NAME( "tint_contrast" );
+static const std::string TINT_CONTRAST_FG_VAR_NAME( "tint_contrast_fg" );
+static const std::string TINT_CONTRAST_BG_VAR_NAME( "tint_contrast_bg" );
+
 static const std::string TINT_BRIGHTNESS_VAR_NAME( "tint_brightness" );
+static const std::string TINT_BRIGHTNESS_FG_VAR_NAME( "tint_brightness_fg" );
+static const std::string TINT_BRIGHTNESS_BG_VAR_NAME( "tint_brightness_bg" );
 
 /**
  *  Value and metadata for one property of an item

--- a/src/vehicle_preview.cpp
+++ b/src/vehicle_preview.cpp
@@ -95,11 +95,11 @@ class veh_preview_adapter : public cata_tiles
          * Get the paint colors for a vehicle part.
          * Uses get_vpart_color which will return actual colors when painting is implemented.
          */
-        static color_tint_pair get_part_colors( const vehicle &veh, int part_idx ) {
-            map &here = get_map();
+        color_tint_pair get_part_colors( const vehicle &veh, int part_idx ) const {
+            const map &here = get_map();
             const auto part_pos = veh.bub_part_location( part_idx );
             const optional_vpart_position vp = here.veh_at( part_pos );
-            return cata_tiles::get_vpart_color( vp, here, part_pos );
+            return get_vpart_color( vp, here, part_pos );
         }
 
         /**
@@ -226,6 +226,7 @@ void vehicle_preview_window::draw_cursor_at_pixel( point pixel_pos )
 void vehicle_preview_window::display( const vehicle &veh, tripoint_mnt_veh cursor,
                                       int highlight_part )
 {
+    const veh_preview_adapter *adapter = veh_preview_adapter::convert( &*tilecontext );
     const point center_px = calc_window_center_pixels();
 
     // Get tile dimensions at current zoom
@@ -264,7 +265,7 @@ void vehicle_preview_window::display( const vehicle &veh, tripoint_mnt_veh curso
         const vpart_id &vp_id = veh.part_id_string( part_idx, false, part_mod );
 
         // Get paint colors for this part (will return actual colors when painting is implemented)
-        const auto [bg_color, fg_color] = veh_preview_adapter::get_part_colors( veh, part_idx );
+        const auto [bg_color, fg_color] = adapter->get_part_colors( veh, part_idx );
 
         const auto part_direction = normalize( 270_degrees + veh.part_display_direction( part_idx ) -
                                                veh.face.dir() );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Improve tileset defined tinting support

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

* Inherit tileset default tint values for data var painting (paint vars override tileset values)
* Extend tileset tint support for more types
* Fix alpha on Additive blend mode

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

N/A

## Testing

N/A

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2255e6b](https://github.com/cataclysmbn/Cataclysm-BN/commit/2255e6b6cf3e9841fed3acadbc58b28379dd1ed9) (style(autofix.ci): automated formatting) on 2026-06-10 04:52:33

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27250610923/artifacts/7526377242)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27250610923/artifacts/7526535393)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27250610923/artifacts/7526424487)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27250610923/artifacts/7526733195)
<!-- END artifact comment -->