### PR TITLE
fix: correct capitalization of head alloy and minirose CBMs

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -83,7 +83,7 @@
   {
     "id": "bio_armor_head",
     "type": "bionic",
-    "name": { "str": "Alloy Plating - head" },
+    "name": { "str": "Alloy Plating - Head" },
     "description": "The flesh on your head has been surgically replaced by alloy plating, protecting both your head and jaw regions.  Provides 6 bash and cut protection, and 5 ballistic protection.",
     "occupied_bodyparts": [ [ "head", 5 ], [ "mouth", 1 ] ],
     "bash_protec": [ [ "head", 6 ], [ "mouth", 6 ] ],
@@ -516,7 +516,7 @@
   {
     "id": "bio_minirose",
     "type": "bionic",
-    "name": { "str": "minirose" },
+    "name": { "str": "Minirose" },
     "description": "A dead man's switch and literal mininuke wired through the torso and major blood vessels.  It can be armed or disabled, and detonates upon death while armed or manual trigger.  You wouldn't want to use it, unless you'd like to demonstrate the bottomless malice within the human heart to a certain ant.",
     "occupied_bodyparts": [ [ "torso", 20 ] ],
     "act_cost": "1 J",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -433,7 +433,7 @@
     "id": "bio_minirose",
     "copy-from": "bionic_general_npc_usable",
     "type": "BIONIC_ITEM",
-    "name": { "str": "minirose CBM" },
+    "name": { "str": "Minirose CBM" },
     "looks_like": "bio_int_enhancer",
     "description": "An implanted dead man's switch and mininuke payload. Detonates upon death or manual trigger. You wouldn't want to use it, unless you'd like to demonstrate the bottomless malice within the human heart to a certain ant.",
     "price": "10 kUSD",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Tiny fixes.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Fixed minirose not being capitalized as is standard in both bionic and bionic item names.
2. Fixed head alloy plating lacking capitalization.

## Describe alternatives you've considered

ALL CAPS
NO ITEMS
ALONSO ONLY
FINAL DESTINATION

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

I can read :D

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.