### PR TITLE
feat: Support Colored Lights on CPU Path

### DIFF
--- a/src/compute/gpu_lm.cpp
+++ b/src/compute/gpu_lm.cpp
@@ -2782,7 +2782,7 @@ auto begin_gpu_lighting(SDL_GPUDevice* const device, run_gpu_lighting_params con
         dynamic_sources = std::move(collection.dynamic_sources);
         colored_sources = std::move(collection.colored_sources);
         write_source_map_to_level_caches(*p.m, source_collection_levels, all_sources);
-        if (collect_colored_sources && colored_sources.empty()) {
+        if (!colored_lighting || (collect_colored_sources && colored_sources.empty())) {
             clear_colored_light_caches(*p.m, source_collection_levels);
         }
     }

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -31,9 +31,11 @@
 #include "fragment_cloud.h" // IWYU pragma: keep
 #include "game.h"
 #include "game_constants.h"
+#include "hsv_color.h"
 #include "int_id.h"
 #include "item.h"
 #include "item_stack.h"
+#include "itype.h"
 #include "line.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -278,6 +280,220 @@ void record_cpu_lm_read( const bool valid, std::atomic<int64_t> &valid_counter,
     return counter.exchange( 0, std::memory_order_relaxed );
 }
 
+struct cpu_colored_item_light {
+    float luminance = 0.0f;
+    uint32_t color_rgb = 0u;
+};
+
+struct cpu_colored_light_cache_context {
+    level_cache *cache = nullptr;
+    uint32_t color_rgb = 0u;
+};
+
+struct cpu_colored_light_3d_context {
+    map *here = nullptr;
+    tripoint_bub_ms source;
+    float luminance = 0.0f;
+    int skip_zlev = 0;
+    float dir_x = 0.0f;
+    float dir_y = 0.0f;
+    float cone_cos = -1.0f;
+    uint32_t color_rgb = 0u;
+    bool directional = false;
+};
+
+struct apply_cpu_colored_light_3d_options {
+    tripoint_bub_ms source;
+    float luminance = 0.0f;
+    uint32_t color_rgb = 0u;
+    float dir_x = 0.0f;
+    float dir_y = 0.0f;
+    float cone_cos = -1.0f;
+    bool directional = false;
+    int skip_zlev = 0;
+};
+
+auto color_is_set( const RGBColor &color ) -> bool
+{
+    return color.a != 0 && ( color.r != 0 || color.g != 0 || color.b != 0 );
+}
+
+auto pack_rgb( const RGBColor &color ) -> uint32_t
+{
+    return ( static_cast<uint32_t>( color.r ) << 16 ) |
+           ( static_cast<uint32_t>( color.g ) << 8 ) |
+           static_cast<uint32_t>( color.b );
+}
+
+auto color_rgb_from_optional( const std::optional<RGBColor> &color ) -> std::optional<uint32_t>
+{
+    if( !color || !color_is_set( *color ) ) {
+        return std::nullopt;
+    }
+    return pack_rgb( *color );
+}
+
+auto item_light_color( const item &itm ) -> std::optional<uint32_t>
+{
+    return color_rgb_from_optional( itm.typeId().obj().light_color );
+}
+
+auto field_light_color( const field_entry &entry ) -> std::optional<uint32_t>
+{
+    return color_rgb_from_optional(
+               entry.get_field_type().obj().get_light_color( entry.get_field_intensity() - 1 ) );
+}
+
+auto map_data_light_color( const map_data_common_t &data ) -> std::optional<uint32_t>
+{
+    return color_rgb_from_optional( data.light_color );
+}
+
+auto vehicle_light_color( const vpart_reference &part ) -> std::optional<uint32_t>
+{
+    if( part.info().light_color && color_is_set( *part.info().light_color ) ) {
+        return pack_rgb( *part.info().light_color );
+    }
+
+    const auto [bg, fg] = part.part().get_color( true );
+    if( color_is_set( fg ) ) {
+        return pack_rgb( fg );
+    }
+    if( color_is_set( bg ) ) {
+        return pack_rgb( bg );
+    }
+    return std::nullopt;
+}
+
+auto character_colored_item_light( const Character &ch ) -> std::optional<cpu_colored_item_light>
+{
+    auto best = std::optional<cpu_colored_item_light> {};
+    ch.has_item_with( [&best]( const item & itm ) {
+        const auto color_rgb = item_light_color( itm );
+        const auto luminance = static_cast<float>( itm.getlight_emit() );
+        if( color_rgb && luminance > LIGHT_AMBIENT_LOW && ( !best || luminance > best->luminance ) ) {
+            best = cpu_colored_item_light{
+                .luminance = luminance,
+                .color_rgb = *color_rgb,
+            };
+        }
+        return false;
+    } );
+    return best;
+}
+
+auto packed_colored_light_value( const float intensity, const uint32_t color_rgb ) -> uint32_t
+{
+    if( intensity <= LIGHT_AMBIENT_LOW || color_rgb == 0u ) {
+        return 0u;
+    }
+    const auto rank = static_cast<uint32_t>(
+                          std::clamp( static_cast<int>( std::lround( intensity * 2.0f ) ), 1, 255 ) );
+    return ( rank << 24 ) | ( color_rgb & 0x00ffffffu );
+}
+
+auto atomic_colored_light_max( uint32_t &cell, const uint32_t value ) -> void
+{
+    if( value == 0u ) {
+        return;
+    }
+#if defined( __cpp_lib_atomic_ref )
+    auto atomic_cell = std::atomic_ref<uint32_t> { cell };
+    auto expected = atomic_cell.load( std::memory_order_relaxed );
+    while( expected < value &&
+           !atomic_cell.compare_exchange_weak( expected, value, std::memory_order_relaxed ) ) {
+    }
+#else
+    auto expected = __atomic_load_n( &cell, __ATOMIC_RELAXED );
+    while( expected < value &&
+           !__atomic_compare_exchange_n( &cell, &expected, value, true, __ATOMIC_RELAXED,
+                                         __ATOMIC_RELAXED ) ) {
+    }
+#endif
+}
+
+auto write_colored_light_cache( level_cache &cache, const int idx, const float intensity,
+                                const uint32_t color_rgb ) -> void
+{
+    atomic_colored_light_max( cache.colored_light_cache[idx],
+                              packed_colored_light_value( intensity, color_rgb ) );
+}
+
+auto cpu_colored_light_allows_direction( const cpu_colored_light_3d_context &ctx, const int x,
+        const int y ) -> bool
+{
+    if( !ctx.directional ) {
+        return true;
+    }
+    const auto dx = static_cast<float>( x - ctx.source.x() );
+    const auto dy = static_cast<float>( y - ctx.source.y() );
+    const auto dist_xy_sq = dx * dx + dy * dy;
+    if( dist_xy_sq <= 0.0001f ) {
+        return false;
+    }
+    const auto cone_dot = ( dx * ctx.dir_x + dy * ctx.dir_y ) / std::sqrt( dist_xy_sq );
+    return cone_dot >= ctx.cone_cos;
+}
+
+auto update_cpu_colored_light_cache( void *context, const int, const int, const int,
+                                     const int idx, const float intensity, quadrant ) -> void
+{
+    auto &ctx = *static_cast<cpu_colored_light_cache_context *>( context );
+    if( ctx.cache == nullptr ) {
+        return;
+    }
+    write_colored_light_cache( *ctx.cache, idx, intensity, ctx.color_rgb );
+}
+
+auto update_cpu_colored_light_cache_3d( void *context, const int z_index, const int x,
+                                        const int y, const int idx, const float intensity,
+                                        quadrant ) -> void
+{
+    auto &ctx = *static_cast<cpu_colored_light_3d_context *>( context );
+    if( ctx.here == nullptr || intensity <= LIGHT_AMBIENT_LOW ) {
+        return;
+    }
+    const auto zlev = z_index - OVERMAP_DEPTH;
+    if( zlev == ctx.skip_zlev || !cpu_colored_light_allows_direction( ctx, x, y ) ) {
+        return;
+    }
+    auto adjusted_intensity = intensity;
+    const auto dx = static_cast<float>( x - ctx.source.x() );
+    const auto dy = static_cast<float>( y - ctx.source.y() );
+    const auto dz = static_cast<float>( zlev - ctx.source.z() ) * Z_LEVEL_SCALE;
+    const auto distance = std::sqrt( dx * dx + dy * dy + dz * dz );
+    if( distance > 0.5f ) {
+        adjusted_intensity = std::min( adjusted_intensity,
+                                       ctx.luminance /
+                                       ( std::exp( LIGHT_TRANSPARENCY_OPEN_AIR * distance ) * distance ) );
+    }
+    if( adjusted_intensity <= LIGHT_AMBIENT_LOW ) {
+        return;
+    }
+    auto &cache = ctx.here->access_cache( zlev );
+    write_colored_light_cache( cache, idx, adjusted_intensity, ctx.color_rgb );
+}
+
+auto make_colored_light_callback( level_cache &cache, const uint32_t color_rgb,
+                                  cpu_colored_light_cache_context &context )
+-> light_update_callback
+{
+    if( !colored_lighting || color_rgb == 0u ) {
+        return {};
+    }
+    context = cpu_colored_light_cache_context{
+        .cache = &cache,
+        .color_rgb = color_rgb,
+    };
+    return light_update_callback{
+        .context = &context,
+        .update = update_cpu_colored_light_cache,
+    };
+}
+
+auto apply_cpu_colored_light_3d( map &here, const apply_cpu_colored_light_3d_options &opt )
+-> void;
+
 } // namespace
 
 static const efftype_id effect_haslight( "haslight" );
