### PR TITLE
fix: stop tree climb descents teleporting across submaps

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -14735,8 +14735,11 @@ void game::vertical_move( int movez, bool force, bool peeking )
         return;
     }
 
-    const auto old_pos = g->u.bub_pos();
     point_rel_sm submap_shift;
+    if( force ) {
+        submap_shift = update_map( u );
+    }
+    const auto old_pos = g->u.bub_pos();
     vertical_shift( z_after );
     if( !force ) {
         submap_shift = update_map( stairs.x(), stairs.y() );
@@ -15357,7 +15360,7 @@ auto game::vertical_shift( const int z_after, const bool keep_grab ) -> void
     scent.reset();
 
     const int z_before = get_levz();
-    u.setpos( tripoint_bub_ms( u.bub_pos().xy(), z_after ) );
+    u.setpos( tripoint_abs_ms( u.abs_pos().xy(), z_after ) );
     if( !m.has_zlevels() ) {
         m.clear_vehicle_cache( );
         m.access_cache( z_before ).vehicle_list.clear();

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -223,6 +223,22 @@ TEST_CASE( "update_map_uses_avatar_absolute_position" )
     CHECK( you.bub_pos() == tripoint_bub_ms( g_half_mapsize_x, g_half_mapsize_y, 0 ) );
 }
 
+TEST_CASE( "vertical_shift_preserves_absolute_position_across_submap_boundary" )
+{
+    clear_all_state();
+
+    auto &here = get_map();
+    auto &you = get_avatar();
+    const auto landing_local = tripoint_bub_ms( g_half_mapsize_x + SEEX, g_half_mapsize_y, 1 );
+    const auto landing_abs = map_local_to_abs( here, landing_local );
+    const auto expected_after_descent = tripoint_abs_ms( landing_abs.xy(), 0 );
+
+    you.setpos( landing_abs );
+    g->vertical_shift( expected_after_descent.z() );
+
+    CHECK( you.abs_pos() == expected_after_descent );
+}
+
 TEST_CASE( "monster_tracker_uses_absolute_positions" )
 {
     clear_all_state();

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -223,7 +223,7 @@ TEST_CASE( "update_map_uses_avatar_absolute_position" )
     CHECK( you.bub_pos() == tripoint_bub_ms( g_half_mapsize_x, g_half_mapsize_y, 0 ) );
 }
 
-TEST_CASE( "vertical_shift_preserves_absolute_position_across_submap_boundary" )
+TEST_CASE( "forced_vertical_move_preserves_absolute_position_across_submap_boundary" )
 {
     clear_all_state();
 
@@ -234,7 +234,7 @@ TEST_CASE( "vertical_shift_preserves_absolute_position_across_submap_boundary" )
     const auto expected_after_descent = tripoint_abs_ms( landing_abs.xy(), 0 );
 
     you.setpos( landing_abs );
-    g->vertical_shift( expected_after_descent.z() );
+    g->vertical_move( -1, true );
 
     CHECK( you.abs_pos() == expected_after_descent );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9442

Climbing down from trees across submap boundaries could land the player one submap away.

## Describe the solution (The How)

- Recenter the map before forced vertical movement when the avatar already moved to the fall/climb-down x/y.
- Preserve absolute x/y when changing z-levels.
- Add regression coverage for forced descent across a submap boundary.

## Testing

- Added regression test; it failed before the fix with `(60,60,0) == (72,60,0)`.
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `CATA_TEST_COMPUTE_ACCELERATION=cpu ./out/build/linux-full/tests/cata_test-tiles -D "forced_vertical_move_preserves_absolute_position_across_submap_boundary"`
- Full `CATA_TEST_COMPUTE_ACCELERATION=cpu ./out/build/linux-full/tests/cata_test-tiles -D` was blocked by `vision_see_out_of_vehicle` / `vision_see_into_vehicle`; reproduced on `upstream/main` (`0d4f741121`).

## Checklist

### Mandatory

- [x] I linked any relevant issues using github keyword syntax.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b579b8e](https://github.com/cataclysmbn/Cataclysm-BN/commit/b579b8e182105a8f43a9d5e91c1f4d19e966dc14) (fix: preserve forced vertical move position) on 2026-06-13 13:40:35

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27467473062/artifacts/7611047829)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27467473062)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27467473062/artifacts/7611067354)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27467473062/artifacts/7611075266)
<!-- END artifact comment -->