### PR TITLE
ci: move docs translation warnings into PR bodies

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -121,7 +121,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      issues: write
       pull-requests: write
 
     steps:
@@ -146,7 +145,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with: { cache: true }
 
-      - name: Warn on stale docs translations
+      - name: Update docs translation PR body
         if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -55,6 +55,7 @@
     "@std/fs": "jsr:@std/fs@^1.0.19",
     "@std/path": "jsr:@std/path@^1.1.2",
     "@std/yaml": "jsr:@std/yaml@^1.0.10",
-    "@valibot/valibot": "jsr:@valibot/valibot@^1.1.0"
+    "@valibot/valibot": "jsr:@valibot/valibot@^1.1.0",
+    "markdown-table": "npm:markdown-table@3.0.4"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -47,6 +47,7 @@
     "npm:@octokit/rest@21.0.2": "21.0.2",
     "npm:dprint@*": "0.47.5",
     "npm:json-order@*": "1.1.3",
+    "npm:markdown-table@3.0.4": "3.0.4",
     "npm:sharp@~0.33.5": "0.33.5",
     "npm:ts-pattern@5.0.5": "5.0.5",
     "npm:type-fest@*": "4.27.0"
@@ -641,6 +642,9 @@
     "lodash.clonedeep@4.5.0": {
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
+    "markdown-table@3.0.4": {
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="
+    },
     "semver@7.7.3": {
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "bin": true
@@ -953,7 +957,8 @@
       "jsr:@std/path@^1.1.2",
       "jsr:@std/yaml@^1.0.10",
       "jsr:@valibot/valibot@^1.1.0",
-      "npm:@octokit/rest@21.0.2"
+      "npm:@octokit/rest@21.0.2",
+      "npm:markdown-table@3.0.4"
     ]
   }
 }

--- a/scripts/docs_translation_warning.ts
+++ b/scripts/docs_translation_warning.ts
@@ -3,26 +3,24 @@
 /**
  * @module
  *
- * Warns on PRs that change localized docs without updating every language variant.
+ * Updates PR bodies when localized docs changed without every tracked language variant.
  */
 
-import { Command } from "@cliffy/command"
+import { walk } from "@std/fs"
 import { Octokit, type RestEndpointMethodTypes } from "@octokit/rest"
+import { markdownTable } from "markdown-table"
 
-const marker = "<!-- docs-translation-sync-warning -->"
-const docExt = /\.(?:md|mdx)$/
+const beginMarker = "<!-- BEGIN docs comment -->"
+const endMarker = "<!-- END docs comment -->"
+const markerPattern = new RegExp(`\n*${beginMarker}[\\s\\S]*?${endMarker}\\s*`, "g")
 const changedStatuses = new Set(["added", "modified", "removed", "renamed", "changed"])
+const trackedLanguages = ["en", "ja", "ko"]
 
 type PullFile = Pick<
   RestEndpointMethodTypes["pulls"]["listFiles"]["response"]["data"][number],
   "filename" | "previous_filename" | "status"
 >
