### PR TITLE
fix(UI): allow mouse travel to remembered tiles

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -19,6 +19,7 @@
 #include "posix_time.h"
 #include "ranged.h"
 #include "translations.h"
+#include "travel/travel_destination.h"
 #include "type_id.h"
 #include "ui_manager.h"
 #include "weather.h"
@@ -869,7 +870,7 @@ void draw_line_curses( game &g, const tripoint_bub_ms &center,
 void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
                       const std::vector<tripoint_bub_ms> &points, bool noreveal )
 {
-    if( !noreveal && !u.sees( p ) ) {
+    if( !noreveal && !avatar_knows_travel_destination( u, p ) ) {
         return;
     }
 
@@ -884,7 +885,7 @@ void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
 void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
                       const std::vector<tripoint_bub_ms> &points, bool noreveal )
 {
-    if( !noreveal && !u.sees( p ) ) {
+    if( !noreveal && !avatar_knows_travel_destination( u, p ) ) {
         return;
     }
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -81,6 +81,7 @@
 #include "submap_load_manager.h"
 #include "tileray.h"
 #include "translations.h"
+#include "travel/travel_destination.h"
 #include "trap.h"
 #include "type_id.h"
 #include "veh_type.h"
@@ -6949,12 +6950,15 @@ void cata_tiles::draw_line()
         return;
     }
     static std::string line_overlay = "animation_line";
-    for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
-        draw_from_id_string(
-        {line_overlay, C_NONE, empty_string, 0, 0},
-        *it, std::nullopt, std::nullopt,
-        lit_level::LIT, false, 0, false
-        );
+    const auto target_known = avatar_knows_travel_destination( g->u, line_pos );
+    if( should_draw_travel_line_overlay( is_target_line, target_known ) ) {
+        for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
+            draw_from_id_string(
+            {line_overlay, C_NONE, empty_string, 0, 0},
+            *it, std::nullopt, std::nullopt,
+            lit_level::LIT, false, 0, false
+            );
+        }
     }
 
     draw_from_id_string(

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -192,6 +192,7 @@
 #include "tileray.h"
 #include "timed_event.h"
 #include "translations.h"
+#include "travel/travel_destination.h"
 #include "trap.h"
 #include "ui.h"
 #include "ui_manager.h"
@@ -9924,8 +9925,8 @@ look_around_result game::look_around( bool show_window, tripoint_bub_ms &center,
             u.view_offset.z() = center.z() - u.bub_pos().z();
             m.invalidate_map_cache( center.z() );
         } else if( action == "TRAVEL_TO" ) {
-            if( !u.sees( lp ) ) {
-                add_msg( _( "You can't see that destination." ) );
+            if( !avatar_knows_travel_destination( u, lp ) ) {
+                add_msg( _( "You don't know that destination." ) );
                 continue;
             }
 
@@ -11171,8 +11172,9 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             mSortCategory.clear();
             refilter = true;
         } else if( action == "TRAVEL_TO" && activeItem ) {
-            if( !u.sees( u.bub_pos() + active_pos ) ) {
-                add_msg( _( "You can't see that destination." ) );
+            if( !avatar_knows_travel_destination( u, u.bub_pos() + active_pos ) ) {
+                add_msg( _( "You don't know that destination." ) );
+                continue;
             }
             auto route = m.route( u.bub_pos(), u.bub_pos() + active_pos, u.get_legacy_pathfinding_settings(),
                                   u.get_legacy_path_avoid() );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -93,6 +93,7 @@
 #include "string_id.h"
 #include "string_input_popup.h"
 #include "translations.h"
+#include "travel/travel_destination.h"
 #include "ui.h"
 #include "ui_manager.h"
 #include "utils/url.h"
@@ -1954,13 +1955,13 @@ bool game::handle_action()
             const std::optional<tripoint_bub_ms> mouse_pos = ctxt.get_coordinates( w_terrain );
             if( !mouse_pos ) {
                 return false;
-            } else if( !u.sees( *mouse_pos ) ) {
-                // Not clicked in visible terrain
-                return false;
             }
             mouse_target = mouse_pos;
 
             if( act == ACTION_SELECT ) {
+                if( !avatar_knows_travel_destination( u, *mouse_target ) ) {
+                    return false;
+                }
                 // Note: The following has the potential side effect of
                 // setting auto-move destination state in addition to setting
                 // act.
@@ -1968,6 +1969,10 @@ bool game::handle_action()
                     return false;
                 }
             } else if( act == ACTION_SEC_SELECT ) {
+                if( !u.sees( *mouse_target ) ) {
+                    // Right-click actions examine or target current terrain and creatures.
+                    return false;
+                }
                 if( !try_get_right_click_action( act, *mouse_target ) ) {
                     return false;
                 }

--- a/src/travel/travel_destination.cpp
+++ b/src/travel/travel_destination.cpp
@@ -1,0 +1,14 @@
+#include "travel/travel_destination.h"
+
+#include "avatar.h"
+#include "coordinates.h"
+
+auto avatar_knows_travel_destination( const avatar &you, const tripoint_bub_ms &p ) -> bool
+{
+    return you.sees( p ) || you.has_memorized_tile_for_autodrive( bub_to_abs( p ) );
+}
+
+auto should_draw_travel_line_overlay( const bool target_line, const bool target_known ) -> bool
+{
+    return !target_line || target_known;
+}

--- a/src/travel/travel_destination.cpp
+++ b/src/travel/travel_destination.cpp
@@ -3,12 +3,10 @@
 #include "avatar.h"
 #include "coordinates.h"
 
-auto avatar_knows_travel_destination( const avatar &you, const tripoint_bub_ms &p ) -> bool
-{
-    return you.sees( p ) || you.has_memorized_tile_for_autodrive( bub_to_abs( p ) );
+auto avatar_knows_travel_destination(const avatar& you, const tripoint_bub_ms& p) -> bool {
+    return you.sees(p) || you.has_memorized_tile_for_autodrive(bub_to_abs(p));
 }
 
-auto should_draw_travel_line_overlay( const bool target_line, const bool target_known ) -> bool
-{
+auto should_draw_travel_line_overlay(const bool target_line, const bool target_known) -> bool {
     return !target_line || target_known;
 }

--- a/src/travel/travel_destination.h
+++ b/src/travel/travel_destination.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "coordinates.h"
+
+class avatar;
+
+auto avatar_knows_travel_destination( const avatar &you, const tripoint_bub_ms &p ) -> bool;
+auto should_draw_travel_line_overlay( bool target_line, bool target_known ) -> bool;

--- a/src/travel/travel_destination.h
+++ b/src/travel/travel_destination.h
@@ -4,5 +4,5 @@
 
 class avatar;
 
-auto avatar_knows_travel_destination( const avatar &you, const tripoint_bub_ms &p ) -> bool;
-auto should_draw_travel_line_overlay( bool target_line, bool target_known ) -> bool;
+auto avatar_knows_travel_destination(const avatar& you, const tripoint_bub_ms& p) -> bool;
+auto should_draw_travel_line_overlay(bool target_line, bool target_known) -> bool;

--- a/tests/travel_destination_test.cpp
+++ b/tests/travel_destination_test.cpp
@@ -1,5 +1,26 @@
+#include "avatar.h"
+#include "cata_utility.h"
 #include "catch/catch.hpp"
+#include "coordinates.h"
+#include "game.h"
+#include "state_helpers.h"
 #include "travel/travel_destination.h"
+
+TEST_CASE( "travel_destination_accepts_memorized_tiles", "[travel][map_memory]" )
+{
+    clear_all_state();
+
+    avatar &you = get_avatar();
+    you.clear_map_memory();
+    const auto cleanup = on_out_of_scope( [&you]() { you.clear_map_memory(); } );
+
+    const auto target = tripoint_bub_ms( 0, 0, you.bub_pos().z() );
+    REQUIRE_FALSE( you.sees( target ) );
+
+    you.memorize_symbol( bub_to_abs( target ), '#' );
+
+    CHECK( avatar_knows_travel_destination( you, target ) );
+}
 
 TEST_CASE( "travel_line_overlay_is_drawn_for_known_targets", "[travel][tiles]" )
 {

--- a/tests/travel_destination_test.cpp
+++ b/tests/travel_destination_test.cpp
@@ -1,0 +1,9 @@
+#include "catch/catch.hpp"
+#include "travel/travel_destination.h"
+
+TEST_CASE( "travel_line_overlay_is_drawn_for_known_targets", "[travel][tiles]" )
+{
+    CHECK( should_draw_travel_line_overlay( true, true ) );
+    CHECK_FALSE( should_draw_travel_line_overlay( true, false ) );
+    CHECK( should_draw_travel_line_overlay( false, false ) );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

for some reason
- you couldn't see mouse travel preview
- you couldn't travel to tiles you went before but cannot see

## Describe the solution (The How)

- Treat currently visible or memorized tiles as known travel destinations.
- Use the same known-destination check for mouse travel, look-around travel, and travel line drawing.
- Keep right-click actions limited to currently visible terrain.

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/0e51f4bb-6084-40c1-a4e2-8e62776346c9" />

## Checklist

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit in the Linux kernel format.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [56454c2](https://github.com/cataclysmbn/Cataclysm-BN/commit/56454c25122b46a6099a51c4f828c3f90917d80d) (style(autofix.ci): automated formatting) on 2026-06-22 03:51:33

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27926870862/artifacts/7782503491)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27926870862/artifacts/7782850291)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27926870862/artifacts/7782791621)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27926870862/artifacts/7782594085)
<!-- END artifact comment -->