### PR TITLE
feat(balance): add more bionics to scenarios

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -43,6 +43,7 @@
     "react_cost": "1 J",
     "trigger_cost": "25 kJ",
     "time": 1,
+    "starting_bionic": true,
     "points": 1
   },
   {
@@ -424,6 +425,7 @@
     "fuel_efficiency": 0.5,
     "exothermic_power_gen": true,
     "time": 1,
+    "starting_bionic": true,
     "points": 2,
     "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "BIONIC_TOGGLED" ]
   },
@@ -743,6 +745,7 @@
     "description": "Surgically embedded in your right hand is a powerful electromagnet, allowing you to use your own strength to pull all nearby magnetic objects towards you.  Unlucky bystanders might be injured or killed by flying objects.",
     "occupied_bodyparts": [ [ "hand_r", 3 ] ],
     "act_cost": "10 kJ",
+    "starting_bionic": true,
     "points": 2
   },
   {
@@ -777,6 +780,7 @@
     "fuel_options": [ "metabolism" ],
     "fuel_efficiency": 0.25,
     "time": 1,
+    "starting_bionic": true,
     "points": 2,
     "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ]
   },
@@ -1219,6 +1223,7 @@
     "description": "Surgically implanted in your hands and fingers is a set of tools - screwdriver, hammer, wrench, hacksaw, drill, welder, and heating elements.  You can use this in place of many tools when crafting.",
     "occupied_bodyparts": [ [ "hand_l", 3 ], [ "hand_r", 3 ] ],
     "fake_item": "toolset",
+    "starting_bionic": true,
     "points": 4,
     "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE", "BIONIC_TOOLS", "INITIALLY_ACTIVATE" ]
   },
@@ -1231,6 +1236,7 @@
     "fuel_options": [ "muscle" ],
     "fuel_efficiency": 0.125,
     "passive_fuel_efficiency": 0.00625,
+    "starting_bionic": true,
     "points": 2,
     "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_NPC_USABLE", "BIONIC_TOGGLED" ]
   },
@@ -1458,6 +1464,7 @@
     "fuel_options": [ "sunlight" ],
     "fuel_efficiency": 1,
     "time": 1,
+    "starting_bionic": true,
     "points": 1,
     "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ]
   },
@@ -1479,6 +1486,7 @@
     "name": { "str": "Linguistic Coprocessor" },
     "description": "The left hemisphere of your brain has been augmented with a microcomputer that moderately increases the speed that language and written words are processed, granting a 25% increase to reading speed.",
     "occupied_bodyparts": [ [ "head", 1 ] ],
+    "starting_bionic": true,
     "points": 1,
     "bio_enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "READING_SPEED", "multiply": -0.25 } ] } ]
   },

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -406,7 +406,18 @@
     "//": "Do not give the lab rat a gun.",
     "forbidden_traits": [ "CARRY_PERMIT" ],
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ],
-    "bionics": [ "bio_ethanol", "bio_fuel_cell_hydrogen", "bio_magnet", "bio_infrared", "bio_leukocyte", "bio_underwater_propellers" ]
+    "bionics": [
+      "afs_bio_dopamine_stimulators",
+      "bio_fuel_cell_hydrogen",
+      "bio_ground_sonar",
+      "bio_infrared",
+      "bio_leukocyte",
+      "bio_minirose",
+      "bio_painkiller",
+      "bio_reactor",
+      "bio_underwater_propellers",
+      "bio_wings"
+    ]
   },
   {
     "type": "scenario",
@@ -433,10 +444,11 @@
     "bionics": [
       "bio_atomic_battery",
       "bio_surgical_razor",
-      "bio_metabolics",
-      "bio_torsionratchet",
-      "bio_tools",
+      "bio_fuel_cell_hydrogen",
+      "bio_synaptic_regen",
+      "bio_blood_anal",
       "bio_memory",
+      "bio_electrosense",
       "bio_geiger"
     ]
   },
@@ -699,7 +711,18 @@
     ],
     "forbidden_traits": [ "CARRY_PERMIT" ],
     "flags": [ "LONE_START" ],
