### PR TITLE
ci: automate PR checklist drift warnings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,8 +28,6 @@ NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive
 
 ### Mandatory
 
-- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
-- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
 - [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
 
 ### Optional
@@ -57,7 +55,6 @@ NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive
 - [ ] This PR adds/removes a mod.
   - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
   - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
-  - [ ] I have committed the output of `deno task semantic`.
 - [ ] This PR modifies lua scripts or the lua API.
   - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
   - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -70,11 +70,13 @@ scopes:
   - mods/jump_pad
   - mods/lethal_zeds
   - mods/limit_fungal_growth
+  - mods/lua_ai_attitude_debug
   - mods/manualbionicinstall
   - mods/my_sweet_cataclysm
   - mods/no_global_uniques
   - mods/no_npc_food
   - mods/no_reviving_zombies
+  - mods/no_vehicle_colors
   - mods/no_zombify
   - mods/novitamins
   - mods/npc_lua_hook_test
@@ -97,5 +99,6 @@ scopes:
   - mods/test_lua_require
   - mods/udp_redux
   - mods/underground_dynamic_temperature
+  - mods/vehicle_color_expansion
   - mods/weather_variants
   - mods

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -131,6 +131,27 @@ jobs:
           github.event.action == 'reopened'
         uses: scarf005/conventional-prs@v0.5.1
 
+      - name: Checkout base docs warning script
+        if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            docs
+            scripts/docs_translation_warning.ts
+            deno.jsonc
+            deno.lock
+
+      - name: Setup Deno for docs warning
+        if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
+        uses: denoland/setup-deno@v2
+        with: { cache: true }
+
+      - name: Warn on stale docs translations
+        if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: deno task docs:translation-warning ${{ github.event.pull_request.number }}
+
       - name: Comment and close pull request
         if: >-
           always() &&

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -110,7 +110,11 @@ jobs:
         run: |
           # deno lint
           deno test --allow-read --allow-env=npm_package_config_libvips,TILESET_PYTHON --allow-ffi
+
+      - name: check generated semantic PR config
+        run: |
           deno run --allow-read --allow-write scripts/semantic.ts
+          git diff --exit-code -- .github/semantic.yml
 
   lint:
     if: github.event_name == 'pull_request_target'

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -21,6 +21,7 @@
       "description": "update available semantic commit types",
       "command": "deno run -R=data/mods -W=.github/semantic.yml scripts/semantic.ts"
     },
+    "docs:translation-warning": "deno run --allow-read=docs --allow-env=GITHUB_TOKEN,GITHUB_REPOSITORY --allow-net=api.github.com scripts/docs_translation_warning.ts",
     "affected-files": "deno run -RWEN --allow-run scripts/affected_files.ts"
   },
   "test": { "include": ["scripts", ".agents"] },

