### PR TITLE
feat(balance): standarize hearing protection items at 40 NRR, clarify effectiveness in descriptions

### DIFF
--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -384,7 +384,7 @@
     "id": "hat_noise_cancelling",
     "type": "ARMOR",
     "name": { "str": "noise canceling headgear" },
-    "description": "Padding over your ears kept in place by some string.  Blocks incoming sounds.",
+    "description": "Padding over your ears kept in place by some string.  They block enough incoming sound to make it easier to sleep, but aren't designed to protect your hearing.",
     "weight": "72 g",
     "volume": "500 ml",
     "price": "25 USD",
@@ -399,7 +399,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "OVERSIZE", "HELMET_COMPAT", "ALLOWS_NATURAL_ATTACKS" ],
-    "hearing_protection": 8
+    "hearing_protection": 10
   },
   {
     "id": "hat_sombrero",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -59,7 +59,7 @@
     "id": "ear_plugs",
     "type": "ARMOR",
     "name": { "str": "pair of ear plugs", "str_pl": "pairs of ear plugs" },
-    "description": "Industrial grade ear plugs.  They fit inside the ear.",
+    "description": "Industrial grade ear plugs that fit inside the ear.  Adequate for most purposes, though you'll want to pair them with protective earmuffs if you're firing high-powered rifles or artillery.",
     "weight": "10 g",
     "volume": "10 ml",
     "price": "10 cent",
@@ -69,7 +69,7 @@
     "color": "light_gray",
     "coverage": 1,
     "material_thickness": 1,
-    "hearing_protection": 12,
+    "hearing_protection": 20,
     "flags": [ "OVERSIZE", "POWERARMOR_COMPATIBLE" ]
   },
   {
@@ -2725,7 +2725,7 @@
     "symbol": "[",
     "color": "blue",
     "name": { "str_sp": "shooter's earmuffs" },
-    "description": "A pair of earmuffs favored by shooters.  Without batteries or when turned off they function like normal earmuffs and block all sound.  They will block sounds over a certain decibel amount when turned on.  The earmuffs are currently off.",
+    "description": "A pair of earmuffs favored by shooters.  Currently turned off they block most sounds, though you should pair them with ear plugs if firing high-powered rifles or artillery.  If turned on they provide the same protection while still allowing you to hear normal sounds.",
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "COMBAT_NPC_USE" ],
     "price": "125 USD",
     "price_postapoc": "750 cent",
@@ -2747,7 +2747,7 @@
     "encumbrance": 5,
     "coverage": 10,
     "material_thickness": 2,
