### PR TITLE
fix: use correct explosion for hellfire longbow missiles

### DIFF
--- a/data/json/items/ammo/hellfire.json
+++ b/data/json/items/ammo/hellfire.json
@@ -17,7 +17,7 @@
     "range": 100,
     "recoil": 12000,
     "loudness": 120,
-    "effects": [ "EXPLOSIVE_HUGE", "NEVER_MISFIRES", "NO_PENETRATE_OBSTACLES" ]
+    "effects": [ "AMMO_HELLFIRE_HEAT", "NEVER_MISFIRES", "NO_PENETRATE_OBSTACLES" ]
   },
   {
     "type": "AMMO",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
For some reason hellfire longbow missiles used the generic EXPLOSION_HUGE rather than the custom made AMMO_HELLFIRE_HEAT
#9436 
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Changes the explosion to the correct one.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
No big boom
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [000f6d4](https://github.com/cataclysmbn/Cataclysm-BN/commit/000f6d4feeb95b61702b6932125ad8e6ca6b6125) (Update hellfire.json) on 2026-06-13 15:32:35

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27470072248/artifacts/7611839007)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27470072248/artifacts/7612047850)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27470072248/artifacts/7611852910)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27470072248/artifacts/7611875014)
<!-- END artifact comment -->