### PR TITLE
fix: keep components fresh when crafting near vehicle faucets

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6772,7 +6772,11 @@ std::vector<detached_ptr<item>> map::use_charges( const tripoint_bub_ms &origin,
             tmp->charges = faupart->vehicle().drain( ftype, quantity );
             // TODO: Handle water poison when crafting starts respecting it
             quantity -= tmp->charges;
-            ret.push_back( std::move( tmp ) );
+            // Don't return a 0-charge phantom for types the tanks can't provide:
+            // it would replace the real component during crafting (#9440)
+            if( tmp->charges > 0 ) {
+                ret.push_back( std::move( tmp ) );
+            }
 
             if( quantity == 0 ) {
                 return ret;
@@ -6790,7 +6794,9 @@ std::vector<detached_ptr<item>> map::use_charges( const tripoint_bub_ms &origin,
             detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
             tmp->charges = autoclavepart->vehicle().drain( ftype, quantity );
             quantity -= tmp->charges;
-            ret.push_back( std::move( tmp ) );
+            if( tmp->charges > 0 ) {
+                ret.push_back( std::move( tmp ) );
+            }
 
             if( quantity == 0 ) {
                 return ret;

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -41,6 +41,9 @@
 #include "string_id.h"
 #include "type_id.h"
 #include "value_ptr.h"
+#include "vehicle.h"
+#include "vehicle_part.h"
+#include "weather.h"
 
 class inventory;
 
@@ -1085,4 +1088,329 @@ TEST_CASE( "tool selection ui", "[crafting][ui]" )
             CHECK( result.comp.type == enough.type );
         }
     }
+}
+
+// REPRO for issue #9254: cooking in a vehicle kitchen with a fresh vehicle-stored
+// component should NOT produce a rotten result.
+TEST_CASE( "vehicle kitchen craft preserves fresh component rot", "[crafting][rot]" )
+{
+    clear_all_state();
+    // Day 19, midday for crafting light.
+    calendar::turn = calendar::start_of_cataclysm + 19_days + 12_hours;
+    get_weather().temperature = 18_c;
+    get_weather().clear_temp_cache();
+
+    avatar &you = get_avatar();
+    clear_avatar();
+
+    auto &here = get_map();
+    const tripoint_bub_ms vpos( 60, 60, 0 );
+    auto *veh = here.add_vehicle( vproto_id( "none" ), vpos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
+    const int kitchen = veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "kitchen_unit" ), true );
+    REQUIRE( kitchen >= 0 );
+    // Give the kitchen battery power for the hotplate (on an adjacent mount).
+    REQUIRE( veh->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "frame_vertical" ),
+                                true ) >= 0 );
+    const int batt = veh->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "storage_battery" ),
+                                        true );
+    REQUIRE( batt >= 0 );
+    veh->charge_battery( 5000 );
+    here.add_vehicle_to_cache( veh );
+    here.build_map_cache( vpos.z(), true );
+    REQUIRE( here.veh_at( vpos ) );
+
+    // Fresh meat (bday = now = day 19) into the kitchen cargo.
+    auto meat = item::spawn( "meat" );
+    REQUIRE( meat->goes_bad() );
+    INFO( "spawned meat bday_turn=" << to_turn<int>( meat->birthday() )
+          << " now=" << to_turn<int>( calendar::turn ) );
+    REQUIRE_FALSE( veh->add_item( kitchen, std::move( meat ) ) );
+
+    // Stand adjacent to the kitchen (kitchen is an OBSTACLE), like the real repro.
+    const tripoint_bub_ms stand = vpos + tripoint( 0, 1, 0 );
+    you.setpos( stand );
+    REQUIRE_FALSE( here.veh_at( stand ) );
+    REQUIRE( here.veh_at( vpos ) );
+
+    const recipe_id rid( "meat_cooked" );
+    const recipe &rec = rid.obj();
+    you.set_skill_level( rec.skill_used, std::max( rec.difficulty, 2 ) );
+    you.learn_recipe( &rec );
+    set_time( calendar::turn ); // refresh light at current (day 19 midday)
+
+    you.invalidate_crafting_inventory();
+    REQUIRE( you.crafting_inventory().has_components( itype_id( "meat" ), 1 ) );
+
+    you.make_craft( rid, 1, vpos );
+    REQUIRE( you.activity );
+    int guard = 0;
+    while( you.activity && you.activity->id() == activity_id( "ACT_CRAFT" ) ) {
+        you.moves = 100;
+        you.activity->do_turn( you );
+        if( ++guard > 100000 ) {
+            break;
+        }
+    }
+
+    // Find the cooked meat result (inventory, ground, or vehicle).
+    item *result = nullptr;
+    you.visit_items( [&]( item * it ) {
+        if( it->typeId() == itype_id( "meat_cooked" ) ) {
+            result = it;
+            return VisitResponse::ABORT;
+        }
+        return VisitResponse::NEXT;
+    } );
+    for( const tripoint_bub_ms &p : { vpos, stand } ) {
+        if( result ) {
+            break;
+        }
+        for( item *&it : here.i_at( p ) ) {
+            if( it->typeId() == itype_id( "meat_cooked" ) ) {
+                result = it;
+            }
+        }
+    }
+    if( !result ) {
+        for( item *&it : veh->get_items( kitchen ) ) {
+            if( it->typeId() == itype_id( "meat_cooked" ) ) {
+                result = it;
+            }
+        }
+    }
+    REQUIRE( result != nullptr );
+    INFO( "result relative_rot = " << result->get_relative_rot() );
+    INFO( "result rot turns = " << to_turns<int>( result->get_rot() ) );
+    CHECK_FALSE( result->rotten() );
+    CHECK( result->get_relative_rot() < 0.5 );
+}
+
+// AUTOCLAVE variant of the BN9254 test above: map::use_charges' AUTOCLAVE branch has the
+// same phantom-injection hole as the FAUCET branch (for non-autoclave requests ftype stays
+// NULL_ID, drain returns 0, and the 0-charge phantom was pushed unconditionally). The
+// autoclave part is CARGO+AUTOCLAVE on one tile, so the phantom always precedes the real
+// component. Cooking tools come from the avatar's inventory so the autoclave is the only
+// vehicle feature in play; the vehicle deliberately has no battery.
+TEST_CASE( "vehicle autoclave craft preserves fresh component rot", "[crafting][rot]" )
+{
+    clear_all_state();
+    // Day 19, midday for crafting light.
+    calendar::turn = calendar::start_of_cataclysm + 19_days + 12_hours;
+    get_weather().temperature = 18_c;
+    get_weather().clear_temp_cache();
+
+    avatar &you = get_avatar();
+    clear_avatar();
+
+    auto &here = get_map();
+    const tripoint_bub_ms vpos( 60, 60, 0 );
+    auto *veh = here.add_vehicle( vproto_id( "none" ), vpos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
+    const int clave = veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "autoclave" ), true );
+    REQUIRE( clave >= 0 );
+    here.add_vehicle_to_cache( veh );
+    here.build_map_cache( vpos.z(), true );
+    REQUIRE( here.veh_at( vpos ) );
+
+    // Fresh meat (bday = now = day 19) into the autoclave's cargo space.
+    auto meat = item::spawn( "meat" );
+    REQUIRE( meat->goes_bad() );
+    INFO( "spawned meat bday_turn=" << to_turn<int>( meat->birthday() )
+          << " now=" << to_turn<int>( calendar::turn ) );
+    REQUIRE_FALSE( veh->add_item( clave, std::move( meat ) ) );
+
+    // Stand adjacent (the autoclave is an OBSTACLE); cooking tools live in inventory.
+    const tripoint_bub_ms stand = vpos + tripoint( 0, 1, 0 );
+    you.setpos( stand );
+    REQUIRE_FALSE( here.veh_at( stand ) );
+    you.i_add( item::spawn( "hotplate", calendar::turn, 20 ) );
+    you.i_add( item::spawn( "pot", calendar::turn ) );
+
+    const recipe_id rid( "meat_cooked" );
+    const recipe &rec = rid.obj();
+    you.set_skill_level( rec.skill_used, std::max( rec.difficulty, 2 ) );
+    you.learn_recipe( &rec );
+    set_time( calendar::turn ); // refresh light at current (day 19 midday)
+
+    you.invalidate_crafting_inventory();
+    REQUIRE( you.crafting_inventory().has_components( itype_id( "meat" ), 1 ) );
+
+    you.make_craft( rid, 1, vpos );
+    REQUIRE( you.activity );
+    int guard = 0;
+    while( you.activity && you.activity->id() == activity_id( "ACT_CRAFT" ) ) {
+        you.moves = 100;
+        you.activity->do_turn( you );
+        if( ++guard > 100000 ) {
+            break;
+        }
+    }
+
+    // Find the cooked meat result (inventory, ground, or vehicle).
+    item *result = nullptr;
+    you.visit_items( [&]( item * it ) {
+        if( it->typeId() == itype_id( "meat_cooked" ) ) {
+            result = it;
+            return VisitResponse::ABORT;
+        }
+        return VisitResponse::NEXT;
+    } );
+    for( const tripoint_bub_ms &p : { vpos, stand } ) {
+        if( result ) {
+            break;
+        }
+        for( item *&it : here.i_at( p ) ) {
+            if( it->typeId() == itype_id( "meat_cooked" ) ) {
+                result = it;
+            }
+        }
+    }
+    if( !result ) {
+        for( item *&it : veh->get_items( clave ) ) {
+            if( it->typeId() == itype_id( "meat_cooked" ) ) {
+                result = it;
+            }
+        }
+    }
+    REQUIRE( result != nullptr );
+    INFO( "result relative_rot = " << result->get_relative_rot() );
+    INFO( "result rot turns = " << to_turns<int>( result->get_rot() ) );
+    CHECK_FALSE( result->rotten() );
+    CHECK( result->get_relative_rot() < 0.5 );
+}
+
+// REPRO for issue #9440: cooking with a FROZEN ingredient (kept fresh for 19 days in a
+// powered vehicle freezer) in a vehicle kitchen should NOT produce a rotten result.
+// Frozen variant of the BN9254 test above: the FAUCET phantom-component mechanism
+// predicts the same poisoned result regardless of the real component's frozen state,
+// because the consumed front item is a counterfeit spawned at start_of_cataclysm.
+// NOTE: BN has no per-item FROZEN tag; "frozen" is positional (rot.cpp
+// temperature_flag_for_part -> TEMP_FREEZER while stored in an enabled freezer part).
+// The item is frozen for 19 days in a minifreezer, then moved into the kitchen cargo
+// on the craft turn (same-tile-as-faucet, deterministic consume order; no rot accrues
+// in the same turn).
+TEST_CASE( "vehicle kitchen craft preserves frozen component rot", "[crafting][rot]" )
+{
+    clear_all_state();
+    // Spawn at day 0 + 12h; freeze 19 days; craft at day 19, midday (same craft time
+    // as the BN9254 test).
+    calendar::turn = calendar::start_of_cataclysm + 12_hours;
+    get_weather().temperature = 18_c;
+    get_weather().clear_temp_cache();
+
+    avatar &you = get_avatar();
+    clear_avatar();
+
+    auto &here = get_map();
+    const tripoint_bub_ms vpos( 60, 60, 0 );
+    auto *veh = here.add_vehicle( vproto_id( "none" ), vpos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
+    const int kitchen = veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "kitchen_unit" ), true );
+    REQUIRE( kitchen >= 0 );
+    // Battery power for the hotplate.
+    REQUIRE( veh->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "frame_vertical" ),
+                                true ) >= 0 );
+    const int batt = veh->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "storage_battery" ),
+                                        true );
+    REQUIRE( batt >= 0 );
+    // Working freezer on a third mount.
+    REQUIRE( veh->install_part( tripoint_mnt_veh( -1, 0, 0 ), vpart_id( "frame_vertical" ),
+                                true ) >= 0 );
+    const int freezer = veh->install_part( tripoint_mnt_veh( -1, 0, 0 ), vpart_id( "minifreezer" ),
+                                           true );
+    REQUIRE( freezer >= 0 );
+    veh->part( freezer ).enabled = true;
+    veh->charge_battery( 5000 );
+    here.add_vehicle_to_cache( veh );
+    here.build_map_cache( vpos.z(), true );
+    REQUIRE( here.veh_at( vpos ) );
+
+    // Fresh meat (bday = day 0 + 12h) into the powered freezer.
+    auto meat = item::spawn( "meat" );
+    REQUIRE( meat->goes_bad() );
+    INFO( "spawned meat bday_turn=" << to_turn<int>( meat->birthday() )
+          << " now=" << to_turn<int>( calendar::turn ) );
+    REQUIRE_FALSE( veh->add_item( freezer, std::move( meat ) ) );
+
+    // 19 days pass; the freezer keeps the meat at zero rot.
+    calendar::turn += 19_days;
+    {
+        auto frozen_items = veh->get_items( freezer );
+        REQUIRE( frozen_items.size() == 1 );
+        item &frozen = frozen_items.only_item();
+        // get_relative_rot() actualizes rot using the freezer's TEMP_FREEZER flag.
+        INFO( "POST-FREEZE meat bday_turn=" << to_turn<int>( frozen.birthday() )
+              << " relative_rot=" << frozen.get_relative_rot()
+              << " rot_turns=" << to_turns<int>( frozen.get_rot() )
+              << " now=" << to_turn<int>( calendar::turn ) );
+        REQUIRE( frozen.get_rot() == 0_turns );
+        // Move the still-frozen-fresh meat into the kitchen cargo on the craft turn.
+        frozen.attempt_detach( [&]( detached_ptr<item> &&it ) {
+            return veh->add_item( kitchen, std::move( it ) );
+        } );
+    }
+    REQUIRE( veh->get_items( freezer ).empty() );
+    REQUIRE( veh->get_items( kitchen ).size() == 1 );
+
+    // Stand adjacent to the kitchen (kitchen is an OBSTACLE), like the real repro.
+    const tripoint_bub_ms stand = vpos + tripoint( 0, 1, 0 );
+    you.setpos( stand );
+    REQUIRE_FALSE( here.veh_at( stand ) );
+    REQUIRE( here.veh_at( vpos ) );
+
+    const recipe_id rid( "meat_cooked" );
+    const recipe &rec = rid.obj();
+    you.set_skill_level( rec.skill_used, std::max( rec.difficulty, 2 ) );
+    you.learn_recipe( &rec );
+    set_time( calendar::turn ); // refresh light at current (day 19 midday)
+
+    you.invalidate_crafting_inventory();
+    REQUIRE( you.crafting_inventory().has_components( itype_id( "meat" ), 1 ) );
+
+    you.make_craft( rid, 1, vpos );
+    REQUIRE( you.activity );
+    int guard = 0;
+    while( you.activity && you.activity->id() == activity_id( "ACT_CRAFT" ) ) {
+        you.moves = 100;
+        you.activity->do_turn( you );
+        if( ++guard > 100000 ) {
+            break;
+        }
+    }
+
+    // Find the cooked meat result (inventory, ground, or vehicle).
+    item *result = nullptr;
+    you.visit_items( [&]( item * it ) {
+        if( it->typeId() == itype_id( "meat_cooked" ) ) {
+            result = it;
+            return VisitResponse::ABORT;
+        }
+        return VisitResponse::NEXT;
+    } );
+    for( const tripoint_bub_ms &p : { vpos, stand } ) {
+        if( result ) {
+            break;
+        }
+        for( item *&it : here.i_at( p ) ) {
+            if( it->typeId() == itype_id( "meat_cooked" ) ) {
+                result = it;
+            }
+        }
+    }
+    if( !result ) {
+        for( item *&it : veh->get_items( kitchen ) ) {
+            if( it->typeId() == itype_id( "meat_cooked" ) ) {
+                result = it;
+            }
+        }
+    }
+    REQUIRE( result != nullptr );
+    INFO( "result relative_rot = " << result->get_relative_rot() );
+    INFO( "result rot turns = " << to_turns<int>( result->get_rot() ) );
+    CHECK_FALSE( result->rotten() );
+    CHECK( result->get_relative_rot() < 0.5 );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

