### PR TITLE
style: add trailing commas to .jsonc

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -33,6 +33,7 @@
     "exclude": ["doc", "**/*.svg"],
     "include": ["scripts", ".agents", "doc", "docs", "*.md", ".github", ".claude"],
     "semiColons": false,
+    "json.trailingCommas": "jsonc",
     "lineWidth": 100,
     "proseWrap": "preserve"
   },

--- a/docs/deno.jsonc
+++ b/docs/deno.jsonc
@@ -3,65 +3,53 @@
     "lume/": "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.4/",
     "lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.14/jsx-runtime.ts",
     "wiki/": "https://raw.githubusercontent.com/lumeland/theme-simple-wiki/v0.15.1/",
-    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.14.9/"
+    "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@0.14.9/",
   },
   "lock": false,
   "tasks": {
     "serve": {
       "description": "serve local documentation site in your browser",
-      "command": "deno task lume -s"
+      "command": "deno task lume -s",
     },
     "lume": {
       "description": "Run Lume command",
-      "command": "deno run -P=lume lume/cli.ts"
+      "command": "deno run -P=lume lume/cli.ts",
     },
     "build": {
       "description": "Build the site for production",
-      "command": "deno task lume"
+      "command": "deno task lume",
     },
-    "cms": "deno task lume cms"
+    "cms": "deno task lume cms",
   },
   "fmt": {
     "semiColons": false,
     "lineWidth": 100,
-    "proseWrap": "preserve"
+    "json.trailingCommas": "jsonc",
+    "proseWrap": "preserve",
   },
   "compilerOptions": {
-    "types": [
-      "lume/types.ts"
-    ],
+    "types": ["lume/types.ts"],
     "jsx": "react-jsx",
     "jsxImportSource": "lume",
-    "checkJs": true
+    "checkJs": true,
   },
-  "unstable": [
-    "temporal",
-    "fmt-component",
-    "raw-imports"
-  ],
+  "unstable": ["temporal", "fmt-component", "raw-imports"],
   "lint": {
-    "plugins": [
-      "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.4/lint.ts"
-    ],
+    "plugins": ["https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.4/lint.ts"],
     "rules": {
-      "exclude": [
-        "no-unversioned-import",
-        "no-import-prefix"
-      ]
-    }
+      "exclude": ["no-unversioned-import", "no-import-prefix"],
+    },
   },
   "permissions": {
     "lume": {
       "read": true,
-      "write": [
-        "./"
-      ],
+      "write": ["./"],
       "import": [
         "cdn.jsdelivr.net:443",
         "jsr.io:443",
         "deno.land:443",
         "esm.sh:443",
-        "raw.githubusercontent.com:443"
+        "raw.githubusercontent.com:443",
       ],
       "net": [
         "0.0.0.0",
@@ -71,12 +59,12 @@
         "deno.land:443",
         "esm.sh:443",
         "registry.npmjs.org:443",
-        "raw.githubusercontent.com:443"
+        "raw.githubusercontent.com:443",
       ],
       "env": true,
       "run": true,
       "ffi": true,
-      "sys": true
-    }
-  }
+      "sys": true,
+    },
+  },
 }


### PR DESCRIPTION
use trailing commas for `.jsonc` files. this currently only affects config files and excludes `data/*` (because we haven't #7749 _yet_)
trailing commas are simply superior format, more consistent, easier to read, better diffs.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d95dfd1](https://github.com/cataclysmbn/Cataclysm-BN/commit/d95dfd1932f9785a64b6b69b4dd03500de80c839) (style: add trailing commas to .jsonc) on 2026-06-11 20:57:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27366864703/artifacts/7573317610)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27366864703/artifacts/7576659973)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27366864703/artifacts/7573176514)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27366864703/artifacts/7573706582)
<!-- END artifact comment -->