@@ -292,10 +508,17 @@ void map::add_light_from_items( const tripoint_bub_ms &p, const item_stack::iter
         units::angle iwidth = 0_degrees; // 0-360 degrees. 0 is a circular light_source
         units::angle idir = 0_degrees;   // otherwise, it's a light_arc pointed in this direction
         if( ( *itm_it )->getlight( ilum, iwidth, idir ) ) {
+            const auto color_rgb = item_light_color( **itm_it ).value_or( 0u );
             if( iwidth > 0_degrees ) {
-                apply_light_arc( p, idir, ilum, iwidth );
+                apply_light_arc( {
+                    .p = p,
+                    .angle = idir,
+                    .luminance = ilum,
+                    .wideangle = iwidth,
+                    .color_rgb = color_rgb,
+                } );
             } else {
-                add_light_source( p, ilum );
+                add_light_source( p, ilum, color_rgb );
             }
         }
     }
@@ -836,7 +1059,13 @@ void map::apply_character_light( Character &p )
     }
 
     const float held_luminance = p.active_light();
-    if( held_luminance > LIGHT_AMBIENT_LOW ) {
+    const auto colored_light = colored_lighting ? character_colored_item_light( p ) :
+                               std::optional<cpu_colored_item_light> {};
+    if( colored_light ) {
+        apply_light_source( p.bub_pos(), colored_light->luminance, colored_light->color_rgb );
+    }
+    if( held_luminance > LIGHT_AMBIENT_LOW &&
+        ( !colored_light || held_luminance > colored_light->luminance ) ) {
         apply_light_source( p.bub_pos(), held_luminance );
     }
 
@@ -1131,11 +1360,15 @@ void map::generate_lightmap( const int zlev )
     auto &lm = map_cache.lm;
     auto &sm = map_cache.sm;
     auto &light_source_buffer = map_cache.light_source_buffer;
+    auto &colored_light_source_buffer = map_cache.colored_light_source_buffer;
+    auto &light_source_color_buffer = map_cache.light_source_color_buffer;
     auto &light_source_points = map_cache.light_source_points;
 
     std::ranges::fill( lm, 0.0f );
     std::fill( sm.begin(), sm.end(), 0.0f );
     std::fill( light_source_buffer.begin(), light_source_buffer.end(), 0.0f );
+    std::fill( colored_light_source_buffer.begin(), colored_light_source_buffer.end(), 0.0f );
+    std::fill( light_source_color_buffer.begin(), light_source_color_buffer.end(), 0u );
     light_source_points.clear();
 
     build_sunlight_cache( zlev );
@@ -1184,8 +1417,9 @@ void map::generate_lightmap_worker( const int zlev )
      * Step 4: Profit!
     */
     auto &light_source_buffer = map_cache.light_source_buffer;
-    auto add_deferred_point_light = [&]( const tripoint_bub_ms & source, const float luminance ) {
-        add_light_source( source, luminance );
+    auto add_deferred_point_light = [&]( const tripoint_bub_ms & source,
+    const float luminance, const uint32_t color_rgb = 0u ) {
+        add_light_source( source, luminance, color_rgb );
     };
 
     constexpr std::array<int, 4> dir_x = { {  0, -1, 1, 0 } };    //    [0]
@@ -1205,12 +1439,14 @@ void map::generate_lightmap_worker( const int zlev )
             tripoint_bub_ms p;
             int direction;
             float luminance;
+            uint32_t color_rgb = 0u;
         };
         struct arc_light_def {
             tripoint_bub_ms p;
             units::angle dir;
             float luminance;
             units::angle width;
+            uint32_t color_rgb = 0u;
         };
         struct smx_acc {
             std::vector<std::pair<tripoint_bub_ms, float>> lm_override;
@@ -1294,11 +1530,12 @@ void map::generate_lightmap_worker( const int zlev )
                             units::angle iwidth = 0_degrees;
                             units::angle idir = 0_degrees;
                             if( ( *itm_it )->getlight( ilum, iwidth, idir ) ) {
+                                const auto color_rgb = item_light_color( **itm_it ).value_or( 0u );
                                 if( iwidth > 0_degrees ) {
                                     // apply_light_arc writes to arbitrary lm positions; defer.
-                                    local.arc_lights.push_back( { p, idir, ilum, iwidth } );
+                                    local.arc_lights.push_back( { p, idir, ilum, iwidth, color_rgb } );
                                 } else {
-                                    add_deferred_point_light( p, ilum );
+                                    add_deferred_point_light( p, ilum, color_rgb );
                                 }
                             }
                         }
@@ -1306,11 +1543,13 @@ void map::generate_lightmap_worker( const int zlev )
 
                     const ter_id terrain = cur_submap->get_ter( sm_ms );
                     if( terrain->light_emitted > 0 ) {
-                        add_deferred_point_light( p, terrain->light_emitted );
+                        add_deferred_point_light( p, terrain->light_emitted,
+                                                  map_data_light_color( terrain.obj() ).value_or( 0u ) );
                     }
                     const furn_id furniture = cur_submap->get_furn( sm_ms );
                     if( furniture->light_emitted > 0 ) {
-                        add_deferred_point_light( p, furniture->light_emitted );
+                        add_deferred_point_light( p, furniture->light_emitted,
+                                                  map_data_light_color( furniture.obj() ).value_or( 0u ) );
                     }
 
                     std::ranges::for_each( cur_submap->get_field( sm_ms ), [&]( auto & fld ) {
@@ -1325,7 +1564,8 @@ void map::generate_lightmap_worker( const int zlev )
                         const auto *cur = &fld.second;
                         const int light_emitted = cur->light_emitted();
                         if( light_emitted > 0 ) {
-                            add_deferred_point_light( p, light_emitted );
+                            add_deferred_point_light( p, light_emitted,
+                                                      field_light_color( *cur ).value_or( 0u ) );
                         }
                         const float light_override = cur->local_light_override();
                         if( light_override >= 0.0 ) {
@@ -1348,10 +1588,21 @@ void map::generate_lightmap_worker( const int zlev )
         std::ranges::for_each( smx_accs, [&]( auto & local ) {
             lm_override.insert( lm_override.end(), local.lm_override.begin(), local.lm_override.end() );
             std::ranges::for_each( local.dir_lights, [&]( auto & dl ) {
-                apply_directional_light( dl.p, dl.direction, dl.luminance );
+                apply_directional_light( {
+                    .p = dl.p,
+                    .direction = dl.direction,
+                    .luminance = dl.luminance,
+                    .color_rgb = dl.color_rgb,
+                } );
             } );
             std::ranges::for_each( local.arc_lights, [&]( auto & al ) {
-                apply_light_arc( al.p, al.dir, al.luminance, al.width );
+                apply_light_arc( {
+                    .p = al.p,
+                    .angle = al.dir,
+                    .luminance = al.luminance,
+                    .wideangle = al.width,
+                    .color_rgb = al.color_rgb,
+                } );
             } );
         } );
 
@@ -1389,30 +1640,44 @@ void map::generate_lightmap_worker( const int zlev )
                 float luminance = 0.0f;
                 units::angle width = 0_degrees;
                 bool external = false;
+                uint32_t color_rgb = 0u;
             };
             struct vehicle_point_light_def {
                 tripoint_bub_ms src;
                 float luminance = 0.0f;
                 bool external = false;
+                uint32_t color_rgb = 0u;
             };
 
             auto apply_vehicle_arc = [&]( const vehicle_arc_light_def & def ) {
                 if( def.external ) {
                     apply_external_light( [&]() {
-                        apply_light_arc( def.src, def.direction, def.luminance, def.width );
+                        apply_light_arc( {
+                            .p = def.src,
+                            .angle = def.direction,
+                            .luminance = def.luminance,
+                            .wideangle = def.width,
+                            .color_rgb = def.color_rgb,
+                        } );
                     } );
                 } else {
-                    apply_light_arc( def.src, def.direction, def.luminance, def.width );
+                    apply_light_arc( {
+                        .p = def.src,
+                        .angle = def.direction,
+                        .luminance = def.luminance,
+                        .wideangle = def.width,
+                        .color_rgb = def.color_rgb,
+                    } );
                 }
             };
 
             auto apply_vehicle_point = [&]( const vehicle_point_light_def & def ) {
                 if( def.external ) {
                     apply_external_light( [&]() {
-                        apply_light_source( def.src, def.luminance );
+                        apply_light_source( def.src, def.luminance, def.color_rgb );
                     } );
                 } else {
-                    add_deferred_point_light( def.src, def.luminance );
+                    add_deferred_point_light( def.src, def.luminance, def.color_rgb );
                 }
             };
 
@@ -1429,6 +1694,7 @@ void map::generate_lightmap_worker( const int zlev )
                 }
 
                 const auto external = vehicle_lighting::is_external( part );
+                const auto color_rgb = vehicle_light_color( part ).value_or( 0u );
                 if( vp.has_flag( VPFLAG_CONE_LIGHT ) ) {
                     if( veh_luminance > lit_level::LIT ) {
                         apply_vehicle_arc( {
@@ -1437,6 +1703,7 @@ void map::generate_lightmap_worker( const int zlev )
                             .luminance = veh_luminance,
                             .width = vehicle_lighting::arc_width( vp ),
                             .external = external,
+                            .color_rgb = color_rgb,
                         } );
                     }
 
@@ -1448,6 +1715,7 @@ void map::generate_lightmap_worker( const int zlev )
                             .luminance = veh_luminance,
                             .width = vehicle_lighting::arc_width( vp ),
                             .external = external,
+                            .color_rgb = color_rgb,
                         } );
                     }
 