-
-type DocPath = {
-  lang: string
-  path: string
-}
-
+type DocPath = { lang: string; path: string }
 export type TranslationWarning = {
   path: string
   changed: string[]
@@ -30,147 +28,84 @@ export type TranslationWarning = {
   missing: string[]
 }
 
-const repoSchema = /^(?<owner>[^/]+)\/(?<repo>[^/]+)$/
+const docPaths = (paths: (string | undefined)[]): DocPath[] =>
+  paths.flatMap((file) => {
+    const [root, lang, ...rest] = file?.split("/") ?? []
+    const path = rest.join("/")
+    return root === "docs" && /\.(?:md|mdx)$/.test(path) ? [{ lang, path }] : []
+  })
 
-const isFile = async (path: string): Promise<boolean> => {
-  try {
-    return (await Deno.stat(path)).isFile
-  } catch (error) {
-    if (error instanceof Deno.errors.NotFound) return false
-    throw error
-  }
-}
+const changedDocPaths = ({ filename, previous_filename, status }: PullFile): DocPath[] =>
+  changedStatuses.has(status) ? docPaths([filename, previous_filename]) : []
 
-export const getDocLanguages = async (): Promise<string[]> => {
-  const result: string[] = []
-  for await (const entry of Deno.readDir("docs")) {
-    if (!entry.isDirectory) continue
-    if (await isFile(`docs/${entry.name}/_data.yml`)) result.push(entry.name)
-  }
-  return result.toSorted()
-}
-
-export const parseLocalizedDocPath = (path: string): DocPath | undefined => {
-  if (!docExt.test(path)) return undefined
-  const parts = path.split("/")
-  if (parts[0] !== "docs" || parts.length < 3) return undefined
-  return { lang: parts[1], path: parts.slice(2).join("/") }
-}
-
-const changedDocPaths = ({ filename, previous_filename, status }: PullFile): DocPath[] => {
-  if (!changedStatuses.has(status)) return []
-  return [filename, previous_filename]
-    .filter((path): path is string => path !== undefined)
-    .map(parseLocalizedDocPath)
-    .filter((path): path is DocPath => path !== undefined)
-}
-
-export const findTranslationWarnings = async (
+export const findTranslationWarnings = (
   files: PullFile[],
   languages: string[],
-  existsInBase: (lang: string, path: string) => Promise<boolean>,
-): Promise<TranslationWarning[]> => {
-  const knownLanguages = new Set(languages)
-  const changed = new Map<string, Set<string>>()
-
-  for (const path of files.flatMap(changedDocPaths)) {
-    if (!knownLanguages.has(path.lang)) continue
-    changed.set(path.path, (changed.get(path.path) ?? new Set()).add(path.lang))
-  }
-
-  const warnings = await Promise.all(
-    Array.from(changed.entries()).map(async ([path, changedLangs]) => {
-      const untouched = languages.filter((lang) => !changedLangs.has(lang))
-      const stale: string[] = []
-      const missing: string[] = []
-      for (const lang of untouched) {
-        if (await existsInBase(lang, path)) stale.push(lang)
-        else missing.push(lang)
-      }
-      return { path, changed: Array.from(changedLangs).toSorted(), stale, missing }
-    }),
+  existingDocs: DocPath[],
+): TranslationWarning[] => {
+  const changed = Map.groupBy(
+    files.flatMap(changedDocPaths).filter(({ lang }) => languages.includes(lang)),
+    ({ path }) => path,
   )
+  if (changed.size <= 1) return []
 
-  return warnings
+  const existing = Map.groupBy(
+    existingDocs.filter(({ lang }) => languages.includes(lang)),
+    ({ path }) => path,
+  )
+  return [...changed].map(([path, docs]) => {
+    const changed = docs.map(({ lang }) => lang).toSorted()
+    const stale = (existing.get(path) ?? [])
+      .map(({ lang }) => lang)
+      .filter((lang) => !changed.includes(lang))
+      .toSorted()
+    const missing = languages.filter((lang) => !(changed.includes(lang) || stale.includes(lang)))
+    return { path, changed, stale, missing }
+  })
     .filter(({ stale, missing }) => stale.length > 0 || missing.length > 0)
     .toSorted((a, b) => a.path.localeCompare(b.path))
 }
 
-const ticks = (xs: string[]) => xs.map((x) => `\`${x}\``).join(", ")
-
-export const renderWarningComment = (warnings: TranslationWarning[]): string | undefined => {
-  if (warnings.length === 0) return undefined
-  const shown = warnings.slice(0, 20)
-  const lines = shown.map(({ path, changed, stale, missing }) => {
-    const parts = [`changed ${ticks(changed)}`]
-    if (stale.length > 0) parts.push(`stale ${ticks(stale)}`)
-    if (missing.length > 0) parts.push(`missing ${ticks(missing)}`)
-    return `- \`${path}\`: ${parts.join("; ")}`
-  })
-  if (shown.length < warnings.length) lines.push(`- … ${warnings.length - shown.length} more`)
-  return `${marker}\n⚠️ Following langs are not updated:\n${lines.join("\n")}`
+export const renderTranslationBlock = (ws: TranslationWarning[]): string | undefined => {
+  if (ws.length === 0) return undefined
+  const table = markdownTable([
+    ["post", "changed", "stale", "missing"],
+    ...ws.map((w) => [w.path, w.changed.join(", "), w.stale.join(", "), w.missing.join(", ")]),
+  ])
+  return [beginMarker, "", "## Translations", "", table, "", endMarker].join("\n")
 }
 
-const getPullFiles = async (octokit: Octokit, owner: string, repo: string, pr: number) =>
-  await octokit.paginate(octokit.rest.pulls.listFiles, {
+const existingDocPaths = async () =>
+  docPaths(
+    await Array.fromAsync(walk("docs", { exts: [".md", ".mdx"], includeDirs: false }), ({ path }) =>
+      path),
+  )
+
+const withTranslationBlock = (body: string, block: string | undefined): string => {
+  const cleanBody = body.replace(markerPattern, "").replace(/[ \t]+\n/g, "\n").trimEnd()
+  return block === undefined ? cleanBody : [cleanBody, block].filter(Boolean).join("\n\n")
+}
+
+if (import.meta.main) {
+  const token = Deno.env.get("GITHUB_TOKEN")
+  const [owner, repo] = Deno.env.get("GITHUB_REPOSITORY")?.split("/") ?? []
+  const pr = Number(Deno.args[0])
+  if (!token) throw new Error("GITHUB_TOKEN is required")
+  if (!owner || !repo) throw new Error("GITHUB_REPOSITORY must be owner/repo")
+  if (!Number.isInteger(pr)) throw new Error("PR number is required")
+
+  const octokit = new Octokit({ auth: token })
+  const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
     owner,
     repo,
     pull_number: pr,
     per_page: 100,
   })
-
-const upsertComment = async (
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  pr: number,
-  body: string | undefined,
-) => {
-  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
-    owner,
-    repo,
-    issue_number: pr,
-    per_page: 100,
-  })
-  const existing = comments.find((comment) => comment.body?.includes(marker))
-
-  if (body === undefined) {
-    if (existing) await octokit.rest.issues.deleteComment({ owner, repo, comment_id: existing.id })
-    return
-  }
-
-  if (existing) {
-    await octokit.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
-  } else {
-    await octokit.rest.issues.createComment({ owner, repo, issue_number: pr, body })
-  }
-}
-
-const main = new Command()
-  .name("docs-translation-warning")
-  .description("Warn when localized docs are not updated across all languages.")
-  .arguments("<pr:number>")
-  .action(async (_options, pr) => {
-    const token = Deno.env.get("GITHUB_TOKEN")
-    const repository = Deno.env.get("GITHUB_REPOSITORY")
-    if (!token) throw new Error("GITHUB_TOKEN is required")
-    const match = repository?.match(repoSchema)
-    if (!match?.groups) throw new Error("GITHUB_REPOSITORY must be owner/repo")
-
-    const { owner, repo } = match.groups
-    const octokit = new Octokit({ auth: token })
-    const [files, languages] = await Promise.all([
-      getPullFiles(octokit, owner, repo, pr),
-      getDocLanguages(),
-    ])
-    const warnings = await findTranslationWarnings(
-      files,
-      languages,
-      (lang, path) => isFile(`docs/${lang}/${path}`),
-    )
-    await upsertComment(octokit, owner, repo, pr, renderWarningComment(warnings))
-  })
-
-if (import.meta.main) {
-  await main.parse(Deno.args)
+  const block = renderTranslationBlock(
+    findTranslationWarnings(files, trackedLanguages, await existingDocPaths()),
+  )
+  const { data } = await octokit.rest.pulls.get({ owner, repo, pull_number: pr })
+  const oldBody = data.body ?? ""
+  const body = withTranslationBlock(oldBody, block)
+  if (body !== oldBody) await octokit.rest.pulls.update({ owner, repo, pull_number: pr, body })
 }

--- a/scripts/docs_translation_warning_test.ts
+++ b/scripts/docs_translation_warning_test.ts
@@ -1,47 +1,61 @@
 import { assertEquals } from "@std/assert"
-import {
-  findTranslationWarnings,
-  parseLocalizedDocPath,
-  renderWarningComment,
-} from "./docs_translation_warning.ts"
+import { findTranslationWarnings, renderTranslationBlock } from "./docs_translation_warning.ts"
 
-Deno.test("parseLocalizedDocPath() accepts localized markdown docs", () => {
-  assertEquals(parseLocalizedDocPath("docs/en/game/foo.md"), { lang: "en", path: "game/foo.md" })
-  assertEquals(parseLocalizedDocPath("docs/media.css"), undefined)
-  assertEquals(parseLocalizedDocPath("docs/en/_data.yml"), undefined)
-})
-
-Deno.test("findTranslationWarnings() flags stale and missing language variants", async () => {
-  const existing = new Set(["docs/en/foo.md", "docs/ko/foo.md"])
-  const warnings = await findTranslationWarnings(
-    [{ filename: "docs/en/foo.md", status: "modified" }],
-    ["en", "ja", "ko"],
-    (lang, path) => Promise.resolve(existing.has(`docs/${lang}/${path}`)),
-  )
-
-  assertEquals(warnings, [{ path: "foo.md", changed: ["en"], stale: ["ko"], missing: ["ja"] }])
-})
-
-Deno.test("findTranslationWarnings() ignores docs updated in every language", async () => {
-  const warnings = await findTranslationWarnings(
+Deno.test("findTranslationWarnings() flags stale and missing language variants", () => {
+  const warnings = findTranslationWarnings(
     [
       { filename: "docs/en/foo.md", status: "modified" },
-      { filename: "docs/ja/foo.md", status: "added" },
-      { filename: "docs/ko/foo.md", status: "modified" },
+      { filename: "docs/en/bar.md", status: "modified" },
     ],
     ["en", "ja", "ko"],
-    () => Promise.resolve(false),
+    [
+      { lang: "en", path: "foo.md" },
+      { lang: "ko", path: "foo.md" },
+      { lang: "en", path: "bar.md" },
+    ],
+  )
+
+  assertEquals(warnings, [
+    { path: "bar.md", changed: ["en"], stale: [], missing: ["ja", "ko"] },
+    { path: "foo.md", changed: ["en"], stale: ["ko"], missing: ["ja"] },
+  ])
+})
+
+Deno.test("findTranslationWarnings() ignores a single changed doc path", () => {
+  const warnings = findTranslationWarnings(
+    [{ filename: "docs/en/foo.md", status: "modified" }],
+    ["en", "ja", "ko"],
+    [],
   )
 
   assertEquals(warnings, [])
 })
 
-Deno.test("findTranslationWarnings() treats renames as old and new doc paths", async () => {
-  const existing = new Set(["docs/en/old.md", "docs/ko/old.md"])
-  const warnings = await findTranslationWarnings(
+Deno.test("findTranslationWarnings() ignores docs updated in every language", () => {
+  const warnings = findTranslationWarnings(
+    [
+      { filename: "docs/en/foo.md", status: "modified" },
+      { filename: "docs/ja/foo.md", status: "added" },
+      { filename: "docs/ko/foo.md", status: "modified" },
+      { filename: "docs/en/bar.md", status: "modified" },
+      { filename: "docs/ja/bar.md", status: "added" },
+      { filename: "docs/ko/bar.md", status: "modified" },
+    ],
+    ["en", "ja", "ko"],
+    [],
+  )
+
+  assertEquals(warnings, [])
+})
+
+Deno.test("findTranslationWarnings() treats renames as old and new doc paths", () => {
+  const warnings = findTranslationWarnings(
     [{ filename: "docs/en/new.md", previous_filename: "docs/en/old.md", status: "renamed" }],
     ["en", "ko"],
-    (lang, path) => Promise.resolve(existing.has(`docs/${lang}/${path}`)),
+    [
+      { lang: "en", path: "old.md" },
+      { lang: "ko", path: "old.md" },
+    ],
   )
 
   assertEquals(warnings, [
@@ -50,9 +64,23 @@ Deno.test("findTranslationWarnings() treats renames as old and new doc paths", a
   ])
 })
 
-Deno.test("renderWarningComment() stays terse", () => {
+Deno.test("renderTranslationBlock() renders a PR body table", () => {
   assertEquals(
-    renderWarningComment([{ path: "foo.md", changed: ["en"], stale: ["ko"], missing: ["ja"] }]),
-    "<!-- docs-translation-sync-warning -->\n⚠️ Following langs are not updated:\n- `foo.md`: changed `en`; stale `ko`; missing `ja`",
+    renderTranslationBlock([
+      { path: "i18n/guides/mods.md", changed: ["en"], stale: ["ja", "ko"], missing: [] },
+      { path: "mod/dialogue.md", changed: ["en"], stale: [], missing: ["ja", "ko"] },
+    ]),
+    [
+      "<!-- BEGIN docs comment -->",
+      "",
+      "## Translations",
+      "",
+      "| post                | changed | stale  | missing |",
+      "| ------------------- | ------- | ------ | ------- |",
+      "| i18n/guides/mods.md | en      | ja, ko |         |",
+      "| mod/dialogue.md     | en      |        | ja, ko  |",
+      "",
+      "<!-- END docs comment -->",
+    ].join("\n"),
   )
 })


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #9437. Docs translation drift comment are too noisy imo

## Describe the solution (The How)

- Track only `en`, `ja`, and `ko` docs variants.
- Move drift details into a `## Translations` PR body block with a `markdown-table` table.
- Remove the block unless more than one localized docs path changed.
- Keep Octokit PR file types while compacting the warning script.

## Testing

- `deno fmt scripts/docs_translation_warning.ts scripts/docs_translation_warning_test.ts`
- `deno check scripts/docs_translation_warning.ts scripts/docs_translation_warning_test.ts`
- `deno test scripts/docs_translation_warning_test.ts`
- `deno lint scripts/docs_translation_warning.ts scripts/docs_translation_warning_test.ts`

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [545abe5](https://github.com/cataclysmbn/Cataclysm-BN/commit/545abe5e54c86258cf13bb71149be3994d9fd25d) (ci: move docs translation warnings into PR bodies) on 2026-06-13 10:11:48

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27462972276/artifacts/7609608178)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27462972276/artifacts/7609809439)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27462972276/artifacts/7609619334)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27462972276/artifacts/7609639215)
<!-- END artifact comment -->