### PR TITLE
fix: set correct defaults for evolve_* in monstergroup

### DIFF
--- a/src/mongroup.h
+++ b/src/mongroup.h
@@ -66,8 +66,8 @@ struct MonsterGroup {
     mongroup_id name;
     mtype_id defaultMonster;
     FreqDef  monsters;
-    int evolve_chance;
-    int evolve_repeat;
+    int evolve_chance = 0;
+    int evolve_repeat = 0;
     bool IsMonsterInGroup( const mtype_id &id ) const;
     bool is_animal = false;
     // replaces this group after a period of


### PR DESCRIPTION
## Purpose of change (The Why)

Fix over aggressive monster evolution
closes #9441
related #8649 

## Describe the solution (The How)

Sets defaults for evolve_repeat and evolve_chance so that they are not random values

## Testing

From testing no longer see the bad behavior, but it's a difficult test because it's nondeterministic.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f444b38](https://github.com/cataclysmbn/Cataclysm-BN/commit/f444b3823ebb4cb1b1cce1c984c41005b4999af7) (fix: set correct defaults for evolve_* in monstergroup) on 2026-06-13 06:05:27

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27457183694/artifacts/7607904069)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27457183694/artifacts/7607848664)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27457183694/artifacts/7607646908)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27457183694/artifacts/7607669651)
<!-- END artifact comment -->