--- a/scripts/docs_translation_warning.ts
+++ b/scripts/docs_translation_warning.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env -S deno run --allow-read=docs --allow-env=GITHUB_TOKEN,GITHUB_REPOSITORY --allow-net=api.github.com
+
+/**
+ * @module
+ *
+ * Warns on PRs that change localized docs without updating every language variant.
+ */
+
+import { Command } from "@cliffy/command"
+import { Octokit, type RestEndpointMethodTypes } from "@octokit/rest"
+
+const marker = "<!-- docs-translation-sync-warning -->"
+const docExt = /\.(?:md|mdx)$/
+const changedStatuses = new Set(["added", "modified", "removed", "renamed", "changed"])
+
+type PullFile = Pick<
+  RestEndpointMethodTypes["pulls"]["listFiles"]["response"]["data"][number],
+  "filename" | "previous_filename" | "status"
+>
+
+type DocPath = {
+  lang: string
+  path: string
+}
+
+export type TranslationWarning = {
+  path: string
+  changed: string[]
+  stale: string[]
+  missing: string[]
+}
+
+const repoSchema = /^(?<owner>[^/]+)\/(?<repo>[^/]+)$/
+
+const isFile = async (path: string): Promise<boolean> => {
+  try {
+    return (await Deno.stat(path)).isFile
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false
+    throw error
+  }
+}
+
+export const getDocLanguages = async (): Promise<string[]> => {
+  const result: string[] = []
+  for await (const entry of Deno.readDir("docs")) {
+    if (!entry.isDirectory) continue
+    if (await isFile(`docs/${entry.name}/_data.yml`)) result.push(entry.name)
+  }
+  return result.toSorted()
+}
+
+export const parseLocalizedDocPath = (path: string): DocPath | undefined => {
+  if (!docExt.test(path)) return undefined
+  const parts = path.split("/")
+  if (parts[0] !== "docs" || parts.length < 3) return undefined
+  return { lang: parts[1], path: parts.slice(2).join("/") }
+}
+
+const changedDocPaths = ({ filename, previous_filename, status }: PullFile): DocPath[] => {
+  if (!changedStatuses.has(status)) return []
+  return [filename, previous_filename]
+    .filter((path): path is string => path !== undefined)
+    .map(parseLocalizedDocPath)
+    .filter((path): path is DocPath => path !== undefined)
+}
+
+export const findTranslationWarnings = async (
+  files: PullFile[],
+  languages: string[],
+  existsInBase: (lang: string, path: string) => Promise<boolean>,
+): Promise<TranslationWarning[]> => {
+  const knownLanguages = new Set(languages)
+  const changed = new Map<string, Set<string>>()
+
+  for (const path of files.flatMap(changedDocPaths)) {
+    if (!knownLanguages.has(path.lang)) continue
+    changed.set(path.path, (changed.get(path.path) ?? new Set()).add(path.lang))
+  }
+
+  const warnings = await Promise.all(
+    Array.from(changed.entries()).map(async ([path, changedLangs]) => {
+      const untouched = languages.filter((lang) => !changedLangs.has(lang))
+      const stale: string[] = []
+      const missing: string[] = []
+      for (const lang of untouched) {
+        if (await existsInBase(lang, path)) stale.push(lang)
+        else missing.push(lang)
+      }
+      return { path, changed: Array.from(changedLangs).toSorted(), stale, missing }
+    }),
+  )
+
+  return warnings
+    .filter(({ stale, missing }) => stale.length > 0 || missing.length > 0)
+    .toSorted((a, b) => a.path.localeCompare(b.path))
+}
+
+const ticks = (xs: string[]) => xs.map((x) => `\`${x}\``).join(", ")
+
+export const renderWarningComment = (warnings: TranslationWarning[]): string | undefined => {
+  if (warnings.length === 0) return undefined
+  const shown = warnings.slice(0, 20)
+  const lines = shown.map(({ path, changed, stale, missing }) => {
+    const parts = [`changed ${ticks(changed)}`]
+    if (stale.length > 0) parts.push(`stale ${ticks(stale)}`)
+    if (missing.length > 0) parts.push(`missing ${ticks(missing)}`)
+    return `- \`${path}\`: ${parts.join("; ")}`
+  })
+  if (shown.length < warnings.length) lines.push(`- … ${warnings.length - shown.length} more`)
+  return `${marker}\n⚠️ Following langs are not updated:\n${lines.join("\n")}`
+}
+
+const getPullFiles = async (octokit: Octokit, owner: string, repo: string, pr: number) =>
+  await octokit.paginate(octokit.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: pr,
+    per_page: 100,
+  })
+
+const upsertComment = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pr: number,
+  body: string | undefined,
+) => {
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: pr,
+    per_page: 100,
+  })
+  const existing = comments.find((comment) => comment.body?.includes(marker))
+
+  if (body === undefined) {
+    if (existing) await octokit.rest.issues.deleteComment({ owner, repo, comment_id: existing.id })
+    return
+  }
+
+  if (existing) {
+    await octokit.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+  } else {
+    await octokit.rest.issues.createComment({ owner, repo, issue_number: pr, body })
+  }
+}
+
+const main = new Command()
+  .name("docs-translation-warning")
+  .description("Warn when localized docs are not updated across all languages.")
+  .arguments("<pr:number>")
+  .action(async (_options, pr) => {
+    const token = Deno.env.get("GITHUB_TOKEN")
+    const repository = Deno.env.get("GITHUB_REPOSITORY")
+    if (!token) throw new Error("GITHUB_TOKEN is required")
+    const match = repository?.match(repoSchema)
+    if (!match?.groups) throw new Error("GITHUB_REPOSITORY must be owner/repo")
+
+    const { owner, repo } = match.groups
+    const octokit = new Octokit({ auth: token })
+    const [files, languages] = await Promise.all([
+      getPullFiles(octokit, owner, repo, pr),
+      getDocLanguages(),
+    ])
+    const warnings = await findTranslationWarnings(
+      files,
+      languages,
+      (lang, path) => isFile(`docs/${lang}/${path}`),
+    )
+    await upsertComment(octokit, owner, repo, pr, renderWarningComment(warnings))
+  })
+
+if (import.meta.main) {
+  await main.parse(Deno.args)
+}