-    "hearing_protection": 12,
+    "hearing_protection": 20,
     "magazines": [
       [
         "battery",
@@ -2770,14 +2770,13 @@
     "type": "TOOL_ARMOR",
     "repairs_like": "powered_earmuffs",
     "name": { "str_sp": "shooter's earmuffs (on)" },
-    "description": "A pair of earmuffs favored by shooters.  The earmuffs are turned on.  They will block sounds over a certain decibel amount, assuming it is charged with batteries.",
+    "description": "A pair of earmuffs favored by shooters.  The earmuffs are turned on, protecting you from most loud sounds short of high-powered rifles or artillery without compromising your ability to hear.",
     "//": "3M Peltors claim to go 100 hours on 2 AAs",
     "power_draw": 60,
     "revert_to": "powered_earmuffs",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s flicks off.", "target": "powered_earmuffs" },
     "extend": { "flags": [ "PARTIAL_DEAF", "COMBAT_NPC_ON" ] },
-    "hearing_protection": 6,
-    "adv_hearing_protection": 20
+    "adv_hearing_protection": 40
   },
   {
     "id": "army_powered_earmuffs",
@@ -2786,7 +2785,7 @@
     "symbol": "[",
     "color": "green",
     "name": { "str_sp": "tactical headset" },
-    "description": "An active headset used by the military.  Without batteries or when turned off they function like normal earmuffs and block all sound.  They will block sounds over a certain decibel amount as well as function as a two-way radio when turned on.  The headset is currently off.",
+    "description": "An active headset used by the military.  Currently turned off they block most sounds, though you should pair them with ear plugs if firing high-powered rifles or artillery.  If turned on they provide the same protection while still allowing you to hear normal sounds, and double as a two-way radio.",
     "flags": [ "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "COMBAT_NPC_USE", "SKINTIGHT", "POWERARMOR_COMPATIBLE" ],
     "price": "250 USD",
     "price_postapoc": "15 USD",
@@ -2808,7 +2807,7 @@
     "encumbrance": 5,
     "coverage": 10,
     "material_thickness": 2,
-    "hearing_protection": 12,
+    "hearing_protection": 20,
     "magazines": [
       [
         "battery",
@@ -2831,14 +2830,13 @@
     "type": "TOOL_ARMOR",
     "repairs_like": "army_powered_earmuffs",
     "name": { "str_sp": "tactical headset (on)" },
-    "description": "An active headset used by the military.  Without batteries or when turned off they function like normal earmuffs and block all sound.  They will block sounds over a certain decibel amount as well as function as a two-way radio when turned on.",
+    "description": "An active headset used by the military.  They're turned on, serving as a two-way radio and protecting you from most loud sounds short of high-powered rifles or artillery, without compromising your ability to hear.",
     "//": "3M Peltors claim to go 100 hours on 2 AAs",
     "power_draw": 60,
     "revert_to": "army_powered_earmuffs",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s flicks off.", "target": "army_powered_earmuffs" },
     "extend": { "flags": [ "COMBAT_NPC_ON", "TWO_WAY_RADIO" ] },
-    "hearing_protection": 6,
-    "adv_hearing_protection": 24
+    "adv_hearing_protection": 40
   },
   {
     "id": "stethoscope",
@@ -3205,7 +3203,7 @@
     "id": "attached_ear_plugs_on",
     "type": "ARMOR",
     "name": { "str": "pair of attached ear plugs (in)", "str_pl": "pairs of attached ear plugs (in)" },
-    "description": "A pair of industrial grade ear plugs attached together by some string.  They are inside your ears, activate them to take them out.",
+    "description": "A pair of industrial grade ear plugs attached together by some string.  Adequate for most purposes, though you'll want to pair them with protective earmuffs if you're firing high-powered rifles or artillery.  They are inside your ears, activate them to take them out.",
     "copy-from": "ear_plugs",
     "use_action": {
       "type": "transform",
@@ -3214,14 +3212,14 @@
       "menu_text": "Unplug",
       "need_worn": true
     },
-    "hearing_protection": 12
+    "hearing_protection": 20
   },
   {
     "id": "attached_ear_plugs_off",
     "type": "ARMOR",
     "repairs_like": "attached_ear_plugs_on",
     "name": { "str": "pair of attached ear plugs (out)", "str_pl": "pairs of attached ear plugs (out)" },
-    "description": "A pair of industrial grade ear plugs, they are attached together by some string.  They hang around your neck, use them to plug them in.",
+    "description": "A pair of industrial grade ear plugs, they are attached together by some string.  They hang around your neck, use them to plug them in.  They'll protect your hearing from most sounds when plugged in, though for high-powered rifles or artillery you'd want to pair them with protective earmuffs.",
     "copy-from": "attached_ear_plugs_on",
     "use_action": {
       "type": "transform",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This standardizes hearing protection items so that they work more consitently for gameplay purposes, and makes it more clear how they work.

Closes https://github.com/cataclysmbn/Cataclysm-BN/issues/9404

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Set hearing protection at a consistent 40 across the board. Idea is this is enough to ensure that any standard pistol rounds will be safe to use with just one earpro item, which isn't realistic in terms of protecting against permanent hearing loss but is adequate against temporary hearing loss (the only one we really model), and moreover is more intuitive for gameplay purposes. That's 20 `hearing_protection` or 40 `adv_hearing_protection` (I'll fix those numbers scaling differently after https://github.com/cataclysmbn/Cataclysm-BN/pull/9319 is merged). Idea being if you double up on them you get 80 which is adequate for basically anything.
2. Set active hearing protection to rely entirely on `adv_hearing_protection` instead of a mix of both, again for more sensible gameplay behavior.
3. Misc: Set headgear to have 20 NRR, which is still not enough for protection from gunshots but should work better for its intended purpose of sleeping through noises.
4. Updated item descriptions so that it better clarifies how they work and reference the need to double up on hearing protection for maximum protection.

## Describe alternatives you've considered

Scream, but not be heard.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported to playthrough build and load-tested.
3. Put in ear plugs and fired a glock, no more ringing ears.
4. Fired off a Barrett, ears still explode as intended.
5. Piared ear plugs with a headset, no ear explosions even with the Barrett.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2f2d667](https://github.com/cataclysmbn/Cataclysm-BN/commit/2f2d667e6fd49fae1c6210f6f22e39876f5603eb) (commit for remote) on 2026-06-11 00:54:34

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27310582729/artifacts/7550826736)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27310582729)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27310582729/artifacts/7550275712)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27310582729/artifacts/7550580266)
<!-- END artifact comment -->