### PR TITLE
fix(UI): fix multi option in filters

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2164,7 +2164,6 @@ void inventory_multiselector::set_chosen_count( inventory_entry &entry, size_t c
     }
 }
 
-[[clang::optnone]]
 std::vector<inventory_entry *> inventory_multiselector::get_selection_column_items() const
 {
     auto func = []( const inventory_entry & e ) { return e.is_item();};
@@ -2634,7 +2633,6 @@ std::vector<pickup::pick_drop_selection> inventory_pickup_selector::execute()
     return std::vector<pickup::pick_drop_selection>();
 }
 
-[[clang::optnone]]
 inventory_selector::stats inventory_pickup_selector::get_raw_stats() const
 {
     units::mass weight_carried = u.weight_carried();

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -180,7 +180,7 @@ std::function<bool( const itype & )> itype_filter_from_string( const std::string
 std::pair<std::string, std::string> get_both( const std::string &a )
 {
     size_t split_mark = a.find( ';' );
-    return std::make_pair( a.substr( 0, split_mark),
+    return std::make_pair( a.substr( 0, split_mark ),
                            a.substr( split_mark + 1 ) );
 }
 

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -177,13 +177,15 @@ std::function<bool( const itype & )> itype_filter_from_string( const std::string
     return filter_from_string<itype>( filter, basic_itype_filter );
 }
 
+[[clang::optnone]]
 std::pair<std::string, std::string> get_both( const std::string &a )
 {
     size_t split_mark = a.find( ';' );
-    return std::make_pair( a.substr( 0, split_mark - 1 ),
+    return std::make_pair( a.substr( 0, split_mark),
                            a.substr( split_mark + 1 ) );
 }
 
+[[clang::optnone]]
 std::function<bool( const item & )> wildcard_item_filter( std::string filter )
 {
     size_t colon;

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -177,7 +177,6 @@ std::function<bool( const itype & )> itype_filter_from_string( const std::string
     return filter_from_string<itype>( filter, basic_itype_filter );
 }
 
-[[clang::optnone]]
 std::pair<std::string, std::string> get_both( const std::string &a )
 {
     size_t split_mark = a.find( ';' );
@@ -185,7 +184,6 @@ std::pair<std::string, std::string> get_both( const std::string &a )
                            a.substr( split_mark + 1 ) );
 }
 
-[[clang::optnone]]
 std::function<bool( const item & )> wildcard_item_filter( std::string filter )
 {
     size_t colon;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Makes the "b:" flag work properly in filters/autopickup
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Previous the string "b:k:fabrication;*unread*" would get split into "k:fabricatio" and "unread" because the index was off by 1. This fixes that.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Loaded world, entered "b:k:*;*unread*" and spawned a unread skill book. The autopickup successfully picked up the book.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [171562e](https://github.com/cataclysmbn/Cataclysm-BN/commit/171562e09fdf89819243c8b4bab1a34bd4173436) (style(autofix.ci): automated formatting) on 2026-06-13 04:40:44

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27454816305/artifacts/7607317086)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27454816305/artifacts/7607144245)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27454816305/artifacts/7607037834)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27454816305/artifacts/7607039938)
<!-- END artifact comment -->