### PR TITLE
ci: remove inline PR artifact body publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -815,18 +815,6 @@ jobs:
           path: ${{ runner.os == 'Windows' && format('cataclysmbn-{0}/', inputs.version-label) || format('cbn-{0}-{1}.{2}', matrix.artifact, inputs.version-label, matrix.ext) }}
           if-no-files-found: error
 
-      - name: Publish platform artifact link
-        if: github.event_name == 'pull_request' && inputs.upload-artifacts && matrix.upload-artifact == true
-        continue-on-error: true
-        uses: ./.github/actions/publish-pr-artifact-body
-        with:
-          repository: ${{ github.repository }}
-          pr-number: ${{ github.event.pull_request.number }}
-          run-id: ${{ github.run_id }}
-          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          head-sha: ${{ github.event.pull_request.head.sha }}
-          token: ${{ github.token }}
-
       - name: Upload to release
         if: inputs.upload-to-release
         run: |

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -219,18 +219,6 @@ jobs:
           path: cbn-linux-tiles-x64-pr-${{ github.event.pull_request.number || github.run_id }}.tar.gz
           if-no-files-found: error
 
-      - name: Publish Linux artifact link
-        if: ${{ success() && github.event_name == 'pull_request' && env.SKIP == 'false' && matrix.upload-artifact == true }}
-        continue-on-error: true
-        uses: ./.github/actions/publish-pr-artifact-body
-        with:
-          repository: ${{ github.repository }}
-          pr-number: ${{ github.event.pull_request.number }}
-          run-id: ${{ github.run_id }}
-          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          head-sha: ${{ github.event.pull_request.head.sha }}
-          token: ${{ github.token }}
-
       - name: run tests
         if: ${{ github.ref_name != 'main' && env.SKIP == 'false' }}
         run: |


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #8921. Fork PRs can emit noisy `gh: Resource not accessible by integration (HTTP 403)` from redundant inline PR body publishing.

## Describe the solution (The How)

Remove the inline artifact body publishing steps from untrusted pull_request build jobs. Artifact uploads and the trusted workflow_run publisher remain intact.

## Testing

- `python3 -c "import pathlib, yaml; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/matrix.yml','.github/workflows/build.yml','.github/workflows/pr-artifact-publish.yml']]; print('workflow yaml parsed')"`

## Checklist

### Mandatory

- [x] I wrote the PR title in conventional commit format.
- [ ] I ran the code formatter. (YAML-only change; syntax-validated instead.)
- [x] I linked the relevant PR: #8921.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [30ba969](https://github.com/cataclysmbn/Cataclysm-BN/commit/30ba96946fc24439e8d299b0f2c92c31f9cc2bb2) (ci: remove inline PR artifact body publishing) on 2026-06-12 02:14:21

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27386401690/artifacts/7581420949)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27386401690/artifacts/7581455491)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27386401690/artifacts/7580685805)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27386401690/artifacts/7581193797)
<!-- END artifact comment -->