### PR TITLE
feat(balance): increase capacity of some bandoliers, allow storing shurikens and similar in throwing knife bandoliers

### DIFF
--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -43,7 +43,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "bandolier",
-      "capacity": 25,
+      "capacity": 30,
       "ammo": [ "22", "223", "300blk", "5x50", "3006", "308", "300", "762", "762R", "8x40mm", "4570", "50" ],
       "draw_cost": 20
     },
@@ -108,7 +108,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "bandolier",
-      "capacity": 20,
+      "capacity": 30,
       "ammo": [ "flintlock", "flintlockshot", "36paper", "44paper", "blunderbuss", "shotcanister", "shotpaper" ],
       "draw_cost": 20
     },
@@ -235,7 +235,7 @@
     "id": "bandolier_knife",
     "type": "ARMOR",
     "name": { "str": "throwing knife bandolier" },
-    "description": "A bandolier worn across the chest with small leather sheathes sewn on.  Able to hold up to ten small knives, whether throwing knives or other small blades.  Activate to sheath or draw a knife.",
+    "description": "A bandolier worn across the chest with small leather loops sewn on.  Able to hold up to twelve small knives or similar tools, whether throwing knives, shurikens, or other small items.  Activate to sheath or draw a tool.",
     "weight": "140 g",
     "volume": "250 ml",
     "price": "19 USD",
@@ -251,13 +251,13 @@
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
-      "holster_prompt": "Sheath knife",
+      "holster_prompt": "Sheath tool",
       "holster_msg": "You sheath your %s",
-      "multi": 10,
+      "multi": 12,
       "min_volume": "15 ml",
       "max_volume": "250 ml",
       "draw_cost": 50,
-      "flags": [ "SHEATH_KNIFE" ]
+      "flags": [ "SHEATH_KNIFE", "BELT_CLIP" ]
     },
     "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
   }

--- a/data/json/items/ranged/throwing.json
+++ b/data/json/items/ranged/throwing.json
@@ -186,7 +186,7 @@
     "weight": "125 g",
     "cutting": 5,
     "thrown_damage": [ { "damage_type": "stab", "amount": 10 } ],
-    "flags": [ "HURT_WHEN_WIELDED" ]
+    "flags": [ "HURT_WHEN_WIELDED", "BELT_CLIP" ]
   },
   {
     "id": "throwing_stick",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6129,10 +6129,7 @@
         ],
         "entries": [
           { "item": "tanto_inferior", "container-item": "bootsheath" },
-          {
-            "item": "bandolier_knife",
-            "contents-group": "bandolier_shuriken_ninja"
-          },
+          { "item": "bandolier_knife", "contents-group": "bandolier_shuriken_ninja" },
           { "item": "katana_inferior", "custom-flags": [ "auto_wield" ] }
         ]
       },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -744,7 +744,13 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "flintlock_pouch_reenactor",
