### PR TITLE
fix: remove duplicate bathtub recipe and group

### DIFF
--- a/data/json/construction/construct_furn.json
+++ b/data/json/construction/construct_furn.json
@@ -911,19 +911,6 @@
   },
   {
     "type": "construction",
-    "id": "constr_bathtub",
-    "group": "build_bathtub",
-    "category": "FURN",
-    "required_skills": [ [ "fabrication", 2 ], [ "mechanics", 1 ] ],
-    "time": "90 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH", "level": 1 } ] ],
-    "components": [ [ [ "metal_tank", 1 ] ], [ [ "pipe", 2 ] ], [ [ "scrap", 6 ], [ "sheet_metal", 2 ] ] ],
-    "pre_special": "check_empty",
-    "dark_craftable": true,
-    "post_furniture": "f_bathtub"
-  },
-  {
-    "type": "construction",
     "id": "constr_shower",
     "group": "build_shower",
     "category": "FURN",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1933,10 +1933,5 @@
     "type": "construction_group",
     "id": "place_roulette",
     "name": "Place Roulette Table"
-  },
-  {
-    "type": "construction_group",
-    "id": "build_bathtub",
-    "name": "Build Bathtub"
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
UNOwen added his own bathtub construction recipe that is more fitting to what the bathtub drops when bashed. Scarf's shower pr also added a bathtub recipe, but since it took so long to finally get merged there were now two bathtub recipes and two bathtub construction categories.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Removes the duplicate build_bathtub group, and removes one of the bathtub recipes that doesn't fit with the bash results.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
idk
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [467fde9](https://github.com/cataclysmbn/Cataclysm-BN/commit/467fde93f6b048a1abe139da3ac0f3116e47df04) (Update construction_group.json) on 2026-06-12 15:30:11

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27422920941/artifacts/7594833977)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27422920941/artifacts/7595687282)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27422920941/artifacts/7594909327)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27422920941/artifacts/7594972047)
<!-- END artifact comment -->