@@ -1464,6 +1732,7 @@ void map::generate_lightmap_worker( const int zlev )
                             .luminance = static_cast<float>( vp.bonus ),
                             .width = rotating_light.arc_width(),
                             .external = external,
+                            .color_rgb = color_rgb,
                         } );
                     }
                 } else if( vp.has_flag( VPFLAG_HALF_CIRCLE_LIGHT ) ) {
@@ -1473,6 +1742,7 @@ void map::generate_lightmap_worker( const int zlev )
                         .luminance = static_cast<float>( vp.bonus ),
                         .width = vehicle_lighting::arc_width( vp ),
                         .external = external,
+                        .color_rgb = color_rgb,
                     } );
 
                 } else if( vp.has_flag( VPFLAG_CIRCLE_LIGHT ) ) {
@@ -1482,6 +1752,7 @@ void map::generate_lightmap_worker( const int zlev )
                             .src = src,
                             .luminance = static_cast<float>( vp.bonus ),
                             .external = external,
+                            .color_rgb = color_rgb,
                         } );
                     }
 
@@ -1490,6 +1761,7 @@ void map::generate_lightmap_worker( const int zlev )
                         .src = src,
                         .luminance = static_cast<float>( vp.bonus ),
                         .external = external,
+                        .color_rgb = color_rgb,
                     } );
                 }
             }
