### PR TITLE
feat(mods,lua,balance): reward varied diets with hearty meals

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -100,6 +100,7 @@ scopes:
   - mods/test_lua_require
   - mods/udp_redux
   - mods/underground_dynamic_temperature
+  - mods/varied_diet
   - mods/vehicle_color_expansion
   - mods/weather_variants
   - mods

--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -1,6 +1,8 @@
 [
   "bn",
   "bn_lua",
+  "varied_diet",
+  "nuclear_tear",
   "no_npc_food",
   "novitamins",
   "No_Rail_Stations",

--- a/data/mods/varied_diet/config.lua
+++ b/data/mods/varied_diet/config.lua
@@ -1,0 +1,158 @@
+---@class VariedDietFoodRule
+---@field group string|nil
+---@field complexity number|nil
+---@field points number|nil
+---@field multiplier number|nil
+
+---@class VariedDietGroupRule
+---@field patterns string[]
+---@field complexity number|nil
+---@field multiplier number|nil
+
+---@class VariedDietThreshold
+---@field score number
+---@field morale integer
+---@field health integer
+
+---@class VariedDietRepeatStep
+---@field count integer
+---@field morale integer
+---@field health integer
+
+---@class VariedDietConfig
+---@field enabled boolean
+---@field storage_key string
+---@field minimum_kcal integer
+---@field history_window_hours integer
+---@field item_repeat_window_hours integer
+---@field group_repeat_window_hours integer
+---@field kcal_reference number
+---@field kcal_log_base number
+---@field max_kcal_points number
+---@field fun_divisor number
+---@field healthy_divisor number
+---@field same_item_point_penalty number
+---@field same_group_point_penalty number
+---@field reward_morale_type string
+---@field penalty_morale_type string
+---@field reward_duration_hours integer
+---@field reward_decay_start_hours integer
+---@field penalty_duration_hours integer
+---@field penalty_decay_start_hours integer
+---@field health_cooldown_hours integer
+---@field reward_health_cap integer
+---@field penalty_health_cap integer
+---@field thresholds VariedDietThreshold[]
+---@field item_repeat_penalties VariedDietRepeatStep[]
+---@field group_repeat_penalties VariedDietRepeatStep[]
+---@field group_order string[]
+---@field groups table<string, VariedDietGroupRule>
+---@field foods table<string, VariedDietFoodRule>
+
+---@type VariedDietConfig
+return {
+  enabled = true,
+  storage_key = "varied_diet_history",
+  minimum_kcal = 75,
+  history_window_hours = 72,
+  item_repeat_window_hours = 48,
+  group_repeat_window_hours = 24,
+  kcal_reference = 250,
+  kcal_log_base = 2.0,
+  max_kcal_points = 5.0,
+  fun_divisor = 8.0,
+  healthy_divisor = 2.0,
+  same_item_point_penalty = 1.75,
+  same_group_point_penalty = 0.5,
+  reward_morale_type = "morale_varied_diet",
+  penalty_morale_type = "morale_food_repetition",
+  reward_duration_hours = 12,
+  reward_decay_start_hours = 6,
+  penalty_duration_hours = 8,
+  penalty_decay_start_hours = 3,
+  health_cooldown_hours = 6,
+  reward_health_cap = 100,
+  penalty_health_cap = -100,
+  thresholds = {
+    { score = 6, morale = 2, health = 0 },
+    { score = 12, morale = 5, health = 1 },
+    { score = 22, morale = 9, health = 2 },
+    { score = 36, morale = 14, health = 3 },
+  },
+  item_repeat_penalties = {
+    { count = 2, morale = -1, health = 0 },
+    { count = 3, morale = -3, health = -1 },
+    { count = 5, morale = -6, health = -2 },
+  },
+  group_repeat_penalties = {
+    { count = 4, morale = -1, health = 0 },
+    { count = 6, morale = -3, health = -1 },
+  },
+  group_order = { "complex", "protein", "grain", "fruit", "vegetable", "dairy", "snack", "drink" },
+  groups = {
+    complex = {
+      patterns = {
+        "pizza",
+        "sandwich",
+        "soup",
+        "stew",
+        "curry",
+        "casserole",
+        "pie",
+        "cake",
+        "deluxe",
+        "meal",
+        "dinner",
+        "breakfast",
+        "salad",
+      },
+      complexity = 2.0,
+      multiplier = 1.2,
+    },
+    protein = {
+      patterns = { "meat", "fish", "egg", "sausage", "jerky", "bacon", "pemmican" },
+      complexity = 0.5,
+      multiplier = 1.0,
+    },
+    grain = {
+      patterns = { "bread", "wheat", "oat", "rice", "pasta", "noodle", "flour", "cereal" },
+      complexity = 0.25,
+      multiplier = 1.0,
+    },
+    fruit = {
+      patterns = { "apple", "berry", "fruit", "orange", "lemon", "melon", "grape", "pear", "peach" },
+      complexity = 0.0,
+      multiplier = 0.9,
+    },
+    vegetable = {
+      patterns = { "veg", "broccoli", "cabbage", "carrot", "tomato", "potato", "onion", "garlic", "bean" },
+      complexity = 0.0,
+      multiplier = 0.9,
+    },
+    dairy = {
+      patterns = { "milk", "cheese", "yogurt", "butter", "cream" },
+      complexity = 0.0,
+      multiplier = 0.9,
+    },
+    snack = {
+      patterns = { "candy", "chips", "chocolate", "cookie", "cracker", "protein_bar", "junk" },
+      complexity = -0.5,
+      multiplier = 0.55,
+    },
+    drink = {
+      patterns = { "juice", "smoothie", "shake", "cider", "soda" },
+      complexity = 0.0,
+      multiplier = 0.65,
+    },
+  },
+  foods = {
+    oatmeal_deluxe = { group = "complex", complexity = 1.5 },
+    pizza_cheese = { group = "complex", complexity = 2.0 },
+    pizza = { group = "complex", complexity = 2.0 },
+    meat_cooked = { group = "protein", complexity = 0.5 },
+    meat_smoked = { group = "protein", complexity = 0.75 },
+    dehydrated_meat = { group = "protein", complexity = 0.25, multiplier = 0.75 },
+    cracklins = { group = "snack", complexity = -0.25, multiplier = 0.6 },
+    candy = { group = "snack", complexity = -1.0, multiplier = 0.35 },
+  },
+}

--- a/data/mods/varied_diet/main.lua
+++ b/data/mods/varied_diet/main.lua
@@ -1,0 +1,312 @@
+gdebug.log_info("Varied Diet: Main")
+
+---@class ModVariedDiet
+local mod = game.mod_runtime[game.current_mod]
+local gettext = locale.gettext
+
+---@type VariedDietConfig
+mod.config = require("config")
+
+---@type VariedDietConfig
+local config = mod.config
+
+---@class VariedDietConsumeFoodParams
+---@field character Character
+---@field food Item
+---@field nutrition integer
+---@field calories integer
+---@field quench integer
+---@field healthy integer
+---@field fun integer
+---@field fun_cap integer
+---@field spoiled boolean
+---@field when TimePoint
+
+---@class VariedDietEvent
+---@field turn integer
+---@field id string
+---@field group string
+---@field points number
+
+---@param value number
+---@param low number
+---@param high number
+---@return number
+local function clamp(value, low, high) return math.max(low, math.min(high, value)) end
+
+---@param hours integer
+---@return integer
+local function hours_to_turns(hours) return TimeDuration.from_hours(hours):to_turns() end
+
+---@param value string
+---@return VariedDietEvent[]
+local function parse_history(value)
+  local history = {}
+  for raw in string.gmatch(value, "([^;]+)") do
+    local turn_text, id, group, points_text = string.match(raw, "^([^,]+),([^,]+),([^,]+),([^,]+)$")
+    if turn_text ~= nil and id ~= nil and group ~= nil and points_text ~= nil then
+      table.insert(history, {
+        turn = tonumber(turn_text) or 0,
+        id = id,
+        group = group,
+        points = tonumber(points_text) or 0,
+      })
+    end
+  end
+  return history
+end
+
+---@param history VariedDietEvent[]
+---@return string
+local function serialize_history(history)
+  local chunks = {}
+  for _, event in ipairs(history) do
+    table.insert(chunks, string.format("%d,%s,%s,%.3f", event.turn, event.id, event.group, event.points))
+  end
+  return table.concat(chunks, ";")
+end
+
+---@param history VariedDietEvent[]
+---@param now integer
+---@return VariedDietEvent[]
+local function recent_history(history, now)
+  local cutoff = now - hours_to_turns(config.history_window_hours)
+  local recent = {}
+  for _, event in ipairs(history) do
+    if event.turn >= cutoff then table.insert(recent, event) end
+  end
+  table.sort(recent, function(left, right) return left.turn > right.turn end)
+  return recent
+end
+
+---@param id string
+---@param rule VariedDietFoodRule|nil
+---@return VariedDietGroupRule|nil
+local function group_rule_for(id, rule)
+  local group = rule and rule.group or id
+  return config.groups[group]
+end
+
+---@param text string
+---@param patterns string[]
+---@return boolean
+local function matches_any(text, patterns)
+  for _, pattern in ipairs(patterns) do
+    if string.find(text, pattern, 1, true) then return true end
+  end
+  return false
+end
+
+---@param id string
+---@return string, VariedDietGroupRule|nil, VariedDietFoodRule|nil
+local function classify_food(id)
+  local rule = config.foods[id]
+  if rule and rule.group then return rule.group, group_rule_for(id, rule), rule end
+
+  for _, group in ipairs(config.group_order) do
+    local group_rule = config.groups[group]
+    if group_rule ~= nil and matches_any(id, group_rule.patterns) then return group, group_rule, rule end
+  end
+
+  return id, nil, rule
+end
+
+---@param params VariedDietConsumeFoodParams
+---@return integer
+local function effective_calories(params)
+  if params.calories ~= nil then return params.calories end
+  return params.food:get_kcal()
+end
+
+---@param params VariedDietConsumeFoodParams
+---@param group_rule VariedDietGroupRule|nil
+---@param food_rule VariedDietFoodRule|nil
+---@return number
+local function food_points(params, group_rule, food_rule)
+  local kcal = effective_calories(params)
+  if kcal < config.minimum_kcal then return 0 end
+
+  local kcal_points = math.log(1 + kcal / config.kcal_reference) / math.log(config.kcal_log_base)
+  kcal_points = clamp(kcal_points, 0, config.max_kcal_points)
+
+  local complexity = food_rule and food_rule.complexity or group_rule and group_rule.complexity or 0
+  local multiplier = food_rule and food_rule.multiplier or group_rule and group_rule.multiplier or 1
+  local fun_bonus = math.max(0, params.fun or params.food:get_comestible_fun()) / config.fun_divisor
+  local health_bonus = math.max(0, params.healthy or 0) / config.healthy_divisor
+  local explicit_points = food_rule and food_rule.points or 0
+
+  return math.max(0, (kcal_points + complexity + fun_bonus + health_bonus + explicit_points) * multiplier)
+end
+
+---@param history VariedDietEvent[]
+---@param now integer
+---@param id string|nil
+---@param group string|nil
+---@param window_hours integer
+---@return integer
+local function count_recent(history, now, id, group, window_hours)
+  local cutoff = now - hours_to_turns(window_hours)
+  local count = 0
+  for _, event in ipairs(history) do
+    if event.turn >= cutoff and (id == nil or event.id == id) and (group == nil or event.group == group) then
+      count = count + 1
+    end
+  end
+  return count
+end
+
+---@param history VariedDietEvent[]
+---@param now integer
+---@return number
+local function diet_score(history, now)
+  local seen_items = {}
+  local seen_groups = {}
+  local score = 0
+  local window = hours_to_turns(config.history_window_hours)
+  for _, event in ipairs(history) do
+    local age = math.max(0, now - event.turn)
+    local age_weight = clamp(1 - age / window, 0.1, 1.0)
+    local item_weight = seen_items[event.id] and 0.35 or 1.0
+    local group_weight = seen_groups[event.group] and 0.75 or 1.0
+    score = score + event.points * age_weight * item_weight * group_weight
+    seen_items[event.id] = true
+    seen_groups[event.group] = true
+  end
+  return score
+end
+
+---@param score number
+---@return VariedDietThreshold|nil
+local function reward_for_score(score)
+  local best = nil
+  for _, threshold in ipairs(config.thresholds) do
+    if score >= threshold.score and (best == nil or threshold.score > best.score) then best = threshold end
+  end
+  return best
+end
+
+---@param count integer
+---@param steps VariedDietRepeatStep[]
+---@return VariedDietRepeatStep|nil
+local function penalty_for_count(count, steps)
+  local best = nil
+  for _, step in ipairs(steps) do
+    if count >= step.count and (best == nil or step.count > best.count) then best = step end
+  end
+  return best
+end
+
+---@param character Character
+---@param morale_type MoraleTypeDataId
+---@param target integer
+---@param duration_hours integer
+---@param decay_start_hours integer
+---@return nil
+local function refresh_morale(character, morale_type, target, duration_hours, decay_start_hours)
+  if target == 0 then return end
+  local current = character:get_morale(morale_type)
+  local delta = target > 0 and math.max(0, target - current) or math.min(0, target - current)
+  if delta == 0 then return end
+  character:add_morale(
+    morale_type,
+    delta,
+    target,
+    TimeDuration.from_hours(duration_hours),
+    TimeDuration.from_hours(decay_start_hours),
+    true,
+    nil
+  )
+end
+
+---@param character Character
+---@param key string
+---@param now integer
+---@return boolean
+local function can_apply_health(character, key, now)
+  local last = tonumber(character:get_value(key)) or -hours_to_turns(config.health_cooldown_hours)
+  return now - last >= hours_to_turns(config.health_cooldown_hours)
+end
+
+---@param character Character
+---@param key string
+---@param now integer
+---@param delta integer
+---@param cap integer
+---@return nil
+local function apply_health(character, key, now, delta, cap)
+  if delta == 0 or not can_apply_health(character, key, now) then return end
+  character:mod_healthy_mod(delta, cap)
+  character:set_value(key, tostring(now))
+end
+
+---@param params VariedDietConsumeFoodParams
+---@return boolean
+local function should_track(params)
+  if not config.enabled then return false end
+  if params.character == nil or params.food == nil then return false end
+  if params.food:is_medication() then return false end
+  if params.spoiled then return false end
+  return params.food:is_food() or params.food:is_food_container() or effective_calories(params) >= config.minimum_kcal
+end
+
+---@param params VariedDietConsumeFoodParams
+---@return nil
+function mod.on_character_consumed_food(params)
+  if not should_track(params) then return end
+
+  local character = params.character
+  local food = params.food
+  local now = params.when ~= nil and params.when:to_turn() or gapi.current_turn():to_turn()
+  local id = food:get_type():str()
+  local group, group_rule, food_rule = classify_food(id)
+  local points = food_points(params, group_rule, food_rule)
+  if points <= 0 then return end
+
+  local history = recent_history(parse_history(character:get_value(config.storage_key)), now)
+  local item_count = count_recent(history, now, id, nil, config.item_repeat_window_hours) + 1
+  local group_count = count_recent(history, now, nil, group, config.group_repeat_window_hours) + 1
+  points = math.max(
+    0,
+    points - (item_count - 1) * config.same_item_point_penalty - (group_count - 1) * config.same_group_point_penalty
+  )
+
+  table.insert(history, 1, { turn = now, id = id, group = group, points = points })
+  character:set_value(config.storage_key, serialize_history(history))
+
+  local score = diet_score(history, now)
+  local reward = reward_for_score(score)
+  local reward_morale_type = MoraleTypeDataId.new(config.reward_morale_type)
+  if reward ~= nil then
+    refresh_morale(
+      character,
+      reward_morale_type,
+      reward.morale,
+      config.reward_duration_hours,
+      config.reward_decay_start_hours
+    )
+    apply_health(character, config.storage_key .. "_reward_health", now, reward.health, config.reward_health_cap)
+  end
+
+  local item_penalty = penalty_for_count(item_count, config.item_repeat_penalties)
+  local group_penalty = penalty_for_count(group_count, config.group_repeat_penalties)
+  local penalty_morale_type = MoraleTypeDataId.new(config.penalty_morale_type)
+  local penalty_morale = (item_penalty and item_penalty.morale or 0) + (group_penalty and group_penalty.morale or 0)
+  local penalty_health = (item_penalty and item_penalty.health or 0) + (group_penalty and group_penalty.health or 0)
+
+  if penalty_morale ~= 0 then
+    refresh_morale(
+      character,
+      penalty_morale_type,
+      penalty_morale,
+      config.penalty_duration_hours,
+      config.penalty_decay_start_hours
+    )
+  end
+  apply_health(character, config.storage_key .. "_penalty_health", now, penalty_health, config.penalty_health_cap)
+
+  if character:is_avatar() and reward ~= nil and reward.morale >= 9 and penalty_morale == 0 then
+    gapi.add_msg(MsgType.good, string.format(gettext("Your varied diet feels satisfying. Diet score: %.1f."), score))
+  elseif character:is_avatar() and penalty_morale < 0 then
+    gapi.add_msg(MsgType.warning, gettext("Eating the same kind of food again is getting tiresome."))
+  end
+end

--- a/data/mods/varied_diet/modinfo.json
+++ b/data/mods/varied_diet/modinfo.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "varied_diet",
+    "name": "Varied Diet",
+    "authors": [ "Cataclysm: Bright Nights contributors" ],
+    "description": "Rewards varied, hearty meals and discourages repeating the same easy food.",
+    "category": "rebalance",
+    "lua_api_version": 2,
+    "dependencies": [ "bn" ]
+  }
+]

