### PR TITLE
docs: add game installation guide

### DIFF
--- a/docs/en/install/install.md
+++ b/docs/en/install/install.md
@@ -1,0 +1,56 @@
+# How to install the game
+## Install the base game
+- Go here https://github.com/cataclysmbn/Cataclysm-BN
+- Under `Executables`, select the base game version you want
+1) `Stable` is less bug free, but you won't have the latest content. There is a stable every few months
+2) `Latest release` is where the Nightlies are published (one release every night). You get the latest content, but they might be unstable
+<img width="834" height="170" alt="image" src="https://github.com/user-attachments/assets/c23f8629-dc4f-46c7-8f09-28f4d0f2cbfb" />
+
+- In both cases **Always back up your save before updating your game** (preferably your whole game folder)
+- Select the right game version for your OS
+<img width="1231" height="639" alt="image" src="https://github.com/user-attachments/assets/9f82e154-1034-477b-b8ad-5c83c746dc16" />
+
+- Create a new folder where you want the game to be installed (here called "CBN_TUTO_INSTALL")
+- Double click on the game zip, select all the files, drag & drop them on the newly created folder
+<img width="1917" height="1077" alt="image" src="https://github.com/user-attachments/assets/ded02968-52ac-48a5-813c-1883885951cf" />
+
+- Congratulations! The game is already installed, you can start the game by double clicking the file called `cataclysm-bn-tiles`
+
+## Get external mods
+- Bright Night already includes enough mods for your first playthrough, but maybe you want even _more_
+- Go to https://mods.cataclysmbn.org/ , click on `View all XXX mods`
+<img width="1903" height="930" alt="image" src="https://github.com/user-attachments/assets/08786ffd-6cff-46a5-afb1-83b5db997d7a" />
+
+- Click on a mod that seems interesting to get more info about it
+<img width="1919" height="932" alt="image" src="https://github.com/user-attachments/assets/3a63722b-11f3-4fdb-b903-c8a9e0affdf3" />
+
+- Click on the link below `Installation` to download the mod
+<img width="1914" height="937" alt="image" src="https://github.com/user-attachments/assets/37052212-929d-4459-b383-a665d10f500e" />
+
+- Same as what we did for the base game, drag & drop the mod file(s) in `/gamefolder/mods/`
+- _A mod folder must have a modinfo.json file, you need to drag & drop the folder that contains it_
+<img width="1917" height="1076" alt="image" src="https://github.com/user-attachments/assets/da63f3ff-40e5-44c2-82cc-15bcb3e3e9b2" />
+
+- The mod is installed!
+
+## Get a ~~real~~ soundpack
+- Go to https://mods.cataclysmbn.org/mods/otopack_bn_mk_2/
+- Repeat the process of `Get external mods` but this time we will put the files in `/gamefolder/sound`
+- PS: Create the `sound` folder in `/gamefolder/` if it doesn't exist. *You musn't install anything in `data`, although it works too, this is reserved for the base game files*
+<img width="1914" height="1064" alt="image" src="https://github.com/user-attachments/assets/a71770dc-a032-4ed5-93a6-bf90c60e4a99" />
+
+- The soundpack is installed!
+## (optional) Get extra musics for the soundpack
+- If you want extra musics for this soundpack, click the link here https://github.com/leoCottret/cbn-leocottret-mods/tree/main/MUSICS for instructions
+## Enabling everything in game
+- To enable the soundpack in game, `Settings` > `Options` (`Enter`) >  
+<img width="1924" height="1079" alt="image" src="https://github.com/user-attachments/assets/f59a43c1-c92a-4a32-b3b1-111d15e7b43e" />
+
+- `General` > `Choose soundpack` "Otopack BN" > `ESC` key > Select `Yes`
+<img width="1914" height="1079" alt="image" src="https://github.com/user-attachments/assets/54c1af2a-be56-4bc8-85dd-4013ff73b85e" />
+
+- To start a game with a new mod, just press `Enter` on it while creating a world
+- `World` > `Create World` > Go on your mod > Press `Enter`
+<img width="1916" height="1079" alt="image" src="https://github.com/user-attachments/assets/7da9ea69-d95e-4d87-8285-57242dc2efd0" />
+
+- Golden rule: from anywhere in the game, press `?` to see (and change) the available keys in this specific context

