### PR TITLE
fix: Absolute Peek Anchor

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2095,12 +2095,11 @@ void throw_activity_actor::do_turn( player_activity &act, Character &who )
         return;
     }
 
-    // Shift our position to our "peeking" position, so that the UI
-    // for picking a throw point lets us target the location we couldn't
-    // otherwise see.
-    const auto original_player_position = who.bub_pos();
+    // Shift our position to our peeking position so the target UI can see from there.
+    const auto original_player_position = who.abs_pos();
     if( blind_throw_pos ) {
-        who.setpos( *blind_throw_pos );
+        who.setpos( bub_to_abs( *blind_throw_pos ) );
+        g->update_map( who );
     }
 
     target_handler::trajectory trajectory = target_handler::mode_throw( *who.as_avatar(), *it,
@@ -2109,6 +2108,7 @@ void throw_activity_actor::do_turn( player_activity &act, Character &who )
     // If we previously shifted our position, put ourselves back now that we've picked our target.
     if( blind_throw_pos ) {
         who.setpos( original_player_position );
+        g->update_map( who );
     }
 
     if( trajectory.empty() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13368,17 +13368,17 @@ void game::place_player_overmap( const tripoint_abs_omt &om_dest )
 
 bool game::phasing_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
 {
-    if( dest_loc.z() != u.bub_pos().z() && !via_ramp ) {
+    if( dest_loc.z() != u.abs_pos().z() && !via_ramp ) {
         // No vertical phasing yet
         return false;
     }
 
     //probability travel through walls but not water
-    auto dest = dest_loc;
+    auto dest = bub_to_abs( dest_loc );
     // tile is impassable
     int tunneldist = 0;
-    const point d( sgn( dest.x() - u.bub_pos().x() ), sgn( dest.y() - u.bub_pos().y() ) );
-    while( m.impassable( dest ) ||
+    const point d( sgn( dest.x() - u.abs_pos().x() ), sgn( dest.y() - u.abs_pos().y() ) );
+    while( m.impassable( abs_to_bub( dest ) ) ||
            ( critter_at( dest ) != nullptr && tunneldist > 0 ) ) {
         //add 1 to tunnel distance for each impassable tile in the line
         tunneldist += 1;
@@ -13425,7 +13425,7 @@ bool game::phasing_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
         u.setpos( dest );
         m.invalidate_visibility_caches();
 
-        if( m.veh_at( u.bub_pos() ).part_with_feature( "BOARDABLE", true ) ) {
+        if( m.veh_at( dest ).part_with_feature( "BOARDABLE", true ) ) {
             m.board_vehicle( u.bub_pos(), &u );
         }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8824,26 +8824,26 @@ void game::peek()
         return;
     }
 
-    peek( u.bub_pos() + *p );
+    peek( *p );
 }
 
-void game::peek( const tripoint_bub_ms &p )
+void game::peek( const tripoint_rel_ms &p )
 {
     u.moves -= 200;
-    auto prev = u.bub_pos();
-    u.setpos( p );
+    auto prev = u.abs_pos();
+    u.setpos( prev + p );
     // Force a full cache rebuild from the peek position so look_around renders
     // correct FOV and lighting.  Without this, lightmap_dirty may already be
     // false (built from the pre-peek player position earlier this turn), causing
     // look_around to display stale lighting and visibility.
     m.invalidate_map_cache( p.z() );
-    auto center = p;
+    auto center = u.bub_pos();
     const look_around_result result = look_around( /*show_window=*/true, center, center, false, false,
                                       true );
     u.setpos( prev );
 
     if( result.peek_action && *result.peek_action == PA_BLIND_THROW ) {
-        avatar_action::plthrow( u, nullptr, p );
+        avatar_action::plthrow( u, nullptr, u.bub_pos() + p );
     }
     m.invalidate_map_cache( p.z() );
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8799,8 +8799,7 @@ void game::pickup_feet()
     }
 }
 
-//Shift player by one tile, look_around(), then restore previous position.
-//represents carefully peeking around a corner, hence the large move cost.
+// Shift player by one tile for rendering/look_around(), then restore previous position.
 void game::peek()
 {
     const std::optional<tripoint_rel_ms> p = choose_direction( _( "Peek where?" ), true );
@@ -8808,19 +8807,17 @@ void game::peek()
         return;
     }
 
+    const auto current_pos = u.bub_pos();
+    const auto peek_pos = current_pos + *p;
     if( p->z() != 0 ) {
-        const auto old_pos = u.bub_pos();
-        vertical_move( p->z(), false, true );
-
-        if( old_pos != u.bub_pos() ) {
-            vertical_move( p->z() * -1, false, true );
-        } else {
+        const auto can_fly = character_funcs::can_fly( u );
+        if( !m.valid_move( current_pos, peek_pos, false, can_fly ) ) {
             return;
         }
     }
 
-    if( m.impassable( u.bub_pos() + *p ) ||
-        m.obstructed_by_vehicle_rotation( u.bub_pos(), u.bub_pos() + *p ) ) {
+    if( m.impassable( peek_pos ) ||
+        m.obstructed_by_vehicle_rotation( current_pos, peek_pos ) ) {
         return;
     }
 
@@ -8829,23 +8826,32 @@ void game::peek()
 
 void game::peek( const tripoint_rel_ms &p )
 {
-    u.moves -= 200;
-    auto prev = u.abs_pos();
-    u.setpos( prev + p );
+    const auto prev = u.abs_pos();
+    const auto peek_pos = prev + p;
+    auto restore_player_pos = [&]() {
+        u.setpos( prev );
+        update_map( u );
+        m.invalidate_map_cache( get_levz() );
+    };
+    auto restore_on_return = on_out_of_scope( restore_player_pos );
+
+    u.setpos( peek_pos );
+    update_map( u );
     // Force a full cache rebuild from the peek position so look_around renders
     // correct FOV and lighting.  Without this, lightmap_dirty may already be
     // false (built from the pre-peek player position earlier this turn), causing
     // look_around to display stale lighting and visibility.
-    m.invalidate_map_cache( p.z() );
+    m.invalidate_map_cache( get_levz() );
     auto center = u.bub_pos();
     const look_around_result result = look_around( /*show_window=*/true, center, center, false, false,
                                       true );
-    u.setpos( prev );
+    restore_player_pos();
+    restore_on_return.cancel();
+    u.moves -= 200;
 
     if( result.peek_action && *result.peek_action == PA_BLIND_THROW ) {
-        avatar_action::plthrow( u, nullptr, u.bub_pos() + p );
+        avatar_action::plthrow( u, nullptr, abs_to_bub( peek_pos ) );
     }
-    m.invalidate_map_cache( p.z() );
 }
 ////////////////////////////////////////////////////////////////////////////////////////////
 std::optional<tripoint_bub_ms> game::look_debug()
@@ -13423,9 +13429,10 @@ bool game::phasing_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
         //tunneling costs 100 moves baseline, 50 per extra tile up to a cap of 500 moves
         u.moves -= ( 50 + ( tunneldist * 50 ) );
         u.setpos( dest );
+        update_map( u );
         m.invalidate_visibility_caches();
 
-        if( m.veh_at( dest ).part_with_feature( "BOARDABLE", true ) ) {
+        if( m.veh_at( u.bub_pos() ).part_with_feature( "BOARDABLE", true ) ) {
             m.board_vehicle( u.bub_pos(), &u );
         }
 

--- a/src/game.h
+++ b/src/game.h
@@ -676,7 +676,7 @@ class game : public submap_load_listener
         void suggest_auto_walk_to_stairs( Character &u, map &m, const std::string &direction );
 
         void peek();
-        void peek( const tripoint_bub_ms &p );
+        void peek( const tripoint_rel_ms &p );
         std::optional<tripoint_bub_ms> look_debug();
 
         bool check_zone( const zone_type_id &type, const tripoint_bub_ms &where ) const;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2063,7 +2063,7 @@ void iexamine::door_peephole( player &p, const tripoint_bub_ms &examp )
     }
 
     if( here.can_open_door( &p, examp, true ) ) {
-        g->peek( examp );
+        g->peek( p.bub_pos() - examp );
         p.add_msg_if_player( _( "You peek through the peephole." ) );
     } else {
         // Peek through the peephole, or open the door.
@@ -2073,7 +2073,7 @@ void iexamine::door_peephole( player &p, const tripoint_bub_ms &examp )
         } );
         if( choice == 0 ) {
             // Peek
-            g->peek( examp );
+            g->peek( p.bub_pos() - examp );
             p.add_msg_if_player( _( "You peek through the peephole." ) );
         } else if( choice == 1 ) {
             here.open_door( &p, examp, true );
@@ -5141,7 +5141,7 @@ void iexamine::curtains( player &p, const tripoint_bub_ms &examp )
     const int choice = window_menu.ret;
     if( choice == 0 ) {
         // Peek
-        g->peek( examp );
+        g->peek( p.bub_pos() - examp );
         p.add_msg_if_player( _( "You carefully peek through the curtains." ) );
     } else if( choice == 1 ) {
         // Mr. Gorbachev, tear down those curtains!

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2160,7 +2160,7 @@ void vehicle::interact_with( const tripoint_bub_ms &pos, int interact_part )
         }
         case PEEK_CURTAIN: {
             add_msg( _( "You carefully peek through the curtains." ) );
-            g->peek( pos );
+            g->peek( you.bub_pos() - pos );
             return;
         }
         case USE_HOTPLATE: {


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #9421

## Describe the solution (The How)

Make peek relative
Use player absolute position as anchor point
Do the same for phasing movement since a user reported it in the same issue thread

## Describe alternatives you've considered

Reconstructing last location keeping submap shifting in mind?
Only terrible alternatives remain. Just do it right.

## Testing

Tested peaking and probability drive, seem perfectly functional.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f0de9d9](https://github.com/cataclysmbn/Cataclysm-BN/commit/f0de9d9b56cd11b2cbafea484c6b6c78ecd420c8) (Fix shift issues) on 2026-06-13 00:02:49

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27447297145/artifacts/7604649488)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27447297145/artifacts/7605137053)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27447297145/artifacts/7604500499)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27447297145/artifacts/7604625907)
<!-- END artifact comment -->