### PR TITLE
chore: add preset-free formatting commands

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -60,11 +60,8 @@ jobs:
           path: ${{ env.DENO_DIR }}
           key: deno-${{ hashFiles('deno.lock') }}
 
-      - name: configure cmake for formatting
-        run: cmake --preset lint
-
       - name: format C++ files
-        run: cmake --build build --target format
+        run: build-scripts/format-cpp.sh
 
       - name: format Markdown and TypeScript files
         run: deno fmt
@@ -73,7 +70,7 @@ jobs:
         run: deno task dprint fmt
 
       - name: format JSON
-        run: cmake --build build --target style-json-parallel
+        run: build-scripts/format-json.sh
 
       # autofix.ci cannot edit .github directory due to security reasons
       - name: unstage .github

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -197,7 +197,8 @@ jobs:
       - name: run JSON formatting check (test-stage only)
         if: ${{ env.SKIP == 'false' && env.TEST_STAGE == '1' }}
         run: |
-          cmake --build build --target style-json-parallel
+          build-scripts/format-json.sh
+          git diff --exit-code -- '*.json'
           tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*/*/*
 
       - name: create Linux tiles playtest package

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: fmt
+        name: Format staged files
+        entry: build-scripts/fmt.sh
+        language: system
+        files: \.(cpp|h|hpp|json|lua|md|ts)$
+        pass_filenames: false
+        stages: [pre-commit]

--- a/build-scripts/fmt.sh
+++ b/build-scripts/fmt.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+usage() {
+    cat >&2 <<'USAGE'
+usage: build-scripts/fmt.sh [--all|cpp [files...]|json [files...]|docs|lua]
+USAGE
+}
+
+mode=staged
+case "${1:-}" in
+    "")
+        ;;
+    --all)
+        mode=all
+        shift
+        ;;
+    cpp|json|docs|lua)
+        mode="$1"
+        shift
+        ;;
+    *)
+        usage
+        exit 2
+        ;;
+esac
+
+if (( $# > 0 )) && [[ "$mode" != cpp && "$mode" != json ]]; then
+    usage
+    exit 2
+fi
+
+if [[ "$mode" == cpp ]]; then
+    build-scripts/format-cpp.sh "$@"
+    exit 0
+fi
+
+if [[ "$mode" == json ]]; then
+    build-scripts/format-json.sh "$@"
+    exit 0
+fi
+
+if [[ "$mode" == docs ]]; then
+    deno fmt
+    exit 0
+fi
+
+if [[ "$mode" == lua ]]; then
+    deno task dprint fmt
+    exit 0
+fi
+
+cpp_files=()
+json_files=()
+stage_files=()
+
+append_stage_file() {
+    local file="$1"
+    for staged in "${stage_files[@]}"; do
+        if [[ "$staged" == "$file" ]]; then
+            return
+        fi
+    done
+    stage_files+=( "$file" )
+}
+
+if [[ "$mode" == staged ]]; then
+    while IFS= read -r -d '' file; do
+        file="${file#./}"
+        if [[ ! -f "$file" ]]; then
+            continue
+        fi
+
+        case "$file" in
+            *.cpp|*.h|*.hpp)
+                cpp_files+=( "$file" )
+                append_stage_file "$file"
+                ;;
+            *.json)
+                if [[ "$file" != data/names/* ]]; then
+                    json_files+=( "$file" )
+                    append_stage_file "$file"
+                fi
+                ;;
+            *.md|*.ts|*.lua)
+                append_stage_file "$file"
+                ;;
+        esac
+    done < <(git diff --cached --name-only --diff-filter=ACMR -z)
+fi
+
+deno fmt
+deno task dprint fmt
+
+if [[ "$mode" == all ]]; then
+    build-scripts/format-cpp.sh
+    build-scripts/format-json.sh
+else
+    if (( ${#cpp_files[@]} > 0 )); then
+        build-scripts/format-cpp.sh "${cpp_files[@]}"
+    fi
+    if (( ${#json_files[@]} > 0 )); then
+        build-scripts/format-json.sh "${json_files[@]}"
+    fi
+    if (( ${#stage_files[@]} > 0 )); then
+        git add -- "${stage_files[@]}"
+    fi
+fi

--- a/build-scripts/format-all.sh
+++ b/build-scripts/format-all.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+build-scripts/fmt.sh --all

--- a/build-scripts/format-cpp.sh
+++ b/build-scripts/format-cpp.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+clang_format_sources=()
+astyle_sources=()
+
+append_clang_format_source() {
+    local file="${1#"$repo_root/"}"
+    file="${file#./}"
+    if [[ -f "$file" && "$file" == src/*/* && "$file" != src/lua/* && "$file" != src/sol/* && "$file" != src/third-party/* ]]; then
+        case "$file" in
+            *.cpp|*.h|*.hpp)
+                clang_format_sources+=( "$file" )
+                ;;
+        esac
+    fi
+}
+
+append_astyle_source() {
+    local file="${1#"$repo_root/"}"
+    file="${file#./}"
+    if [[ ! -f "$file" ]]; then
+        return
+    fi
+
+    case "$file" in
+        tests/iteminfo_test.cpp|tests/json_test.cpp)
+            return
+            ;;
+    esac
+
+    if [[ "$file" =~ ^src/[^/]+\.(cpp|h)$ || "$file" =~ ^tests/.+\.(cpp|h)$ || "$file" =~ ^tools/(format|clang-tidy-plugin)/.+\.(cpp|h)$ ]]; then
+        astyle_sources+=( "$file" )
+    fi
+}
+
+if (( $# > 0 )); then
+    for file in "$@"; do
+        append_clang_format_source "$file"
+        append_astyle_source "$file"
+    done
+else
+    while IFS= read -r -d '' file; do
+        append_clang_format_source "$file"
+    done < <(
+        find src -mindepth 2 \
+            \( -path 'src/lua/*' -o -path 'src/sol/*' -o -path 'src/third-party/*' \) -prune -o \
+            -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) -print0
+    )
+
+    while IFS= read -r -d '' file; do
+        append_astyle_source "$file"
+    done < <(find src -maxdepth 1 -type f \( -name '*.cpp' -o -name '*.h' \) -print0)
+
+    while IFS= read -r -d '' file; do
+        append_astyle_source "$file"
+    done < <(find tests tools/format tools/clang-tidy-plugin -type f \( -name '*.cpp' -o -name '*.h' \) -print0)
+fi
+
+if (( ${#clang_format_sources[@]} > 0 )); then
+    if ! command -v clang-format >/dev/null 2>&1; then
+        echo "error: clang-format executable was not found" >&2
+        exit 1
+    fi
+    clang-format -i "${clang_format_sources[@]}"
+elif (( $# == 0 )); then
+    echo "warning: no subdirectory C++ files available for clang-format" >&2
+fi
+
+if (( ${#astyle_sources[@]} > 0 )); then
+    if ! command -v astyle >/dev/null 2>&1; then
+        echo "error: Artistic Style executable was not found" >&2
+        exit 1
+    fi
+    astyle --options=.astylerc -n "${astyle_sources[@]}"
+elif (( $# == 0 )); then
+    echo "warning: no top-level C++ files available for astyle" >&2
+fi
+
+if (( ${#clang_format_sources[@]} == 0 && ${#astyle_sources[@]} == 0 && $# > 0 )); then
+    echo "warning: no supported C++ files were provided" >&2
+fi

--- a/build-scripts/format-json.sh
+++ b/build-scripts/format-json.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+json_files=()
+if (( $# > 0 )); then
+    for file in "$@"; do
+        file="${file#"$repo_root/"}"
+        file="${file#./}"
+        if [[ -f "$file" && "$file" == *.json && "$file" != data/names/* ]]; then
+            json_files+=( "$file" )
+        fi
+    done
+else
+    while IFS= read -r -d '' file; do
+        json_files+=( "$file" )
+    done < <(find data -name '*.json' -type f -not -path 'data/names/*' -print0)
+fi
+
+if (( ${#json_files[@]} == 0 )); then
+    exit 0
+fi
+
+build_dir="${CATA_JSON_FORMAT_BUILD_DIR:-out/build/json-format}"
+json_formatter="$build_dir/tools/format/json_formatter"
+
+jobs="${CMAKE_BUILD_PARALLEL_LEVEL:-}"
+if [[ -z "$jobs" ]]; then
+    jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
+fi
+
+cmake_args=(
+    -S .
+    -B "$build_dir"
+    -DCMAKE_BUILD_TYPE=Release
+    -DJSON_FORMAT=ON
+    -DCATA_FORMAT_TARGETS=OFF
+    -DTESTS=OFF
+    -DTILES=OFF
+    -DCURSES=OFF
+    -DSOUND=OFF
+    -DLANGUAGES=none
+    -DLUA_DOCS_ON_BUILD=OFF
+)
+
+if [[ -n "${CMAKE_GENERATOR:-}" ]]; then
+    cmake_args+=( -G "$CMAKE_GENERATOR" )
+elif command -v ninja >/dev/null 2>&1; then
+    cmake_args+=( -G Ninja )
+fi
+
+cmake "${cmake_args[@]}"
+cmake --build "$build_dir" --target json_formatter --parallel "$jobs"
+
+json_status=0
+for file in "${json_files[@]}"; do
+    file_status=0
+    "$json_formatter" "$file" || file_status=$?
+    if (( file_status != 0 && file_status != 1 )); then
+        json_status="$file_status"
+    fi
+done
+
+exit "$json_status"

--- a/build-scripts/format-staged.sh
+++ b/build-scripts/format-staged.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+build-scripts/fmt.sh

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -49,10 +49,6 @@ if [ -n "$COMPILER" ]; then
     cmake_args+=( -DCMAKE_CXX_COMPILER="$COMPILER" )
 fi
 
-if [ -n "$TEST_STAGE" ]; then
-    cmake_args+=( -DJSON_FORMAT=ON )
-fi
-
 if [ "$OS" = "macos-14" ]; then
     cmake_args+=( -DCMAKE_OSX_DEPLOYMENT_TARGET=14 )
 fi
@@ -62,7 +58,8 @@ cmake "${cmake_args[@]}"
 if [ -n "$TEST_STAGE" ]
 then
     build-scripts/lint-json.sh
-    cmake --build build --target style-json-parallel --parallel "$num_jobs"
+    CMAKE_BUILD_PARALLEL_LEVEL="$num_jobs" build-scripts/format-json.sh
+    git diff --exit-code -- '*.json'
     tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*/*/*
 fi
 

--- a/build-scripts/lint-all.sh
+++ b/build-scripts/lint-all.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+build-scripts/lint-json.sh
+tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*/*/*

--- a/docs/en/dev/guides/formatting.md
+++ b/docs/en/dev/guides/formatting.md
@@ -6,13 +6,14 @@ This guide explains how to format and lint code in Cataclysm: Bright Nights.
 
 ## Quick Reference
 
-| File Type       | Tool                | Command                                            |
-| --------------- | ------------------- | -------------------------------------------------- |
-| C++ (`.cpp/.h`) | astyle/clang-format | `cmake --build build --target format`              |
-| JSON            | json_formatter      | `cmake --build build --target style-json-parallel` |
-| Markdown        | deno fmt            | `deno fmt`                                         |
-| TypeScript      | deno fmt            | `deno fmt`                                         |
-| Lua             | dprint              | `deno task dprint fmt`                             |
+| Scope           | Tool                | Command          |
+| --------------- | ------------------- | ---------------- |
+| Staged files    | all formatters      | `just fmt`       |
+| All files       | all formatters      | `just fmt --all` |
+| C++ (`.cpp/.h`) | astyle/clang-format | `just fmt-cpp`   |
+| JSON            | json_formatter      | `just fmt-json`  |
+| Markdown/TS     | deno fmt            | `just fmt-docs`  |
+| Lua             | dprint              | `just fmt-lua`   |
 
 ## Automated Formatting
 
@@ -40,14 +41,12 @@ sudo dnf install astyle clang-tools-extra
 brew install astyle clang-format
 ```
 
-### Using CMake
+### Using the script
 
 ```sh
-# Configure (only needed once, or use an existing build)
-cmake --preset lint
-
-# Format all C++ files
-cmake --build build --target format
+just fmt-cpp
+# or
+build-scripts/format-cpp.sh
 ```
 
 The style configurations are in `.astylerc` and `.clang-format` at the repository root.
@@ -56,18 +55,17 @@ The style configurations are in `.astylerc` and `.clang-format` at the repositor
 
 JSON files are formatted with `json_formatter`, a custom tool built from the project source.
 
-### Using CMake
+### Using the script
 
 ```sh
-# Configure (only needed once, or use an existing build)
-cmake --preset lint
-
-# Format all JSON files in parallel
-cmake --build build --target style-json-parallel
-
-# Format all JSON files sequentially (slower, but useful for debugging)
-cmake --build build --target style-json
+just fmt-json
+# or
+build-scripts/format-json.sh
 ```
+
+The script builds `json_formatter` in `out/build/json-format` and formats JSON files. It does not
+require a configured game build or a CMake preset. Override the helper build directory with
+`CATA_JSON_FORMAT_BUILD_DIR` if needed.
 
 > [!NOTE]
 > The `data/names/` directory is excluded from formatting because name files have special formatting
@@ -114,17 +112,32 @@ tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*
 
 ## Pre-commit Workflow
 
-Before committing, run these checks:
+Install the optional pre-commit hook with [`prek`](https://github.com/j178/prek):
 
 ```sh
-# Configure once (creates build directory with formatting tools)
-cmake --preset lint
+prek install
+# or
+just hooks-setup
+```
 
-# Format all code
-cmake --build build --target format           # C++
-cmake --build build --target style-json-parallel  # JSON
-deno fmt                                       # Markdown/TypeScript
-deno task dprint fmt                           # Lua
+When you commit, the hook runs `just fmt`: Deno and dprint run normally, while C++ and JSON formatters
+run only on staged created/updated files. Formatted staged files are re-added so the commit includes
+the formatted result.
+
+To run the same formatting manually against staged files:
+
+```sh
+just fmt
+```
+
+Before committing without the hook, run these checks:
+
+```sh
+# Format staged files
+just fmt
+
+# Format all formattable files
+just fmt --all
 ```
 
 ## CI Integration
@@ -132,7 +145,7 @@ deno task dprint fmt                           # Lua
 The CI pipeline runs these checks automatically:
 
 1. **JSON syntax validation** - `build-scripts/lint-json.sh`
-2. **JSON formatting** - `cmake --build build --target style-json-parallel`
+2. **JSON formatting** - `build-scripts/format-json.sh`
 3. **Dialogue validation** - `tools/dialogue_validator.py`
 
 If any check fails, the build will fail. Use the commands above to fix issues locally before
@@ -191,16 +204,15 @@ autocmd BufWritePre *.md,*.ts !deno fmt %
 
 ## Troubleshooting
 
-### "json_formatter not found" or "style-json-parallel target not found"
+### "json_formatter not found"
 
-Make sure you configured CMake with the `lint` preset or with `-DJSON_FORMAT=ON`:
+Run the JSON formatter script. It configures and builds the formatter helper automatically:
 
 ```sh
-cmake --preset lint
-cmake --build build --target json_formatter
+build-scripts/format-json.sh
 ```
 
-### "format target not found"
+### C++ formatter not found
 
 Make sure `astyle` and `clang-format` are installed and in your PATH:
 
@@ -213,10 +225,10 @@ which clang-format
 sudo apt install astyle clang-format
 ```
 
-Then reconfigure CMake:
+Then rerun:
 
 ```sh
-cmake --preset lint
+build-scripts/format-cpp.sh
 ```
 
 ### C++ formatters produce different results

--- a/docs/ja/dev/guides/formatting.md
+++ b/docs/ja/dev/guides/formatting.md
@@ -6,13 +6,14 @@ title: Formatting & Linting
 
 ## クイックリファレンス
 
-| ファイル形式    | ツール              | コマンド                                           |
-| --------------- | ------------------- | -------------------------------------------------- |
-| C++ (`.cpp/.h`) | astyle/clang-format | `cmake --build build --target format`              |
-| JSON            | json_formatter      | `cmake --build build --target style-json-parallel` |
-| Markdown        | deno fmt            | `deno fmt`                                         |
-| TypeScript      | deno fmt            | `deno fmt`                                         |
-| Lua             | dprint              | `deno task dprint fmt`                             |
+| 対象             | ツール               | コマンド         |
+| ---------------- | -------------------- | ---------------- |
+| staged ファイル  | すべてのフォーマッタ | `just fmt`       |
+| すべてのファイル | すべてのフォーマッタ | `just fmt --all` |
+| C++ (`.cpp/.h`)  | astyle/clang-format  | `just fmt-cpp`   |
+| JSON             | json_formatter       | `just fmt-json`  |
+| Markdown/TS      | deno fmt             | `just fmt-docs`  |
+| Lua              | dprint               | `just fmt-lua`   |
 
 ## 自動フォーマット
 
@@ -39,14 +40,12 @@ sudo dnf install astyle clang-tools-extra
 brew install astyle clang-format
 ```
 
-### CMake を使用する場合
+### スクリプトを使用する場合
 
 ```sh
-# 設定(一度だけ実行、または既存のビルドを使用)
-cmake --preset lint
-
-# すべてのC++ファイルをフォーマット
-cmake --build build --target format
+just fmt-cpp
+# または
+build-scripts/format-cpp.sh
 ```
 
 スタイルの設定は、リポジトリのルートにある `.astylerc` と `.clang-format` に記述されています。
@@ -55,18 +54,15 @@ cmake --build build --target format
 
 JSONファイルは、プロジェクトのソースからビルドされたカスタムツール `json_formatter`を使用してフォーマットします。
 
-### CMake を使用する場合
+### スクリプトを使用する場合
 
 ```sh
-# 設定(一度だけ実行、または既存のビルドを使用)
-cmake --preset lint
-
-# すべてのJSONファイルを並列でフォーマット
-cmake --build build --target style-json-parallel
-
-# すべてのJSONファイルを順次フォーマット (低速ですがデバッグに便利です)
-cmake --build build --target style-json
+just fmt-json
+# または
+build-scripts/format-json.sh
 ```
+
+このスクリプトは `out/build/json-format` に `json_formatter` をビルドし、JSONファイルをフォーマットします。設定済みのゲームビルドや CMake プリセットは不要です。必要に応じて `CATA_JSON_FORMAT_BUILD_DIR` で補助ビルドディレクトリを変更できます。
 
 > [!NOTE]
 > `data/names/` ディレクトリは、名前ファイルに特殊なフォーマット要件があるた
@@ -113,17 +109,30 @@ tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*
 
 ## コミット前のワークフロー
 
-コミットする前に、以下のチェックを実行してください:
+[`prek`](https://github.com/j178/prek) を使った任意の pre-commit フックをインストールできます:
 
 ```sh
-# 設定の実行 (フォーマットツールを含むビルドディレクトリを作成)
-cmake --preset lint
+prek install
+# または
+just hooks-setup
+```
 
-# すべてのコードをフォーマット
-cmake --build build --target format           # C++
-cmake --build build --target style-json-parallel  # JSON
-deno fmt                                       # Markdown/TypeScript
-deno task dprint fmt                           # Lua
+コミット時、フックは `just fmt` を実行します。Deno と dprint は通常どおり実行され、C++ と JSON のフォーマッタは staged の作成/更新ファイルだけを処理します。フォーマットされた staged ファイルは、同じコミットに含まれるよう再度 `git add` されます。
+
+同じフォーマットを staged ファイルに対して手動で実行するには:
+
+```sh
+just fmt
+```
+
+フックを使わずにコミットする前に実行するコマンド:
+
+```sh
+# staged ファイルをフォーマット
+just fmt
+
+# フォーマット可能なすべてのファイルをフォーマット
+just fmt --all
 ```
 
 ## CI 連携
@@ -131,7 +140,7 @@ deno task dprint fmt                           # Lua
 CI パイプラインでは、以下のチェックが自動的に実行されます:
 
 1. **JSON 構文の検証** - `build-scripts/lint-json.sh`
-2. **JSON フォーマット** - `cmake --build build --target style-json-parallel`
+2. **JSON フォーマット** - `build-scripts/format-json.sh`
 3. **ダイアログのバリデーション** - `tools/dialogue_validator.py`
 
 いずれかのチェックに失敗すると、ビルドは失敗します。プッシュする前に、上記のコマンドを使用してローカルで問題を修正してください。
@@ -189,16 +198,15 @@ autocmd BufWritePre *.md,*.ts !deno fmt %
 
 ## トラブルシューティング
 
-### "json_formatter not found" または "style-json-parallel target not found"
+### "json_formatter not found"
 
-CMakeの設定を `lint` プリセット、または `-DJSON_FORMAT=ON`を指定して行っているか確認してください:
+JSON フォーマッタのスクリプトを実行してください。補助フォーマッタを自動的に設定してビルドします:
 
 ```sh
-cmake --preset lint
-cmake --build build --target json_formatter
+build-scripts/format-json.sh
 ```
 
-### "format target not found"
+### C++ フォーマッタが見つからない
 
 `astyle` と `clang-format` がインストールされており、PATH が通っているか確認してください:
 
@@ -211,10 +219,10 @@ which clang-format
 sudo apt install astyle clang-format
 ```
 
-その後、CMake を再構成します:
+その後、再実行してください:
 
 ```sh
-cmake --preset lint
+build-scripts/format-cpp.sh
 ```
 
 ### C++ フォーマッタの実行結果が異なる

--- a/docs/ko/dev/guides/formatting.md
+++ b/docs/ko/dev/guides/formatting.md
@@ -6,13 +6,14 @@ Cataclysm: Bright Nights에서 코드를 포맷하고 린트하는 방법을 설
 
 ## 빠른 참조
 
-| 파일 타입       | 도구                | 명령어                                             |
-| --------------- | ------------------- | -------------------------------------------------- |
-| C++ (`.cpp/.h`) | astyle/clang-format | `cmake --build build --target format`              |
-| JSON            | json_formatter      | `cmake --build build --target style-json-parallel` |
-| Markdown        | deno fmt            | `deno fmt`                                         |
-| TypeScript      | deno fmt            | `deno fmt`                                         |
-| Lua             | dprint              | `deno task dprint fmt`                             |
+| 범위            | 도구                | 명령어           |
+| --------------- | ------------------- | ---------------- |
+| staged 파일     | 모든 포매터         | `just fmt`       |
+| 모든 파일       | 모든 포매터         | `just fmt --all` |
+| C++ (`.cpp/.h`) | astyle/clang-format | `just fmt-cpp`   |
+| JSON            | json_formatter      | `just fmt-json`  |
+| Markdown/TS     | deno fmt            | `just fmt-docs`  |
+| Lua             | dprint              | `just fmt-lua`   |
 
 ## 자동 포매팅
 
@@ -39,14 +40,12 @@ sudo dnf install astyle clang-tools-extra
 brew install astyle clang-format
 ```
 
-### CMake 사용
+### 스크립트 사용
 
 ```sh
-# 구성 (한 번만 필요하거나 기존 빌드 사용)
-cmake --preset lint
-
-# 모든 C++ 파일 포맷
-cmake --build build --target format
+just fmt-cpp
+# 또는
+build-scripts/format-cpp.sh
 ```
 
 스타일 설정은 저장소 루트의 `.astylerc`와 `.clang-format`에 있습니다.
@@ -55,18 +54,15 @@ cmake --build build --target format
 
 JSON 파일은 프로젝트 소스에서 빌드된 커스텀 도구 `json_formatter`로 포맷됩니다.
 
-### CMake 사용
+### 스크립트 사용
 
 ```sh
-# 구성 (한 번만 필요하거나 기존 빌드 사용)
-cmake --preset lint
-
-# 모든 JSON 파일을 병렬로 포맷
-cmake --build build --target style-json-parallel
-
-# 모든 JSON 파일을 순차적으로 포맷 (느리지만 디버깅에 유용)
-cmake --build build --target style-json
+just fmt-json
+# 또는
+build-scripts/format-json.sh
 ```
+
+이 스크립트는 `out/build/json-format`에 `json_formatter`를 빌드하고 JSON 파일을 포맷합니다. 구성된 게임 빌드나 CMake 프리셋은 필요하지 않습니다. 필요하면 `CATA_JSON_FORMAT_BUILD_DIR`로 보조 빌드 디렉터리를 바꿀 수 있습니다.
 
 > [!NOTE]
 > `data/names/` 디렉토리는 이름 파일이 특별한 포맷 요구사항을 가지고 있어 포맷에서 제외됩니다.
@@ -112,17 +108,30 @@ tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*
 
 ## 커밋 전 워크플로우
 
-커밋하기 전에 다음 검사를 실행하세요:
+[`prek`](https://github.com/j178/prek)를 사용하는 선택적 pre-commit 훅을 설치할 수 있습니다:
 
 ```sh
-# 한 번만 구성 (포매팅 도구가 포함된 빌드 디렉토리 생성)
-cmake --preset lint
+prek install
+# 또는
+just hooks-setup
+```
 
-# 모든 코드 포맷
-cmake --build build --target format           # C++
-cmake --build build --target style-json-parallel  # JSON
-deno fmt                                       # Markdown/TypeScript
-deno task dprint fmt                           # Lua
+커밋할 때 훅은 `just fmt`를 실행합니다. Deno와 dprint는 일반적으로 실행되고, C++ 및 JSON 포매터는 staged된 생성/수정 파일만 처리합니다. 포맷된 staged 파일은 같은 커밋에 포함되도록 다시 `git add`됩니다.
+
+staged 파일에 같은 포매팅을 수동으로 실행하려면:
+
+```sh
+just fmt
+```
+
+훅 없이 커밋하기 전에 실행할 명령:
+
+```sh
+# staged 파일 포맷
+just fmt
+
+# 포맷 가능한 모든 파일 포맷
+just fmt --all
 ```
 
 ## CI 통합
@@ -130,7 +139,7 @@ deno task dprint fmt                           # Lua
 CI 파이프라인은 이러한 검사를 자동으로 실행합니다:
 
 1. **JSON 구문 검증** - `build-scripts/lint-json.sh`
-2. **JSON 포매팅** - `cmake --build build --target style-json-parallel`
+2. **JSON 포매팅** - `build-scripts/format-json.sh`
 3. **대화 검증** - `tools/dialogue_validator.py`
 
 검사가 실패하면 빌드가 실패합니다. 푸시하기 전에 위 명령어로 로컬에서 문제를 수정하세요.
@@ -185,16 +194,15 @@ autocmd BufWritePre *.md,*.ts !deno fmt %
 
 ## 문제 해결
 
-### "json_formatter not found" 또는 "style-json-parallel target not found"
+### "json_formatter not found"
 
-`lint` 프리셋으로 CMake를 구성했거나 `-DJSON_FORMAT=ON`을 사용했는지 확인하세요:
+JSON 포매터 스크립트를 실행하세요. 보조 포매터를 자동으로 구성하고 빌드합니다:
 
 ```sh
-cmake --preset lint
-cmake --build build --target json_formatter
+build-scripts/format-json.sh
 ```
 
-### "format target not found"
+### C++ 포매터를 찾을 수 없음
 
 `astyle`과 `clang-format`이 설치되어 있고 PATH에 있는지 확인하세요:
 
@@ -207,10 +215,10 @@ which clang-format
 sudo apt install astyle clang-format
 ```
 
-그런 다음 CMake를 재구성:
+그런 다음 다시 실행하세요:
 
 ```sh
-cmake --preset lint
+build-scripts/format-cpp.sh
 ```
 
 ### C++ 포매터가 다른 결과를 생성

--- a/justfile
+++ b/justfile
@@ -1,0 +1,32 @@
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+default:
+    @just --list
+
+fmt *ARGS:
+    build-scripts/fmt.sh {{ARGS}}
+
+fmt-cpp *FILES:
+    build-scripts/fmt.sh cpp {{FILES}}
+
+fmt-json *FILES:
+    build-scripts/fmt.sh json {{FILES}}
+
+fmt-docs:
+    build-scripts/fmt.sh docs
+
+fmt-lua:
+    build-scripts/fmt.sh lua
+
+lint: lint-json lint-dialogue
+
+lint-json:
+    build-scripts/lint-json.sh
+
+lint-dialogue:
+    tools/dialogue_validator.py data/json/npcs/* data/json/npcs/*/* data/json/npcs/*/*/*
+
+hooks-setup:
+    prek install
+
+check: lint