@@ -1519,11 +1791,24 @@ void map::generate_lightmap_worker( const int zlev )
     */
     {
         ZoneScopedN( "generate_lightmap_flush" );
-        const tripoint_bub_ms cache_start( 0, 0, zlev );
-        const tripoint_bub_ms cache_end( map_cache.cache_x, map_cache.cache_y, zlev );
-        for( const auto &p : points_in_rectangle( cache_start, cache_end ) ) {
-            if( light_source_buffer[map_cache.idx( p.x(), p.y() )] > 0.0 ) {
-                apply_light_source( p, light_source_buffer[map_cache.idx( p.x(), p.y() )] );
+        for( const auto &source : map_cache.light_source_points ) {
+            const auto p = tripoint_bub_ms( source, zlev );
+            const auto idx = map_cache.idx( p.x(), p.y() );
+            const auto luminance = light_source_buffer[idx];
+            const auto colored_luminance = map_cache.colored_light_source_buffer[idx];
+            const auto color_rgb = map_cache.light_source_color_buffer[idx];
+            if( luminance <= 0.0f && colored_luminance <= 0.0f ) {
+                continue;
+            }
+            if( color_rgb != 0u && colored_luminance >= luminance ) {
+                apply_light_source( p, colored_luminance, color_rgb );
+            } else {
+                if( luminance > 0.0f ) {
+                    apply_light_source( p, luminance );
+                }
+                if( color_rgb != 0u && colored_luminance > 0.0f ) {
+                    apply_light_source( p, colored_luminance, color_rgb );
+                }
             }
         }
         for( const std::pair<tripoint_bub_ms, float> &elem : lm_override ) {
@@ -1532,12 +1817,20 @@ void map::generate_lightmap_worker( const int zlev )
     }
 }
 
-void map::add_light_source( const tripoint_bub_ms &p, float luminance )
+void map::add_light_source( const tripoint_bub_ms &p, float luminance, uint32_t color_rgb )
 {
     auto &cache = get_cache( p.z() );
     auto &light_source_buffer = cache.light_source_buffer;
-    light_source_buffer[cache.idx( p.x(), p.y() )] = std::max( luminance,
-            light_source_buffer[cache.idx( p.x(), p.y() )] );
+    const auto idx = cache.idx( p.x(), p.y() );
+    if( light_source_buffer[idx] <= 0.0f && cache.colored_light_source_buffer[idx] <= 0.0f ) {
+        cache.light_source_points.push_back( p.xy() );
+    }
+    light_source_buffer[idx] = std::max( luminance, light_source_buffer[idx] );
+    if( colored_lighting && color_rgb != 0u &&
+        luminance >= cache.colored_light_source_buffer[idx] ) {
+        cache.colored_light_source_buffer[idx] = luminance;
+        cache.light_source_color_buffer[idx] = color_rgb;
+    }
 }
 
 // Tile light/transparency: 3D
@@ -2591,7 +2884,57 @@ static const light_model k_light_model = {
     accumulate_transparency
 };
 
-void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
+namespace
+{
+
+auto apply_cpu_colored_light_3d( map &here, const apply_cpu_colored_light_3d_options &opt )
+-> void
+{
+    if( !colored_lighting || !here.has_zlevels() || opt.color_rgb == 0u ||
+        opt.luminance <= LIGHT_AMBIENT_LOW || !here.inbounds( opt.source ) ) {
+        return;
+    }
+    const auto adjacent_z_intensity =
+        opt.luminance /
+        ( std::exp( LIGHT_TRANSPARENCY_OPEN_AIR * Z_LEVEL_SCALE ) * Z_LEVEL_SCALE );
+    if( adjacent_z_intensity <= LIGHT_AMBIENT_LOW ) {
+        return;
+    }
+
+    auto transparency_caches = array_of_grids_of<const float> {};
+    auto floor_caches = array_of_grids_of<const char> {};
+    auto blocked_caches = array_of_grids_of<const diagonal_blocks> {};
+    auto output_caches = array_of_grids_of<float> {};
+    for( const auto z : std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ) ) {
+        auto &cache = here.access_cache( z );
+        const auto idx = z + OVERMAP_DEPTH;
+        transparency_caches[idx] = { cache.transparency_cache.data(), cache.cache_x, cache.cache_y };
+        floor_caches[idx] = { cache.floor_cache.data(), cache.cache_x, cache.cache_y };
+        blocked_caches[idx] = { cache.vehicle_obscured_cache.data(), cache.cache_x, cache.cache_y };
+        output_caches[idx] = { nullptr, cache.cache_x, cache.cache_y };
+    }
+
+    auto context = cpu_colored_light_3d_context{
+        .here = &here,
+        .source = opt.source,
+        .luminance = opt.luminance,
+        .skip_zlev = opt.skip_zlev,
+        .dir_x = opt.dir_x,
+        .dir_y = opt.dir_y,
+        .cone_cos = opt.cone_cos,
+        .color_rgb = opt.color_rgb,
+        .directional = opt.directional,
+    };
+    cast_zlight( output_caches, transparency_caches, floor_caches, blocked_caches, opt.source, 0,
+                 opt.luminance, k_light_model, {
+        .context = &context,
+        .update = update_cpu_colored_light_cache_3d,
+    } );
+}
+
+} // namespace
+
+void map::apply_light_source( const tripoint_bub_ms &p, float luminance, uint32_t color_rgb )
 {
     auto &cache = get_cache( p.z() );
     auto *lm_data        = cache.lm.data();
@@ -2608,6 +2951,9 @@ void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
         const float min_light = std::max( static_cast<float>( lit_level::LOW ), luminance );
         lm_data[p2.x() * sy + p2.y()] = std::max( lm_data[p2.x() * sy + p2.y()], min_light );
         sm_data[p2.x() * sy + p2.y()] = std::max( sm_data[p2.x() * sy + p2.y()], luminance );
+        if( colored_lighting && color_rgb != 0u ) {
+            write_colored_light_cache( cache, cache.idx( p2.x(), p2.y() ), luminance, color_rgb );
+        }
     }
     if( luminance <= lit_level::LOW ) {
         return;
@@ -2653,16 +2999,35 @@ void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
         mask |= OCTANT_WEST;
     }
     if( mask != 0 ) {
+        auto colored_context = cpu_colored_light_cache_context {};
         castLightOctants( lm_data, trans_data, blocked_data, sx, sy, p2, 0, luminance,
-                          k_light_model, mask, &weather_lookup_ );
+                          k_light_model, mask, &weather_lookup_,
+                          make_colored_light_callback( cache, color_rgb, colored_context ) );
+    }
+    if( color_rgb != 0u ) {
+        apply_cpu_colored_light_3d( *this, {
+            .source = p,
+            .luminance = luminance,
+            .color_rgb = color_rgb,
+            .skip_zlev = p.z(),
+        } );
     }
 }
 
 void map::apply_directional_light( const tripoint_bub_ms &p, int direction, float luminance )
 {
-    const auto p2 = p.xy();
+    apply_directional_light( {
+        .p = p,
+        .direction = direction,
+        .luminance = luminance,
+    } );
+}
 