--- a/scripts/docs_translation_warning_test.ts
+++ b/scripts/docs_translation_warning_test.ts
@@ -1,0 +1,58 @@
+import { assertEquals } from "@std/assert"
+import {
+  findTranslationWarnings,
+  parseLocalizedDocPath,
+  renderWarningComment,
+} from "./docs_translation_warning.ts"
+
+Deno.test("parseLocalizedDocPath() accepts localized markdown docs", () => {
+  assertEquals(parseLocalizedDocPath("docs/en/game/foo.md"), { lang: "en", path: "game/foo.md" })
+  assertEquals(parseLocalizedDocPath("docs/media.css"), undefined)
+  assertEquals(parseLocalizedDocPath("docs/en/_data.yml"), undefined)
+})
+
+Deno.test("findTranslationWarnings() flags stale and missing language variants", async () => {
+  const existing = new Set(["docs/en/foo.md", "docs/ko/foo.md"])
+  const warnings = await findTranslationWarnings(
+    [{ filename: "docs/en/foo.md", status: "modified" }],
+    ["en", "ja", "ko"],
+    (lang, path) => Promise.resolve(existing.has(`docs/${lang}/${path}`)),
+  )
+
+  assertEquals(warnings, [{ path: "foo.md", changed: ["en"], stale: ["ko"], missing: ["ja"] }])
+})
+
+Deno.test("findTranslationWarnings() ignores docs updated in every language", async () => {
+  const warnings = await findTranslationWarnings(
+    [
+      { filename: "docs/en/foo.md", status: "modified" },
+      { filename: "docs/ja/foo.md", status: "added" },
+      { filename: "docs/ko/foo.md", status: "modified" },
+    ],
+    ["en", "ja", "ko"],
+    () => Promise.resolve(false),
+  )
+
+  assertEquals(warnings, [])
+})
+
+Deno.test("findTranslationWarnings() treats renames as old and new doc paths", async () => {
+  const existing = new Set(["docs/en/old.md", "docs/ko/old.md"])
+  const warnings = await findTranslationWarnings(
+    [{ filename: "docs/en/new.md", previous_filename: "docs/en/old.md", status: "renamed" }],
+    ["en", "ko"],
+    (lang, path) => Promise.resolve(existing.has(`docs/${lang}/${path}`)),
+  )
+
+  assertEquals(warnings, [
+    { path: "new.md", changed: ["en"], stale: [], missing: ["ko"] },
+    { path: "old.md", changed: ["en"], stale: ["ko"], missing: [] },
+  ])
+})
+
+Deno.test("renderWarningComment() stays terse", () => {
+  assertEquals(
+    renderWarningComment([{ path: "foo.md", changed: ["en"], stale: ["ko"], missing: ["ja"] }]),
+    "<!-- docs-translation-sync-warning -->\n⚠️ Following langs are not updated:\n- `foo.md`: changed `en`; stale `ko`; missing `ja`",
+  )
+})


### PR DESCRIPTION
## Purpose of change (The Why)

PR checklist items duplicate existing automation, and docs-only language drift is easy to miss in review.

## Describe the solution (The How)

- Remove checklist items covered by title, formatter, and semantic config automation.
- Fail when generated semantic PR scopes are stale.
- Comment tersely when localized docs paths are not changed across all docs languages.

## Testing

- `deno fmt --check ...`
- `deno check ...`
- `deno lint ...`
- `deno test --allow-read --allow-env=npm_package_config_libvips,TILESET_PYTHON --allow-ffi`

## Checklist

### Mandatory

- [x] I linked any relevant issues using github keyword syntax like `closes #1234` in Summary of the PR so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [06209df](https://github.com/cataclysmbn/Cataclysm-BN/commit/06209df15a6bc3ebe3869358e381aefadf1f4a94) (ci: warn on stale docs translations) on 2026-06-12 15:45:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27424228871/artifacts/7595380177)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27424228871/artifacts/7596054624)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27424228871/artifacts/7595410582)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27424228871/artifacts/7595493494)
<!-- END artifact comment -->