--- a/data/mods/varied_diet/morale_types.json
+++ b/data/mods/varied_diet/morale_types.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "morale_varied_diet",
+    "type": "morale_type",
+    "text": "Varied diet"
+  },
+  {
+    "id": "morale_food_repetition",
+    "type": "morale_type",
+    "text": "Repetitive meals"
+  }
+]

--- a/data/mods/varied_diet/preload.lua
+++ b/data/mods/varied_diet/preload.lua
@@ -1,0 +1,6 @@
+gdebug.log_info("Varied Diet: Preload")
+
+---@class ModVariedDiet
+local mod = game.mod_runtime[game.current_mod]
+
+game.add_hook("on_character_consumed_food", function(...) return mod.on_character_consumed_food(...) end)

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -765,6 +765,21 @@ void cata::detail::reg_hooks_examples( sol::state &lua )
     DOC_PARAMS( "params" );
     luna::set_fx( lib, "on_character_effect_removed", []( const sol::table & ) {} );
 
+    DOC( "Called after a character successfully consumes food or drink.  " );
+    DOC( "The hook receives a table with keys:  " );
+    DOC( "* `character` (Character): The consuming character  " );
+    DOC( "* `food` (Item): The consumed food before charge removal  " );
+    DOC( "* `nutrition` (integer): Nutrition value used by normal food morale  " );
+    DOC( "* `calories` (integer): Calories ingested after nutrition adjustments  " );
+    DOC( "* `quench` (integer): Thirst modifier from the comestible  " );
+    DOC( "* `healthy` (integer): Hidden-health modifier from the comestible  " );
+    DOC( "* `fun` (integer): Immediate fun value after built-in monotony  " );
+    DOC( "* `fun_cap` (integer): Built-in fun morale cap  " );
+    DOC( "* `spoiled` (boolean): Whether the food was rotten  " );
+    DOC( "* `when` (TimePoint): The current turn  " );
+    DOC_PARAMS( "params" );
+    luna::set_fx( lib, "on_character_consumed_food", []( const sol::table & ) {} );
+
     DOC( "Called when a character is dead.  " );
     DOC( "The hook receives a table with keys:  " );
     DOC( "* `char` (Character)  " );

