### PR TITLE
fix: brighten colored light tint blending

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4821,7 +4821,7 @@ bool cata_tiles::draw_sprite_at( const tile_type &tile, point_bub_ms p,
         sprite_tex->get_alpha_mod( &old_alpha );
         sprite_tex->get_blend_mode( &old_blend_mode );
 
-        sprite_tex->set_blend_mode( SDL_BLENDMODE_BLEND );
+        sprite_tex->set_blend_mode( SDL_BLENDMODE_ADD );
         sprite_tex->set_color_mod( light_tint.color.r, light_tint.color.g, light_tint.color.b );
         sprite_tex->set_alpha_mod( light_tint.alpha );
         const auto ret = sprite_tex->render_copy_ex( renderer, &destination, rotation, nullptr, flip );


### PR DESCRIPTION
## Purpose of change (The Why)

close #9402
Related: #9016

## Describe the solution (The How)

- Use additive blending for render-only colored light tint overlays so lit tiles do not become dimmer.

## Testing

## before

<img width="1913" height="1116" alt="image" src="https://github.com/user-attachments/assets/24c83b93-9f8b-4eb8-99c3-6fdcfa4cff5d" />

## after

### day

<img width="2686" height="1550" alt="Cataclysm: Bright Nights - 048f7ca4e4 (2026-06-11)_05" src="https://github.com/user-attachments/assets/61d728bb-d728-4479-b051-bf851d9ecbe6" /> 

### night

<img width="2686" height="1550" alt="Cataclysm: Bright Nights - 048f7ca4e4 (2026-06-11)_06" src="https://github.com/user-attachments/assets/65ee5a4c-7a45-425e-963b-5fb4873a6677" />

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [cdcf58e](https://github.com/cataclysmbn/Cataclysm-BN/commit/cdcf58e0da74587b717e13d6da6f2413096584f1) (fix: brighten colored light tint blending) on 2026-06-10 15:55:09

- [⏳ Linux tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27288182583)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27288182583)
- [⏳ macOS tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27288182583)
- [⏳ Android tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27288182583)
<!-- END artifact comment -->