### PR TITLE
fix: Use proper x-coord when deserializing submap radiation

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4629,7 +4629,7 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version,
             int rad_num = jsin.get_int();
             for( int i = 0; i < rad_num; ++i ) {
                 if( rad_cell < SEEX * SEEY ) {
-                    set_radiation( { 0 % SEEX, rad_cell / SEEX }, rad_strength );
+                    set_radiation( { rad_cell % SEEX, rad_cell / SEEX }, rad_strength );
                     rad_cell++;
                 }
             }


### PR DESCRIPTION
Use rad_cell instead of constant 0 (???) before modulo for x-coordinate when loading submap radiation

## Purpose of change (The Why)

Resolves #9444

## Describe the solution (The How)

Noticed the `set_radiation` call in `src/savegame_json.cpp` was always using an x-coordinate of 0, instead of the current cell `X` modulo `SEEX`. Looked wrong, changed it to use the current `rad_cell` (modulo `SEEX`), works properly now.

## Describe alternatives you've considered
Nothing

## Testing
Realized a much easier reproduction of the issue: just save&quit and reload the game at an irradiated site. Do that, observe that it reloads just fine.

## Additional context

Fixed in DDA years ago, but it's a very trivial fix that I independently figured out on my own *before* looking it up over there, not really a port. ("I wonder if it's broken in DDA too...")

But linked for reference nonetheless https://github.com/CleverRaven/Cataclysm-DDA/pull/44210

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

n/a

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7354539](https://github.com/cataclysmbn/Cataclysm-BN/commit/7354539e82a6e83e0a5a3b10d9e0595cacebadb9) (fix: Use proper x-coord when deserializing submap radiation) on 2026-06-12 21:50:32

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27442414391/artifacts/7602796262)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27442414391/artifacts/7603337682)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27442414391/artifacts/7602895903)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27442414391/artifacts/7602989110)
<!-- END artifact comment -->