### PR TITLE
ci: sign PR Android artifacts with debug key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -585,7 +585,27 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
         run: |
-          if [ -n "$KEYSTORE" ] && [ -n "$KEYSTORE_PASSWORD" ] && [ -n "$KEYSTORE_PROPERTIES" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            rm -f app/pr-debug.keystore keystore.properties
+            keytool -genkeypair \
+              -noprompt \
+              -keystore app/pr-debug.keystore \
+              -storetype JKS \
+              -storepass android \
+              -keypass android \
+              -alias cbn-pr-debug \
+              -keyalg RSA \
+              -keysize 2048 \
+              -validity 10000 \
+              -dname "CN=Cataclysm BN PR Debug,O=Cataclysm BN"
+            cat > keystore.properties <<'EOF'
+          storeFile=pr-debug.keystore
+          storePassword=android
+          keyAlias=cbn-pr-debug
+          keyPassword=android
+          EOF
+            echo "::notice::Signing PR Android artifact with the PR debug key"
+          elif [ -n "$KEYSTORE" ] && [ -n "$KEYSTORE_PASSWORD" ] && [ -n "$KEYSTORE_PROPERTIES" ]; then
             printf '%s' "$KEYSTORE" > release.keystore.asc
             gpg -d --passphrase "$KEYSTORE_PASSWORD" --batch release.keystore.asc > app/release.keystore
             printf '%s' "$KEYSTORE_PROPERTIES" > keystore.properties.asc


### PR DESCRIPTION
## Purpose of change (The Why)

PR Android APK artifacts are unsigned when release signing secrets are unavailable, so they cannot be sideloaded normally.

## Describe the solution (The How)

- Generate a PR-only debug keystore in the Android build job.
- Use release signing secrets only outside `pull_request` builds.

## Testing

- `JAVA_HOME=/home/scarf/.local/share/mise/installs/java/11.0.2 UPSTREAM_BUILD_NUMBER=2038 ./gradlew --no-daemon -Pj=$(nproc) -Pabi_arm_32=false -Plocalize=false assembleExperimentalRelease`
- `apksigner verify --verbose android/app/build/outputs/apk/experimental/release/cataclysmbn-3c98f44c00-experimental-arm64-v8a-release.apk`
- `apksigner verify --print-certs ...` showed `CN=Cataclysm BN PR Debug, O=Cataclysm BN`.

Reviewer check: download the Android PR artifact and sideload it; it should install as the experimental app.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a5e361f](https://github.com/cataclysmbn/Cataclysm-BN/commit/a5e361f908c0b352a5a5647e5eea3cc725d56f3d) (ci: sign PR Android artifacts with debug key) on 2026-06-10 08:09:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27258231582/artifacts/7528714797)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27258231582/artifacts/7529457745)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27258231582/artifacts/7528687812)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27258231582/artifacts/7529148228)
<!-- END artifact comment -->