-    auto &cache = get_cache( p.z() );
+auto map::apply_directional_light( const apply_directional_light_options &opt ) -> void
+{
+    const auto p2 = opt.p.xy();
+
+    auto &cache = get_cache( opt.p.z() );
     auto *lm_data      = cache.lm.data();
     auto *trans_data   = cache.transparency_cache.data();
     auto *blocked_data = cache.vehicle_obscured_cache.data();
@@ -2673,46 +3038,64 @@ void map::apply_directional_light( const tripoint_bub_ms &p, int direction, floa
     // 270=south-facing (north), 180=west-facing (east).  Each maps to the two octants
     // covering the relevant half-space in k_octant_xforms.
     auto mask = uint8_t{};
-    if( direction == 90 ) {
+    if( opt.direction == 90 ) {
         mask = OCTANT_NORTH;
-    } else if( direction == 0 ) {
+    } else if( opt.direction == 0 ) {
         mask = OCTANT_EAST;
-    } else if( direction == 270 ) {
+    } else if( opt.direction == 270 ) {
         mask = OCTANT_SOUTH;
-    } else if( direction == 180 ) {
+    } else if( opt.direction == 180 ) {
         mask = OCTANT_WEST;
     }
     if( mask != 0 ) {
-        castLightOctants( lm_data, trans_data, blocked_data, sx, sy, p2, 0, luminance,
-                          k_light_model, mask, &weather_lookup_ );
+        auto colored_context = cpu_colored_light_cache_context {};
+        castLightOctants( lm_data, trans_data, blocked_data, sx, sy, p2, 0, opt.luminance,
+                          k_light_model, mask, &weather_lookup_,
+                          make_colored_light_callback( cache, opt.color_rgb, colored_context ) );
     }
 }
 
 void map::apply_light_arc( const tripoint_bub_ms &p, units::angle angle, float luminance,
                            units::angle wideangle )
 {
-    if( luminance <= LIGHT_SOURCE_LOCAL ) {
+    apply_light_arc( {
+        .p = p,
+        .angle = angle,
+        .luminance = luminance,
+        .wideangle = wideangle,
+    } );
+}
+
+auto map::apply_light_arc( const apply_light_arc_options &opt ) -> void
+{
+    if( opt.luminance <= LIGHT_SOURCE_LOCAL ) {
         return;
     }
 
-    const auto &arc_cache = get_cache( p.z() );
+    const auto &arc_cache = get_cache( opt.p.z() );
     auto lit = std::vector<bool>( static_cast<size_t>( arc_cache.cache_x ) * arc_cache.cache_y,
                                   false );
 
-    apply_light_source( p, LIGHT_SOURCE_LOCAL );
+    apply_light_source( opt.p, LIGHT_SOURCE_LOCAL );
 
     // Normalize (should work with negative values too)
-    const units::angle wangle = wideangle / 2.0;
+    const units::angle wangle = opt.wideangle / 2.0;
 
-    units::angle nangle = fmod( angle, 360_degrees );
+    units::angle nangle = fmod( opt.angle, 360_degrees );
 
     tripoint_bub_ms end;
-    int range = LIGHT_RANGE( luminance );
-    calc_ray_end( nangle, range, p, end );
-    apply_light_ray( lit, p, end, luminance );
+    auto range = LIGHT_RANGE( opt.luminance );
+    calc_ray_end( nangle, range, opt.p, end );
+    apply_light_ray( {
+        .lit = lit,
+        .s = opt.p,
+        .e = end,
+        .luminance = opt.luminance,
+        .color_rgb = opt.color_rgb,
+    } );
 
     tripoint_bub_ms test;
-    calc_ray_end( wangle + nangle, range, p, test );
+    calc_ray_end( wangle + nangle, range, opt.p, test );
 
     const float wdist = hypot( end.x() - test.x(), end.y() - test.y() );
     if( wdist <= 0.5 ) {
@@ -2725,49 +3108,97 @@ void map::apply_light_arc( const tripoint_bub_ms &p, units::angle angle, float l
     // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
     for( units::angle ao = wstep; ao <= wangle; ao += wstep ) {
         if( trigdist ) {
-            double fdist = ( ao * M_PI_2 ) / wangle;
+            auto fdist = ( ao * M_PI_2 ) / wangle;
             end.x() = static_cast<int>(
-                          p.x() + ( static_cast<double>( range ) - fdist * 2.0 ) * cos( nangle + ao ) );
+                          opt.p.x() + ( static_cast<double>( range ) - fdist * 2.0 ) * cos( nangle + ao ) );
             end.y() = static_cast<int>(
-                          p.y() + ( static_cast<double>( range ) - fdist * 2.0 ) * sin( nangle + ao ) );
-            apply_light_ray( lit, p, end, luminance );
+                          opt.p.y() + ( static_cast<double>( range ) - fdist * 2.0 ) * sin( nangle + ao ) );
+            apply_light_ray( {
+                .lit = lit,
+                .s = opt.p,
+                .e = end,
+                .luminance = opt.luminance,
+                .color_rgb = opt.color_rgb,
+            } );
 
             end.x() = static_cast<int>(
-                          p.x() + ( static_cast<double>( range ) - fdist * 2.0 ) * cos( nangle - ao ) );
+                          opt.p.x() + ( static_cast<double>( range ) - fdist * 2.0 ) * cos( nangle - ao ) );
             end.y() = static_cast<int>(
-                          p.y() + ( static_cast<double>( range ) - fdist * 2.0 ) * sin( nangle - ao ) );
-            apply_light_ray( lit, p, end, luminance );
+                          opt.p.y() + ( static_cast<double>( range ) - fdist * 2.0 ) * sin( nangle - ao ) );
+            apply_light_ray( {
+                .lit = lit,
+                .s = opt.p,
+                .e = end,
+                .luminance = opt.luminance,
+                .color_rgb = opt.color_rgb,
+            } );
         } else {
-            calc_ray_end( nangle + ao, range, p, end );
-            apply_light_ray( lit, p, end, luminance );
-            calc_ray_end( nangle - ao, range, p, end );
-            apply_light_ray( lit, p, end, luminance );
+            calc_ray_end( nangle + ao, range, opt.p, end );
+            apply_light_ray( {
+                .lit = lit,
+                .s = opt.p,
+                .e = end,
+                .luminance = opt.luminance,
+                .color_rgb = opt.color_rgb,
+            } );
+            calc_ray_end( nangle - ao, range, opt.p, end );
+            apply_light_ray( {
+                .lit = lit,
+                .s = opt.p,
+                .e = end,
+                .luminance = opt.luminance,
+                .color_rgb = opt.color_rgb,
+            } );
         }
+    }
+    if( opt.color_rgb != 0u ) {
+        apply_cpu_colored_light_3d( *this, {
+            .source = opt.p,
+            .luminance = opt.luminance,
+            .color_rgb = opt.color_rgb,
+            .dir_x = static_cast<float>( units::cos( opt.angle ) ),
+            .dir_y = static_cast<float>( units::sin( opt.angle ) ),
+            .cone_cos = static_cast<float>( units::cos( opt.wideangle / 2.0 ) ),
+            .directional = true,
+            .skip_zlev = opt.p.z(),
+        } );
     }
 }
 
 void map::apply_light_ray( std::vector<bool> &lit,
                            const tripoint_bub_ms &s, const tripoint_bub_ms &e, float luminance )
 {
-    point_bub_ms a( std::abs( e.x() - s.x() ) * 2, std::abs( e.y() - s.y() ) * 2 );
-    point_bub_ms d( ( s.x() < e.x() ) ? 1 : -1, ( s.y() < e.y() ) ? 1 : -1 );
-    auto p = s.xy();
+    apply_light_ray( {
+        .lit = lit,
+        .s = s,
+        .e = e,
+        .luminance = luminance,
+    } );
+}
+
+auto map::apply_light_ray( const apply_light_ray_options &opt ) -> void
+{
+    auto a = point_bub_ms( std::abs( opt.e.x() - opt.s.x() ) * 2,
+                           std::abs( opt.e.y() - opt.s.y() ) * 2 );
+    auto d = point_bub_ms( ( opt.s.x() < opt.e.x() ) ? 1 : -1,
+                           ( opt.s.y() < opt.e.y() ) ? 1 : -1 );
+    auto p = opt.s.xy();
 
     // TODO: Invert that z comparison when it's sane
-    if( s.z() != e.z() || ( s.x() == e.x() && s.y() == e.y() ) ) {
+    if( opt.s.z() != opt.e.z() || ( opt.s.x() == opt.e.x() && opt.s.y() == opt.e.y() ) ) {
         return;
     }
 
-    auto &cache_ref = get_cache( s.z() );
+    auto &cache_ref = get_cache( opt.s.z() );
     auto *lm_data          = cache_ref.lm.data();
     auto *trans_data       = cache_ref.transparency_cache.data();
     const int sx = cache_ref.cache_x;
     const int sy = cache_ref.cache_y;
 
-    float distance = 1.0;
-    float transparency = LIGHT_TRANSPARENCY_OPEN_AIR;
-    const float scaling_factor = static_cast<float>( rl_dist( s, e ) ) /
-                                 static_cast<float>( square_dist( s, e ) );
+    auto distance = 1.0f;
+    auto transparency = LIGHT_TRANSPARENCY_OPEN_AIR;
+    const float scaling_factor = static_cast<float>( rl_dist( opt.s, opt.e ) ) /
+                                 static_cast<float>( square_dist( opt.s, opt.e ) );
     // TODO: [lightmap] Pull out the common code here rather than duplication
     if( a.x() > a.y() ) {
         int t = a.y() - ( a.x() / 2 );
@@ -2783,13 +3214,16 @@ void map::apply_light_ray( std::vector<bool> &lit,
             // TODO: clamp coordinates to map bounds before this method is called.
             if( p.x() >= 0 && p.y() >= 0 && p.x() < sx && p.y() < sy ) {
                 const int idx = p.x() * sy + p.y();
-                float current_transparency = trans_data[idx];
-                bool is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
-                if( !lit[idx] ) {
+                auto current_transparency = trans_data[idx];
+                auto is_opaque = current_transparency == LIGHT_TRANSPARENCY_SOLID;
+                if( !opt.lit[idx] ) {
                     // Multiple rays will pass through the same squares so we need to record that
-                    lit[idx] = true;
-                    float lm_val = luminance / ( fastexp( transparency * distance ) * distance );
+                    opt.lit[idx] = true;
+                    auto lm_val = opt.luminance / ( fastexp( transparency * distance ) * distance );
                     lm_data[idx] = std::max( lm_data[idx], lm_val );
+                    if( colored_lighting && opt.color_rgb != 0u ) {
+                        write_colored_light_cache( cache_ref, idx, lm_val, opt.color_rgb );
+                    }
                 }
                 if( is_opaque ) {
                     break;
@@ -2801,7 +3235,7 @@ void map::apply_light_ray( std::vector<bool> &lit,
             }
 
             distance += scaling_factor;
-        } while( !( p.x() == e.x() && p.y() == e.y() ) );
+        } while( !( p.x() == opt.e.x() && p.y() == opt.e.y() ) );
     } else {
         int t = a.x() - ( a.y() / 2 );
         do {
@@ -2815,13 +3249,16 @@ void map::apply_light_ray( std::vector<bool> &lit,
 
             if( p.x() >= 0 && p.y() >= 0 && p.x() < sx && p.y() < sy ) {
                 const int idx = p.x() * sy + p.y();
-                float current_transparency = trans_data[idx];
-                bool is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
-                if( !lit[idx] ) {
+                auto current_transparency = trans_data[idx];
+                auto is_opaque = current_transparency == LIGHT_TRANSPARENCY_SOLID;
+                if( !opt.lit[idx] ) {
                     // Multiple rays will pass through the same squares so we need to record that
-                    lit[idx] = true;
-                    float lm_val = luminance / ( fastexp( transparency * distance ) * distance );
+                    opt.lit[idx] = true;
+                    auto lm_val = opt.luminance / ( fastexp( transparency * distance ) * distance );
                     lm_data[idx] = std::max( lm_data[idx], lm_val );
+                    if( colored_lighting && opt.color_rgb != 0u ) {
+                        write_colored_light_cache( cache_ref, idx, lm_val, opt.color_rgb );
+                    }
                 }
                 if( is_opaque ) {
                     break;
@@ -2833,6 +3270,6 @@ void map::apply_light_ray( std::vector<bool> &lit,
             }
 
             distance += scaling_factor;
-        } while( !( p.x() == e.x() && p.y() == e.y() ) );
+        } while( !( p.x() == opt.e.x() && p.y() == opt.e.y() ) );
     }
 }

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -2919,7 +2919,7 @@ auto apply_cpu_colored_light_3d( map &here, const apply_cpu_colored_light_3d_opt
         .directional = opt.directional,
     };
     cast_zlight( output_caches, transparency_caches, floor_caches, blocked_caches, opt.source, 0,
-                 opt.luminance, k_light_model, {
+    opt.luminance, k_light_model, {
         .context = &context,
         .update = update_cpu_colored_light_cache_3d,
     } );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10854,15 +10854,17 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         // GPU path: lightmap rebuilds only run for lightmap-dirty levels.
         // Player movement and other FoV-only updates are handled by
         // update_visibility_cache(), which can rebuild resident seen data.
-        for( const int z : dirty_lightmap_levels ) {
-            auto &c = get_cache( z );
-            std::fill( c.sm.begin(), c.sm.end(), 0.0f );
-            std::fill( c.light_source_buffer.begin(), c.light_source_buffer.end(), 0.0f );
-            c.light_source_points.clear();
-            std::ranges::fill( c.lm, 0.0f );
-            c.lm_cpu_cache_valid = false;
-            ++c.lm_cpu_cache_generation;
-        }
+            for( const int z : dirty_lightmap_levels ) {
+                auto &c = get_cache( z );
+                std::fill( c.sm.begin(), c.sm.end(), 0.0f );
+                std::fill( c.light_source_buffer.begin(), c.light_source_buffer.end(), 0.0f );
+                std::fill( c.colored_light_source_buffer.begin(), c.colored_light_source_buffer.end(), 0.0f );
+                std::fill( c.light_source_color_buffer.begin(), c.light_source_color_buffer.end(), 0u );
+                c.light_source_points.clear();
+                std::ranges::fill( c.lm, 0.0f );
+                c.lm_cpu_cache_valid = false;
+                ++c.lm_cpu_cache_generation;
+            }
         pending_gpu_lighting = cata_gpu::begin_gpu_lighting( gpu_device, {
             .m            = this,
             .dirty_levels = &dirty_lightmap_levels,
@@ -10958,6 +10960,18 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
 #endif
         {
             if( !dirty_lightmap_levels.empty() ) {
+                auto colored_light_levels = std::vector<int> {};
+                if( zlevels ) {
+                    std::ranges::copy( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ),
+                                       std::back_inserter( colored_light_levels ) );
+                } else {
+                    colored_light_levels = dirty_lightmap_levels;
+                }
+                for( const auto z : colored_light_levels ) {
+                    auto &c = get_cache( z );
+                    std::ranges::fill( c.colored_light_cache, 0u );
+                    c.colored_light_cache_active = false;
+                }
 
                 if( dirty_lightmap_levels.size() > 1 && parallel_enabled && parallel_map_cache ) {
                     // Multiple dirty levels: hoist shared initialization outside the
@@ -10969,6 +10983,9 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
                         auto &c = get_cache( z );
                         std::fill( c.sm.begin(), c.sm.end(), 0.0f );
                         std::fill( c.light_source_buffer.begin(), c.light_source_buffer.end(), 0.0f );
+                        std::fill( c.colored_light_source_buffer.begin(), c.colored_light_source_buffer.end(),
+                                   0.0f );
+                        std::fill( c.light_source_color_buffer.begin(), c.light_source_color_buffer.end(), 0u );
                         c.light_source_points.clear();
                         std::ranges::fill( c.lm, 0.0f );
                         c.lm_cpu_cache_valid = false;
@@ -11012,6 +11029,16 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
                     }
                 }
 
+                if( colored_lighting ) {
+                    for( const auto z : colored_light_levels ) {
+                        auto &c = get_cache( z );
+                        c.colored_light_cache_active = std::ranges::any_of(
+                            c.colored_light_cache, []( const auto packed ) {
+                                return packed != 0u;
+                            } );
+                    }
+                }
+
                 // Mark each regenerated level clean so subsequent redraws this turn skip it.
                 // Also mark visibility dirty: the lightmap just changed, so any visibility
                 // cache computed before this rebuild (e.g. from handle_action's unconditional
@@ -11021,8 +11048,6 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
                     c.lightmap_dirty = false;
                     c.lm_cpu_cache_valid = true;
                     c.visibility_cache_dirty = true;
-                    std::ranges::fill( c.colored_light_cache, 0u );
-                    c.colored_light_cache_active = false;
                 } );
 
             } // end if( !dirty_lightmap_levels.empty() )
@@ -11627,6 +11652,8 @@ level_cache::level_cache( int mx, int my )
       lm( static_cast<size_t>( mx * my ), 0.0f ),
       sm( static_cast<size_t>( mx * my ), 0.0f ),
       light_source_buffer( static_cast<size_t>( mx * my ), 0.0f ),
+      colored_light_source_buffer( static_cast<size_t>( mx * my ), 0.0f ),
+      light_source_color_buffer( static_cast<size_t>( mx * my ), 0u ),
       outside_cache( static_cast<size_t>( mx * my ), '\0' ),
       sheltered_cache( static_cast<size_t>( mx * my ), '\0' ),
       floor_cache( static_cast<size_t>( mx * my ), false ),

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10871,9 +10871,12 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
             for( const int z : dirty_lightmap_levels ) {
                 auto &c = get_cache( z );
                 std::fill( c.sm.begin(), c.sm.end(), 0.0f );
-                std::fill( c.light_source_buffer.begin(), c.light_source_buffer.end(), 0.0f );
-                std::fill( c.colored_light_source_buffer.begin(), c.colored_light_source_buffer.end(), 0.0f );
-                std::fill( c.light_source_color_buffer.begin(), c.light_source_color_buffer.end(), 0u );
+                std::fill( c.light_source_buffer.begin(),
+                           c.light_source_buffer.end(), 0.0f );
+                std::fill( c.colored_light_source_buffer.begin(),
+                           c.colored_light_source_buffer.end(), 0.0f );
+                std::fill( c.light_source_color_buffer.begin(),
+                           c.light_source_color_buffer.end(), 0u );
                 c.light_source_points.clear();
                 std::ranges::fill( c.lm, 0.0f );
                 c.lm_cpu_cache_valid = false;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10868,20 +10868,20 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         // GPU path: lightmap rebuilds only run for lightmap-dirty levels.
         // Player movement and other FoV-only updates are handled by
         // update_visibility_cache(), which can rebuild resident seen data.
-            for( const int z : dirty_lightmap_levels ) {
-                auto &c = get_cache( z );
-                std::fill( c.sm.begin(), c.sm.end(), 0.0f );
-                std::fill( c.light_source_buffer.begin(),
-                           c.light_source_buffer.end(), 0.0f );
-                std::fill( c.colored_light_source_buffer.begin(),
-                           c.colored_light_source_buffer.end(), 0.0f );
-                std::fill( c.light_source_color_buffer.begin(),
-                           c.light_source_color_buffer.end(), 0u );
-                c.light_source_points.clear();
-                std::ranges::fill( c.lm, 0.0f );
-                c.lm_cpu_cache_valid = false;
-                ++c.lm_cpu_cache_generation;
-            }
+        for( const int z : dirty_lightmap_levels ) {
+            auto &c = get_cache( z );
+            std::fill( c.sm.begin(), c.sm.end(), 0.0f );
+            std::fill( c.light_source_buffer.begin(),
+                       c.light_source_buffer.end(), 0.0f );
+            std::fill( c.colored_light_source_buffer.begin(),
+                       c.colored_light_source_buffer.end(), 0.0f );
+            std::fill( c.light_source_color_buffer.begin(),
+                       c.light_source_color_buffer.end(), 0u );
+            c.light_source_points.clear();
+            std::ranges::fill( c.lm, 0.0f );
+            c.lm_cpu_cache_valid = false;
+            ++c.lm_cpu_cache_generation;
+        }
         pending_gpu_lighting = cata_gpu::begin_gpu_lighting( gpu_device, {
             .m            = this,
             .dirty_levels = &dirty_lightmap_levels,
@@ -11050,9 +11050,9 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
                     for( const auto z : colored_light_levels ) {
                         auto &c = get_cache( z );
                         c.colored_light_cache_active = std::ranges::any_of(
-                            c.colored_light_cache, []( const auto packed ) {
-                                return packed != 0u;
-                            } );
+                        c.colored_light_cache, []( const auto packed ) {
+                            return packed != 0u;
+                        } );
                     }
                 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -391,6 +391,8 @@ struct level_cache {
     // To prevent redundant ray casting into neighbors: precalculate bulk light source positions.
     // This is only valid for the duration of generate_lightmap
     std::vector<float>              light_source_buffer;
+    std::vector<float>              colored_light_source_buffer;
+    std::vector<uint32_t>           light_source_color_buffer;
     // Source tiles touched in light_source_buffer.
     std::vector<point_bub_ms>        light_source_points;
 
@@ -2541,17 +2543,40 @@ class map : public submap_load_listener
                               const maptile &tile, const drawsq_params &params ) const;
 
         int determine_wall_corner( const tripoint_bub_ms &p ) const;
+        struct apply_directional_light_options {
+            tripoint_bub_ms p;
+            int direction = 0;
+            float luminance = 0.0f;
+            uint32_t color_rgb = 0u;
+        };
+        struct apply_light_arc_options {
+            tripoint_bub_ms p;
+            units::angle angle = 0_degrees;
+            float luminance = 0.0f;
+            units::angle wideangle = 30_degrees;
+            uint32_t color_rgb = 0u;
+        };
+        struct apply_light_ray_options {
+            std::vector<bool> &lit;
+            tripoint_bub_ms s;
+            tripoint_bub_ms e;
+            float luminance = 0.0f;
+            uint32_t color_rgb = 0u;
+        };
         // apply a circular light pattern immediately, however it's best to use...
-        void apply_light_source( const tripoint_bub_ms &p, float luminance );
+        void apply_light_source( const tripoint_bub_ms &p, float luminance, uint32_t color_rgb = 0u );
         // ...this, which will apply the light after at the end of generate_lightmap, and prevent redundant
         // light rays from causing massive slowdowns, if there's a huge amount of light.
-        void add_light_source( const tripoint_bub_ms &p, float luminance );
+        void add_light_source( const tripoint_bub_ms &p, float luminance, uint32_t color_rgb = 0u );
         // Handle just cardinal directions and 45 deg angles.
         void apply_directional_light( const tripoint_bub_ms &p, int direction, float luminance );
+        auto apply_directional_light( const apply_directional_light_options &opt ) -> void;
         void apply_light_arc( const tripoint_bub_ms &p, units::angle, float luminance,
                               units::angle wideangle = 30_degrees );
+        auto apply_light_arc( const apply_light_arc_options &opt ) -> void;
         void apply_light_ray( std::vector<bool> &lit,
                               const tripoint_bub_ms &s, const tripoint_bub_ms &e, float luminance );
+        auto apply_light_ray( const apply_light_ray_options &opt ) -> void;
         void add_light_from_items( const tripoint_bub_ms &p, const item_stack::iterator &begin,
                                    const item_stack::iterator &end );
         std::unique_ptr<vehicle> add_vehicle_to_map( std::unique_ptr<vehicle> veh, bool merge_wrecks );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4209,6 +4209,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
     bool pixel_minimap_changed = false;
     bool terminal_size_changed = false;
     bool force_tile_change = false;
+    bool colored_lighting_changed = false;
 
     for( auto &iter : OPTIONS_OLD ) {
         if( iter.second != OPTIONS[iter.first] ) {
@@ -4242,6 +4243,9 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
             } else if( iter.first == "TERMINAL_X" || iter.first == "TERMINAL_Y" ) {
                 terminal_size_changed = true;
             }
+            if( iter.first == "COLORED_LIGHTING" || iter.first == "USE_TILES" ) {
+                colored_lighting_changed = true;
+            }
         }
     }
     for( auto &iter : WOPTIONS_OLD ) {
@@ -4263,12 +4267,16 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                 world_generator->active_world->info->WORLD_OPTIONS = ACTIVE_WORLD_OPTIONS;
                 world_generator->active_world->info->save();
             }
+            if( ingame && colored_lighting_changed ) {
+                g->m.invalidate_lightmap_caches();
+            }
             g->on_options_changed();
         } else {
             lang_changed = false;
             terminal_size_changed = false;
             used_tiles_changed = false;
             pixel_minimap_changed = false;
+            colored_lighting_changed = false;
             OPTIONS = OPTIONS_OLD;
             if( ingame && world_options_changed ) {
                 ACTIVE_WORLD_OPTIONS = WOPTIONS_OLD;

--- a/src/shadowcasting.cpp
+++ b/src/shadowcasting.cpp
@@ -248,7 +248,8 @@ static void castLight(
     octant_xform xf,
     int row, float start, float end,
     float cumulative_transparency,
-    const exp_lookup *lookup )
+    const exp_lookup *lookup,
+    light_update_callback callback )
 {
     if( start < end ) {
         return;
@@ -342,6 +343,10 @@ static void castLight(
             } else {
                 model.update_quadrants( output_cache[idx], last_intensity, update_quad );
             }
+            if( callback.update != nullptr ) {
+                callback.update( callback.context, 0, current.x, current.y, idx, last_intensity,
+                                 update_quad );
+            }
 
             if( new_transparency == current_transparency ) {
                 continue;
@@ -364,7 +369,7 @@ static void castLight(
                 castLight<Out>( output_cache, input_array, blocked_array, sx, sy,
                                 offset, offset_distance, numerator, model, xf,
                                 distance + 1, start, trailing_edge,
-                                next_cumulative, next_lookup );
+                                next_cumulative, next_lookup, callback );
             }
 
             // Advance the leading edge.
@@ -392,7 +397,7 @@ static void castLight(
                             offset, offset_distance, numerator, model, xf,
                             distance + 1, start, end,
                             model.accumulate( lookup->transparency, current_transparency, distance ),
-                            nullptr );
+                            nullptr, callback );
             return;
         }
 
@@ -414,7 +419,8 @@ void castLightAll(
     int sx, int sy,
     point_bub_ms offset, int offset_distance, float numerator,
     const light_model &model,
-    const exp_lookup *weather_lookup )
+    const exp_lookup *weather_lookup,
+    light_update_callback callback )
 {
     ZoneScoped;
 
@@ -436,7 +442,7 @@ void castLightAll(
 
         castLight<float>( output_cache, input_array, blocked_array, sx, sy,
                           offset, offset_distance, numerator, model, xf,
-                          1, 1.0f, 0.0f, LIGHT_TRANSPARENCY_OPEN_AIR, fast );
+                          1, 1.0f, 0.0f, LIGHT_TRANSPARENCY_OPEN_AIR, fast, callback );
     }
 }
 
@@ -448,7 +454,8 @@ void castLightOctants(
     point_bub_ms offset, int offset_distance, float numerator,
     const light_model &model,
     uint8_t octant_mask,
-    const exp_lookup *weather_lookup )
+    const exp_lookup *weather_lookup,
+    light_update_callback callback )
 {
     ZoneScoped;
 
@@ -471,7 +478,7 @@ void castLightOctants(
         }
         castLight<float>( output_cache, input_array, blocked_array, sx, sy,
                           offset, offset_distance, numerator, model, xf,
-                          1, 1.0f, 0.0f, LIGHT_TRANSPARENCY_OPEN_AIR, fast );
+                          1, 1.0f, 0.0f, LIGHT_TRANSPARENCY_OPEN_AIR, fast, callback );
     }
 }
 
@@ -494,7 +501,8 @@ static void cast_zlight_segment(
     float start_major = 0.0f, float end_major = 1.0f,
     float start_minor = 0.0f, float end_minor = 1.0f,
     float cumulative_transparency = LIGHT_TRANSPARENCY_OPEN_AIR,
-    int x_skip = -1, int z_skip = -1 )
+    int x_skip = -1, int z_skip = -1,
+    light_update_callback callback = {} )
 {
     if( start_major >= end_major || start_minor > end_minor ) {
         return;
@@ -600,8 +608,15 @@ static void cast_zlight_segment(
                     last_intensity = model.calc( numerator, cumulative_transparency, dist_2d );
                 }
 
-                float &out_cell = output_caches[z_index].at( current.x, current.y );
-                atomic_float_max<UseAtomic>( out_cell, last_intensity );
+                const auto idx = current.x * ic.sy + current.y;
+                if( output_caches[z_index].data != nullptr ) {
+                    float &out_cell = output_caches[z_index].at( current.x, current.y );
+                    atomic_float_max<UseAtomic>( out_cell, last_intensity );
+                }
+                if( callback.update != nullptr ) {
+                    callback.update( callback.context, z_index, current.x, current.y, idx,
+                                     last_intensity, quad );
+                }
 
                 if( new_transparency != current_transparency || new_floor != current_floor ) {
                     // ── Split: A (past rows), B (processed x so far), C (rest) ─
@@ -632,7 +647,7 @@ static void cast_zlight_segment(
                             start_major, std::min( mid_major, end_major ),
                             start_minor, end_minor,
                             next_cumulative,
-                            -1, -1 );
+                            -1, -1, callback );
                     }
 
                     const float mid_minor = ( current_transparency < new_transparency )
@@ -646,7 +661,7 @@ static void cast_zlight_segment(
                         distance,
                         std::max( mid_major, start_major ), end_major,
                         std::max( mid_minor, start_minor ), end_minor,
-                        cumulative_transparency, delta.x, delta.z );
+                        cumulative_transparency, delta.x, delta.z, callback );
 
                     // Continue with section B (already-processed x tiles).
                     if( delta.x == x_start ) {
@@ -677,7 +692,7 @@ static void cast_zlight_segment(
                         start_major, top_edge,
                         start_minor, end_minor,
                         next_cumulative,
-                        -1, -1 );
+                        -1, -1, callback );
                 }
                 start_major = ( delta.z + 0.5f ) / ( delta.y - 0.5001f );
                 if( start_major >= end_major ) {
@@ -708,26 +723,29 @@ void cast_zlight(
     const array_of_grids_of<const char> &floor_caches,
     const array_of_grids_of<const diagonal_blocks> &blocked_caches,
     const tripoint_bub_ms &origin, int offset_distance, float numerator,
-    const light_model &model )
+    const light_model &model,
+    light_update_callback callback )
 {
     ZoneScoped;
 
     // Ensure the z-distance lookup table matches current runtime settings.
     rebuild_zdist_table();
 
-    if( parallel_enabled ) {
+    if( parallel_enabled && !is_pool_worker_thread() ) {
         parallel_for_chunked( 0, static_cast<int>( k_zlight_xforms.size() ), 1, [&]( int i ) {
             cast_zlight_segment<true>(
                 output_caches, input_arrays, floor_caches, blocked_caches,
                 origin, offset_distance, numerator, model, k_zlight_xforms[i],
-                1, 0.0f, 1.0f, 0.0f, 1.0f, LIGHT_TRANSPARENCY_OPEN_AIR, -1, -1 );
+                1, 0.0f, 1.0f, 0.0f, 1.0f, LIGHT_TRANSPARENCY_OPEN_AIR, -1, -1,
+                callback );
         } );
     } else {
         std::ranges::for_each( k_zlight_xforms, [&]( const octant_xform_3d & xf ) {
             cast_zlight_segment<false>(
                 output_caches, input_arrays, floor_caches, blocked_caches,
                 origin, offset_distance, numerator, model, xf,
-                1, 0.0f, 1.0f, 0.0f, 1.0f, LIGHT_TRANSPARENCY_OPEN_AIR, -1, -1 );
+                1, 0.0f, 1.0f, 0.0f, 1.0f, LIGHT_TRANSPARENCY_OPEN_AIR, -1, -1,
+                callback );
         } );
     }
 }