--- a/src/catalua_hooks.cpp
+++ b/src/catalua_hooks.cpp
@@ -23,6 +23,7 @@ constexpr auto hook_names = std::array
     "on_character_effect_added",
     "on_character_effect",
     "on_character_effect_removed",
+    "on_character_consumed_food",
     "on_mon_effect_added",
     "on_mon_effect",
     "on_mon_effect_removed",

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -18,6 +18,8 @@
 #include "avatar.h"
 #include "bionics.h"
 #include "calendar.h"
+#include "catalua_hooks.h"
+#include "catalua_sol.h"
 #include "cata_utility.h"
 #include "craft_command.h"
 #include "debug.h"
@@ -1251,6 +1253,7 @@ bool Character::consume_effects( item &food )
     if( has_effect( effect_tapeworm ) ) {
         ingested.nutr /= 2;
     }
+    const auto fun = fun_for( food );
     int excess_kcal = get_stored_kcal() + stomach.get_calories() + ingested.nutr.kcal -
                       max_stored_kcal();
 
@@ -1270,6 +1273,21 @@ bool Character::consume_effects( item &food )
         !food.has_flag( flag_NO_BLOAT ) &&
         !has_trait( trait_GOURMAND ) ) {
         add_effect( effect_bloated, 5_minutes );
+    }
+
+    if( food.is_food() || food.is_food_container() ) {
+        cata::run_hooks( "on_character_consumed_food", [ &, this]( auto & params ) {
+            params["character"] = this;
+            params["food"] = &food;
+            params["nutrition"] = nutr;
+            params["calories"] = ingested.nutr.kcal;
+            params["quench"] = comest.quench;
+            params["healthy"] = comest.healthy;
+            params["fun"] = fun.first;
+            params["fun_cap"] = fun.second;
+            params["spoiled"] = relative_rot > 1.0f;
+            params["when"] = calendar::turn;
+        } );
     }
 
     return true;

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -1754,6 +1754,47 @@ TEST_CASE("lua_hook_wiring_character_reset_stats", "[lua]") {
     CHECK(*char_ptr == &get_avatar());
 }
 
