### PR TITLE
test: make monster upgrade time test deterministic

### DIFF
--- a/.agents/skills/test-quality/SKILL.md
+++ b/.agents/skills/test-quality/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: test-quality
+description: Write or review Cataclysm-BN tests that avoid flakes, use deterministic fixtures, and clean up global state.
+---
+
+# Test Quality
+
+Use when adding or changing automated tests.
+
+## Gates
+
+- Test one behavior contract, not incidental implementation details.
+- Use deterministic fixtures from `data/mods/TEST_DATA` for data with random, balance, or evolving behavior.
+- Avoid assertions that rely on probability, wall-clock time, locale, file order, or current global options unless the test pins them.
+- Reproduce reported flakes with the failing `--rng-seed` before accepting the fix.
+- Keep Lua/C++ integration tests on real bound objects when the binding behavior is under test.
+
+## Cleanup
+
+- Restore global state with `restore_on_out_of_scope` for calendar, options, globals, and singleton state.
+- Use `clear_map()` and explicit player placement when map contents matter.
+- Do not leave creatures, items, hooks, worlds, temp files, or option changes that can affect later tests.
+- Prefer new `TEST_DATA` fixtures over mutating base-game data in the test body.

--- a/data/mods/TEST_DATA/monsters.json
+++ b/data/mods/TEST_DATA/monsters.json
@@ -14,5 +14,16 @@
     "name": { "str": "unstabbable monster" },
     "description": "This monster exists only for testing purposes.",
     "armor_stab": 1000
+  },
+  {
+    "id": "mon_test_lua_upgrade_zombie",
+    "copy-from": "debug_mon",
+    "type": "MONSTER",
+    "name": { "str": "Lua upgrade test zombie" },
+    "description": "This monster exists only for testing purposes.",
+    "default_faction": "zombie",
+    "species": [ "ZOMBIE", "HUMAN" ],
+    "symbol": "Z",
+    "upgrades": { "age_grow": 14, "into": "mon_zombie" }
   }
 ]

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -256,17 +256,22 @@ TEST_CASE( "lua_place_monster_pins_upgrade_time", "[lua][monster]" )
     put_player_underground();
     calendar::turn = calendar::start_of_cataclysm + 2 * calendar::season_length();
 
+    const auto monster_id = mtype_id( "mon_test_lua_upgrade_zombie" );
+    const auto &monster_type = monster_id.obj();
+    REQUIRE( monster_type.upgrades );
+    REQUIRE( monster_type.age_grow == 14 );
+
     auto lua = make_lua_state();
     auto test_data = lua.create_table();
     lua.globals()["test_data"] = test_data;
-    test_data["monster_id"] = mtype_id( "mon_zombie" );
+    test_data["monster_id"] = monster_id;
     test_data["pos"] = tripoint_bub_ms{ 5, 5, 0 };
 
     run_lua_test_script( lua, "place_monster_upgrade_time_test.lua" );
 
     const auto current_day = to_days<int>( calendar::turn - calendar::turn_zero );
     REQUIRE( test_data.get<bool>( "monster_spawned" ) );
-    CHECK( test_data.get<std::string>( "monster_type" ) == "mon_zombie" );
+    CHECK( test_data.get<std::string>( "monster_type" ) == "mon_test_lua_upgrade_zombie" );
     CHECK( test_data.get<int>( "upgrade_time" ) > current_day );
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

PR #9226 pinned Lua-spawned monster upgrade time, but the CI run on #9426 still hit `mon_zombie`'s random half-life path with seed `1781197944`: `-1 > 60`.

## Describe the solution (The How)

- Add a `TEST_DATA` Lua upgrade test zombie with deterministic `age_grow` evolution.
- Use that fixture in the Lua monster upgrade test.
- Add a `test-quality` skill covering deterministic fixtures and cleanup.

## Testing

- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "lua_place_monster_pins_upgrade_time" --rng-seed 1781197944`
- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target style-json-parallel`
- `./build-scripts/lint-json.sh`
- `./out/build/linux-full/src/cataclysm-bn-tiles --dont-debugmsg --check-mods test_data`

## Additional context

Related: #9226, https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27363689245/job/80858826310?pr=9426

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4906d06](https://github.com/cataclysmbn/Cataclysm-BN/commit/4906d06af4622447e676db335170d7c673180b39) (docs: add test quality skill) on 2026-06-11 19:15:38

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27366367670/artifacts/7572723561)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27366367670/artifacts/7574354534)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27366367670/artifacts/7573223953)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27366367670/artifacts/7573552105)
<!-- END artifact comment -->