### PR TITLE
fix: block vision through floors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ auto print_button( const catacurses::window &w, const button_options &opts ) -> 
   - type MUST be one of: `feat`, `fix`, `refactor`, `chore`, `build`, `ci`
 - **Code**: Refer to [code changes](#when-working-on-code-changes).
 - **PR**: Use [Template](./.github/pull_request_template.md). **DO NOT ADD fluff**. create via `git push && gh pr create --web --fill`.
+- After opening or updating a Cataclysm-BN PR, track `gh pr checks` until CI finishes or a concrete blocker is identified; inspect failing job logs, fix branch-owned failures, commit, and push before finalizing. For transient or infrastructure failures, rerun when permitted or report the exact failing job and evidence.
 - Before running broad formatter targets, prefer file-scoped formatting for touched files when available; if only a broad target exists, inspect and revert unrelated formatter-only changes before continuing.
 
 ### WHEN working on code changes

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -2140,8 +2140,8 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z )
                         const int   fy = static_cast<int>( std::lround(
                                                                static_cast<float>( origin.y() ) + t * dy ) );
                         const int floor_z = ( dz < 0.0f )
-                                            ? static_cast<int>( origin.z() ) - k
-                                            : static_cast<int>( origin.z() ) + k + 1;
+                        ? static_cast<int>( origin.z() ) - k
+                        : static_cast<int>( origin.z() ) + k + 1;
                         if( floor_z < -OVERMAP_DEPTH || floor_z > OVERMAP_HEIGHT ) {
                             continue;
                         }
@@ -2212,8 +2212,8 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z )
                     const int   fy = static_cast<int>( std::lround(
                                                            static_cast<float>( origin.y() ) + t * dy ) );
                     const int floor_z = ( dz < 0.0f )
-                                        ? static_cast<int>( origin.z() ) - k
-                                        : static_cast<int>( origin.z() ) + k + 1;
+                    ? static_cast<int>( origin.z() ) - k
+                    : static_cast<int>( origin.z() ) + k + 1;
                     if( floor_z < -OVERMAP_DEPTH || floor_z > OVERMAP_HEIGHT ) {
                         continue;
                     }

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -2130,7 +2130,6 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z )
                 //               so check floor_cache at z=(origin.z-k).
                 //   Going up:   crossing k separates z=(origin.z+k) from z=(origin.z+k+1),
                 //               so check floor_cache at z=(origin.z+k+1).
-                // The origin tile is exempted: the player stands on top of that floor.
                 {
                     const int n_cross = static_cast<int>( std::abs( dz ) );
                     for( int k = 0; k < n_cross; ++k )
@@ -2140,10 +2139,6 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z )
                                                                static_cast<float>( origin.x() ) + t * dx ) );
                         const int   fy = static_cast<int>( std::lround(
                                                                static_cast<float>( origin.y() ) + t * dy ) );
-                        if( k == 0 && dz < 0.0f &&
-                            fx == origin.x() && fy == origin.y() ) {
-                            continue; // player's own floor; they stand on top of it
-                        }
                         const int floor_z = ( dz < 0.0f )
                                             ? static_cast<int>( origin.z() ) - k
                                             : static_cast<int>( origin.z() ) + k + 1;
@@ -2216,10 +2211,6 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z )
                                                            static_cast<float>( origin.x() ) + t * dx ) );
                     const int   fy = static_cast<int>( std::lround(
                                                            static_cast<float>( origin.y() ) + t * dy ) );
-                    if( k == 0 && dz < 0.0f &&
-                        fx == origin.x() && fy == origin.y() ) {
-                        continue; // player's own floor
-                    }
                     const int floor_z = ( dz < 0.0f )
                                         ? static_cast<int>( origin.z() ) - k
                                         : static_cast<int>( origin.z() ) + k + 1;

--- a/src/shaders/lm_seen_compute.hlsl
+++ b/src/shaders/lm_seen_compute.hlsl
@@ -175,9 +175,6 @@ void main( uint3 group_id : SV_GroupID, uint3 thread_id : SV_GroupThreadID )
                                       0, cache_x - 1 );
             const int   iy_z = clamp( player_y + round_nearest_int( (float)sdy * t_z ),
                                       0, cache_y - 1 );
-            if( sign_z < 0 && k == 0 && ix_z == player_x && iy_z == player_y ) {
-                continue;
-            }
             const int floor_z = sign_z > 0 ? player_z_idx + k + 1 : player_z_idx - k;
             if( floor_z >= 0 && floor_z < z_count ) {
                 const int fl_idx = floor_z * cache_xy + ix_z * cache_y + iy_z;

--- a/tests/zlevel_visibility_cache_test.cpp
+++ b/tests/zlevel_visibility_cache_test.cpp
@@ -85,6 +85,36 @@ TEST_CASE( "opening_floor_invalidates_below_seen_cache", "[vision][zlevel]" )
     CHECK( here.access_cache( hole_pos.z() - 1 ).seen_cache_dirty );
 }
 
+TEST_CASE( "solid_floor_blocks_directly_below_visibility", "[vision][zlevel]" )
+{
+    clear_all_state();
+
+    map &here = get_map();
+
+    const ter_id t_floor( "t_floor" );
+
+    g->place_player( tripoint_bub_ms( 60, 60, 1 ) );
+
+    calendar::turn = calendar::turn_zero + 12_hours;
+    g->reset_light_level();
+
+    const auto player_pos = g->u.bub_pos();
+    const auto below_pos = player_pos + tripoint_below;
+
+    here.ter_set( player_pos, t_floor );
+    here.ter_set( below_pos, t_floor );
+
+    here.invalidate_map_cache( player_pos.z() );
+    here.invalidate_map_cache( below_pos.z() );
+    here.build_map_cache( player_pos.z() );
+    here.update_visibility_cache( player_pos.z() );
+
+    const level_cache &below_cache = here.access_cache( below_pos.z() );
+    CHECK( below_cache.seen_cache[below_cache.idx( below_pos.x(), below_pos.y() )] == 0.0f );
+    CHECK( below_cache.visibility_cache[below_cache.idx( below_pos.x(),
+                                                         below_pos.y() )] == lit_level::BLANK );
+}
+
 TEST_CASE( "opening_floor_rebuilds_below_visibility", "[vision][zlevel]" )
 {
     clear_all_state();


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9453

Looking one z-level down could reveal the tile directly under the player through a solid floor.

## Describe the solution (The How)

- Treat the player's current floor as an occluder for downward vision rays.
- Apply the same crossing rule to CPU and SDL_GPU seen-cache paths.
- Add a z-level visibility regression test for the tile directly below the player.
- Document that BN PR CI must be tracked and fixed after PR updates.

## Describe alternatives you've considered

Keep the standing-floor exception for movement only; vision should still be blocked.

## Testing

- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `CATA_TEST_COMPUTE_ACCELERATION=cpu ./out/build/linux-full/tests/cata_test-tiles "[vision][zlevel]"`

Local SDL_GPU software test execution still crashes in z-level visibility tests, including the existing `opening_floor_rebuilds_below_visibility`; shader recompilation completed in the build step. Initial CI `build` also hit a transient vcpkg lz4 download 502 before this update.

## Additional context

Related: #8198, #8868

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [00cdea4](https://github.com/cataclysmbn/Cataclysm-BN/commit/00cdea41eeaf1d11e9b0ba60d50d0e7ddec68dcc) (docs: track BN PR CI status) on 2026-06-13 14:31:42

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27467731868/artifacts/7611129091)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27467731868/artifacts/7611593879)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27467731868/artifacts/7611155609)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27467731868/artifacts/7611178091)
<!-- END artifact comment -->