### PR TITLE
feat(mods): split rocky zombies from lethal zombies

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -70,11 +70,13 @@ scopes:
   - mods/jump_pad
   - mods/lethal_zeds
   - mods/limit_fungal_growth
+  - mods/lua_ai_attitude_debug
   - mods/manualbionicinstall
   - mods/my_sweet_cataclysm
   - mods/no_global_uniques
   - mods/no_npc_food
   - mods/no_reviving_zombies
+  - mods/no_vehicle_colors
   - mods/no_zombify
   - mods/novitamins
   - mods/npc_lua_hook_test
@@ -82,6 +84,7 @@ scopes:
   - mods/pathfinding_stockfish
   - mods/pride_flags
   - mods/resurrection_tech
+  - mods/rocky_zombies
   - mods/rpg_system
   - mods/sample-uv-mod
   - mods/saveload_lua_test
@@ -97,5 +100,6 @@ scopes:
   - mods/test_lua_require
   - mods/udp_redux
   - mods/underground_dynamic_temperature
+  - mods/vehicle_color_expansion
   - mods/weather_variants
   - mods

--- a/data/mods/lethal_zeds/monster_overwrites.json
+++ b/data/mods/lethal_zeds/monster_overwrites.json
@@ -1,26 +1,5 @@
 [
   {
-    "id": "zombie_thrown_rock",
-    "copy-from": "fake_item",
-    "type": "GUN",
-    "name": { "str": "zombie rock gun" },
-    "description": "This is a bug if you have this.  No recovery on rocks, we don't want a deluge of stone.",
-    "weight": "1 g",
-    "volume": "1 L",
-    "price": "2 USD",
-    "price_postapoc": "2 USD",
-    "material": [ "steel" ],
-    "color": "yellow",
-    "range": 10,
-    "skill": "throw",
-    "ammo_effects": [ "NO_PENETRATE_OBSTACLES" ],
-    "ranged_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 10 } ],
-    "dispersion": 3000,
-    "modes": [ [ "DEFAULT", "semi", 1 ] ],
-    "loudness": 1,
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD" ]
-  },
-  {
     "id": "mon_zombie",
     "copy-from": "mon_zombie",
     "type": "MONSTER",
@@ -37,20 +16,6 @@
         "cooldown": 4,
         "no_infection_chance": 2,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
-      },
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
       },
       [ "GRAB", 2 ],
       [ "scratch", 10 ]
@@ -87,23 +52,7 @@
     "grab_strength": 3,
     "extend": { "flags": [ "GOODHEARING" ] },
     "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
-    "special_attacks": [
-      [ "GRAB", 2 ],
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
-      }
-    ]
+    "special_attacks": [ [ "GRAB", 2 ] ]
   },
   {
     "id": "mon_zombie_crawler",
@@ -140,20 +89,6 @@
         "no_infection_chance": 2,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
       },
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
-      },
       [ "GRAB", 2 ],
       [ "scratch", 10 ]
     ]
@@ -167,24 +102,7 @@
     "hp": 90,
     "extend": { "flags": [ "GOODHEARING" ] },
     "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
-    "special_attacks": [
-      [ "GRAB", 2 ],
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
-      },
-      [ "scratch", 5 ]
-    ]
+    "special_attacks": [ [ "GRAB", 2 ], [ "scratch", 5 ] ]
   },
   {
     "id": "mon_zombie_hazmat",
@@ -196,22 +114,7 @@
     "hp": 90,
     "extend": { "flags": [ "GOODHEARING" ] },
     "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
-    "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
-      }
-    ]
+    "special_attacks": [  ]
   },
   {
     "id": "mon_zombie_rot",
@@ -229,20 +132,6 @@
         "cooldown": 4,
         "no_infection_chance": 1,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
-      },
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
       }
     ]
   },
@@ -255,22 +144,7 @@
     "grab_strength": 3,
     "extend": { "flags": [ "GOODHEARING" ] },
     "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
-    "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
-      }
-    ]
+    "special_attacks": [  ]
   },
   {
     "id": "mon_zombie_tough",
@@ -288,20 +162,6 @@
         "cooldown": 4,
         "no_infection_chance": 2,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
-      },
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
       },
       [ "GRAB", 2 ],
       [ "scratch", 20 ]
@@ -356,20 +216,6 @@
         "cooldown": 4,
         "no_infection_chance": 2,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 10, "armor_penetration": 8 } ]
-      },
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
       }
     ]
   },
@@ -391,20 +237,6 @@
         "cooldown": 4,
         "no_infection_chance": 2,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 10, "armor_penetration": 8 } ]
-      },
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
       }
     ]
   },
@@ -417,22 +249,7 @@
     "hp": 540,
     "extend": { "flags": [ "GOODHEARING" ] },
     "melee_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 4, "armor_multiplier": 0.2 } ],
-    "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
-      }
-    ]
+    "special_attacks": [  ]
   },
   {
     "id": "mon_zombie_hunter",
@@ -450,20 +267,6 @@
         "cooldown": 4,
         "no_infection_chance": 2,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 6, "armor_penetration": 8 } ]
-      },
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
       }
     ]
   },
@@ -484,20 +287,6 @@
         "cooldown": 2,
         "no_infection_chance": 2,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 4, "armor_penetration": 8 } ]
-      },
-      {
-        "type": "gun",
-        "cooldown": 6,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
       }
     ]
   },
