### PR TITLE
fix: load saved texture streaming settings

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,6 +46,7 @@
         "CURSES": "ON",
         "TILES": "OFF",
         "SOUND": "OFF",
+        "LIBBACKTRACE": "ON",
         "USE_PREFIX_DATA_DIR": "OFF",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "LINKER": "mold",

--- a/src/preload_config.cpp
+++ b/src/preload_config.cpp
@@ -22,6 +22,19 @@ struct state_t {
 
 state_t s_state;
 
+auto tristate_from_legacy_int( const int value ) -> tristate
+{
+    switch( static_cast<tristate>( value ) ) {
+        case tristate::enable:
+            return tristate::enable;
+        case tristate::disable:
+            return tristate::disable;
+        default:
+        case tristate::auto_select:
+            return tristate::auto_select;
+    }
+}
+
 } // namespace
 
 auto load() -> void
@@ -39,9 +52,14 @@ auto load() -> void
             s_state.gpu_backend = jObj.get_string( "gpu_backend", "" );
         }
 
-        s_state.texture_streaming = tristate_from_string(
-                                        jObj.get_string( "texture_streaming", "auto" ) //
-                                    );
+        if( jObj.has_string( "texture_streaming" ) ) {
+            s_state.texture_streaming = tristate_from_string(
+                                            jObj.get_string( "texture_streaming" ) );
+        } else {
+            s_state.texture_streaming = tristate_from_legacy_int(
+                                            jObj.get_int( "texture_streaming",
+                                                    static_cast<int>( tristate::auto_select ) ) );
+        }
     },
     true );
 }
@@ -56,7 +74,8 @@ auto save() -> void
         if( !s_state.gpu_backend.empty() ) {
             jout.member( "gpu_backend", s_state.gpu_backend );
         }
-        jout.member( "texture_streaming", s_state.texture_streaming );
+        jout.member( "texture_streaming",
+                     std::string{ tristate_to_string( s_state.texture_streaming ) } );
         jout.end_object();
     }, "preload config" );
 }

--- a/tests/preload_config_test.cpp
+++ b/tests/preload_config_test.cpp
@@ -1,0 +1,64 @@
+#include "catch/catch.hpp"
+
+#include "filesystem.h"
+#include "path_info.h"
+#include "preload_config.h"
+
+#include <fstream>
+#include <iterator>
+#include <string>
+
+namespace
+{
+
+class preload_config_file_guard
+{
+    public:
+        ~preload_config_file_guard() {
+            remove_file( PATH_INFO::preload() );
+            preload_config::set_texture_streaming( preload_config::tristate::auto_select );
+        }
+};
+
+auto read_preload_config() -> std::string
+{
+    REQUIRE( assure_dir_exist( PATH_INFO::config_dir() ) );
+    auto file = std::ifstream( PATH_INFO::preload(), std::ios::binary );
+    REQUIRE( file.good() );
+    return { std::istreambuf_iterator<char>( file ), std::istreambuf_iterator<char>() };
+}
+
+auto write_preload_config( const std::string &contents ) -> void
+{
+    REQUIRE( assure_dir_exist( PATH_INFO::config_dir() ) );
+    auto file = std::ofstream( PATH_INFO::preload(), std::ios::binary );
+    REQUIRE( file.good() );
+    file << contents;
+}
+
+} // namespace
+
+TEST_CASE( "preload config saves texture streaming as a string", "[preload_config]" )
+{
+    auto restore_preload_config = preload_config_file_guard();
+
+    preload_config::set_texture_streaming( preload_config::tristate::enable );
+    REQUIRE( assure_dir_exist( PATH_INFO::config_dir() ) );
+
+    preload_config::save();
+
+    const auto contents = read_preload_config();
+    CHECK( contents.find( R"("texture_streaming": "enable")" ) != std::string::npos );
+}
+
+TEST_CASE( "preload config loads legacy numeric texture streaming", "[preload_config]" )
+{
+    auto restore_preload_config = preload_config_file_guard();
+    write_preload_config( R"({ "compute_acceleration": "auto", "texture_streaming": 0 })" );
+
+    preload_config::set_texture_streaming( preload_config::tristate::enable );
+
+    preload_config::load();
+
+    CHECK( preload_config::get_texture_streaming() == preload_config::tristate::auto_select );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

A generated `preload.json` could save `texture_streaming` as a number, but startup later expected a string. On curses builds without libbacktrace this made a config read error spend ~29 seconds in `addr2line` before the menu.

```text
ERROR: Failed to read from "/home/scarf/.cataclysm-bn/config/preload.json": ... expected string but got '0'
  "texture_streaming": 0
Backtrace emission took 29 seconds.
```

Related:
- https://github.com/cataclysmbn/Cataclysm-BN/pull/9016
- https://github.com/cataclysmbn/Cataclysm-BN/pull/9335
- https://github.com/cataclysmbn/Cataclysm-BN/pull/9356
- https://github.com/cataclysmbn/Cataclysm-BN/pull/9379

## Describe the solution (The How)

- Save `texture_streaming` as text.
- Accept legacy numeric `texture_streaming` values.
- Enable `LIBBACKTRACE` for the local `linux-curses` preset.

## Testing

- Reproduced the slow startup with numeric `texture_streaming: 0` before the fix.
- Added `[preload_config]` coverage for string save and legacy numeric load.
- Confirmed `[preload_config]` passes on `linux-full` and `linux-curses`.
- Confirmed `out/build/linux-curses/CMakeCache.txt` has `LIBBACKTRACE:BOOL=ON`.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] If applicable, add checks on game load that would validate the loaded data.
  - [x] If it modifies format of save files, please add migration from the old format.
- [x] This is a PR that modifies build process or code organization.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bd2ecc7](https://github.com/cataclysmbn/Cataclysm-BN/commit/bd2ecc7c7418653c5dc58f3b8eec2a6d7752e089) (fix: load saved texture streaming settings) on 2026-06-11 08:13:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27331015360/artifacts/7557698740)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27331015360/artifacts/7558289115)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27331015360/artifacts/7557702547)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27331015360/artifacts/7558214993)
<!-- END artifact comment -->
