### PR TITLE
chore(mods): remove obsoleted mod "closable reality tears" from default mod loadout

### DIFF
--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -1,7 +1,6 @@
 [
   "bn",
   "bn_lua",
-  "nuclear_tear",
   "no_npc_food",
   "novitamins",
   "No_Rail_Stations",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
#9263 mainlined the "closable reality tears" mod and made it obsolete, but the pr forgot to remove it from the default mod loadout

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Delete the obsolete mod from the default mod loadout

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
1. Start game
2. Enter "Create World"
3. See "Closable Reality Tears" mod no longer there

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ca21ea9](https://github.com/cataclysmbn/Cataclysm-BN/commit/ca21ea911001266e7a288ff1be34d31740898b10) (Deleted obsoleted mod "closable reality tears" from default mod loadout) on 2026-06-13 09:02:22

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27461496134/artifacts/7609267780)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27461496134/artifacts/7609298594)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27461496134/artifacts/7609124946)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27461496134/artifacts/7609148050)
<!-- END artifact comment -->