### PR TITLE
ci: enforce Lua type checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,8 +389,6 @@ jobs:
 
       - name: Generate Lua reference/annotations for typecheck
         if: runner.os == 'Linux' && matrix.artifact == 'linux-tiles-x64'
-        id: lua-docs-typecheck
-        continue-on-error: true
         env:
           CATA_EXE: ./cataclysm-bn-tiles
         run: |
@@ -398,9 +396,7 @@ jobs:
           deno task docs:gen
 
       - name: Run EmmyLua check
-        if: runner.os == 'Linux' && matrix.artifact == 'linux-tiles-x64' && steps.lua-docs-typecheck.outcome == 'success'
-        id: emmylua-check
-        continue-on-error: true
+        if: runner.os == 'Linux' && matrix.artifact == 'linux-tiles-x64'
         run: emmylua_check .
 
       - name: Generate documentation artifacts


### PR DESCRIPTION
## Purpose of change (The Why)

Make Lua typecheck mandatory so existing EmmyLua errors fail CI instead of being ignored.

Related: #8616, #9417

## Describe the solution (The How)

- Stop ignoring Lua docs/typecheck failures.
- Run `emmylua_check .` as a blocking CI step.

## Testing

- `conventional-prs --input 'ci: enforce Lua type checks'`
- `emmylua_check --help`
- `git merge-base --is-ancestor upstream/main HEAD`

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [ ] I ran the code formatter. YAML-only CI change; broad formatters not run.
- [ ] I linked relevant issues using GitHub keyword syntax.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [401d7e5](https://github.com/cataclysmbn/Cataclysm-BN/commit/401d7e5d856d1a29df971dd781306085875ffe14) (ci: enforce Lua type checks) on 2026-06-11 09:38:00

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27335739603/artifacts/7559742903)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27335739603/artifacts/7560390523)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27335739603/artifacts/7559758828)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27335739603/artifacts/7560319186)
<!-- END artifact comment -->