-    "bionics": [ "bio_ethanol", "bio_fuel_cell_hydrogen", "bio_magnet", "bio_infrared", "bio_leukocyte", "bio_underwater_propellers" ]
+    "bionics": [
+      "afs_bio_dopamine_stimulators",
+      "bio_fuel_cell_hydrogen",
+      "bio_ground_sonar",
+      "bio_infrared",
+      "bio_leukocyte",
+      "bio_minirose",
+      "bio_painkiller",
+      "bio_reactor",
+      "bio_underwater_propellers",
+      "bio_wings"
+    ]
   },
   {
     "type": "scenario",
@@ -772,8 +795,8 @@
     "flags": [ "HELI_CRASH", "LONE_START" ],
     "bionics": [
       "bio_reactor",
-      "bio_metabolics",
-      "bio_ethanol",
+      "bio_adrenaline",
+      "bio_ads",
       "bio_ups",
       "bio_targeting",
       "bio_geiger",
@@ -900,14 +923,14 @@
     ],
     "bionics": [
       "bio_atomic_battery",
-      "bn_bio_solar",
+      "bio_fuel_cell_hydrogen",
       "bio_climate",
       "bio_evap",
-      "bio_metabolics",
+      "bio_faraday",
       "bio_recycler",
       "bio_shock_absorber",
-      "bio_tools",
-      "bio_torsionratchet",
+      "bio_soporific",
+      "bio_geiger",
       "bio_weight"
     ]
   },
@@ -946,8 +969,8 @@
     "flags": [ "CHALLENGE", "LONE_START", "CITY_START" ],
     "bionics": [
       "bio_reactor",
-      "bio_metabolics",
-      "bio_ethanol",
+      "bio_adrenaline",
+      "bio_ads",
       "bio_ups",
       "bio_targeting",
       "bio_geiger",
@@ -1016,8 +1039,8 @@
     "flags": [ "CHALLENGE", "LONE_START" ],
     "bionics": [
       "bio_reactor",
-      "bio_metabolics",
-      "bio_ethanol",
+      "bio_adrenaline",
+      "bio_ads",
       "bio_ups",
       "bio_targeting",
       "bio_geiger",
@@ -1042,8 +1065,8 @@
     "flags": [ "CITY_START", "LONE_START", "SUM_START" ],
     "bionics": [
       "bio_reactor",
-      "bio_metabolics",
-      "bio_ethanol",
+      "bio_adrenaline",
+      "bio_ads",
       "bio_ups",
       "bio_targeting",
       "bio_geiger",
@@ -1085,6 +1108,16 @@
       "hacker"
     ],
     "allowed_locs": [ "sloc_lab_concourse_area" ],
+    "bionics": [
+      "bio_atomic_battery",
+      "bio_surgical_razor",
+      "bio_fuel_cell_hydrogen",
+      "bio_synaptic_regen",
+      "bio_blood_anal",
+      "bio_memory",
+      "bio_electrosense",
+      "bio_geiger"
+    ],
     "flags": [ "CHALLENGE", "LONE_START" ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Further expands upon available bionics selectable in chargen.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added `starting_bionic` to all bionics that are part of the `bionics_common` itemgroup but previously lacked it: integrated toolset, electromagnetic unit, alarm system, metabolic interchange, ethanol burner, joint torsion ratchet, solar panels, and linguistic coprocessor.
2. Accordingly removed now-starting bionics from the bonus bionic lists of professions and scenarios that previously got access to them that way.
3. In their place, swapped in additional bionics from relevant itemgroups (`bionics` for lab patient/experiment, `bionics_sci` for lab staff, `bionics_mil` for military scenarios, `bionics_survivalist` for HTLL) to replace their inclusions in associated scenarios.
4. Misc: Added standard array of bionics used in lab staff scenario to TCL scenario, derp.
5. Misc: Added a few more bionics here and there to the list of those allowed by lab/experiment scenarios since they seemed a tad short, so now all scenarios that permit adding bonus bionics gain 10 more.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for snytax and lint errors.
2. Load-tested in test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ad6ac52](https://github.com/cataclysmbn/Cataclysm-BN/commit/ad6ac52cc5943232b226e85866f12577626e136f) (feat(balance): add more bionics to scenarios) on 2026-06-15 04:22:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27521745203/artifacts/7628878536)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27521745203/artifacts/7628743353)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27521745203/artifacts/7628446541)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27521745203/artifacts/7628473558)
<!-- END artifact comment -->