### PR TITLE
feat(balance): add missing flags to various enemies

### DIFF
--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -1094,6 +1094,7 @@
         "fake_dex": 12,
         "fake_per": 14,
         "ranges": [ [ 0, 30, "SINGLE" ] ],
+        "require_targeting_player": false,
         "description": "The feral black-ops fires their sniper rifle!",
         "no_crits": true
       }

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -756,6 +756,7 @@
     ],
     "death_function": [ "NORMAL" ],
     "regenerates": 1,
+    "regeneration_modifiers": [ { "effect": "emp", "base_mod": -1 } ],
     "death_drops": "mon_feral_pa_boss_death_drops",
     "zombify_into": "mon_zombie_armored",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
@@ -887,6 +888,7 @@
         "no_crits": true
       }
     ],
+    "special_when_hit": [ "RETURN_FIRE", 75 ],
     "death_function": [ "NORMAL" ],
     "death_drops": "mon_feral_blackops_boss_commander_death_drops",
     "zombify_into": "mon_zombie_soldier_blackops_2",
@@ -947,6 +949,7 @@
     "special_when_hit": [ "ZAPBACK", 75 ],
     "death_function": [ "NORMAL" ],
     "regenerates": 1,
+    "regeneration_modifiers": [ { "effect": "emp", "base_mod": -1 } ],
     "death_drops": "mon_feral_blackops_boss_bioop_death_drops",
     "zombify_into": "mon_zombie_soldier_blackops_2",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -903,7 +903,8 @@
       "HUMAN",
       "CAN_OPEN_DOORS",
       "PATH_AVOID_DANGER_1",
-      "NIGHT_INVISIBILITY"
+      "NIGHT_INVISIBILITY",
+      "PRIORITIZE_TARGETS"
     ]
   },
   {
@@ -962,7 +963,8 @@
       "CAN_OPEN_DOORS",
       "PATH_AVOID_DANGER_1",
       "NIGHT_INVISIBILITY",
-      "HARDTOSHOOT"
+      "HARDTOSHOOT",
+      "PRIORITIZE_TARGETS"
     ]
   },
   {
@@ -1036,7 +1038,8 @@
       "HUMAN",
       "CAN_OPEN_DOORS",
       "PATH_AVOID_DANGER_1",
-      "NIGHT_INVISIBILITY"
+      "NIGHT_INVISIBILITY",
+      "PRIORITIZE_TARGETS"
     ]
   },
   {
@@ -1107,7 +1110,8 @@
       "HUMAN",
       "CAN_OPEN_DOORS",
       "PATH_AVOID_DANGER_1",
-      "NIGHT_INVISIBILITY"
+      "NIGHT_INVISIBILITY",
+      "PRIORITIZE_TARGETS"
     ]
   }
 ]

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -759,7 +759,7 @@
     "death_drops": "mon_feral_pa_boss_death_drops",
     "zombify_into": "mon_zombie_armored",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER_1", "ELECTRIC" ]
   },
   {
     "id": "mon_feral_corpo",

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -760,7 +760,18 @@
     "death_drops": "mon_feral_pa_boss_death_drops",
     "zombify_into": "mon_zombie_armored",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER_1", "ELECTRIC" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "WARM",
+      "BASHES",
+      "GROUP_BASH",
+      "HUMAN",
+      "CAN_OPEN_DOORS",
+      "PATH_AVOID_DANGER_1",
+      "ELECTRIC"
+    ]
   },
   {
     "id": "mon_feral_corpo",

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -1087,7 +1087,7 @@
       {
         "type": "gun",
         "cooldown": 20,
-        "move_cost": 100,
+        "move_cost": 200,
         "gun_type": "rm11b_sniper_rifle",
         "ammo_type": "8mm_hvp",
         "fake_skills": [ [ "gun", 20 ], [ "rifle", 20 ] ],
@@ -1095,14 +1095,7 @@
         "fake_per": 14,
         "ranges": [ [ 0, 30, "SINGLE" ] ],
         "description": "The feral black-ops fires their sniper rifle!",
-        "no_crits": false,
-        "require_targeting_player": true,
-        "require_targeting_npc": true,
-        "require_targeting_monster": false,
-        "target_moving_vehicles": true,
-        "laser_lock": true,
-        "targeting_cost": 300,
-        "targeting_timeout_extend": -10
+        "no_crits": true
       }
     ],
     "death_function": [ "NORMAL" ],

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -1094,7 +1094,6 @@
         "fake_dex": 12,
         "fake_per": 14,
         "ranges": [ [ 0, 30, "SINGLE" ] ],