--- a/src/shadowcasting.h
+++ b/src/shadowcasting.h
@@ -195,6 +195,12 @@ inline float sight_from_lookup( const float &numerator, const float &transparenc
     return numerator * transparency;
 }
 
+struct light_update_callback {
+    void *context = nullptr;
+    void ( *update )( void *context, int z_index, int x, int y, int idx,
+                      float intensity, quadrant q ) = nullptr;
+};
+
 // ── Public shadowcasting API ──────────────────────────────────────────────────
 
 /// 2D FOV / light cast — writes to a flat float array (seen_cache, shrapnel).
@@ -210,7 +216,8 @@ void castLightAll(
     int sx, int sy,
     point_bub_ms offset, int offset_distance, float numerator,
     const light_model &model,
-    const exp_lookup *weather_lookup = nullptr );
+    const exp_lookup *weather_lookup = nullptr,
+    light_update_callback callback = {} );
 
 // ── Octant bitmasks ───────────────────────────────────────────────────────────
 // Bit i selects k_octant_xforms[i].  Used by map::apply_light_source and
@@ -231,7 +238,8 @@ void castLightOctants(
     point_bub_ms offset, int offset_distance, float numerator,
     const light_model &model,
     uint8_t octant_mask,
-    const exp_lookup *weather_lookup = nullptr );
+    const exp_lookup *weather_lookup = nullptr,
+    light_update_callback callback = {} );
 
 /// 3D FOV cast across all z-levels.
 /// Only model.calc, model.check, and model.accumulate are consulted;
