### PR TITLE
fix: keep frozen ingredients fresh when crafting

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -827,17 +827,25 @@ void item::set_damage( int qty )
 
 auto item::prepare_for_location_removal() -> void
 {
-    if( goes_bad() && is_in_preserving_container() ) {
+    if( !goes_bad() ) {
+        return;
+    }
+    if( is_in_preserving_container() ) {
         mark_rot_checked_now();
+        return;
+    }
+    if( is_loaded() && has_position() ) {
+        const auto vehicle_loc = dynamic_cast<vehicle_item_location *>( loc );
+        const auto temperature = vehicle_loc != nullptr ? vehicle_loc->storage_temperature() :
+                                 rot::temperature_flag_for_location( get_map(), *this );
+        update_rot( position(), temperature, get_weather() );
     }
 }
 
 detached_ptr<item> item::split( int qty )
 {
     const bool split_from_preserving_container = goes_bad() && is_in_preserving_container();
-    if( split_from_preserving_container ) {
-        prepare_for_location_removal();
-    }
+    prepare_for_location_removal();
     if( qty <= 0 || !count_by_charges() || qty >= charges ) {
         return detach();
     }
@@ -890,10 +898,8 @@ bool item::attempt_split( int qty,
                           const std::function < detached_ptr<item>( detached_ptr<item> && ) > & cb )
 {
     const bool split_from_preserving_container = goes_bad() && is_in_preserving_container();
-    if( split_from_preserving_container ) {
-        prepare_for_location_removal();
-    }
-    const bool split_needs_rot_actualization = goes_bad() && has_position() &&
+    prepare_for_location_removal();
+    const bool split_needs_rot_actualization = goes_bad() && is_loaded() && has_position() &&
             !split_from_preserving_container;
     const auto split_pos = split_needs_rot_actualization ? position() : tripoint_bub_ms::zero();
     const auto vehicle_loc = dynamic_cast<vehicle_item_location *>( loc );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -6,11 +6,13 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "coordinates.h"
+#include "crafting.h"
 #include "enums.h"
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "game.h" // Just for get_convection_temperature(), TODO: Remove
+#include "requirements.h"
 #include "rot.h"
 #include "state_helpers.h"
 #include "units_temperature.h"
@@ -63,11 +65,22 @@ static auto make_storage( const vpart_id &storage_part,
     return { .veh = veh, .part_index = part_index, .pos = vehicle_pos };
 }
 
+static auto add_food_to_vehicle_part( vehicle &veh, const int part_index,
+                                      const itype_id &food_type ) -> void
+{
+    auto food = item::spawn( food_type );
+    REQUIRE( food->goes_bad() );
+    REQUIRE_FALSE( veh.add_item( part_index, std::move( food ) ) );
+}
+
 static auto add_sashimi_to_vehicle_part( vehicle &veh, const int part_index ) -> void
 {
-    auto sashimi = item::spawn( "sashimi" );
-    REQUIRE( sashimi->goes_bad() );
-    REQUIRE_FALSE( veh.add_item( part_index, std::move( sashimi ) ) );
+    add_food_to_vehicle_part( veh, part_index, itype_id( "sashimi" ) );
+}
+
+static auto add_bread_to_vehicle_part( vehicle &veh, const int part_index ) -> void
+{
+    add_food_to_vehicle_part( veh, part_index, itype_id( "bread" ) );
 }
 
 static auto add_canned_red_sauce_to_vehicle_part( vehicle &veh, const int part_index ) -> void
@@ -75,6 +88,19 @@ static auto add_canned_red_sauce_to_vehicle_part( vehicle &veh, const int part_i
     auto sauce = item::in_its_container( item::spawn( "sauce_red" ) );
     REQUIRE( sauce->goes_bad_after_opening( true ) );
     REQUIRE_FALSE( veh.add_item( part_index, std::move( sauce ) ) );
+}
+
+static auto complete_recipe_from_components( Character &crafter, const recipe_id &recipe_to_make,
+        std::vector<detached_ptr<item>> components ) -> void
+{
+    auto craft = item::spawn( &recipe_to_make.obj(), 1, std::move( components ),
+                              std::vector<item_comp> {} );
+    complete_craft( crafter, *craft );
+}
+
+static auto completed_items( Character &who, const itype_id &type ) -> std::vector<item *>
+{
+    return who.items_with( [&type]( const item & it ) { return it.typeId() == type; } );
 }
 
 static auto move_to_inventory_with_attempt_detach( item &stored ) -> item * // *NOPAD*
@@ -105,10 +131,17 @@ static auto prepare_map_storage_test() -> void
     set_map_temperature( get_weather(), 18_c );
 }
 
+static auto add_food_to_map( const tripoint_bub_ms &pos, const itype_id &food_type ) -> void
+{
+    auto food = item::spawn( food_type );
+    REQUIRE( food->goes_bad() );
+    get_map().add_item( pos, std::move( food ) );
+    REQUIRE( get_map().i_at( pos ).size() == 1 );
+}
+
 static auto add_sashimi_to_map( const tripoint_bub_ms &pos ) -> void
 {
-    get_map().add_item( pos, item::spawn( "sashimi" ) );
-    REQUIRE( get_map().i_at( pos ).size() == 1 );
+    add_food_to_map( pos, itype_id( "sashimi" ) );
 }
 
 TEST_CASE( "Rate of rotting" )
@@ -479,6 +512,104 @@ TEST_CASE( "Vehicle storage temperature controls food rot" )
         CHECK( components.front()->get_rot() == 0_turns );
         CHECK( !components.front()->rotten() );
     }
+
+    SECTION( "powered freezer cargo keeps whole food fresh when consumed for crafting" ) {
+        auto fixture = make_storage( vpart_id( "minifreezer" ), true );
+        add_sashimi_to_vehicle_part( *fixture.veh, fixture.part_index );
+
+        calendar::turn += 21_days;
+
+        auto quantity = 1;
+        auto components = get_map().use_amount( fixture.pos, PICKUP_RANGE, itype_id( "sashimi" ),
+                                                quantity, return_true<item> );
+
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+        CHECK( components.front()->get_rot() == 0_turns );
+        CHECK( !components.front()->rotten() );
+    }
+
+    SECTION( "powered freezer cargo keeps crafted food fresh from frozen ingredients" ) {
+        auto fixture = make_storage( vpart_id( "minifreezer" ), true );
+        add_food_to_vehicle_part( *fixture.veh, fixture.part_index, itype_id( "meat" ) );
+
+        calendar::turn += 21_days;
+
+        auto quantity = 1;
+        auto components = get_map().use_amount( fixture.pos, PICKUP_RANGE, itype_id( "meat" ),
+                                                quantity, return_true<item> );
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+
+        auto &avatar = get_avatar();
+        complete_recipe_from_components( avatar, recipe_id( "meat_cooked" ), std::move( components ) );
+
+        const auto crafted = completed_items( avatar, itype_id( "meat_cooked" ) );
+        REQUIRE( crafted.size() == 1 );
+        CHECK( crafted.front()->get_rot() == 0_turns );
+        CHECK( !crafted.front()->rotten() );
+    }
+
+    SECTION( "powered fridge cargo catches up whole food rot when consumed for crafting" ) {
+        auto fixture = make_storage( vpart_id( "minifridge" ), true );
+        add_sashimi_to_vehicle_part( *fixture.veh, fixture.part_index );
+
+        calendar::turn += 24_hours;
+
+        auto quantity = 1;
+        auto components = get_map().use_amount( fixture.pos, PICKUP_RANGE, itype_id( "sashimi" ),
+                                                quantity, return_true<item> );
+
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+        CHECK( components.front()->get_relative_rot() > 0.0 );
+        CHECK( components.front()->get_relative_rot() < 1.0 );
+    }
+
+    SECTION( "powered freezer cargo keeps charge food fresh when consumed for crafting" ) {
+        auto fixture = make_storage( vpart_id( "minifreezer" ), true );
+        add_bread_to_vehicle_part( *fixture.veh, fixture.part_index );
+
+        calendar::turn += 20_days;
+
+        auto quantity = 1;
+        auto components = get_map().use_charges( fixture.pos, 0, itype_id( "bread" ), quantity,
+                          return_true<item> );
+
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+        CHECK( components.front()->charges == 1 );
+        CHECK( components.front()->get_rot() == 0_turns );
+        CHECK( !components.front()->rotten() );
+
+        auto remaining = fixture.veh->get_items( fixture.part_index );
+        REQUIRE( remaining.size() == 1 );
+        CHECK( remaining.only_item().charges == 1 );
+        CHECK( remaining.only_item().get_rot() == 0_turns );
+    }
+
+    SECTION( "powered fridge cargo catches up charge food rot when consumed for crafting" ) {
+        auto fixture = make_storage( vpart_id( "minifridge" ), true );
+        add_bread_to_vehicle_part( *fixture.veh, fixture.part_index );
+
+        calendar::turn += 24_hours;
+
+        auto quantity = 1;
+        auto components = get_map().use_charges( fixture.pos, 0, itype_id( "bread" ), quantity,
+                          return_true<item> );
+
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+        CHECK( components.front()->charges == 1 );
+        CHECK( components.front()->get_relative_rot() > 0.0 );
+        CHECK( components.front()->get_relative_rot() < 1.0 );
+
+        auto remaining = fixture.veh->get_items( fixture.part_index );
+        REQUIRE( remaining.size() == 1 );
+        CHECK( remaining.only_item().charges == 1 );
+        CHECK( remaining.only_item().get_relative_rot() > 0.0 );
+        CHECK( remaining.only_item().get_relative_rot() < 1.0 );
+    }
 }
 
 TEST_CASE( "Contained item keeps parent location while temporarily detached" )
