### PR TITLE
fix: structural boat hulls function again

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4998,6 +4998,9 @@ double vehicle::coeff_water_drag() const
     }
     std::vector<int> hull_indices = all_parts_at_location( part_location_under );
     double hull_coverage;
+    if( hull_indices.empty() && !floating.empty() ) {
+        hull_indices = all_parts_at_location( part_location_structure );
+    }
     if( hull_indices.empty() ) {
         hull_coverage = 0;
     } else {


### PR DESCRIPTION
## Purpose of change (The Why)
MST Extra has log boats that did not float anymore

## Describe the solution (The How)
If floatable, but no under parts, swap hull and under

## Describe alternatives you've considered
None

## Testing
MST extra boat works?

## Additional context
I scrunglescrem

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0dc1c1f](https://github.com/cataclysmbn/Cataclysm-BN/commit/0dc1c1f42ca377e3ae1144dba728d484e80b5418) (fix: structural boat hulls function again) on 2026-06-12 19:21:27

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27435611548/artifacts/7599944127)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27435611548/artifacts/7600563862)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27435611548/artifacts/7600036153)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27435611548/artifacts/7600049113)
<!-- END artifact comment -->