@@ -242,4 +250,5 @@ void cast_zlight(
     const array_of_grids_of<const char> &floor_caches,
     const array_of_grids_of<const diagonal_blocks> &blocked_caches,
     const tripoint_bub_ms &origin, int offset_distance, float numerator,
-    const light_model &model );
+    const light_model &model,
+    light_update_callback callback = {} );


### PR DESCRIPTION
## Purpose of change (The Why)

Colored lighting currently isn't supported when not using the GPU for compute, and there's an option for it that may confuse users. The lack of it also makes the derg sad.

## Describe the solution (The How)

Write color information while calculating lighting for CPU.

## Describe alternatives you've considered

<img width="357" height="280" alt="image" src="https://github.com/user-attachments/assets/0d271390-a424-4715-a6e0-d5de4a31069e" />

## Testing

Checked both paths, and colored lights work without a terrible performance impact.

## Additional context

Dedicated to @chaosvolt who put up with a lot of testing while I tried being clever about CPU compute shaders.
Honestly, it's not even as bad for performance as I'd thought it would be. 3D sunlight shadows are worse.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bffe308](https://github.com/cataclysmbn/Cataclysm-BN/commit/bffe308aa1f464f81e084032cd5092c27e8cfe81) (style(autofix.ci): automated formatting) on 2026-06-14 12:22:02

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27496795862/artifacts/7620739688)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27496795862/artifacts/7620923498)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27496795862/artifacts/7620559420)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27496795862/artifacts/7620593939)
<!-- END artifact comment -->