--- a/docs/en/install/install.md
+++ b/docs/en/install/install.md
@@ -1,56 +1,65 @@
 # How to install the game
+
 ## Install the base game
+
 - Go here https://github.com/cataclysmbn/Cataclysm-BN
 - Under `Executables`, select the base game version you want
-1) `Stable` is less bug free, but you won't have the latest content. There is a stable every few months
-2) `Latest release` is where the Nightlies are published (one release every night). You get the latest content, but they might be unstable
-<img width="834" height="170" alt="image" src="https://github.com/user-attachments/assets/c23f8629-dc4f-46c7-8f09-28f4d0f2cbfb" />
+
+1. `Stable` is less bug free, but you won't have the latest content. There is a stable every few months
+2. `Latest release` is where the Nightlies are published (one release every night). You get the latest content, but they might be unstable
+   <img width="834" height="170" alt="image" src="https://github.com/user-attachments/assets/c23f8629-dc4f-46c7-8f09-28f4d0f2cbfb" />
 
 - In both cases **Always back up your save before updating your game** (preferably your whole game folder)
 - Select the right game version for your OS
-<img width="1231" height="639" alt="image" src="https://github.com/user-attachments/assets/9f82e154-1034-477b-b8ad-5c83c746dc16" />
+  <img width="1231" height="639" alt="image" src="https://github.com/user-attachments/assets/9f82e154-1034-477b-b8ad-5c83c746dc16" />
 
 - Create a new folder where you want the game to be installed (here called "CBN_TUTO_INSTALL")
 - Double click on the game zip, select all the files, drag & drop them on the newly created folder
-<img width="1917" height="1077" alt="image" src="https://github.com/user-attachments/assets/ded02968-52ac-48a5-813c-1883885951cf" />
+  <img width="1917" height="1077" alt="image" src="https://github.com/user-attachments/assets/ded02968-52ac-48a5-813c-1883885951cf" />
 
 - Congratulations! The game is already installed, you can start the game by double clicking the file called `cataclysm-bn-tiles`
 
 ## Get external mods
+
 - Bright Night already includes enough mods for your first playthrough, but maybe you want even _more_
 - Go to https://mods.cataclysmbn.org/ , click on `View all XXX mods`
-<img width="1903" height="930" alt="image" src="https://github.com/user-attachments/assets/08786ffd-6cff-46a5-afb1-83b5db997d7a" />
+  <img width="1903" height="930" alt="image" src="https://github.com/user-attachments/assets/08786ffd-6cff-46a5-afb1-83b5db997d7a" />
 
 - Click on a mod that seems interesting to get more info about it
-<img width="1919" height="932" alt="image" src="https://github.com/user-attachments/assets/3a63722b-11f3-4fdb-b903-c8a9e0affdf3" />
+  <img width="1919" height="932" alt="image" src="https://github.com/user-attachments/assets/3a63722b-11f3-4fdb-b903-c8a9e0affdf3" />
 
 - Click on the link below `Installation` to download the mod
-<img width="1914" height="937" alt="image" src="https://github.com/user-attachments/assets/37052212-929d-4459-b383-a665d10f500e" />
+  <img width="1914" height="937" alt="image" src="https://github.com/user-attachments/assets/37052212-929d-4459-b383-a665d10f500e" />
 
 - Same as what we did for the base game, drag & drop the mod file(s) in `/gamefolder/mods/`
 - _A mod folder must have a modinfo.json file, you need to drag & drop the folder that contains it_
-<img width="1917" height="1076" alt="image" src="https://github.com/user-attachments/assets/da63f3ff-40e5-44c2-82cc-15bcb3e3e9b2" />
+  <img width="1917" height="1076" alt="image" src="https://github.com/user-attachments/assets/da63f3ff-40e5-44c2-82cc-15bcb3e3e9b2" />
 
 - The mod is installed!
 
 ## Get a ~~real~~ soundpack
+
 - Go to https://mods.cataclysmbn.org/mods/otopack_bn_mk_2/
 - Repeat the process of `Get external mods` but this time we will put the files in `/gamefolder/sound`