+TEST_CASE("lua_hook_wiring_character_consumed_food", "[lua][consumption]") {
+    clear_all_state();
+    auto& state = *DynamicDataLoader::get_instance().lua;
+    sol::state& lua = state.lua;
+
+    const auto char_ptr = std::make_shared<Character*>(nullptr);
+    const auto item_ptr = std::make_shared<item*>(nullptr);
+    const auto item_id = std::make_shared<std::string>();
+    const auto calories = std::make_shared<int>(0);
+    const auto nutrition = std::make_shared<int>(0);
+    const auto when = std::make_shared<time_point>();
+
+    const auto [list, idx] = push_hook(lua, "on_character_consumed_food",
+        [char_ptr, item_ptr, item_id, calories, nutrition, when](sol::table params) {
+            *char_ptr = params["character"].get<sol::optional<Character*>>().value_or(nullptr);
+            *item_ptr = params["food"].get<sol::optional<item*>>().value_or(nullptr);
+            *item_id = (*item_ptr)->typeId().str();
+            *calories = params["calories"].get<int>();
+            *nutrition = params["nutrition"].get<int>();
+            *when = params["when"].get<time_point>();
+        });
+    hook_cleanup cleanup{list, idx};
+
+    auto meds = item(itype_id("aspirin"), calendar::turn, item::default_charges_tag{});
+    REQUIRE(meds.is_medication());
+    REQUIRE(get_avatar().consume_effects(meds));
+    CHECK(*char_ptr == nullptr);
+
+    auto food = item(itype_id("apple"), calendar::turn, item::default_charges_tag{});
+    REQUIRE(food.is_food());
+
+    REQUIRE(get_avatar().consume_effects(food));
+
+    CHECK(*char_ptr == &get_avatar());
+    CHECK(*item_ptr == &food);
+    CHECK(*item_id == "apple");
+    CHECK(*calories > 0);
+    CHECK(*nutrition > 0);
+    CHECK(*when == calendar::turn);
+}
+
 TEST_CASE("lua_hook_wiring_monster_loaded", "[lua]") {
     clear_all_state();
     auto& state = *DynamicDataLoader::get_instance().lua;

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -1766,7 +1766,8 @@ TEST_CASE("lua_hook_wiring_character_consumed_food", "[lua][consumption]") {
     const auto nutrition = std::make_shared<int>(0);
     const auto when = std::make_shared<time_point>();
 
-    const auto [list, idx] = push_hook(lua, "on_character_consumed_food",
+    const auto [list, idx] = push_hook(
+        lua, "on_character_consumed_food",
         [char_ptr, item_ptr, item_id, calories, nutrition, when](sol::table params) {
             *char_ptr = params["character"].get<sol::optional<Character*>>().value_or(nullptr);
             *item_ptr = params["food"].get<sol::optional<item*>>().value_or(nullptr);


### PR DESCRIPTION
## Purpose of change (The Why)

Add an opt-out default balance mod inspired by https://modrinth.com/mod/spice-of-life-apple-pie-edition: varied, hearty meals should feel better than repeating easy foods.

## Describe the solution (The How)

- Add `varied_diet` to default mods.
- Add a Lua consumption hook with calories, fun, health, and item context.
- Track recent foods in character values, score variety/complexity from `config.lua`, and apply configurable morale/health rewards or repeat penalties.

## Testing

- `cmake --build out/build/linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `XDG_CONFIG_HOME=$(mktemp -d) ./out/build/linux-full/tests/cata_test-tiles "[lua]"`
- `./build-scripts/lint-json.sh`
- `deno task semantic`
- `XDG_CONFIG_HOME=$(mktemp -d) SDL_VIDEODRIVER=dummy out/build/linux-full/src/cataclysm-bn-tiles --dont-debugmsg --check-mods varied_diet`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This PR adds/removes a mod.
  - [x] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [x] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [x] I have committed the output of `deno task semantic`.
- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [x] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d6f8910](https://github.com/cataclysmbn/Cataclysm-BN/commit/d6f891033f3895519a738fbe86fd210dae5bae89) (style(autofix.ci): automated formatting) on 2026-07-02 14:35:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28586993567/artifacts/8041700456)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28586993567/artifacts/8040329992)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28586993567/artifacts/8041426705)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28586993567/artifacts/8040239389)
<!-- END artifact comment -->