### PR TITLE
feat: allow pens to be used as writing tools

### DIFF
--- a/data/json/items/tool/stationary.json
+++ b/data/json/items/tool/stationary.json
@@ -15,17 +15,22 @@
   },
   {
     "id": "pen",
-    "type": "GENERIC",
-    "category": "other",
+    "type": "TOOL",
+    "category": "tools",
     "name": { "str": "pen" },
-    "description": "A plastic ball point pen.",
+    "description": "A plastic ball point pen.  Use it to write something down.",
     "weight": "20 g",
     "volume": "10 ml",
     "price": "25 cent",
     "price_postapoc": "10 cent",
     "material": "plastic",
     "symbol": ";",
-    "color": "light_gray"
+    "color": "light_gray",
+    "initial_charges": 100,
+    "max_charges": 100,
+    "charges_per_use": 1,
+    "use_action": { "type": "inscribe", "verb": "Write", "gerund": "Written", "on_terrain": true, "material_restricted": false },
+    "flags": [ "WRITE_MESSAGE" ]
   },
   {
     "id": "scissors",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1467,7 +1467,18 @@
     ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "pants", "socks", "boots", "coat_lab", "gloves_rubber", "glasses_safety", "smart_phone", "wristwatch" ],
+        "items": [
+          "dress_shirt",
+          "pants",
+          "socks",
+          "boots",
+          "coat_lab",
+          "gloves_rubber",
+          "glasses_safety",
+          "smart_phone",
+          "wristwatch",
+          "pen"
+        ],
         "entries": [ { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "chemistry_set" } ]
       },
       "male": [ "briefs" ],
@@ -2766,7 +2777,8 @@
         "bandages",
         "aspirin",
         "grahmcrackers",
-        "stethoscope"
+        "stethoscope",
+        "pen"
       ],
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -2970,7 +2982,9 @@
     "age": { "min": 22, "max": 26 },
     "skills": [ { "level": 4, "name": "electronics" }, { "level": 2, "name": "fabrication" }, { "level": 2, "name": "computer" } ],
     "items": {
-      "both": { "items": [ "pants", "dress_shirt", "socks", "dress_shoes", "wristwatch", "water_clean", "smart_phone", "file" ] },
+      "both": {
+        "items": [ "pants", "dress_shirt", "socks", "dress_shoes", "wristwatch", "water_clean", "smart_phone", "file", "pen" ]
+      },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     }
@@ -2984,7 +2998,9 @@
     "age": { "min": 22, "max": 26 },
     "skills": [ { "level": 4, "name": "mechanics" }, { "level": 2, "name": "fabrication" }, { "level": 2, "name": "computer" } ],
     "items": {
-      "both": { "items": [ "pants", "dress_shirt", "socks", "dress_shoes", "wristwatch", "water_clean", "smart_phone", "file" ] },
+      "both": {
+        "items": [ "pants", "dress_shirt", "socks", "dress_shoes", "wristwatch", "water_clean", "smart_phone", "file", "pen" ]
+      },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     }
@@ -3469,7 +3485,7 @@
     "points": 0,
     "skills": [ { "level": 4, "name": "barter" } ],
     "items": {
-      "both": { "items": [ "suit", "knit_scarf", "socks", "dress_shoes", "smart_phone", "wristwatch" ] },
+      "both": { "items": [ "suit", "knit_scarf", "socks", "dress_shoes", "smart_phone", "wristwatch", "pen" ] },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     }
@@ -3782,7 +3798,8 @@
           "story_book",
           "smart_phone",
           "howto_computer",
-          "novel_coa"
+          "novel_coa",
+          "pen"
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -3802,7 +3819,7 @@
     "forbidden_traits": [ "CARRY_PERMIT" ],
     "items": {
       "both": {
-        "items": [ "pants", "tshirt", "socks", "sneakers", "backpack", "wristwatch", "smart_phone" ],
+        "items": [ "pants", "tshirt", "socks", "sneakers", "backpack", "wristwatch", "smart_phone", "pen" ],
         "entries": [ { "contents-group": [ "manuals_school", "textbooks_school", "light_reading" ], "item": "box_medium" } ]
       },
       "male": [ "boxer_shorts" ],
@@ -4154,7 +4171,7 @@
     "skills": [ { "level": 2, "name": "barter" }, { "level": 2, "name": "speech" } ],
     "no_bonus": "teleumbrella",
     "items": {
-      "both": [ "socks", "suit", "dress_shoes", "knit_scarf", "briefcase", "file", "teleumbrella" ],
+      "both": [ "socks", "suit", "dress_shoes", "knit_scarf", "briefcase", "file", "teleumbrella", "pen" ],
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     }
@@ -5025,7 +5042,8 @@
         "wristwatch",
         "smart_phone",
         "briefcase",
-        "file"
+        "file",
+        "pen"
       ],
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -6386,7 +6404,8 @@
         "mbag",
         "water_mineral",
         "smart_phone",
