### PR TITLE
fix: prevent reactor override crash without plutonium

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1391,9 +1391,9 @@ bool Character::burn_fuel( bionic &bio, bool start )
             } else if( is_perpetual_fuel ) {
                 current_fuel_stock = 1;
             } else if( is_cable_powered ) {
-                current_fuel_stock = std::stoi( get_value( "rem_" + fuel.str() ) );
+                current_fuel_stock = get_value_as_int( "rem_" + fuel.str() ).value_or( 0 );
             } else {
-                current_fuel_stock = std::stoi( get_value( fuel.str() ) );
+                current_fuel_stock = get_value_as_int( fuel.str() ).value_or( 0 );
             }
 
             if( !bio.has_flag( flag_SAFE_FUEL_OFF ) &&
@@ -1780,11 +1780,7 @@ void Character::process_bionic( bionic &bio )
         std::vector<itype_id> fuel_available = get_fuel_available( bio.id );
         if( bio.id->is_remote_fueled ) {
             const itype_id rem_fuel = find_remote_fuel();
-            const std::string rem_amount = get_value( "rem_" + rem_fuel.str() );
-            int rem_fuel_stock = 0;
-            if( !rem_amount.empty() ) {
-                rem_fuel_stock = std::stoi( rem_amount );
-            }
+            const auto rem_fuel_stock = get_value_as_int( "rem_" + rem_fuel.str() ).value_or( 0 );
             if( !rem_fuel.is_empty() && ( rem_fuel_stock > 0 || rem_fuel->has_flag( flag_PERPETUAL ) ) ) {
                 fuel_available.emplace_back( rem_fuel );
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2426,19 +2426,12 @@ std::vector<itype_id> Character::get_fuel_available( const bionic_id &bio ) cons
 
 int Character::get_fuel_type_available( const itype_id &fuel ) const
 {
-    int amount_stored = 0;
-    if( !get_value( fuel.str() ).empty() ) {
-        amount_stored = std::stoi( get_value( fuel.str() ) );
-    }
-    return amount_stored;
+    return get_value_as_int( fuel.str() ).value_or( 0 );
 }
 
 int Character::get_fuel_capacity( const itype_id &fuel ) const
 {
-    int amount_stored = 0;
-    if( !get_value( fuel.str() ).empty() ) {
-        amount_stored = std::stoi( get_value( fuel.str() ) );
-    }
+    const auto amount_stored = get_value_as_int( fuel.str() ).value_or( 0 );
     int capacity = 0;
     for( const bionic &i : get_bionic_collection() ) {
         const bionic_id &bid = i.id;
@@ -2483,7 +2476,7 @@ void Character::update_fuel_storage( const itype_id &fuel )
     if( bids.empty() ) {
         return;
     }
-    int amount_fuel_loaded = std::stoi( get_value( fuel.str() ) );
+    auto amount_fuel_loaded = get_value_as_int( fuel.str() ).value_or( 0 );
     std::vector<bionic_id> loaded_bio;
 
     // Sort bionic in order of decreasing capacity

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -53,6 +53,7 @@
 #include "string_id.h"
 #include "string_utils.h"
 #include "submap_load_manager.h"
+#include "utils/string_to_int.h"
 #include "translations.h"
 #include "value_ptr.h"
 #include "vehicle.h"
@@ -1849,6 +1850,12 @@ std::string Creature::get_value( const std::string &key ) const
     auto it = values.find( key );
     return ( it == values.end() ) ? "" : it->second;
 }
+
+auto Creature::get_value_as_int( const std::string &key ) const -> std::optional<int>
+{
+    return string_utils::string_to_int( get_value( key ) );
+}
+
 auto Creature::get_values_map() const -> const std::unordered_map<std::string, std::string> &
 {
     return values;

--- a/src/creature.h
+++ b/src/creature.h
@@ -3,6 +3,7 @@
 #include <climits>
 #include <cstddef>
 #include <map>
+#include <optional>
 #include <set>
 #include <unordered_map>
 #include <vector>
@@ -570,6 +571,7 @@ class Creature
         void set_value( const std::string &key, const std::string &value );
         void remove_value( const std::string &key );
         std::string get_value( const std::string &key ) const;
+        auto get_value_as_int( const std::string &key ) const -> std::optional<int>;
         auto get_values_map() const -> const std::unordered_map<std::string, std::string> &;
 
         virtual units::mass get_weight() const = 0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -110,6 +110,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
+#include "utils/string_to_int.h"
 #include "units_energy.h"
 #include "units_utility.h"
 #include "value_ptr.h"
@@ -10961,8 +10962,10 @@ detached_ptr<item> item::process_internal( detached_ptr<item> &&self, player *ca
         if( !self->has_var( "ethereal" ) ) {
             return detached_ptr<item>();
         }
-        self->set_var( "ethereal", std::stoi( self->get_var( "ethereal" ) ) - 1 );
-        const bool processed = std::stoi( self->get_var( "ethereal" ) ) <= 0;
+        const auto ethereal_counter = string_utils::string_to_int( self->get_var( "ethereal" ) ).value_or(
+                                          0 ) - 1;
+        self->set_var( "ethereal", ethereal_counter );
+        const bool processed = ethereal_counter <= 0;
         if( processed && carrier != nullptr ) {
             carrier->add_msg_if_player( _( "Your %s disappears!" ), self->tname() );
         }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1287,8 +1287,7 @@ void Character::suffer_from_radiation()
     }
     // Reactor override increases power output but irradiates you faster
     if( has_active_bionic( bio_reactoroverride ) ) {
-        const auto stored_plutonium = get_value( itype_plut_cell.str() );
-        const auto current_fuel_stock = stored_plutonium.empty() ? 0 : std::stoi( stored_plutonium );
+        const auto current_fuel_stock = get_value_as_int( itype_plut_cell.str() ).value_or( 0 );
         if( current_fuel_stock <= 0 ) {
             add_msg_player_or_npc( m_info,
                                    _( "Your %s runs out of fuel and turn off." ),

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1287,11 +1287,18 @@ void Character::suffer_from_radiation()
     }
     // Reactor override increases power output but irradiates you faster
     if( has_active_bionic( bio_reactoroverride ) ) {
-        int current_fuel_stock = std::stoi( get_value( itype_plut_cell.str() ) );
+        const auto stored_plutonium = get_value( itype_plut_cell.str() );
+        const auto current_fuel_stock = stored_plutonium.empty() ? 0 : std::stoi( stored_plutonium );
+        if( current_fuel_stock <= 0 ) {
+            add_msg_player_or_npc( m_info,
+                                   _( "Your %s runs out of fuel and turn off." ),
+                                   _( "<npcname>'s %s runs out of fuel and turn off." ),
+                                   bio_reactoroverride->name );
+            deactivate_bionic( get_bionic_state( bio_reactoroverride ), true );
+            return;
+        }
 
-        current_fuel_stock -= 50;
-
-        set_value( itype_plut_cell.str(), std::to_string( current_fuel_stock ) );
+        set_value( itype_plut_cell.str(), std::to_string( std::max( 0, current_fuel_stock - 50 ) ) );
         update_fuel_storage( itype_plut_cell );
 
         mod_power_level( 40_kJ );

--- a/src/utils/string_to_int.h
+++ b/src/utils/string_to_int.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <charconv>
+#include <optional>
+#include <string>
+#include <system_error>
+
+namespace string_utils {
+
+inline auto string_to_int(const std::string& value) -> std::optional<int> {
+    if (value.empty()) { return std::nullopt; }
+
+    auto parsed = 0;
+    const auto* first = value.data();
+    const auto* last = first + value.size();
+    const auto result = std::from_chars(first, last, parsed);
+    if (result.ec != std::errc() || result.ptr != last) { return std::nullopt; }
+    return parsed;
+}
+
+} // namespace string_utils

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -101,6 +101,7 @@ TEST_CASE( "bionics", "[bionics] [item]" )
 
 static const bionic_id bio_reactor( "bio_reactor" );
 static const bionic_id bio_advreactor( "bio_advreactor" );
+static const auto bio_reactoroverride = bionic_id( "bio_reactoroverride" );
 static const itype_id itype_plut_cell( "plut_cell" );
 
 /// Helper: set up a character with power storage and a reactor bionic loaded with fuel.
@@ -197,6 +198,38 @@ TEST_CASE( "microreactor_fuel_consumption", "[bionics] [reactor]" )
         auto active_gain = dummy.get_power_level() - power_before_active;
 
         CHECK( active_gain > passive_gain );
+    }
+
+    SECTION( "bio_reactoroverride without plutonium powers down instead of throwing" ) {
+        setup_reactor( dummy, bio_reactor, 0 );
+        REQUIRE( dummy.has_bionic( bio_reactoroverride ) );
+        auto &safety_override = dummy.get_bionic_state( bio_reactoroverride );
+
+        dummy.set_power_level( safety_override.info().power_activate );
+        REQUIRE( dummy.activate_bionic( safety_override ) );
+        REQUIRE( safety_override.powered );
+
+        CHECK_NOTHROW( dummy.process_turn() );
+        CHECK_FALSE( safety_override.powered );
+    }
+
+    SECTION( "bio_reactoroverride produces extra power and radiation while reactor runs" ) {
+        auto &reactor = setup_reactor( dummy, bio_reactor, 1000 );
+        REQUIRE( dummy.has_bionic( bio_reactoroverride ) );
+        auto &safety_override = dummy.get_bionic_state( bio_reactoroverride );
+
+        REQUIRE( dummy.activate_bionic( reactor ) );
+        dummy.set_power_level( safety_override.info().power_activate );
+        REQUIRE( dummy.activate_bionic( safety_override ) );
+        REQUIRE( safety_override.powered );
+
+        const auto power_before = dummy.get_power_level();
+        const auto rad_before = dummy.get_rad();
+        dummy.process_turn();
+
+        CHECK( safety_override.powered );
+        CHECK( dummy.get_power_level() > power_before );
+        CHECK( dummy.get_rad() > rad_before );
     }
 }
 

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -103,6 +103,7 @@ static const bionic_id bio_reactor( "bio_reactor" );
 static const bionic_id bio_advreactor( "bio_advreactor" );
 static const auto bio_reactoroverride = bionic_id( "bio_reactoroverride" );
 static const itype_id itype_plut_cell( "plut_cell" );
+static const auto malformed_fuel_stock = std::string( "not-a-number" );
 
 /// Helper: set up a character with power storage and a reactor bionic loaded with fuel.
 /// Returns a reference to the installed bionic.
@@ -230,6 +231,41 @@ TEST_CASE( "microreactor_fuel_consumption", "[bionics] [reactor]" )
         CHECK( safety_override.powered );
         CHECK( dummy.get_power_level() > power_before );
         CHECK( dummy.get_rad() > rad_before );
+    }
+
+    SECTION( "bio_reactor with malformed plutonium powers down instead of throwing" ) {
+        auto &reactor = setup_reactor( dummy, bio_reactor, 0 );
+        dummy.set_value( itype_plut_cell.str(), malformed_fuel_stock );
+
+        REQUIRE( dummy.activate_bionic( reactor ) );
+        REQUIRE( reactor.powered );
+        reactor.charge_timer = 0;
+
+        CHECK_NOTHROW( dummy.process_turn() );
+        CHECK_FALSE( reactor.powered );
+    }
+
+    SECTION( "bio_reactoroverride with malformed plutonium powers down instead of throwing" ) {
+        setup_reactor( dummy, bio_reactor, 0 );
+        dummy.set_value( itype_plut_cell.str(), malformed_fuel_stock );
+        auto &safety_override = dummy.get_bionic_state( bio_reactoroverride );
+
+        dummy.set_power_level( safety_override.info().power_activate );
+        REQUIRE( dummy.activate_bionic( safety_override ) );
+        REQUIRE( safety_override.powered );
+
+        CHECK_NOTHROW( dummy.process_turn() );
+        CHECK_FALSE( safety_override.powered );
+    }
+
+    SECTION( "bionic fuel storage helpers treat malformed fuel as empty" ) {
+        setup_reactor( dummy, bio_reactor, 0 );
+        dummy.set_value( itype_plut_cell.str(), malformed_fuel_stock );
+
+        CHECK_NOTHROW( dummy.get_fuel_type_available( itype_plut_cell ) );
+        CHECK( dummy.get_fuel_type_available( itype_plut_cell ) == 0 );
+        CHECK_NOTHROW( dummy.get_fuel_capacity( itype_plut_cell ) );
+        CHECK_NOTHROW( dummy.update_fuel_storage( itype_plut_cell ) );
     }
 }
 

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -7,6 +7,7 @@
 
 #include "calendar.h"
 #include "enums.h"
+#include "flag.h"
 #include "item.h"
 #include "itype.h"
 #include "ret_val.h"
@@ -53,6 +54,17 @@ TEST_CASE( "gun_layer", "[item]" )
     CHECK( gun.is_gunmod_compatible( *mod ).success() );
     gun.put_in( std::move( mod ) );
     CHECK( gun.get_layer() == BELTED_LAYER );
+}
+
+TEST_CASE( "ethereal_item_with_malformed_counter_expires_without_throwing", "[item]" )
+{
+    auto ethereal = item::spawn( "rock" );
+    ethereal->set_flag( flag_ETHEREAL_ITEM );
+    ethereal->set_var( "ethereal", "not-a-number" );
+
+    CHECK_NOTHROW( ethereal = item::process( std::move( ethereal ), nullptr,
+                              tripoint_bub_ms::zero(), false ) );
+    CHECK_FALSE( ethereal );
 }
 
 TEST_CASE( "gun_cycle_mode_wraps_from_last_to_first", "[item]" )


### PR DESCRIPTION
## Purpose of change (The Why)

External report: https://m.dcinside.com/board/rlike/519522

Activating Micro Reactor Safety Override with missing plutonium crashed on the next turn:

```text
TYPE: St16invalid_argument
MESSAGE: stoi
src/suffer.cpp:1290 Character::suffer_from_radiation()
```

Related: https://github.com/cataclysmbn/Cataclysm-BN/pull/2747

## Describe the solution (The How)

- Parse stored string integers through a safe `std::optional<int>` utility in `src/utils/`.
- Treat missing or malformed bionic fuel counters as empty fuel and power down instead of throwing.
- Apply the same safe parsing to ethereal item counters.

## Testing

- Reproduced the reactor override `stoi` failure with regression coverage before the fix.
- Confirmed malformed bionic fuel values and ethereal counters no longer throw.
- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[bionics][reactor]"`
- `./out/build/linux-full/tests/cata_test-tiles "*ethereal*"`

## Checklist

- [x] External report linked above; no GitHub issue to close.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a314f3e](https://github.com/cataclysmbn/Cataclysm-BN/commit/a314f3e166d3205a16984fdcf2a7014e3b6634ec) (fix: parse stored integer values safely) on 2026-06-15 01:49:14

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27516976019/artifacts/7627052010)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27516976019/artifacts/7627428918)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27516976019/artifacts/7627057103)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27516976019/artifacts/7626964015)
<!-- END artifact comment -->