### PR TITLE
perf: reduce no-op EMP blast tile work

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <queue>
 #include <random>
+#include <ranges>
 #include <set>
 #include <utility>
 #include <variant>
@@ -100,6 +101,9 @@ static const itype_id itype_rm13_armor_on( "rm13_armor_on" );
 
 namespace
 {
+
+const auto flag_CONSOLE = std::string( "CONSOLE" );
+
 auto is_dead_for_explosion( const Creature &critter ) -> bool
 {
     if( const auto *const character = dynamic_cast<const Character *>( &critter ) ) {
@@ -107,6 +111,13 @@ auto is_dead_for_explosion( const Creature &critter ) -> bool
     }
     return critter.is_dead_state();
 }
+
+auto is_emp_card_reader( const ter_id &terrain ) -> bool
+{
+    return terrain == t_card_science || terrain == t_card_military ||
+           terrain == t_card_industrial;
+}
+
 } // namespace
 
 static float obstacle_blast_percentage( float range, float distance )
@@ -1871,31 +1882,48 @@ void emp_blast( const tripoint_bub_ms &p )
 {
     map &here = get_map();
     Character &u = get_player_character();
-    const bool sight = u.sees( p );
-    if( here.has_flag( "CONSOLE", p ) ) {
-        if( sight ) {
+    const auto terrain = here.ter( p );
+    const auto console = here.has_flag( flag_CONSOLE, p );
+    const auto card_reader = is_emp_card_reader( terrain );
+    auto *const mon_ptr = g->critter_at<monster>( p );
+    const auto player_here = u.bub_pos() == p;
+    const auto has_items = here.has_items( p );
+
+    if( !console && !card_reader && mon_ptr == nullptr && !player_here && !has_items ) {
+        return;
+    }
+
+    auto sight = std::optional<bool> {};
+    auto player_sees = [&]() -> bool {
+        if( sight ) { return *sight; }
+        sight = u.sees( p );
+        return *sight;
+    };
+
+    if( console ) {
+        if( player_sees() ) {
             add_msg( _( "The %s is rendered non-functional!" ), here.tername( p ) );
         }
         here.ter_set( p, t_console_broken );
         return;
     }
     // TODO: More terrain effects.
-    if( here.ter( p ) == t_card_science || here.ter( p ) == t_card_military ||
-        here.ter( p ) == t_card_industrial ) {
-        int rn = rng( 1, 100 );
+    if( card_reader ) {
+        const int rn = rng( 1, 100 );
         if( rn > 92 || rn < 40 ) {
-            if( sight ) {
+            if( player_sees() ) {
                 add_msg( _( "The card reader is rendered non-functional." ) );
             }
             here.ter_set( p, t_card_reader_broken );
         }
         if( rn > 80 ) {
-            if( sight ) {
+            if( player_sees() ) {
                 add_msg( _( "The nearby doors slide open!" ) );
             }
-            for( int i = -3; i <= 3; i++ ) {
-                for( int j = -3; j <= 3; j++ ) {
-                    auto p2 = p + tripoint( i, j, 0 );
+            using namespace std::views;
+            for( const int i : iota( -3, 4 ) ) {
+                for( const int j : iota( -3, 4 ) ) {
+                    const auto p2 = p + tripoint( i, j, 0 );
                     if( here.ter( p2 ) == t_door_metal_locked ) {
                         here.ter_set( p2, t_floor );
                     }
@@ -1903,12 +1931,12 @@ void emp_blast( const tripoint_bub_ms &p )
             }
         }
         if( rn >= 40 && rn <= 80 ) {
-            if( sight ) {
+            if( player_sees() ) {
                 add_msg( _( "Nothing happens." ) );
             }
         }
     }
-    if( monster *const mon_ptr = g->critter_at<monster>( p ) ) {
+    if( mon_ptr != nullptr ) {
         monster &critter = *mon_ptr;
         if( critter.has_flag( MF_ELECTRONIC ) ) {
             int deact_chance = 0;
@@ -1926,7 +1954,7 @@ void emp_blast( const tripoint_bub_ms &p )
                     break;
             }
             if( !mon_item_id.is_empty() && deact_chance != 0 && one_in( deact_chance ) ) {
-                if( sight ) {
+                if( player_sees() ) {
                     add_msg( _( "The %s beeps erratically and deactivates!" ), critter.name() );
                 }
                 here.add_item_or_charges( p, critter.to_item() );
@@ -1937,7 +1965,7 @@ void emp_blast( const tripoint_bub_ms &p )
                 }
                 g->remove_zombie( critter );
             } else {
-                if( sight ) {
+                if( player_sees() ) {
                     add_msg( _( "The EMP blast fries the %s!" ), critter.name() );
                 }
                 int dam = dice( 10, 10 );
@@ -1949,13 +1977,13 @@ void emp_blast( const tripoint_bub_ms &p )
             }
         } else if( critter.has_flag( MF_ELECTRIC_FIELD ) ) {
             if( !critter.has_effect( effect_emp ) ) {
-                if( sight ) {
+                if( player_sees() ) {
                     add_msg( m_good, _( "The %s's electrical field momentarily goes out!" ), critter.name() );
                 }
                 critter.add_effect( effect_emp, 3_minutes );
             } else if( critter.has_effect( effect_emp ) ) {
                 int dam = dice( 3, 5 );
-                if( sight ) {
+                if( player_sees() ) {
                     add_msg( m_good, _( "The %s's disabled electrical field reverses polarity!" ),
                              critter.name() );
                     add_msg( m_good, _( "It takes %d damage." ), dam );
@@ -1964,7 +1992,7 @@ void emp_blast( const tripoint_bub_ms &p )
                 critter.apply_damage( nullptr, bodypart_id( "torso" ), dam );
                 critter.check_dead_state();
             }
-        } else if( sight ) {
+        } else if( player_sees() ) {
             add_msg( _( "The %s is unaffected by the EMP blast." ), critter.name() );
         }
     }
@@ -1987,9 +2015,11 @@ void emp_blast( const tripoint_bub_ms &p )
         }
     }
     // Drain any items of their battery charge
-    for( auto &it : here.i_at( p ) ) {
-        if( it->is_tool() && it->ammo_current() == itype_battery ) {
-            it->charges = 0;
+    if( here.has_items( p ) ) {
+        for( auto &it : here.i_at( p ) ) {
+            if( it->is_tool() && it->ammo_current() == itype_battery ) {
+                it->charges = 0;
+            }
         }
     }
     // TODO: Drain NPC energy reserves

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -1893,15 +1893,11 @@ void emp_blast( const tripoint_bub_ms &p )
         return;
     }
 
-    auto sight = std::optional<bool> {};
-    auto player_sees = [&]() -> bool {
-        if( sight ) { return *sight; }
-        sight = u.sees( p );
-        return *sight;
-    };
+    const auto needs_sight = console || card_reader || mon_ptr != nullptr;
+    const bool sight = needs_sight && u.sees( p );
 
     if( console ) {
-        if( player_sees() ) {
+        if( sight ) {
             add_msg( _( "The %s is rendered non-functional!" ), here.tername( p ) );
         }
         here.ter_set( p, t_console_broken );
@@ -1911,13 +1907,13 @@ void emp_blast( const tripoint_bub_ms &p )
     if( card_reader ) {
         const int rn = rng( 1, 100 );
         if( rn > 92 || rn < 40 ) {
-            if( player_sees() ) {
+            if( sight ) {
                 add_msg( _( "The card reader is rendered non-functional." ) );
             }
             here.ter_set( p, t_card_reader_broken );
         }
         if( rn > 80 ) {
-            if( player_sees() ) {
+            if( sight ) {
                 add_msg( _( "The nearby doors slide open!" ) );
             }
             using namespace std::views;
@@ -1931,7 +1927,7 @@ void emp_blast( const tripoint_bub_ms &p )
             }
         }
         if( rn >= 40 && rn <= 80 ) {
-            if( player_sees() ) {
+            if( sight ) {
                 add_msg( _( "Nothing happens." ) );
             }
         }
@@ -1954,7 +1950,7 @@ void emp_blast( const tripoint_bub_ms &p )
                     break;
             }
             if( !mon_item_id.is_empty() && deact_chance != 0 && one_in( deact_chance ) ) {
-                if( player_sees() ) {
+                if( sight ) {
                     add_msg( _( "The %s beeps erratically and deactivates!" ), critter.name() );
                 }
                 here.add_item_or_charges( p, critter.to_item() );
@@ -1965,7 +1961,7 @@ void emp_blast( const tripoint_bub_ms &p )
                 }
                 g->remove_zombie( critter );
             } else {
-                if( player_sees() ) {
+                if( sight ) {
                     add_msg( _( "The EMP blast fries the %s!" ), critter.name() );
                 }
                 int dam = dice( 10, 10 );
@@ -1977,13 +1973,13 @@ void emp_blast( const tripoint_bub_ms &p )
             }
         } else if( critter.has_flag( MF_ELECTRIC_FIELD ) ) {
             if( !critter.has_effect( effect_emp ) ) {
-                if( player_sees() ) {
+                if( sight ) {
                     add_msg( m_good, _( "The %s's electrical field momentarily goes out!" ), critter.name() );
                 }
                 critter.add_effect( effect_emp, 3_minutes );
             } else if( critter.has_effect( effect_emp ) ) {
                 int dam = dice( 3, 5 );
-                if( player_sees() ) {
+                if( sight ) {
                     add_msg( m_good, _( "The %s's disabled electrical field reverses polarity!" ),
                              critter.name() );
                     add_msg( m_good, _( "It takes %d damage." ), dam );
@@ -1992,7 +1988,7 @@ void emp_blast( const tripoint_bub_ms &p )
                 critter.apply_damage( nullptr, bodypart_id( "torso" ), dam );
                 critter.check_dead_state();
             }
-        } else if( player_sees() ) {
+        } else if( sight ) {
             add_msg( _( "The %s is unaffected by the EMP blast." ), critter.name() );
         }
     }


### PR DESCRIPTION
## Purpose of change (The Why)

- might close #7467.
- might fix https://gall.dcinside.com/board/view/?id=rlike&no=519412

EMP explosions can spend work on every radius tile even when most tiles have no EMP-reactive terrain, critter, player, or items.

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/debd47b9-340a-4625-b033-4d553b095a38" />

## Describe the solution (The How)

- Skip inert EMP blast tiles before visibility/message work.
- Keep a direct `sight` bool, but only compute it for tiles that can emit visibility-gated messages.
- Avoid item-stack iteration when the tile has no items.

## Performance evidence

EMP bomb radius 10 scans 441 same-z tiles.

| Case | Before | After |
| --- | ---: | ---: |
| Inert EMP tile `u.sees()` calls | 1 | 0 |
| Fully inert EMP bomb area `u.sees()` calls | 441 | 0 |

## Testing

- Built `cataclysm-bn-tiles` and `cata_test-tiles`.
- `CATA_TEST_COMPUTE_ACCELERATION=cpu SDL_VIDEODRIVER=offscreen ./out/build/linux-full/tests/cata_test-tiles "[explosion]"`: passed, 7 test cases / 698 assertions.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2297140](https://github.com/cataclysmbn/Cataclysm-BN/commit/229714024ea00a8b03f6537a6f0eefabcfe80c7c) (perf: use direct EMP sight check after fast path) on 2026-06-15 04:16:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27521212202/artifacts/7628717131)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27521212202/artifacts/7628948011)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27521212202/artifacts/7628296977)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27521212202/artifacts/7628273253)
<!-- END artifact comment -->