- closes #9440

Cooking with fresh or frozen ingredients at a vehicle kitchen still produces instantly-rotten results (#9440, originally reported as #9254). The in-progress craft already displays `(rotten)` at 0% progress, and the product rots away on completion, with severity proportional to world age.

#9322, #9381 and #9389 each fixed real rot-accounting bugs in this symptom cluster, but the reported scenario has a different root cause that none of them touch: the regression tests in this PR fail on current `main`, which contains all three.

## Describe the solution (The How)

The fix: only push the spawned item if the faucet/autoclave actually drained charges into it (`if( tmp->charges > 0 )`, both branches). Legitimate faucet use with liquids actually in the tanks is unchanged.

`map::use_charges` injects a counterfeit component when crafting near a vehicle faucet:

- The FAUCET branch handles **any** by-charges component request at a faucet tile by spawning `item::spawn( type, calendar::start_of_cataclysm )` (the `// TODO: add a sane birthday arg` site), draining the tanks 0 charges for anything not actually in them, e.g. meat and pushing the 0-charge phantom into the results **unconditionally**. The AUTOCLAVE branch has the identical hole.
- `consume_items`' condense loop merges charge stacks into `ret.front()`. For a kitchen unit (CARGO+CRAFTER+FAUCET on one part) the faucet branch runs before the cargo branch, so the phantom is always first: the **consumed component is the phantom**, born at the start of the cataclysm, and the real fresh/frozen item is destroyed by the merge.
- Since #9010 made `get_relative_rot()` actualize on read, the craft constructor's `get_most_rotten_component()` materializes the phantom's entire world age as rot at craft start (hence `(rotten)` at 0%), and `complete_craft`'s max-component-rot pass reads the same poisoned value at completion.

This also explains why the frozen-ingredient fixes didn't resolve #9440: #9381/#9389 actualize rot when a real item leaves a real location (`prepare_for_location_removal`), but the phantom never had a location, so those hooks structurally cannot run on it.



## Describe alternatives you've considered

- Also fixing liquids that can rot(milk, juice, broth) stored in tanks in the vehicle, but this touches more code and areas. Not sure how many players are driving around with tanks of milk though? But should probably be fixed at some point
- Hardening the downstream consumers instead (a non-mutating rot peek for craft seeding, temperature-correct actualization in the vehicle-cargo consume path). But that blast radius is far too large to tackle in something like this and my knowledge level at this time

## Testing

- For the reviewer: The easiest way to test this is to start a new game using The Next Summer scenario as this sets the post cataclysm time to be +1 year. Spawn an RV and spawn some meat chunks, place the meat chunks into the kitchen unit and then cook up the meat. You should get delicious cooked meats instead of rotten or disintegrating meat.

- Three new regression tests in `tests/crafting_test.cpp`, mirroring the reports (each verified red on unguarded code, green with the fix):
  - **fresh / FAUCET**: fresh meat in a vehicle kitchen unit's cargo, crafted at day 19. On `main` the consumed component has `bday = 0` and the result's relative rot is ~2.0 (rotten); with the guard the consumed component stays the real fresh meat and the result is fresh.
  - **frozen / FAUCET**: meat genuinely frozen for 19 days in an enabled minifreezer part (rot verified 0), moved to the kitchen cargo and crafted. Fails identically on `main`  the frozen item is replaced by the phantom and passes with the guard.
  - **fresh / AUTOCLAVE**: same scenario against a vehicle autoclave part (no faucet, no battery, cooking tools in inventory), isolating the AUTOCLAVE branch's identical hole (`ftype` stays NULL_ID, `drain` returns 0). Verified red (relative rot 2.016) with only the autoclave guard removed.
- Full test suite passes (779 test cases).
- Manual verification on a Windows tiles build of this branch: the #9440 repro (vehicle kitchen, aged world, fresh ingredient in kitchen cargo) produces rotten food on the current nightly and fresh food with this fix.

## Additional context

- The phantom is injected for every by-charges component (salt, vinegar, …); only perishable ones poison rot, but the guard corrects the bookkeeping for all of them.
- Review side-find (minor): the guard also corrects a niche bug in `suffer.cpp`'s sleeping-asthma handling. When a sleeping asthmatic has a real oxygen tank (but no inhaler) within 2 tiles and is also near a vehicle faucet, the 0-charge inhaler phantom made `use_charges( …, itype_inhaler, … )` return non-empty so they got the "you use your inhaler" message and an antiasthmatic buff while their oxygen tank went unconsumed. With the guard the oxygen tank is correctly consumed instead. (A faucet alone can't trigger this  `nearby_use` still requires a real inhaler/oxygen nearby.)
- Whether the phantom ends up first (and therefore swallows the real item) depends on tile visit order; it is guaranteed for ingredients stored in the faucet part's own cargo, which makes the bug layout-dependent and may explain inconsistent reports.
- The CRAFTER pseudo-tool branch in `map::use_charges` uses the same `start_of_cataclysm` birthday but is type-gated to crafter tools and only affects tool-charge bookkeeping, not food components, so it is deliberately left untouched here.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c924e4d](https://github.com/cataclysmbn/Cataclysm-BN/commit/c924e4d7c3f026f501dfc48419d6530e9ad66d99) (fix: keep components fresh when crafting near vehicle faucets) on 2026-06-13 09:03:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27446888648/artifacts/7604216654)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27446888648/artifacts/7605083927)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27446888648/artifacts/7604299021)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27446888648/artifacts/7604372348)
<!-- END artifact comment -->
