### PR TITLE
fix: Make texture streaming optional

### DIFF
--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -137,7 +137,7 @@ struct null_texture_packer final : detail::texture_packer {
     };
 };
 
-auto dynamic_atlas::update_staging_area(staging& staging, const int width, const int height) const
+auto dynamic_atlas::update_staging_area(staging_area& staging, const int width, const int height) const
     -> std::tuple<SDL_Texture*, SDL_Surface*, SDL_Rect> {
     const auto r_width = round_up(width, hint_sprite_width);
     const auto r_height = round_up(height, hint_sprite_height);

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -138,9 +138,9 @@ struct null_texture_packer final : detail::texture_packer {
     };
 };
 
-auto dynamic_atlas::update_staging_area( staging_area &staging, const int width,
-        const int height ) const
-- > std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>
+auto dynamic_atlas::update_staging_area(
+    staging_area &staging, const int width, const int height )
+const -> std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>
 {
     const auto r_width = round_up( width, hint_sprite_width );
     const auto r_height = round_up( height, hint_sprite_height );

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "preload_config.h"
 #include "sdl_utils.h"
 #include "sdltiles.h"
 
@@ -25,6 +26,31 @@ static T round_up( T n, T m )
         return n;
     }
     return ( ( n + m - 1 ) / m ) * m;
+}
+
+static bool use_texture_streaming() {
+    static std::unordered_map<std::string, bool> auto_values = {
+        {SDL_SOFTWARE_RENDERER, false},
+        {SDL_GPU_RENDERER, true},
+    };
+    const auto &r = get_sdl_renderer();
+    const auto renderer = SDL_GetRendererName( r.get() );
+    switch (preload_config::get_texture_streaming()) {
+        default:
+        case preload_config::tristate::auto_select: {
+            const auto it = auto_values.find(renderer);
+            if (it != auto_values.end()) {
+                return it->second;
+            }
+            return false;
+        }
+        case preload_config::tristate::enable: {
+            return true;
+        }
+        case preload_config::tristate::disable: {
+            return false;
+        }
+    }
 }
 
 struct stripe_texture_packer final : detail::texture_packer {
@@ -111,24 +137,27 @@ struct null_texture_packer final : detail::texture_packer {
     };
 };
 
+auto dynamic_atlas::update_staging_area(staging& staging, const int width, const int height) const
+    -> std::tuple<SDL_Texture*, SDL_Surface*, SDL_Rect> {
+    const auto r_width = round_up(width, hint_sprite_width);
+    const auto r_height = round_up(height, hint_sprite_height);
+
+    if (staging.surf == nullptr || staging.surf->w < r_width || staging.surf->h < r_height) {
+        const auto& r = get_sdl_renderer();
+        staging.surf = create_surface_32(r_width, r_height);
+        staging.tex =
+            CreateTexture(r, sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET, r_width, r_height);
+        SDL_SetTextureBlendMode(staging.tex.get(), SDL_BLENDMODE_NONE);
+        SDL_SetSurfaceBlendMode(staging.surf.get(), SDL_BLENDMODE_NONE);
+    }
+
+    return std::make_tuple(staging.tex.get(), staging.surf.get(), SDL_Rect(0,0, width, height));
+}
+
 auto dynamic_atlas::get_staging_area(
     const int width, const int height ) -> std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>
 {
-    const auto r_width = round_up( width, hint_sprite_width );
-    const auto r_height = round_up( height, hint_sprite_height );
-
-    if( staging_surf == nullptr || staging_surf->w < r_width ||
-        staging_surf->h < r_height ) {
-        const auto &r = get_sdl_renderer();
-        staging_surf = create_surface_32( r_width, r_height );
-        staging_tex = CreateTexture( r, sdl_color_pixel_format,
-                                     SDL_TEXTUREACCESS_TARGET, r_width, r_height );
-        SDL_SetTextureBlendMode( staging_tex.get(), SDL_BLENDMODE_NONE );
-        SDL_SetSurfaceBlendMode( staging_surf.get(), SDL_BLENDMODE_NONE );
-    }
-
-    return std::make_tuple( staging_tex.get(), staging_surf.get(),
-                            SDL_Rect{0, 0, width, height} );
+    return update_staging_area(user_staging, width, height);
 }
 
 auto dynamic_atlas::assign_id_internal( const size_t id, const atlas_texture &tex ) -> bool