-- PS: Create the `sound` folder in `/gamefolder/` if it doesn't exist. *You musn't install anything in `data`, although it works too, this is reserved for the base game files*
-<img width="1914" height="1064" alt="image" src="https://github.com/user-attachments/assets/a71770dc-a032-4ed5-93a6-bf90c60e4a99" />
+- PS: Create the `sound` folder in `/gamefolder/` if it doesn't exist. _You musn't install anything in `data`, although it works too, this is reserved for the base game files_
+  <img width="1914" height="1064" alt="image" src="https://github.com/user-attachments/assets/a71770dc-a032-4ed5-93a6-bf90c60e4a99" />
 
 - The soundpack is installed!
+
 ## (optional) Get extra musics for the soundpack
+
 - If you want extra musics for this soundpack, click the link here https://github.com/leoCottret/cbn-leocottret-mods/tree/main/MUSICS for instructions
+
 ## Enable everything in game
-- To enable the soundpack in game, `Settings` > `Options` (`Enter`) >  
-<img width="1924" height="1079" alt="image" src="https://github.com/user-attachments/assets/f59a43c1-c92a-4a32-b3b1-111d15e7b43e" />
+
+- To enable the soundpack in game, `Settings` > `Options` (`Enter`) >\
+  <img width="1924" height="1079" alt="image" src="https://github.com/user-attachments/assets/f59a43c1-c92a-4a32-b3b1-111d15e7b43e" />
 
 - `General` > `Choose soundpack` "Otopack BN" > `ESC` key > Select `Yes`
-<img width="1914" height="1079" alt="image" src="https://github.com/user-attachments/assets/54c1af2a-be56-4bc8-85dd-4013ff73b85e" />
+  <img width="1914" height="1079" alt="image" src="https://github.com/user-attachments/assets/54c1af2a-be56-4bc8-85dd-4013ff73b85e" />
 
 - To start a game with a new mod, just press `Enter` on it while creating a world
 - `World` > `Create World` > Go on your mod > Press `Enter`
-<img width="1916" height="1079" alt="image" src="https://github.com/user-attachments/assets/7da9ea69-d95e-4d87-8285-57242dc2efd0" />
+  <img width="1916" height="1079" alt="image" src="https://github.com/user-attachments/assets/7da9ea69-d95e-4d87-8285-57242dc2efd0" />
 
 - Golden rule: from anywhere in the game, press `?` to see (and change) the available keys in this specific context

--- a/docs/en/install/install.md
+++ b/docs/en/install/install.md
@@ -42,7 +42,7 @@
 - The soundpack is installed!
 ## (optional) Get extra musics for the soundpack
 - If you want extra musics for this soundpack, click the link here https://github.com/leoCottret/cbn-leocottret-mods/tree/main/MUSICS for instructions
-## Enabling everything in game
+## Enable everything in game
 - To enable the soundpack in game, `Settings` > `Options` (`Enter`) >  
 <img width="1924" height="1079" alt="image" src="https://github.com/user-attachments/assets/f59a43c1-c92a-4a32-b3b1-111d15e7b43e" />
 

--- a/docs/en/install/install.md
+++ b/docs/en/install/install.md
@@ -39,8 +39,9 @@
 
 ## Get a ~~real~~ soundpack
 
+- First, check if there is folder with "otopack" in the name, in `/gamefolder/data/sound/`. If that's the case you can skip this part, otherwise:
 - Go to https://mods.cataclysmbn.org/mods/otopack_bn_mk_2/
-- Repeat the process of `Get external mods` but this time we will put the files in `/gamefolder/sound`
+- Repeat the process of `Get external mods` but this time we will put the files in `/gamefolder/sound/`
 - PS: Create the `sound` folder in `/gamefolder/` if it doesn't exist. _You musn't install anything in `data`, although it works too, this is reserved for the base game files_
   <img width="1914" height="1064" alt="image" src="https://github.com/user-attachments/assets/a71770dc-a032-4ed5-93a6-bf90c60e4a99" />
 


### PR DESCRIPTION
Add a generic game installation guide https://github.com/leoCottret/Cataclysm-BN/blob/add-installation-guide/docs/en/install/install.md