-    "entries": [ { "item": "flintlock_ammo", "charges": 20 } ]
+    "entries": [ { "item": "flintlock_ammo", "charges": 29 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "flintlock_pouch_pirate",
+    "entries": [ { "item": "flintlock_ammo", "charges": 24 } ]
   },
   {
     "type": "item_group",
@@ -781,7 +787,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "flintlock_pouch_skyfarer",
-    "entries": [ { "item": "36navy", "charges": 16 } ]
+    "entries": [ { "item": "36navy", "charges": 19 } ]
   },
   {
     "type": "item_group",
@@ -824,6 +830,12 @@
     "subtype": "collection",
     "id": "quiver_monster_hunter_2",
     "entries": [ { "item": "arrow_stinger", "charges": 20 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "bandolier_shuriken_ninja",
+    "entries": [ { "item": "shuriken", "count": 12 } ]
   },
   {
     "type": "item_group",
@@ -1810,8 +1822,7 @@
         "entries": [
           { "item": "cutlass", "custom-flags": [ "auto_wield" ] },
           { "item": "baldric_holster", "contents-group": "pistols_pirate" },
-          { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
-          { "item": "flintlock_ammo", "charges": 4 }
+          { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_pirate" }
         ]
       }
     },
@@ -6016,7 +6027,6 @@
         "entries": [
           { "item": "rifle_flintlock", "ammo-item": "flintlock_ammo", "charges": 1, "contents-item": "shoulder_strap" },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
-          { "item": "flintlock_ammo", "charges": 9 },
           { "item": "hatchet", "container-item": "axe_ring" },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" }
@@ -6081,7 +6091,6 @@
         "entries": [
           { "item": "rifle_flintlock", "ammo-item": "flintlock_ammo", "charges": 1, "contents-item": "shoulder_strap" },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
-          { "item": "flintlock_ammo", "charges": 9 },
           { "item": "hatchet", "container-item": "axe_ring" },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" }
@@ -6120,7 +6129,10 @@
         ],
         "entries": [
           { "item": "tanto_inferior", "container-item": "bootsheath" },
-          { "item": "shuriken", "count": 12 },
+          {
+            "item": "bandolier_knife",
+            "contents-group": "bandolier_shuriken_ninja"
+          },
           { "item": "katana_inferior", "custom-flags": [ "auto_wield" ] }
         ]
       },
@@ -6159,8 +6171,7 @@
         "entries": [
           { "item": "cutlass_inferior", "custom-flags": [ "auto_wield" ] },
           { "item": "baldric_holster", "contents-group": "pistols_pirate" },
-          { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
-          { "item": "flintlock_ammo", "charges": 4 }
+          { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_pirate" }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -6200,8 +6211,7 @@
         "entries": [
           { "item": "cutlass_inferior", "custom-flags": [ "auto_wield" ] },
           { "item": "baldric_holster", "contents-group": "pistols_pirate" },
-          { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
-          { "item": "flintlock_ammo", "charges": 4 }
+          { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_pirate" }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/mods/exotic_ammo/bandoliers-pouches.json
+++ b/data/mods/exotic_ammo/bandoliers-pouches.json
@@ -160,7 +160,7 @@
     "name": { "str": "rifle bandolier" },
     "use_action": {
       "type": "bandolier",
-      "capacity": 25,
+      "capacity": 30,
       "ammo": [
         "22",
         "223",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Lil more scaling up of bandolier item capacities and making throwing knife bandoliers a bit more useful.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Increased rifle bandolier capacity from 25 to 30, to put it in between shotgun and pistol bandoliers.
2. Bumped flintlock pouch capacity from 20 to 30, on par with rifle bandolier.
3. Bumped knife bandolier capacity up from 10 to 12, and reflavored it to justify adding support for `BELT_CLIP` items of similar size. This meanwhile is paired with...
4. Added `BELT_CLIP` flag to shuriken, on the basis of tucking one point in under a belt loop or the like, allowing it to be stored in the above-mentioned knife bandolier.
5. Adjusted professions who previously had to store some loose rifle or flintlock ammo in their inventory to have it in their bandolier, and set the ninja profession to have their dozen shurikens now spawn in a knife bandolier.
6. Misc: fixed canoe skyfarer profession having only 22 rounds of .36 in total instead of the intended 25.
7. Also updated rifle bandolier in exotic ammo mod.

## Describe alternatives you've considered

Keeping throwing knife bandolier capacity at 10 and just lowering the number of shurikens ninjas start with from 12 to 10.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in test build.
3. Confirmed ninja spawns with 12 shuriken in their new bandolier.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e4fc7e1](https://github.com/cataclysmbn/Cataclysm-BN/commit/e4fc7e1c78826520e3ab32b2a4432fae3a573958) (lint) on 2026-06-15 00:56:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27515457120/artifacts/7626261704)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27515457120/artifacts/7626904497)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27515457120/artifacts/7626304112)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27515457120/artifacts/7626339917)
<!-- END artifact comment -->