### PR TITLE
ci: speed up JSON syntax validation

### DIFF
--- a/build-scripts/lint-json.sh
+++ b/build-scripts/lint-json.sh
@@ -1,2 +1,19 @@
 #!/bin/sh
-find . -name ".*" -not -name "." -prune -o -name "*.json" -type f -exec sh -c 'python -m json.tool "$1" >/dev/null || echo "FAILED: $1"' _ {} \;
+find . -name ".*" -not -name "." -prune -o -name "*.json" -type f -print0 |
+python3 -c '
+import json
+import sys
+
+failed = False
+for raw_path in sys.stdin.buffer.read().split(b"\0"):
+    if not raw_path:
+        continue
+    path = raw_path.decode()
+    try:
+        with open(path, encoding="utf-8") as file:
+            json.load(file)
+    except Exception as error:
+        print(f"FAILED: {path}: {error}", file=sys.stderr)
+        failed = True
+sys.exit(1 if failed else 0)
+'


### PR DESCRIPTION
## Purpose of change (The Why)

_lint-json sooooooo slow, like 250x slow_

Speed up JSON syntax validation in CI. Local benchmark on tracked non-dotdir JSON files (2915 files / 41.4 MB):

| Validator | Time | Difference |
|---|---:|---:|
| Previous `python -m json.tool` per file | 92.5s | 1x |
| New single Python process | 0.375s | 247x faster |
| `jq -e .` comparison | 1.371s | 67x faster |

## Describe the solution (The How)

- Validate all discovered JSON files in one Python process.
- Preserve per-file failure messages and return nonzero on invalid JSON.

there might be faster tool but this doesn't require new deps at least

## Testing

- `sh -n build-scripts/lint-json.sh`
- `./build-scripts/lint-json.sh` (0.378s local)
- Invalid JSON smoke test returns failure

## Checklist
### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style). No shell formatter is configured for this script.
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [71532d8](https://github.com/cataclysmbn/Cataclysm-BN/commit/71532d8b19d0c1a4715013935a912cc6deb65173) (ci: speed up JSON syntax validation) on 2026-06-10 06:36:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27254257676/artifacts/7527351479)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27254257676/artifacts/7527850876)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27254257676/artifacts/7527357068)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27254257676/artifacts/7527688424)
<!-- END artifact comment -->