@@ -521,23 +310,7 @@
     "grab_strength": 3,
     "extend": { "flags": [ "GOODHEARING" ] },
     "melee_damage": [ { "damage_type": "stab", "amount": 6, "armor_penetration": 5, "armor_multiplier": 0.1 } ],
-    "special_attacks": [
-      [ "GRAB", 2 ],
-      {
-        "type": "gun",
-        "cooldown": 7,
-        "move_cost": 100,
-        "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
-        "gun_type": "zombie_thrown_rock",
-        "no_ammo_sound": "",
-        "require_targeting_player": false,
-        "ranges": [ [ 1, 6, "DEFAULT" ] ],
-        "fake_dex": 5,
-        "fake_per": 5,
-        "description": "The zombie throws a rock!",
-        "no_crits": true
-      }
-    ]
+    "special_attacks": [ [ "GRAB", 2 ] ]
   },
   {
     "id": "mon_zombie_dog",

--- a/data/mods/rocky_zombies/modinfo.json
+++ b/data/mods/rocky_zombies/modinfo.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "rocky_zombies",
+    "name": "Rocky Zombies",
+    "authors": [ "RoyalFox" ],
+    "maintainers": [ "RoyalFox" ],
+    "description": "zombies now throw rocks at you. they really hate kites for some reason",
+    "category": "content",
+    "dependencies": [ "bn", "lethal_zeds" ]
+  }
+]

--- a/data/mods/rocky_zombies/monster_overwrites.json
+++ b/data/mods/rocky_zombies/monster_overwrites.json
@@ -1,0 +1,345 @@
+[
+  {
+    "id": "zombie_thrown_rock",
+    "copy-from": "fake_item",
+    "type": "GUN",
+    "name": { "str": "zombie rock gun" },
+    "description": "This is a bug if you have this.  No recovery on rocks, we don't want a deluge of stone.",
+    "weight": "1 g",
+    "volume": "1 L",
+    "price": "2 USD",
+    "price_postapoc": "2 USD",
+    "material": [ "steel" ],
+    "color": "yellow",
+    "range": 10,
+    "skill": "throw",
+    "ammo_effects": [ "NO_PENETRATE_OBSTACLES" ],
+    "ranged_damage": [ { "damage_type": "bash", "amount": 2, "armor_penetration": 10 } ],
+    "dispersion": 3000,
+    "modes": [ [ "DEFAULT", "semi", 1 ] ],
+    "loudness": 1,
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD" ]
+  },
+  {
+    "id": "mon_zombie",
+    "copy-from": "mon_zombie",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_cop",
+    "copy-from": "mon_zombie_cop",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_fat",
+    "copy-from": "mon_zombie_fat",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_fireman",
+    "copy-from": "mon_zombie_fireman",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_hazmat",
+    "copy-from": "mon_zombie_hazmat",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_rot",
+    "copy-from": "mon_zombie_rot",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_swat",
+    "copy-from": "mon_zombie_swat",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_tough",
+    "copy-from": "mon_zombie_tough",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_brute",
+    "copy-from": "mon_zombie_brute",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_brute_grappler",
+    "copy-from": "mon_zombie_brute_grappler",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_hulk",
+    "copy-from": "mon_zombie_hulk",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_hunter",
+    "copy-from": "mon_zombie_hunter",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_runner",
+    "copy-from": "mon_zombie_runner",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 6,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_zombie_miner",
+    "copy-from": "mon_zombie_miner",
+    "type": "MONSTER",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "gun",
+          "cooldown": 7,
+          "move_cost": 100,
+          "fake_skills": [ [ "gun", 1 ], [ "throw", 1 ] ],
+          "gun_type": "zombie_thrown_rock",
+          "no_ammo_sound": "",
+          "require_targeting_player": false,
+          "ranges": [ [ 1, 6, "DEFAULT" ] ],
+          "fake_dex": 5,
+          "fake_per": 5,
+          "description": "The zombie throws a rock!",
+          "no_crits": true
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Purpose of change (The Why)

Players asked for Lethal Zombies without rock throws: https://m.dcinside.com/board/rlike/519340

Related: #6788

## Describe the solution (The How)

- Move zombie rock throwing from `lethal_zeds` into new `rocky_zombies` add-on mod.
- Keep `rocky_zombies` dependent on `lethal_zeds` so enabling it restores the old combined behavior.
- Existing `lethal_zeds` saves intentionally stop getting rock throws unless `rocky_zombies` is manually added.

## Describe alternatives you've considered

Leaving rocks in Lethal Zombies would keep the reported goofy/annoying behavior mandatory.

## Testing

- `cmake --build out/build/linux-full --target style-json-parallel`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./build-scripts/lint-json.sh`
- Verified `lethal_zeds` has no `zombie_thrown_rock` references and `rocky_zombies` carries 14 moved rock attacks.
- `SDL_VIDEODRIVER=dummy out/build/linux-full/src/cataclysm-bn-tiles --userdir /tmp/cbn-check-all --check-all-mods`

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This PR adds/removes a mod.
  - [x] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [x] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
  - [x] I have committed the output of `deno task semantic`.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6fde9b0](https://github.com/cataclysmbn/Cataclysm-BN/commit/6fde9b0a88adf17f735f76c1750101da546c6e11) (feat(mods): split rocky zombies from lethal zombies) on 2026-06-12 02:46:44

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27387776330/artifacts/7581200676)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27387776330/artifacts/7581912045)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27387776330/artifacts/7581145712)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27387776330/artifacts/7581784260)
<!-- END artifact comment -->