### PR TITLE
ci: warm platform build caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,17 @@ jobs:
         with:
           script: |
             core.exportVariable("ACTIONS_CACHE_URL", process.env.ACTIONS_CACHE_URL || "")
+            core.exportVariable("ACTIONS_RESULTS_URL", process.env.ACTIONS_RESULTS_URL || "")
             core.exportVariable("ACTIONS_RUNTIME_TOKEN", process.env.ACTIONS_RUNTIME_TOKEN || "")
+
+      - name: Configure vcpkg binary cache (windows msvc)
+        if: runner.os == 'Windows'
+        run: |
+          $mode = "readwrite"
+          if ("${{ github.event_name }}" -eq "pull_request") {
+            $mode = "read"
+          }
+          "VCPKG_BINARY_SOURCES=clear;x-gha,$mode" >> $env:GITHUB_ENV
 
       - name: Install vcpkg
         if: runner.os == 'Windows'
@@ -362,7 +372,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ${{ matrix.tiles && 'dist-tiles' || 'dist-curses' }}
-          configurePresetAdditionalArgs: "['-DCATA_FORMAT_TARGETS=OFF']"
+          configurePresetAdditionalArgs: ${{ inputs.run-tests && '["-DCATA_FORMAT_TARGETS=OFF", "-DTESTS=ON"]' || '["-DCATA_FORMAT_TARGETS=OFF"]' }}
           buildPreset: ${{ matrix.tiles && 'dist-tiles' || 'dist-curses' }}
 
       - name: Setup Deno (Lua docs)
@@ -530,7 +540,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ${{ matrix.preset }}
-          configurePresetAdditionalArgs: "['-DCATA_FORMAT_TARGETS=OFF']"
+          configurePresetAdditionalArgs: ${{ inputs.run-tests && '["-DCATA_FORMAT_TARGETS=OFF", "-DTESTS=ON"]' || '["-DCATA_FORMAT_TARGETS=OFF"]' }}
           buildPreset: ${{ matrix.preset }}
 
       - name: Rename distribution package (macOS)
@@ -544,6 +554,12 @@ jobs:
         with:
           java-version: "11"
           distribution: "adopt"
+          cache: gradle
+          cache-dependency-path: |
+            android/*.gradle.kts
+            android/**/*.gradle.kts
+            android/gradle.properties
+            android/gradle/wrapper/gradle-wrapper.properties
 
       - name: Setup Build and Dependencies (android)
         if: runner.os == 'Linux' && matrix.android != '' && matrix.android != 'none'
@@ -627,15 +643,99 @@ jobs:
             VERSION_ARG="-Poverride_version=${{ inputs.version-label }}"
           fi
 
+          gradle_retry() {
+            for attempt in 1 2 3; do
+              if ./gradlew "$@"; then
+                return 0
+              fi
+              if [ "$attempt" = 3 ]; then
+                return 1
+              fi
+              echo "::warning::Gradle attempt $attempt failed; retrying after 60 seconds"
+              sleep 60
+            done
+          }
+
           if [ ${{ matrix.android }} = arm64 ]
           then
