### PR TITLE
fix(lua): prevent Map:create_item_at from returning invalid item

### DIFF
--- a/src/catalua_bindings_map.cpp
+++ b/src/catalua_bindings_map.cpp
@@ -357,10 +357,11 @@ void cata::detail::reg_map( sol::state &lua )
         } );
 
         DOC( "Creates a new item(s) at a position on the map." );
+        DOC( "Returns nil. Use gapi.create_item and Map:add_item to modify before placement." );
         luna::set_fx( ut, "create_item_at", []( map & m, const tripoint_bub_ms & p, const itype_id & itype,
-        int count ) -> item* {
-            detached_ptr<item> new_item = item::spawn( itype, calendar::turn, count );
-            return m.add_item_or_charges( p, std::move( new_item ) ).get();
+        int count ) -> void {
+            auto new_item = item::spawn( itype, calendar::turn, count );
+            m.add_item_or_charges( p, std::move( new_item ) );
         } );
 
         DOC( "Spawns a random artifact at a position on the map." );

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -107,6 +107,32 @@ TEST_CASE( "lua_global_functions", "[lua]" )
     REQUIRE( lua_npc_avatar_name == "nil" );
 }
 
+TEST_CASE( "lua_map_create_item_at_places_without_returning_owned_item", "[lua][map]" )
+{
+    clear_all_state();
+    auto lua = make_lua_state();
+    auto test_data = lua.create_table();
+    lua.globals()["test_data"] = test_data;
+
+    auto &here = get_map();
+    const auto pos = get_avatar().bub_pos();
+    here.i_clear( pos );
+    test_data["pos"] = pos;
+
+    const auto script_res = lua.safe_script( R"(
+local map = gapi.get_map()
+local placed = map:create_item_at(test_data["pos"], ItypeId.new("rock"), 1)
+test_data["return_type"] = type(placed)
+test_data["item_count"] = #map:get_items_at(test_data["pos"])
+)", sol::script_pass_on_error );
+    REQUIRE( script_res.valid() );
+
+    CHECK( test_data.get<std::string>( "return_type" ) == "nil" );
+    CHECK( test_data.get<int>( "item_count" ) == 1 );
+
+    here.i_clear( pos );
+}
+
 TEST_CASE( "lua_activity_bindings", "[lua]" )
 {
     clear_all_state();


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #9409: `Map:create_item_at` returned an invalid item handle after moving ownership to the map, which could trigger `Attempted to resolve invalid detached_ptr` when Lua used the return value.

## Describe the solution (The How)

- Make `Map:create_item_at` place the item and return nil.
- Document `gapi.create_item` + `Map:add_item` as the pre-placement mutation path.
- Add real Lua binding coverage for the nil return and placed item.

## Testing

- Formatter ran.
- Built `cataclysm-bn-tiles` and `cata_test-tiles`.
- `cata_test-tiles "[lua][map]"`: pass.
- `cata_test-tiles "[lua]"`: pass.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e5c2911](https://github.com/cataclysmbn/Cataclysm-BN/commit/e5c291159442d774c8e1feb4436fd0a757befabb) (fix(lua): prevent Map:create_item_at from returning invalid item) on 2026-06-11 13:09:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27346378067/artifacts/7564229841)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27346378067/artifacts/7565086028)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27346378067/artifacts/7564328230)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27346378067/artifacts/7564873171)
<!-- END artifact comment -->