-        "money_bundle"
+        "money_bundle",
+        "pen"
       ],
       "male": [ "briefs" ],
       "female": [ "panties" ]
@@ -6430,7 +6449,8 @@
           "knit_scarf",
           "backpack",
           "textbook_chemistry",
-          "wristwatch"
+          "wristwatch",
+          "pen"
         ]
       },
       "male": [ "briefs" ],
@@ -6459,7 +6479,8 @@
           "backpack",
           "smart_phone",
           "mag_electronics",
-          "wristwatch"
+          "wristwatch",
+          "pen"
         ]
       },
       "male": [ "briefs" ],
@@ -6503,7 +6524,7 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "pants", "dress_shirt", "smart_phone", "blazer", "socks", "dress_shoes", "wristwatch" ],
+        "items": [ "pants", "dress_shirt", "smart_phone", "blazer", "socks", "dress_shoes", "wristwatch", "pen" ],
         "entries": [ { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "camera_pro" } ]
       },
       "male": [ "boxer_shorts" ],
@@ -6784,7 +6805,8 @@
           "dnd_handbook",
           "smart_phone",
           "wristwatch",
-          "RPG_die"
+          "RPG_die",
+          "pen"
         ]
       },
       "male": [ "briefs" ],
@@ -6810,7 +6832,7 @@
       { "level": 1, "name": "throw" }
     ],
     "items": {
-      "both": [ "jeans", "polo_shirt", "socks", "dress_shoes", "mbag", "caffeine", "smart_phone", "wristwatch" ],
+      "both": [ "jeans", "polo_shirt", "socks", "dress_shoes", "mbag", "caffeine", "smart_phone", "wristwatch", "pen" ],
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     }
@@ -6959,7 +6981,8 @@
         "tie_skinny",
         "file",
         "ref_lighter",
-        "cigar"
+        "cigar",
+        "pen"
       ],
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -7345,7 +7368,18 @@
     ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "pants", "socks", "boots", "coat_lab", "gloves_rubber", "glasses_safety", "smart_phone", "wristwatch" ],
+        "items": [
+          "dress_shirt",
+          "pants",
+          "socks",
+          "boots",
+          "coat_lab",
+          "gloves_rubber",
+          "glasses_safety",
+          "smart_phone",
+          "wristwatch",
+          "pen"
+        ],
         "entries": [
           { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "chemistry_set" },
           { "item": "scalpel", "custom-flags": [ "auto_wield" ] }
@@ -8119,7 +8153,8 @@
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "m17", "ammo-item": "9mm", "container-item": "holster", "charges": 17 },
           { "item": "legpouch_large", "contents-group": "army_mags_m17" },
-          { "item": "militarymap" }
+          { "item": "militarymap" },
+          { "item": "pen" }
         ]
       },
       "male": { "entries": [ { "item": "boxer_shorts" } ] },
@@ -8420,7 +8455,8 @@
           "kevlar",
           "socks",
           "dress_shoes",
-          "briefcase"
+          "briefcase",
+          "pen"
         ],
         "entries": [
           { "item": "glock_19", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Minor fun flavor addition and making a bloat item actually useful for something.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Adds the `incscribe` use action to pens, changing them from type generic to type tool, with 100 default charges. Basically just copied what survival markers can do.
2. Added a pen to the starting items of several professions for flavor: lab technician, bionic lab-tech, nursing assistant, electrical engineer, mechanical engineer, used car salesman, student, library nerd, bionic boffin, lawyer, bionic student, science club member, A/V club member, photojournalist, game master, bionic game master, career politician, feral scientist, major general, and IRS-CI special agent.

## Describe alternatives you've considered

1. Not letting you scribble on terrain despite survival markers being a glorified pencil yet allowing it.
2. Adding snippets to them for flavor so you can have silly novelty branded pens referencing fake companies.
3. Adding `BELT_CLIP` to pens, main problem with that is it's too small for basically every storage item.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6aacb7e](https://github.com/cataclysmbn/Cataclysm-BN/commit/6aacb7e681850c8a45d99f07f6934f2620c32a67) (feat: allow pens to be used as writing tools) on 2026-06-15 01:30:05

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27516423844/artifacts/7626570650)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27516423844/artifacts/7627242819)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27516423844/artifacts/7626579895)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27516423844/artifacts/7626602438)
<!-- END artifact comment -->