@@ -219,15 +248,35 @@ auto dynamic_atlas::create_sprite(
     if( id.has_value() && !this->assign_id_internal( id.value(), atl_tex ) ) {
         debugmsg( "Duplicate sprite ID in atlas: %x", id.value() );
     }
-    auto& [tex, rect] = atl_tex;
+    auto& [tex, dstRect] = atl_tex;
 
-    SDL_Surface *tmpSurf{};
-    if( SDL_LockTextureToSurface( tex.get(), &rect, &tmpSurf ) ) {
-        const auto tmpRect = SDL_Rect{0, 0, w, h};
-        blitFn( tmpSurf, &tmpRect );
-        SDL_UnlockTexture( tex.get() );
+    const auto tmpRect = SDL_Rect(0, 0, w, h);
+    if (use_texture_streaming()) {
+        SDL_Surface *tmpSurf{};
+        if( SDL_LockTextureToSurface( tex.get(), &dstRect, &tmpSurf ) ) {
+            blitFn( tmpSurf, &tmpRect );
+            SDL_UnlockTexture( tex.get() );
+        } else {
+            debugmsg( "Failed to lock dynamic atlas texture for writing." );
+        }
     } else {
-        debugmsg( "Failed to lock dynamic atlas texture for writing." );
+        const auto &r = get_sdl_renderer();
+
+        const auto [stTex, stSurf, stRect] = update_staging_area(local_staging,  w, h);
+        blitFn( stSurf, &stRect );
+        SDL_UpdateTexture(stTex, nullptr, stSurf->pixels, stSurf->pitch);
+
+        const auto state = sdl_save_render_state( r.get() );
+
+        if ( SDL_SetRenderTarget( r.get(), tex.get() ) ) {
+            const auto fSrc = SDL_FRect( stRect.x, stRect.y, stRect.w, stRect.h );
+            const auto fDst = SDL_FRect( dstRect.x, dstRect.y, dstRect.w, dstRect.h );
+            SDL_RenderTexture( r.get(), stTex, &fSrc, &fDst );
+        } else {
+            debugmsg( "Failed to set dynamic atlas texture as render target." );
+        }
+
+        sdl_restore_render_state(r.get(), state);
     }
 
     return atl_tex;
@@ -278,8 +327,10 @@ atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h 
 
     assert( w <= tex_width && h <= tex_height );
 
-    const auto tex = SDL_CreateTexture( r.get(), sdl_color_pixel_format, SDL_TEXTUREACCESS_STREAMING,
-                                        tex_width, tex_height );
+    const auto access = use_texture_streaming() ? SDL_TEXTUREACCESS_STREAMING : SDL_TEXTUREACCESS_TARGET;
+
+    const auto tex =
+        SDL_CreateTexture(r.get(), sdl_color_pixel_format, access, tex_width, tex_height);
     SDL_SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
     SDL_SetTextureScaleMode( tex, SDL_SCALEMODE_NEAREST );
 

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -28,18 +28,19 @@ static T round_up( T n, T m )
     return ( ( n + m - 1 ) / m ) * m;
 }
 
-static bool use_texture_streaming() {
+static bool use_texture_streaming()
+{
     static std::unordered_map<std::string, bool> auto_values = {
         {SDL_SOFTWARE_RENDERER, false},
         {SDL_GPU_RENDERER, true},
     };
     const auto &r = get_sdl_renderer();
     const auto renderer = SDL_GetRendererName( r.get() );
-    switch (preload_config::get_texture_streaming()) {
+    switch( preload_config::get_texture_streaming() ) {
         default:
         case preload_config::tristate::auto_select: {
-            const auto it = auto_values.find(renderer);
-            if (it != auto_values.end()) {
+            const auto it = auto_values.find( renderer );
+            if( it != auto_values.end() ) {
                 return it->second;
             }
             return false;
@@ -137,27 +138,29 @@ struct null_texture_packer final : detail::texture_packer {
     };
 };
 
-auto dynamic_atlas::update_staging_area(staging_area& staging, const int width, const int height) const
-    -> std::tuple<SDL_Texture*, SDL_Surface*, SDL_Rect> {
-    const auto r_width = round_up(width, hint_sprite_width);
-    const auto r_height = round_up(height, hint_sprite_height);
+auto dynamic_atlas::update_staging_area( staging_area &staging, const int width,
+        const int height ) const
+- > std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>
+{
+    const auto r_width = round_up( width, hint_sprite_width );
+    const auto r_height = round_up( height, hint_sprite_height );
 
-    if (staging.surf == nullptr || staging.surf->w < r_width || staging.surf->h < r_height) {
-        const auto& r = get_sdl_renderer();
-        staging.surf = create_surface_32(r_width, r_height);
+    if( staging.surf == nullptr || staging.surf->w < r_width || staging.surf->h < r_height ) {
+        const auto &r = get_sdl_renderer();
+        staging.surf = create_surface_32( r_width, r_height );
         staging.tex =
-            CreateTexture(r, sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET, r_width, r_height);
-        SDL_SetTextureBlendMode(staging.tex.get(), SDL_BLENDMODE_NONE);
-        SDL_SetSurfaceBlendMode(staging.surf.get(), SDL_BLENDMODE_NONE);
+            CreateTexture( r, sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET, r_width, r_height );
+        SDL_SetTextureBlendMode( staging.tex.get(), SDL_BLENDMODE_NONE );
+        SDL_SetSurfaceBlendMode( staging.surf.get(), SDL_BLENDMODE_NONE );
     }
 
-    return std::make_tuple(staging.tex.get(), staging.surf.get(), SDL_Rect(0,0, width, height));
+    return std::make_tuple( staging.tex.get(), staging.surf.get(), SDL_Rect( 0, 0, width, height ) );
 }
 
 auto dynamic_atlas::get_staging_area(
     const int width, const int height ) -> std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>
 {
-    return update_staging_area(user_staging, width, height);
+    return update_staging_area( user_staging, width, height );
 }
 
 auto dynamic_atlas::assign_id_internal( const size_t id, const atlas_texture &tex ) -> bool
@@ -250,8 +253,8 @@ auto dynamic_atlas::create_sprite(
     }
     auto& [tex, dstRect] = atl_tex;
 
-    const auto tmpRect = SDL_Rect(0, 0, w, h);
-    if (use_texture_streaming()) {
+    const auto tmpRect = SDL_Rect( 0, 0, w, h );
+    if( use_texture_streaming() ) {
         SDL_Surface *tmpSurf{};
         if( SDL_LockTextureToSurface( tex.get(), &dstRect, &tmpSurf ) ) {
             blitFn( tmpSurf, &tmpRect );
@@ -262,13 +265,13 @@ auto dynamic_atlas::create_sprite(
     } else {
         const auto &r = get_sdl_renderer();
 
-        const auto [stTex, stSurf, stRect] = update_staging_area(local_staging,  w, h);
+        const auto [stTex, stSurf, stRect] = update_staging_area( local_staging,  w, h );
         blitFn( stSurf, &stRect );
-        SDL_UpdateTexture(stTex, nullptr, stSurf->pixels, stSurf->pitch);
+        SDL_UpdateTexture( stTex, nullptr, stSurf->pixels, stSurf->pitch );
 
         const auto state = sdl_save_render_state( r.get() );
 
-        if ( SDL_SetRenderTarget( r.get(), tex.get() ) ) {
+        if( SDL_SetRenderTarget( r.get(), tex.get() ) ) {
             const auto fSrc = SDL_FRect( stRect.x, stRect.y, stRect.w, stRect.h );
             const auto fDst = SDL_FRect( dstRect.x, dstRect.y, dstRect.w, dstRect.h );
             SDL_RenderTexture( r.get(), stTex, &fSrc, &fDst );
@@ -276,7 +279,7 @@ auto dynamic_atlas::create_sprite(
             debugmsg( "Failed to set dynamic atlas texture as render target." );
         }
 
-        sdl_restore_render_state(r.get(), state);
+        sdl_restore_render_state( r.get(), state );
     }
 
     return atl_tex;
@@ -327,10 +330,11 @@ atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h 
 
     assert( w <= tex_width && h <= tex_height );
 
-    const auto access = use_texture_streaming() ? SDL_TEXTUREACCESS_STREAMING : SDL_TEXTUREACCESS_TARGET;
+    const auto access = use_texture_streaming() ? SDL_TEXTUREACCESS_STREAMING :
+                        SDL_TEXTUREACCESS_TARGET;
 
     const auto tex =
-        SDL_CreateTexture(r.get(), sdl_color_pixel_format, access, tex_width, tex_height);
+        SDL_CreateTexture( r.get(), sdl_color_pixel_format, access, tex_width, tex_height );
     SDL_SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
     SDL_SetTextureScaleMode( tex, SDL_SCALEMODE_NEAREST );
 

--- a/src/dynamic_atlas.h
+++ b/src/dynamic_atlas.h
@@ -72,8 +72,8 @@ class dynamic_atlas
 
         auto assign_id_internal( size_t id, const atlas_texture &tex ) -> bool;
         auto allocate_sprite_internal( int w, int h ) -> atlas_texture;
-        auto update_staging_area( staging_area& staging, int width, int height ) const
-            -> std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>;
+        auto update_staging_area( staging_area &staging, int width, int height ) const
+        -> std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>;
         std::vector<sprite_sheet> sheets;
         std::unordered_map<size_t, std::pair<int, SDL_Rect>> sprite_ids;
 

--- a/src/dynamic_atlas.h
+++ b/src/dynamic_atlas.h
@@ -65,20 +65,20 @@ class dynamic_atlas
         auto end() const { return sheets.end(); }
 
     private:
-        struct staging {
+        struct staging_area {
             SDL_Surface_Ptr surf;
             SDL_Texture_Ptr tex;
         };
 
         auto assign_id_internal( size_t id, const atlas_texture &tex ) -> bool;
         auto allocate_sprite_internal( int w, int h ) -> atlas_texture;
-        auto update_staging_area( staging& staging, int width, int height ) const
+        auto update_staging_area( staging_area& staging, int width, int height ) const
             -> std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>;
         std::vector<sprite_sheet> sheets;
         std::unordered_map<size_t, std::pair<int, SDL_Rect>> sprite_ids;
 
-        staging user_staging;
-        staging local_staging;
+        staging_area user_staging;
+        staging_area local_staging;
 
         int max_atlas_width;
         int max_atlas_height;

--- a/src/dynamic_atlas.h
+++ b/src/dynamic_atlas.h
@@ -65,12 +65,20 @@ class dynamic_atlas
         auto end() const { return sheets.end(); }
 
     private:
+        struct staging {
+            SDL_Surface_Ptr surf;
+            SDL_Texture_Ptr tex;
+        };
+
         auto assign_id_internal( size_t id, const atlas_texture &tex ) -> bool;
         auto allocate_sprite_internal( int w, int h ) -> atlas_texture;
+        auto update_staging_area( staging& staging, int width, int height ) const
+            -> std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>;
         std::vector<sprite_sheet> sheets;
         std::unordered_map<size_t, std::pair<int, SDL_Rect>> sprite_ids;
-        SDL_Surface_Ptr staging_surf;
-        SDL_Texture_Ptr staging_tex;
+
+        staging user_staging;
+        staging local_staging;
 
         int max_atlas_width;
         int max_atlas_height;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2306,6 +2306,17 @@ void options_manager::add_options_graphics()
        );
 #endif
 
+#if defined(TILES)
+    add( "TEXTURE_STREAMING", graphics, translate_marker( "Texture Streaming" ),
+     translate_marker( "Use texture-streaming instead of render-to-texture for dynamic graphics. Requires restart." ),
+{
+                { "auto", translate_marker( "Auto" ) },
+                { "on", translate_marker( "Enable" ) },
+                { "off", translate_marker( "Disable" ) }
+            },
+"auto" );
+#endif
+
 #if defined(SDL_HINT_RENDER_BATCHING)
     add( "RENDER_BATCHING", graphics, translate_marker( "Allow render batching" ),
          translate_marker( "Use render batching for 2D render API to make it more efficient.  Requires restart." ),
@@ -4455,6 +4466,14 @@ void options_manager::cache_to_globals()
         preload_config::set_compute_accel(
             preload_config::compute_accel_from_string(
                 ::get_option<std::string>( "COMPUTE_ACCELERATION" ) ) );
+    }
+#endif
+
+#if defined(TILES)
+    if( options.contains( "TEXTURE_STREAMING" ) ) {
+        preload_config::set_texture_streaming(
+            preload_config::tristate_from_string(
+                ::get_option<std::string>( "TEXTURE_STREAMING" ) ) );
     }
 #endif
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2308,13 +2308,13 @@ void options_manager::add_options_graphics()
 
 #if defined(TILES)
     add( "TEXTURE_STREAMING", graphics, translate_marker( "Texture Streaming" ),
-     translate_marker( "Use texture-streaming instead of render-to-texture for dynamic graphics. Requires restart." ),
-{
-                { "auto", translate_marker( "Auto" ) },
-                { "on", translate_marker( "Enable" ) },
-                { "off", translate_marker( "Disable" ) }
-            },
-"auto" );
+         translate_marker( "Use texture-streaming instead of render-to-texture for dynamic graphics. Requires restart." ),
+    {
+        { "auto", translate_marker( "Auto" ) },
+        { "on", translate_marker( "Enable" ) },
+        { "off", translate_marker( "Disable" ) }
+    },
+    "auto" );
 #endif
 
 #if defined(SDL_HINT_RENDER_BATCHING)

--- a/src/preload_config.cpp
+++ b/src/preload_config.cpp
@@ -28,22 +28,22 @@ auto load() -> void
 {
     read_from_file_json(
         PATH_INFO::preload(),
-        [&](JsonIn& jsin) {
-            const auto jObj = jsin.get_object();
+    [&]( JsonIn & jsin ) {
+        const auto jObj = jsin.get_object();
 
-            s_state.accel = compute_accel_from_string(
-                jObj.get_string("compute_acceleration", "auto") //
-            );
+        s_state.accel = compute_accel_from_string(
+                            jObj.get_string( "compute_acceleration", "auto" ) //
+                        );
 
-            if (!s_state.gpu_backend_override_set) {
-                s_state.gpu_backend = jObj.get_string("gpu_backend", "");
-            }
+        if( !s_state.gpu_backend_override_set ) {
+            s_state.gpu_backend = jObj.get_string( "gpu_backend", "" );
+        }
 
-            s_state.texture_streaming = tristate_from_string(
-                jObj.get_string("texture_streaming", "auto") //
-            );
-        },
-        true);
+        s_state.texture_streaming = tristate_from_string(
+                                        jObj.get_string( "texture_streaming", "auto" ) //
+                                    );
+    },
+    true );
 }
 
 auto save() -> void

--- a/src/preload_config.cpp
+++ b/src/preload_config.cpp
@@ -17,6 +17,7 @@ struct state_t {
     compute_accel accel{ compute_accel::auto_select };
     std::string gpu_backend;
     bool gpu_backend_override_set = false;
+    tristate texture_streaming { tristate::auto_select };
 };
 
 state_t s_state;
@@ -25,14 +26,24 @@ state_t s_state;
 
 auto load() -> void
 {
-    read_from_file_json( PATH_INFO::preload(), [&]( JsonIn & jsin ) {
-        auto jobj = jsin.get_object();
-        s_state.accel = compute_accel_from_string(
-                            jobj.get_string( "compute_acceleration", "auto" ) );
-        if( !s_state.gpu_backend_override_set ) {
-            s_state.gpu_backend = jobj.get_string( "gpu_backend", "" );
-        }
-    }, true );
+    read_from_file_json(
+        PATH_INFO::preload(),
+        [&](JsonIn& jsin) {
+            const auto jObj = jsin.get_object();
+
+            s_state.accel = compute_accel_from_string(
+                jObj.get_string("compute_acceleration", "auto") //
+            );
+
+            if (!s_state.gpu_backend_override_set) {
+                s_state.gpu_backend = jObj.get_string("gpu_backend", "");
+            }
+
+            s_state.texture_streaming = tristate_from_string(
+                jObj.get_string("texture_streaming", "auto") //
+            );
+        },
+        true);
 }
 
 auto save() -> void
@@ -45,6 +56,7 @@ auto save() -> void
         if( !s_state.gpu_backend.empty() ) {
             jout.member( "gpu_backend", s_state.gpu_backend );
         }
+        jout.member( "texture_streaming", s_state.texture_streaming );
         jout.end_object();
     }, "preload config" );
 }
@@ -58,6 +70,9 @@ auto set_gpu_backend_override( std::string_view s ) -> void
     s_state.gpu_backend = s;
     s_state.gpu_backend_override_set = true;
 }
+
+auto get_texture_streaming() -> tristate                         { return s_state.texture_streaming; }
+auto set_texture_streaming( tristate val ) -> void               { s_state.texture_streaming = val; }
 
 auto compute_accel_from_string( std::string_view s ) -> compute_accel
 {
@@ -74,6 +89,26 @@ auto compute_accel_to_string( compute_accel val ) -> std::string_view
         case compute_accel::force:
             return "force";
         default:
+            return "auto";
+    }
+}
+
+auto tristate_from_string( std::string_view s ) -> tristate
+{
+    if( s == "off" || s == "disable" ) { return tristate::disable; }
+    if( s == "on" || s == "enable" ) { return tristate::enable; }
+    return tristate::auto_select;
+}
+
+auto  tristate_to_string( tristate val ) -> std::string_view
+{
+    switch( val ) {
+        case tristate::enable:
+            return "enable";
+        case tristate::disable:
+            return "disable";
+        default:
+        case tristate::auto_select:
             return "auto";
     }
 }

--- a/src/preload_config.h
+++ b/src/preload_config.h
@@ -10,6 +10,12 @@ enum class compute_accel : int {
     force,
 };
 
+enum class tristate : int {
+    auto_select,
+    enable,
+    disable
+};
+
 auto load()  -> void;
 auto save()  -> void;
 
@@ -19,7 +25,13 @@ auto set_compute_accel( compute_accel ) -> void;
 auto get_gpu_backend_override()                   -> std::string_view;
 auto set_gpu_backend_override( std::string_view ) -> void;
 
+auto get_texture_streaming() -> tristate;
+auto set_texture_streaming( tristate ) -> void;
+
 auto compute_accel_from_string( std::string_view ) -> compute_accel;
 auto compute_accel_to_string( compute_accel )      -> std::string_view;
+
+auto tristate_from_string( std::string_view ) -> tristate;
+auto tristate_to_string( tristate ) -> std::string_view;
 
 } // namespace preload_config

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -323,6 +323,7 @@ static void WinCreate()
                           "Failed to initialize accelerated renderer, falling back to software rendering" ) ) {
             software_renderer = true;
         } else {
+            dbg( DL::Info ) << "Initialized SDL with Renderer: " << SDL_GetRendererName( renderer.get() );
             if( get_option<bool>( "VSYNC" ) ) {
                 SDL_SetRenderVSync( renderer.get(), 1 );
             }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Add option to enable / disable texture streaming (some android device don't like it) - 
Default to false on all renderers except gpu, where the original fix was for

* Followup to #9343 

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

* Add new menu option to graphics tab: Texture Streaming (Auto / Enable / Disable).
* Default is `auto`
* For now `auto` means:
  * `enabled` on `gpu` renderer, 
  * `disabled` for the others

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

N/A

## Testing

* Set Renderer to `gpu` and texture streaming to `auto` or `disabled`
  * No memory leak
* Set texture streaming to `enable`
  * Memory Leak

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Other renderer and texture streaming combinations:
It may be faster or slower, or leak memory, possible issue in SDL itself

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6cb2c35](https://github.com/cataclysmbn/Cataclysm-BN/commit/6cb2c3522c17473d038623723f596f7178fd76dc) (...) on 2026-06-10 07:46:46

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27257335313/artifacts/7528181446)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27257335313/artifacts/7529099606)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27257335313/artifacts/7528288584)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27257335313/artifacts/7528675272)
<!-- END artifact comment -->