### PR TITLE
fix: Prevent bullet vibrators from killing you of exhaustion in your sleep

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9502,7 +9502,7 @@ int iuse::bullet_vibe_on( player *p, item *it, bool t, const tripoint_bub_ms & )
     if( t ) { // Normal use
         if( p->has_item( *it ) ) {
             // Only triggers every 1 minute so that fatigue isn't ridiculous
-            if( action_time_scale::once_every_this_tick( 1_minutes ) ) {
+            if( action_time_scale::once_every_this_tick( 2_minutes ) ) {
                 p->add_morale( MORALE_FEELING_GOOD, 1, 30, 20_minutes, 10_minutes, true );
                 p->mod_fatigue( 1 );
             }


### PR DESCRIPTION
## Purpose of change (The Why)

Players who thought it would be fun to splurge on the Atomic Pleasure upgrade for their bullet vibrators ended up leaving them on while they slept and thus died of exhaustion while they were in bed. This is *very funny*, but probably undesirable.

## Describe the solution (The How)

Make it tick every two minutes rather than one.

## Describe alternatives you've considered

- Figure out how to make the player turn it off automatically
- Leave it in because it's funnier the old way

## Testing
Before the change, I was able to gain tiredness while sleeping (going from Tired to Dead Tired at least)

After the change, I still gained fatigue during the waking hours but not while I was sleeping (or if it was while I was sleeping then it was so slow as to not be a concern).

## Additional context

Finally got around to doing this lmao.

This also still uses the goober method of finding a revert instead of the actual field, but I don't care to change that right now.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2606ff5](https://github.com/cataclysmbn/Cataclysm-BN/commit/2606ff57747688e69a2a4ede8cf77d16daf88bb1) (Make bullet vibes take twice as long to tick) on 2026-06-10 06:51:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27254475406/artifacts/7527857900)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27254475406/artifacts/7528001142)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27254475406/artifacts/7527700136)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27254475406/artifacts/7527808653)
<!-- END artifact comment -->