### PR TITLE
fix: use Metal compute shader entrypoint

### DIFF
--- a/src/compute/gpu_lm.cpp
+++ b/src/compute/gpu_lm.cpp
@@ -238,7 +238,7 @@ auto load_pipeline(
     SDL_GPUComputePipelineCreateInfo const info{
         .code_size = blob.size(),
         .code = reinterpret_cast<Uint8 const*>(blob.data()),
-        .entrypoint = "main",
+        .entrypoint = compute_shader_entrypoint(fmt),
         .format = fmt,
         .num_samplers = 0,
         .num_readonly_storage_textures = 0,

--- a/src/compute/gpu_platform.cpp
+++ b/src/compute/gpu_platform.cpp
@@ -27,6 +27,10 @@
 
 namespace cata_gpu {
 
+auto compute_shader_entrypoint(SDL_GPUShaderFormat const format) -> char const* {
+    return format == SDL_GPU_SHADERFORMAT_MSL ? "main0" : "main";
+}
+
 namespace {
 
 SDL_GPUDevice* s_device = nullptr;
@@ -440,7 +444,7 @@ auto probe_shader(
     SDL_GPUComputePipelineCreateInfo const info{
         .code_size = blob.size(),
         .code = reinterpret_cast<Uint8 const*>(blob.data()),
-        .entrypoint = "main",
+        .entrypoint = compute_shader_entrypoint(fmt),
         .format = fmt,
         .num_samplers = 0,
         .num_readonly_storage_textures = 0,

--- a/src/compute/gpu_platform.h
+++ b/src/compute/gpu_platform.h
@@ -1,7 +1,7 @@
 #pragma once
 #if defined(CATA_SDL)
 
-struct SDL_GPUDevice;
+#include <SDL3/SDL_gpu.h>
 
 namespace cata_gpu {
 
@@ -11,6 +11,10 @@ auto shutdown() -> void;
 // Returns the active GPU device, or nullptr if device creation failed or
 // shutdown already ran.
 auto get_device() -> SDL_GPUDevice*;
+
+// SDL_shadercross emits Metal compute kernels as main0 while the other
+// backends keep the HLSL entry point name.
+auto compute_shader_entrypoint(SDL_GPUShaderFormat format) -> char const*;
 
 } // namespace cata_gpu
 

--- a/src/compute/gpu_transparency.cpp
+++ b/src/compute/gpu_transparency.cpp
@@ -280,7 +280,7 @@ auto ensure_pipeline(SDL_GPUDevice* const device) -> SDL_GPUComputePipeline* {
     SDL_GPUComputePipelineCreateInfo const info{
         .code_size = blob.size(),
         .code = reinterpret_cast<Uint8 const*>(blob.data()),
-        .entrypoint = "main",
+        .entrypoint = compute_shader_entrypoint(fmt),
         .format = fmt,
         .num_samplers = 0,
         .num_readonly_storage_textures = 0,


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9423

Metal compute shader blobs generated by SDL_shadercross expose `main0`, while the GPU pipeline setup requested `main`.

## Describe the solution (The How)

- Select `main0` for MSL compute pipelines.
- Reuse the same entrypoint selection for shader probing, lighting, and transparency compute pipelines.

## Testing

- Confirmed generated `.msl` compute shaders define `kernel void main0`.
- Ran `clang-format -i src/compute/gpu_lm.cpp src/compute/gpu_platform.cpp src/compute/gpu_platform.h src/compute/gpu_transparency.cpp`.
- Ran `git diff --check`.
- Full build not run per request.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [165014c](https://github.com/cataclysmbn/Cataclysm-BN/commit/165014c620873e251c89a32c44f9883bd7d95c58) (fix: use Metal compute shader entrypoint) on 2026-06-11 13:07:16

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27344958431/artifacts/7563700761)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27344958431/artifacts/7565061065)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27344958431/artifacts/7563841233)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27344958431/artifacts/7564346791)
<!-- END artifact comment -->