-               ./gradlew -Pj=$(nproc) -Pabi_arm_32=false -Plocalize=${{ inputs.android-localize }} assemble${VARIANT}Release ${VERSION_ARG}
+               gradle_retry -Pj=$(nproc) -Pabi_arm_32=false -Plocalize=${{ inputs.android-localize }} assemble${VARIANT}Release ${VERSION_ARG}
                mv ./app/build/outputs/apk/${VARIANT_LOWER}/release/*.apk ../cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.apk
           elif [ ${{ matrix.android }} = bundle ]
           then
-               ./gradlew -Pj=$(nproc) -Plocalize=${{ inputs.android-localize }} bundle${VARIANT}Release ${VERSION_ARG}
+               gradle_retry -Pj=$(nproc) -Plocalize=${{ inputs.android-localize }} bundle${VARIANT}Release ${VERSION_ARG}
                mv ./app/build/outputs/bundle/${VARIANT_LOWER}Release/*.aab ../cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.aab
           fi
+
+      - name: Build test executable (desktop)
+        if: inputs.run-tests && (runner.os == 'Windows' || runner.os == 'macOS' || (runner.os == 'Linux' && (matrix.android == '' || matrix.android == 'none')))
+        shell: pwsh
+        run: |
+          $buildDir = if ($IsWindows) {
+            "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc"
+          } else {
+            "${{ github.workspace }}/build"
+          }
+          $target = if ("${{ matrix.tiles }}" -eq "true") { "cata_test-tiles" } else { "cata_test" }
+          cmake --build $buildDir --target $target --config Release
+
+      - name: Run tests (desktop)
+        if: inputs.run-tests && (runner.os == 'Windows' || (runner.os == 'Linux' && (matrix.android == '' || matrix.android == 'none')))
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $buildDir = if ($IsWindows) {
+            "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc"
+          } else {
+            "${{ github.workspace }}/build"
+          }
+          $exeName = if ("${{ matrix.tiles }}" -eq "true") { "cata_test-tiles" } else { "cata_test" }
+          if ($IsWindows) {
+            $exeName = "$exeName.exe"
+          }
+          $testBin = Join-Path $buildDir (Join-Path "tests" $exeName)
+          if (-not (Test-Path $testBin)) {
+            throw "Missing test executable: $testBin"
+          }
+
+          $testOpts = @(
+            "--min-duration", "20",
+            "--use-colour", "yes",
+            "--rng-seed", "time",
+            "--error-format=github-action"
+          )
+          if ($IsLinux) {
+            $testOpts += "--gpu-backend=software"
+          }
+          $filters = @("[slow] ~starting_items", "~[slow] ~[.],starting_items")
+          $jobs = @()
+          for ($i = 0; $i -lt $filters.Count; ++$i) {
+            $userDir = "test_user_dir_$($i + 1)"
+            $jobs += Start-Job -Name "cata-test-$($i + 1)" -ScriptBlock {
+              param($bin, $opts, $filter, $userDir)
+              & $bin @opts "--user-dir=$userDir" $filter
+              if ($LASTEXITCODE -ne 0) {
+                throw "Test shard '$filter' exited with code $LASTEXITCODE"
+              }
+            } -ArgumentList $testBin, $testOpts, $filters[$i], $userDir
+          }
+
+          while ($jobs | Where-Object { $_.State -eq "Running" }) {
+            Start-Sleep -Seconds 30
+            $running = ($jobs | Where-Object { $_.State -eq "Running" }).Name -join ", "
+            Write-Host "Still running: $running"
+          }
+
+          $failed = $false
+          foreach ($job in $jobs) {
+            Receive-Job $job -ErrorAction Continue
+            if ($job.State -ne "Completed") {
+              $failed = $true
+              Write-Host "$($job.Name) failed with state $($job.State)"
+            }
+          }
+          if ($failed) {
+            throw "One or more test shards failed"
+          }
 
       # Upload artifacts
       - name: Upload packaged build artifact
@@ -657,11 +757,6 @@ jobs:
           run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           head-sha: ${{ github.event.pull_request.head.sha }}
           token: ${{ github.token }}
-
-      - name: Run tests (windows msvc)
-        if: runner.os == 'Windows' && inputs.run-tests
-        run: |
-          & "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc/tests/cata_test-tiles.exe" --rng-seed time
 
       - name: Upload to release
         if: inputs.upload-to-release

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -265,6 +265,30 @@ jobs:
           path: build/tests/cata_test${{ matrix.tiles == 1 && '-tiles' || '' }}
           if-no-files-found: ignore
 
+  cache-warm-builds:
+    needs: skip-duplicates
+    if: ${{ github.event_name == 'push' && needs.skip-duplicates.outputs.should_skip_platform != 'true' }}
+    uses: ./.github/workflows/build.yml
+    with:
+      version-label: experimental
+      mode: ci
+      matrix-json: |
+        [
+          { "name": "Windows MSVC", "platform": "windows", "artifact": "windows-tiles-x64-msvc", "os": "windows-latest", "arch": "x64", "tiles": true, "sound": true, "ext": "zip", "content-type": "application/zip" },
+          { "name": "macOS Curses", "platform": "macos", "artifact": "osx-curses-x64", "os": "macos-15-intel", "preset": "osx-curses-x64-dist", "tiles": false, "sound": false, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
+          { "name": "macOS Tiles", "platform": "macos", "artifact": "osx-tiles-x64", "os": "macos-15-intel", "preset": "osx-tiles-x64-dist", "tiles": true, "sound": true, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
+          { "name": "macOS Curses ARM", "platform": "macos", "artifact": "osx-curses-arm", "os": "macos-15", "preset": "osx-curses-arm-dist", "tiles": false, "sound": false, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
+          { "name": "macOS Tiles ARM", "platform": "macos", "artifact": "osx-tiles-arm", "os": "macos-15", "preset": "osx-tiles-arm-dist", "tiles": true, "sound": true, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
+          { "name": "Android ARM64", "platform": "android", "artifact": "android-x64", "os": "ubuntu-latest", "android": "arm64", "tiles": true, "ext": "apk", "content-type": "application/apk" }
+        ]
+      download-translations: false
+      bundle-tilesets: false
+      package-artifacts: false
+      run-tests: true
+      android-localize: false
+      upload-artifacts: false
+    secrets: inherit
+
   builds:
     needs: skip-duplicates
     if: ${{ github.event_name != 'push' && needs.skip-duplicates.outputs.should_skip_platform != 'true' }}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -68,6 +68,7 @@ val abiX8632 = gradleProperty("abi_x86_32").toBoolean()
 val abiX8664 = gradleProperty("abi_x86_64").toBoolean()
 val deps = gradleProperty("deps")
 val shadercross = System.getenv("SHADERCROSS") ?: gradleProperty("shadercross").ifEmpty { "shadercross" }
+val ccache = System.getenv("CCACHE") ?: gradleProperty("ccache").ifEmpty { pathExecutable("ccache")?.absolutePath.orEmpty() }
 val overrideVersion = gradleProperty("override_version")
 val versionHeaderPath = gradleProperty("version_header_path")
 val overrideCompileSdkVersion = gradleProperty("override_compileSdkVersion").toInt()
@@ -81,6 +82,7 @@ println("Using [              njobs]: $njobs")
 println("Using [           localize]: $localize")
 println("Using [               deps]: $deps")
 println("Using [        shadercross]: $shadercross")
+println("Using [             ccache]: ${ccache.ifEmpty { "<disabled>" }}")
 println("Using [   override_version]: $overrideVersion")
 println("Using [version_header_path]: $versionHeaderPath")
 println("Using [  compileSdkVersion]: $overrideCompileSdkVersion")
@@ -242,11 +244,16 @@ fun BaseExtension.configureCommonAndroid() {
 
         externalNativeBuild {
             cmake {
-                arguments(
+                val cmakeArguments = mutableListOf(
                     "-DANDROID_PLATFORM=$overrideNdkBuildAppPlatform",
                     "-DANDROID_STL=c++_shared",
                     "-DCMAKE_BUILD_PARALLEL_LEVEL=$njobs",
                 )
+                if (ccache.isNotEmpty()) {
+                    cmakeArguments += "-DCMAKE_C_COMPILER_LAUNCHER=$ccache"
+                    cmakeArguments += "-DCMAKE_CXX_COMPILER_LAUNCHER=$ccache"
+                }
+                arguments(*cmakeArguments.toTypedArray())
             }
         }
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Purpose of change (The Why)

Windows/macOS/Android platform builds only ran on PRs, so PR ccache restores had no warm main cache. Windows vcpkg also used the default local binary cache and restored 0 packages.

## Describe the solution (The How)

- Add a main-push cache warm build for Windows, macOS, and Android platform jobs without artifact upload.
- Use GitHub Actions vcpkg binary caching for Windows MSVC dependencies.
- Configure Android Gradle and native CMake builds to use restored Gradle/ccache state.
- Build desktop test binaries in reusable Linux/macOS/Windows builds.
- Run Linux/Windows desktop tests in two parallel shards; macOS runners currently fail SDL_GPU test startup without a usable GPU backend.

## Testing

- `actionlint .github/workflows/build.yml .github/workflows/matrix.yml`
- `mise x java@11 -- ./gradlew help -Pabi_arm_32=false -Pabi_arm_64=true -Pabi_x86_32=false -Pabi_x86_64=false -Plocalize=false` from `android/`
- `git diff --check`

Reviewer check: after the first main run, Windows/macOS/Android PR jobs should restore `*-main` ccache entries, and Windows vcpkg should restore packages from `x-gha`.

## Checklist

- [x] I wrote the PR title in conventional commit format.
- [ ] I ran the code formatter.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [19ffcaa](https://github.com/cataclysmbn/Cataclysm-BN/commit/19ffcaaa040a978ca44f16d45a90703a2bdd780c) (ci: warm platform build caches) on 2026-06-10 15:14:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27281056294/artifacts/7537974447)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27281056294/artifacts/7539906266)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27281056294/artifacts/7538458166)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27281056294/artifacts/7538706828)
<!-- END artifact comment -->