### PR TITLE
perf: Improve initial tileset loading speed

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2231,6 +2231,7 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck,
     }
 #if defined(DYNAMIC_ATLAS)
     ts.tileset_atlas = std::make_unique<dynamic_atlas>( 4096, 4096, ts.tile_width, ts.tile_height );
+    ts.tileset_atlas->start_batch();
 #endif
     // Load tile information if available.
     offset = 0;
@@ -2310,6 +2311,7 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck,
 
     ts.tileset_id = tileset_id;
 #if defined(DYNAMIC_ATLAS)
+    ts.tileset_atlas->end_batch();
     ts.tileset_atlas->readback_load();
 #endif
 }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2326,9 +2326,7 @@ void debug()
         }
         case DEBUG_DUMP_TILES: {
 #if defined(TILES) && defined(DYNAMIC_ATLAS)
-            tilecontext->current_tileset()->texture_atlas()->readback_load();
             tilecontext->current_tileset()->texture_atlas()->readback_dump( PATH_INFO::config_dir() );
-            tilecontext->current_tileset()->texture_atlas()->readback_clear();
 #endif
             break;
         }

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -195,12 +195,17 @@ void dynamic_atlas::readback_load()
     const auto state = sdl_save_render_state( r.get() );
     for( auto &it : sheets ) {
         if( it.dirty ) {
-            auto tmpTex = CreateTexture( r, sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET, it.atlas_width,
-                                         it.atlas_height );
-            SDL_SetRenderTarget( r.get(), tmpTex.get() );
-            SDL_RenderTexture( r.get(), it.texture.get(), nullptr, nullptr );
+            SDL_Texture_Ptr tmpTex;
+            if (use_texture_streaming()) {
+                tmpTex = CreateTexture( r, sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET, it.atlas_width,
+                                             it.atlas_height );
+                SDL_SetRenderTarget( r.get(), tmpTex.get() );
+                SDL_RenderTexture( r.get(), it.texture.get(), nullptr, nullptr );
+            } else {
+                SDL_SetRenderTarget(  r.get(), it.texture.get() );
+            }
             // SDL3: SDL_RenderReadPixels returns a new surface owned by us.
-            it.readback.reset( SDL_RenderReadPixels( r.get(), nullptr ) );
+            it.surface.reset( SDL_RenderReadPixels( r.get(), nullptr ) );
             it.dirty = false;
         }
     }
@@ -210,8 +215,29 @@ void dynamic_atlas::readback_load()
 void dynamic_atlas::readback_clear()
 {
     for( auto &it : sheets ) {
-        it.readback.reset();
+        it.surface.reset();
         it.dirty = true;
+    }
+}
+
+void dynamic_atlas::start_batch() {
+    if ( is_batching )
+        return;
+
+    is_batching = true;
+    readback_load();
+}
+
+void dynamic_atlas::end_batch() {
+    if ( !is_batching )
+        return;
+
+    is_batching = false;
+    for (auto& s : sheets) {
+        if (s.dirty) {
+            s.dirty = false;
+            SDL_UpdateTexture(s.texture.get(), nullptr, s.surface->pixels, s.surface->pitch );
+        }
     }
 }
 
@@ -221,12 +247,18 @@ auto dynamic_atlas::readback_find( const texture &tex ) -> std::tuple<bool, SDL_
         return s.texture == tex.sdl_texture_ptr;
     } );
 