@@ -530,6 +661,113 @@ TEST_CASE( "Map powered fridge and freezer furniture controls food rot" )
         REQUIRE( items.size() == 1 );
         CHECK( items.only_item().get_relative_rot() > 0.0 );
         CHECK( items.only_item().get_relative_rot() < 1.0 );
+    }
+
+    SECTION( "powered freezer furniture keeps food fresh when removed after missed processing" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
+        get_map().furn_set( pos, f_test_minifreezer_on );
+        add_sashimi_to_map( pos );
+
+        calendar::turn += 21_days;
+
+        auto items = get_map().i_at( pos );
+        REQUIRE( items.size() == 1 );
+        auto *carried = move_to_inventory_with_attempt_detach( items.only_item() );
+
+        REQUIRE( carried != nullptr );
+        CHECK( carried->get_rot() == 0_turns );
+        CHECK( !carried->rotten() );
+    }
+
+    SECTION( "powered freezer furniture keeps whole food fresh when consumed for crafting" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
+        get_map().furn_set( pos, f_test_minifreezer_on );
+        add_sashimi_to_map( pos );
+
+        calendar::turn += 21_days;
+
+        auto quantity = 1;
+        auto components = get_map().use_amount( pos, PICKUP_RANGE, itype_id( "sashimi" ), quantity,
+                                                return_true<item> );
+
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+        CHECK( components.front()->get_rot() == 0_turns );
+        CHECK( !components.front()->rotten() );
+    }
+
+    SECTION( "powered fridge furniture catches up whole food rot when consumed for crafting" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
+        get_map().furn_set( pos, f_test_fridge_on );
+        add_sashimi_to_map( pos );
+
+        calendar::turn += 24_hours;
+
+        auto quantity = 1;
+        auto components = get_map().use_amount( pos, PICKUP_RANGE, itype_id( "sashimi" ), quantity,
+                                                return_true<item> );
+
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+        CHECK( components.front()->get_relative_rot() > 0.0 );
+        CHECK( components.front()->get_relative_rot() < 1.0 );
+    }
+
+    SECTION( "powered freezer furniture keeps charge food fresh when consumed for crafting" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
+        get_map().furn_set( pos, f_test_minifreezer_on );
+        add_food_to_map( pos, itype_id( "bread" ) );
+
+        calendar::turn += 20_days;
+
+        auto quantity = 1;
+        auto components = get_map().use_charges( pos, 0, itype_id( "bread" ), quantity,
+                          return_true<item> );
+
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+        CHECK( components.front()->charges == 1 );
+        CHECK( components.front()->get_rot() == 0_turns );
+        CHECK( !components.front()->rotten() );
+
+        auto remaining = get_map().i_at( pos );
+        REQUIRE( remaining.size() == 1 );
+        CHECK( remaining.only_item().charges == 1 );
+        CHECK( remaining.only_item().get_rot() == 0_turns );
+    }
+
+    SECTION( "powered fridge furniture catches up charge food rot when consumed for crafting" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
+        get_map().furn_set( pos, f_test_fridge_on );
+        add_food_to_map( pos, itype_id( "bread" ) );
+
+        calendar::turn += 24_hours;
+
+        auto quantity = 1;
+        auto components = get_map().use_charges( pos, 0, itype_id( "bread" ), quantity,
+                          return_true<item> );
+
+        REQUIRE( quantity == 0 );
+        REQUIRE( components.size() == 1 );
+        CHECK( components.front()->charges == 1 );
+        CHECK( components.front()->get_relative_rot() > 0.0 );
+        CHECK( components.front()->get_relative_rot() < 1.0 );
+
+        auto remaining = get_map().i_at( pos );
+        REQUIRE( remaining.size() == 1 );
+        CHECK( remaining.only_item().charges == 1 );
+        CHECK( remaining.only_item().get_relative_rot() > 0.0 );
+        CHECK( remaining.only_item().get_relative_rot() < 1.0 );
     }
 
     SECTION( "unprotected map storage reports stale rot when inspected before processing" ) {


### PR DESCRIPTION
## Purpose of change (The Why)

close #9385

Frozen ingredients consumed from freezer/fridge storage could be detached before their rot was finalized from the source storage temperature, so crafted food could inherit stale room-temperature rot.

Related: #9010, #9381, #9322

## Describe the solution (The How)

- Finalize perishable item rot before location removal using the current source storage temperature.
- Preserve sealed-container freshness behavior.
- Cover freezer/fridge vehicle cargo and map furniture crafting paths, including charge splits and a completed cooked result.

## Testing

- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `SDL_VIDEODRIVER=offscreen ./out/build/linux-full/tests/cata_test-tiles "Rate of rotting,Preserving containers stop contained food rot,Items don't rot away on map load if in a freezer,Vehicle storage temperature controls food rot,Contained item keeps parent location while temporarily detached,Map powered fridge and freezer furniture controls food rot"`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5f32faa](https://github.com/cataclysmbn/Cataclysm-BN/commit/5f32faa533ff749d0fab068959781192066a0e91) (fix: keep frozen ingredients fresh when crafting) on 2026-06-10 08:28:00

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27258708026/artifacts/7528960088)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27258708026/artifacts/7529902936)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27258708026/artifacts/7528986656)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27258708026/artifacts/7529493702)
<!-- END artifact comment -->