-        "require_targeting_player": false,
         "description": "The feral black-ops fires their sniper rifle!",
         "no_crits": false,
         "require_targeting_player": true,

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -1087,7 +1087,7 @@
       {
         "type": "gun",
         "cooldown": 20,
-        "move_cost": 200,
+        "move_cost": 100,
         "gun_type": "rm11b_sniper_rifle",
         "ammo_type": "8mm_hvp",
         "fake_skills": [ [ "gun", 20 ], [ "rifle", 20 ] ],
@@ -1096,7 +1096,14 @@
         "ranges": [ [ 0, 30, "SINGLE" ] ],
         "require_targeting_player": false,
         "description": "The feral black-ops fires their sniper rifle!",
-        "no_crits": true
+        "no_crits": false,
+        "require_targeting_player": true,
+        "require_targeting_npc": true,
+        "require_targeting_monster": false,
+        "target_moving_vehicles": true,
+        "laser_lock": true,
+        "targeting_cost": 300,
+        "targeting_timeout_extend": -10
       }
     ],
     "death_function": [ "NORMAL" ],

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -849,6 +849,7 @@
     "emit_fields": [ { "emit_id": "emit_fog_kraken", "delay": "1 s" } ],
     "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK", "HURT" ],
     "regenerates": 10,
+    "regen_morale": true,
     "special_attacks": [
       [ "SMASH", 15 ],
       [ "RANGED_PULL", 15 ],

--- a/data/json/monsters/zed_lab.json
+++ b/data/json/monsters/zed_lab.json
@@ -61,7 +61,7 @@
     "starting_ammo": { "bot_manhack": 3 },
     "path_settings": { "max_dist": 10 },
     "special_attacks": [ [ "scratch", 20 ], [ "SCIENCE", 18 ] ],
-    "extend": { "flags": [ "DROPS_AMMO", "ACIDPROOF" ] },
+    "extend": { "flags": [ "DROPS_AMMO", "ACIDPROOF", "ELECTRIC" ] },
     "delete": { "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_SCIENCE_UPGRADE" } }
   },
   {
@@ -93,6 +93,7 @@
     ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "harvest": "CBM_SUBS",
+    "extend": { "flags": [ "ELECTRIC" ] },
     "delete": { "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_SCIENCE_UPGRADE" } }
   },
   {
@@ -130,7 +131,6 @@
     "relative": { "hp": 50, "speed": -10, "melee_dice": 1 },
     "special_attacks": [ [ "scratch", 20 ] ],
     "death_drops": "mon_zombie_scientist_admin_death_drops",
-    "special_when_hit": [ "ZAPBACK", 100 ],
     "harvest": "CBM_SCI",
     "delete": { "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_SCIENCE_UPGRADE" } }
   },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Several enemies have some inconsistencies when it comes to their flags, such as scientist zombies that are clearly cbm'd up like the cybernetics researcher, but can't be seen on electrosense due to lack of electric flag.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds the electric flag to the cybernetics researcher, elite zombie scientist, and feral armored bioop, as they all clearly have cybernetics. Adds regen_morale to the kraken so it will actually come out to fight again after regenerating. Removes an unnecessary zapback from the zombie lab admin. Adds prioritize_targets to the feral blackops to hopefully make them a bit smarter. Makes EMPs disable the healing on the feral blackops and armored bioop as its implied their healing comes from cbms. Adds return_fire to the blackops commander so it feels more like an actual firefight.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3219e4a](https://github.com/cataclysmbn/Cataclysm-BN/commit/3219e4ae740822d114118a17e8a7b7ca820eaa4a) (style(autofix.ci): automated formatting) on 2026-06-13 16:31:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27471522404/artifacts/7612278932)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27471522404/artifacts/7612482204)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27471522404/artifacts/7612271266)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27471522404/artifacts/7612312078)
<!-- END artifact comment -->