-    return ( it == sheets.end() )
-           ? std::make_tuple( false, nullptr, SDL_Rect{} )
-    : std::make_tuple( true, it->readback.get(), SDL_Rect{
-        static_cast<int>( tex.srcrect.x ), static_cast<int>( tex.srcrect.y ),
-        static_cast<int>( tex.srcrect.w ), static_cast<int>( tex.srcrect.h )
-    } );
+    if (it == sheets.end()) {
+        return std::make_tuple(false, nullptr, SDL_Rect{});
+    }
+
+    SDL_Rect rect(
+        static_cast<int>(tex.srcrect.x), //
+        static_cast<int>(tex.srcrect.y), //
+        static_cast<int>(tex.srcrect.w), //
+        static_cast<int>(tex.srcrect.h)  //
+    );
+
+    return std::make_tuple( true, it->surface.get(), rect);
 }
 
 auto dynamic_atlas::get_or_create_sprite(
@@ -252,6 +284,22 @@ auto dynamic_atlas::create_sprite(
         debugmsg( "Duplicate sprite ID in atlas: %x", id.value() );
     }
     auto& [tex, dstRect] = atl_tex;
+
+    if (is_batching) {
+        const auto it = std::ranges::find_if( sheets, [&]( const sprite_sheet & s ) {
+            return s.texture == tex;
+        });
+        if ( it == sheets.end() ) {
+            debugmsg( "Failed to find dynamic atlas surface" );
+        }
+        const auto surf = it->surface.get();
+        if ( surf == nullptr ) {
+            debugmsg( "Dynamic atlas surface missing" );
+        } else {
+            blitFn( surf, &dstRect );
+        }
+        return atl_tex;
+    }
 
     const auto tmpRect = SDL_Rect( 0, 0, w, h );
     if( use_texture_streaming() ) {
@@ -338,13 +386,14 @@ atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h 
     SDL_SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
     SDL_SetTextureScaleMode( tex, SDL_SCALEMODE_NEAREST );
 
+    auto surface = is_batching ? CreateSurface(sdl_color_pixel_format, tex_width, tex_height) : nullptr;
     auto s = sprite_sheet{
-        SDL_Texture_Ptr( tex ),
-        std::move( packer ),
-        tex_width,
-        tex_height,
-        nullptr,
-        true
+        .texture = SDL_Texture_Ptr( tex ),
+        .surface = std::move( surface ),
+        .packer = std::move( packer ),
+        .atlas_width = tex_width,
+        .atlas_height = tex_height,
+        .dirty = true
     };
     const auto &entry = sheets.emplace_back( std::move( s ) );
 
@@ -353,14 +402,16 @@ atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h 
     return get_texture( entry.texture, rect.value(), w, h );
 }
 
-void dynamic_atlas::readback_dump( const std::string &s ) const
+void dynamic_atlas::readback_dump( const std::string &s )
 {
+    readback_load();
     int i = 0;
     for( auto &q : sheets ) {
         auto name = std::format( "{}/tile_dump_{}.png", s, i++ );
         // TODO: fix windows saving images with swapped red/blue channels (it seems to want ARGB not ABGR)
-        IMG_SavePNG( q.readback.get(), name.c_str() );
+        IMG_SavePNG( q.surface.get(), name.c_str() );
     }
+    readback_clear();
 }
 
 

--- a/src/dynamic_atlas.cpp
+++ b/src/dynamic_atlas.cpp
@@ -196,13 +196,13 @@ void dynamic_atlas::readback_load()
     for( auto &it : sheets ) {
         if( it.dirty ) {
             SDL_Texture_Ptr tmpTex;
-            if (use_texture_streaming()) {
+            if( use_texture_streaming() ) {
                 tmpTex = CreateTexture( r, sdl_color_pixel_format, SDL_TEXTUREACCESS_TARGET, it.atlas_width,
-                                             it.atlas_height );
+                                        it.atlas_height );
                 SDL_SetRenderTarget( r.get(), tmpTex.get() );
                 SDL_RenderTexture( r.get(), it.texture.get(), nullptr, nullptr );
             } else {
-                SDL_SetRenderTarget(  r.get(), it.texture.get() );
+                SDL_SetRenderTarget( r.get(), it.texture.get() );
             }
             // SDL3: SDL_RenderReadPixels returns a new surface owned by us.
             it.surface.reset( SDL_RenderReadPixels( r.get(), nullptr ) );
@@ -220,23 +220,27 @@ void dynamic_atlas::readback_clear()
     }
 }
 
-void dynamic_atlas::start_batch() {
-    if ( is_batching )
+void dynamic_atlas::start_batch()
+{
+    if( is_batching ) {
         return;
+    }
 
     is_batching = true;
     readback_load();
 }
 
-void dynamic_atlas::end_batch() {
-    if ( !is_batching )
+void dynamic_atlas::end_batch()
+{
+    if( !is_batching ) {
         return;
+    }
 
     is_batching = false;
-    for (auto& s : sheets) {
-        if (s.dirty) {
+    for( auto &s : sheets ) {
+        if( s.dirty ) {
             s.dirty = false;
-            SDL_UpdateTexture(s.texture.get(), nullptr, s.surface->pixels, s.surface->pitch );
+            SDL_UpdateTexture( s.texture.get(), nullptr, s.surface->pixels, s.surface->pitch );
         }
     }
 }
@@ -247,18 +251,18 @@ auto dynamic_atlas::readback_find( const texture &tex ) -> std::tuple<bool, SDL_
         return s.texture == tex.sdl_texture_ptr;
     } );
 
-    if (it == sheets.end()) {
-        return std::make_tuple(false, nullptr, SDL_Rect{});
+    if( it == sheets.end() ) {
+        return std::make_tuple( false, nullptr, SDL_Rect{} );
     }
 
     SDL_Rect rect(
-        static_cast<int>(tex.srcrect.x), //
-        static_cast<int>(tex.srcrect.y), //
-        static_cast<int>(tex.srcrect.w), //
-        static_cast<int>(tex.srcrect.h)  //
+        static_cast<int>( tex.srcrect.x ), //
+        static_cast<int>( tex.srcrect.y ), //
+        static_cast<int>( tex.srcrect.w ), //
+        static_cast<int>( tex.srcrect.h ) //
     );
 
-    return std::make_tuple( true, it->surface.get(), rect);
+    return std::make_tuple( true, it->surface.get(), rect );
 }
 
 auto dynamic_atlas::get_or_create_sprite(
@@ -285,15 +289,15 @@ auto dynamic_atlas::create_sprite(
     }
     auto& [tex, dstRect] = atl_tex;
 
-    if (is_batching) {
+    if( is_batching ) {
         const auto it = std::ranges::find_if( sheets, [&]( const sprite_sheet & s ) {
             return s.texture == tex;
-        });
-        if ( it == sheets.end() ) {
+        } );
+        if( it == sheets.end() ) {
             debugmsg( "Failed to find dynamic atlas surface" );
         }
         const auto surf = it->surface.get();
-        if ( surf == nullptr ) {
+        if( surf == nullptr ) {
             debugmsg( "Dynamic atlas surface missing" );
         } else {
             blitFn( surf, &dstRect );
@@ -386,7 +390,8 @@ atlas_texture dynamic_atlas::allocate_sprite_internal( const int w, const int h 
     SDL_SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
     SDL_SetTextureScaleMode( tex, SDL_SCALEMODE_NEAREST );
 
-    auto surface = is_batching ? CreateSurface(sdl_color_pixel_format, tex_width, tex_height) : nullptr;
+    auto surface = is_batching ? CreateSurface( sdl_color_pixel_format, tex_width,
+                   tex_height ) : nullptr;
     auto s = sprite_sheet{
         .texture = SDL_Texture_Ptr( tex ),
         .surface = std::move( surface ),

--- a/src/dynamic_atlas.h
+++ b/src/dynamic_atlas.h
@@ -42,9 +42,11 @@ class dynamic_atlas
         using sprite_callback = std::function<void( SDL_Surface *, const SDL_Rect * )>;
 
         dynamic_atlas()
-            : max_atlas_width( 0 ), max_atlas_height( 0 ), hint_sprite_width( 0 ), hint_sprite_height( 0 ), is_batching( false ) {}
+            : max_atlas_width( 0 ), max_atlas_height( 0 ), hint_sprite_width( 0 ),
+              hint_sprite_height( 0 ), is_batching( false ) {}
         dynamic_atlas( const int w, const int h, const int sw = 0, const int sh = 0 )
-            : max_atlas_width( w ), max_atlas_height( h ), hint_sprite_width( sw ), hint_sprite_height( sh ), is_batching( false ) {}
+            : max_atlas_width( w ), max_atlas_height( h ), hint_sprite_width( sw ),
+              hint_sprite_height( sh ), is_batching( false ) {}
 
         auto find_sprite( size_t id ) -> std::optional<atlas_texture>;
         auto create_sprite( int w, int h, const std::optional<size_t> &id,

--- a/src/dynamic_atlas.h
+++ b/src/dynamic_atlas.h
@@ -42,9 +42,9 @@ class dynamic_atlas
         using sprite_callback = std::function<void( SDL_Surface *, const SDL_Rect * )>;
 
         dynamic_atlas()
-            : max_atlas_width( 0 ), max_atlas_height( 0 ), hint_sprite_width( 0 ), hint_sprite_height( 0 ) {}
+            : max_atlas_width( 0 ), max_atlas_height( 0 ), hint_sprite_width( 0 ), hint_sprite_height( 0 ), is_batching( false ) {}
         dynamic_atlas( const int w, const int h, const int sw = 0, const int sh = 0 )
-            : max_atlas_width( w ), max_atlas_height( h ), hint_sprite_width( sw ), hint_sprite_height( sh ) {}
+            : max_atlas_width( w ), max_atlas_height( h ), hint_sprite_width( sw ), hint_sprite_height( sh ), is_batching( false ) {}
 
         auto find_sprite( size_t id ) -> std::optional<atlas_texture>;
         auto create_sprite( int w, int h, const std::optional<size_t> &id,

--- a/src/dynamic_atlas.h
+++ b/src/dynamic_atlas.h
@@ -33,10 +33,10 @@ class dynamic_atlas
     public:
         struct sprite_sheet {
             SDL_Texture_SharedPtr texture;
+            SDL_Surface_Ptr surface;
             std::unique_ptr<detail::texture_packer> packer;
             int atlas_width;
             int atlas_height;
-            SDL_Surface_Ptr readback;
             bool dirty;
         };
         using sprite_callback = std::function<void( SDL_Surface *, const SDL_Rect * )>;
@@ -55,8 +55,11 @@ class dynamic_atlas
 
         void readback_load();
         auto readback_find( const texture &tex ) -> std::tuple<bool, SDL_Surface *, SDL_Rect>;
-        void readback_dump( const std::string &s ) const;
+        void readback_dump( const std::string &s );
         void readback_clear();
+
+        void start_batch();
+        void end_batch();
 
         auto get_staging_area( int width,
                                int height ) -> std::tuple<SDL_Texture *, SDL_Surface *, SDL_Rect>;
@@ -84,6 +87,7 @@ class dynamic_atlas
         int max_atlas_height;
         int hint_sprite_width;
         int hint_sprite_height;
+        bool is_batching;
 };
 
 #endif


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Initial texture loading speed can be improved.

Related:
* #9343
* #9386 

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Batch all initial texture atlas sprite creation on CPU, then upload them all at once.

After the initial loading, behavior reverts back to either texture-streaming or render-target for dynamically generated tiles.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

N/A

## Testing

* Load Save
* Tileset part of loading is fast

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Also makes Texture-Streaming `disabled` with `gpu` backend not explode your RAM, since there's only a handful of GPU uploads in the loading loop.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c15663c](https://github.com/cataclysmbn/Cataclysm-BN/commit/c15663cc9e686bae63834532bae78ece908df247) (style(autofix.ci): automated formatting) on 2026-06-10 13:02:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27273649473/artifacts/7534815977)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27273649473/artifacts/7535772389)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27273649473)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27273649473/artifacts/7535313144)
<!-- END artifact comment -->