### PR TITLE
ci: improve Android ccache reuse

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -656,9 +656,17 @@ jobs:
             ${{ matrix.artifact }}-${{ github.ref_name }}
             ${{ matrix.artifact }}-main
             ${{ matrix.artifact }}-
-          max-size: 500M
+          max-size: 2G
           verbose: 2
           save: ${{ github.event_name != 'pull_request' }}
+
+      - name: Configure ccache (android)
+        if: runner.os == 'Linux' && matrix.android != '' && matrix.android != 'none'
+        run: |
+          echo "CCACHE_BASEDIR=${{ github.workspace }}" >> "$GITHUB_ENV"
+          echo "CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros,pch_defines" >> "$GITHUB_ENV"
+          echo "CCACHE_NOHASHDIR=1" >> "$GITHUB_ENV"
+          echo "CCACHE_COMPILERCHECK=content" >> "$GITHUB_ENV"
 
       - name: Build CBN (android)
         if: runner.os == 'Linux' && matrix.android != '' && matrix.android != 'none'
@@ -721,6 +729,27 @@ jobs:
           then
                gradle_retry -Pj=$(nproc) -Plocalize=${{ inputs.android-localize }} bundle${VARIANT}Release ${VERSION_ARG}
                mv ./app/build/outputs/bundle/${VARIANT_LOWER}Release/*.aab ../cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.aab
+          fi
+
+      - name: Verify ccache compatibility (android)
+        if: runner.os == 'Linux' && matrix.android != '' && matrix.android != 'none'
+        run: |
+          set -euo pipefail
+          stats="$(ccache -s -vv 2>&1)"
+          printf '%s\n' "$stats"
+          cacheable="$(printf '%s\n' "$stats" | sed -nE 's/.*Cacheable calls:[[:space:]]*([0-9]+).*/\1/p' | head -n 1)"
+          hits="$(printf '%s\n' "$stats" | sed -nE 's/.*Hits:[[:space:]]*([0-9]+)[[:space:]]*\/.*/\1/p' | head -n 1)"
+          unsupported="$(printf '%s\n' "$stats" | sed -nE 's/.*Unsupported compiler option:[[:space:]]*([0-9]+).*/\1/p' | head -n 1)"
+          if [ "${cacheable:-0}" -le 100 ]; then
+            echo "ccache did not see enough cacheable Android compile calls" >&2
+            exit 1
+          fi
+          if [ "${unsupported:-0}" -ne 0 ]; then
+            echo "ccache saw unsupported Android compiler options" >&2
+            exit 1
+          fi
+          if [ "${hits:-0}" -eq 0 ]; then
+            echo "::warning::Android ccache restored no hits; this is expected until a warm cache is saved for the current ccache settings"
           fi
 
       - name: Verify bundled SDL runtime (android)


### PR DESCRIPTION
## Purpose of change (The Why)

Android CI ccache was cacheable but not reusable; recent warm builds restored a cache then still reported `0 / 458` hits.

this PR makes it 3x faster

Related: #9391, #9159, #8937.

## Describe the solution (The How)

- Raise Android ccache capacity from 500M to 2G.
- Set Android ccache base-dir/no-hash-dir/compiler-check settings before Gradle runs.
- Add an Android ccache compatibility check so CI proves ccache sees the native build.

## Testing

- `actionlint .github/workflows/build.yml`
- `python -c 'import yaml; yaml.safe_load(open(".github/workflows/build.yml", encoding="utf-8")); print("yaml ok")'`
- Fork PR validation: https://github.com/scarf005/Cataclysm-BN/pull/43

| Case | ccache | Time | Savings |
| --- | --- | --- | --- |
| [Before](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27382605461/job/80923947762) | 0 / 458 hits | 32m02s | baseline |
| [After](https://github.com/scarf005/Cataclysm-BN/actions/runs/27389517511/job/80944492913) | 457 / 458 hits | 10m27s | 67.4% less time, 3.07x faster |

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked relevant PRs above.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [54c04c2](https://github.com/cataclysmbn/Cataclysm-BN/commit/54c04c2eea406c0d56c2e5d8cd2e437b26402168) (ci: stabilize Android ccache reuse) on 2026-06-12 03:08:54

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27390189449/artifacts/7581707286)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27390189449/artifacts/7582114908)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27390189449/artifacts/7581785840)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27390189449/artifacts/7581925447)
<!-- END artifact comment -->