### PR DESCRIPTION
## Purpose of change (The Why)

Formatting and linting commands should not require contributors to know the CMake preset/build-dir setup.

Related: #9138

## Describe the solution (The How)

- Add `just fmt` for staged formatting and `just fmt --all` for all formattable files.
- Add `just fmt-cpp`, `just fmt-json`, `just fmt-docs`, and `just fmt-lua` recipes plus script entrypoints for formatter-specific use.
- Add a `prek` pre-commit config that runs staged formatting and re-adds formatted files.
- Update autofix/CI formatting calls and formatting docs to use the scripts.

## Testing

- `bash -n build-scripts/fmt.sh build-scripts/format-cpp.sh build-scripts/format-json.sh build-scripts/format-staged.sh build-scripts/format-all.sh build-scripts/lint-all.sh build-scripts/gha_compile_only.sh`
- `prek validate-config .pre-commit-config.yaml`
- `prek run -v`
- `deno fmt --check docs/en/dev/guides/formatting.md docs/ja/dev/guides/formatting.md docs/ko/dev/guides/formatting.md .pre-commit-config.yaml .github/workflows/matrix.yml`
- `just --dry-run fmt --all`, `just --dry-run fmt-cpp`, `just --dry-run fmt-json`, `just --dry-run fmt-docs`, `just --dry-run fmt-lua`
- `just fmt --all`
- staged TypeScript and JSON hook smoke tests: hook formatted and re-staged the changed files.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This is a PR that modifies build process or code organization.
  - [x] I documented the changes in the appropriate location in the `docs/` folder.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [fa076e6](https://github.com/cataclysmbn/Cataclysm-BN/commit/fa076e601ba6a980cec2b4d7a1dd2c93de5296e0) (chore: add preset-free formatting commands) on 2026-06-14 17:28:20

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27504033045/artifacts/7623199887)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27504033045/artifacts/7623088302)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27504033045/artifacts/7622857693)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27504033045/artifacts/7622885353)
<!-- END artifact comment -->