### PR TITLE
refactor: Absolute migration plus pathfinding behavior

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2099,7 +2099,6 @@ void throw_activity_actor::do_turn( player_activity &act, Character &who )
     const auto original_player_position = who.abs_pos();
     if( blind_throw_pos ) {
         who.setpos( bub_to_abs( *blind_throw_pos ) );
-        g->update_map( who );
     }
 
     target_handler::trajectory trajectory = target_handler::mode_throw( *who.as_avatar(), *it,
@@ -2108,7 +2107,6 @@ void throw_activity_actor::do_turn( player_activity &act, Character &who )
     // If we previously shifted our position, put ourselves back now that we've picked our target.
     if( blind_throw_pos ) {
         who.setpos( original_player_position );
-        g->update_map( who );
     }
 
     if( trajectory.empty() ) {

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -543,6 +543,8 @@ void game::draw_bullet( const tripoint_bub_ms &t, const int i,
                         const std::vector<tripoint_bub_ms> &trajectory, const char bullet,
                         const std::string &custom_sprite )
 {
+    refresh_player_visibility_cache_if_needed();
+
     if( !use_tiles ) {
         draw_bullet_curses( m, t, bullet, nullptr );
         return;
@@ -568,6 +570,7 @@ void game::draw_bullet( const tripoint_bub_ms &t, const int i,
                         const std::vector<tripoint_bub_ms> &trajectory,
                         const char bullet, const std::string & )
 {
+    refresh_player_visibility_cache_if_needed();
     draw_bullet_curses( m, t, bullet, &trajectory[i] );
 }
 #endif
@@ -666,6 +669,8 @@ void draw_bullet_trajectories( const draw_bullet_trajectories_options &options )
     if( options.trajectories.empty() ) {
         return;
     }
+
+    g->refresh_player_visibility_cache_if_needed();
 
 #if !defined( TILES )
     draw_bullet_trajectories_curses( *g, options );
@@ -905,6 +910,8 @@ void draw_line_curses( game &g, const std::vector<tripoint_bub_ms> &points )
 #if defined(TILES)
 void draw_line_of( const draw_sprite_line_options &options )
 {
+    g->refresh_player_visibility_cache_if_needed();
+
     if( !use_tiles ) {
         draw_line_curses( *g, options.points );
         return;

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -864,7 +864,7 @@ void draw_line_curses( game &g, const tripoint_bub_ms &center,
 void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
                       const std::vector<tripoint_bub_ms> &points, bool noreveal )
 {
-    if( !u.sees( p ) ) {
+    if( !noreveal && !u.sees( p ) ) {
         return;
     }
 
@@ -879,7 +879,7 @@ void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
 void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
                       const std::vector<tripoint_bub_ms> &points, bool noreveal )
 {
-    if( !u.sees( p ) ) {
+    if( !noreveal && !u.sees( p ) ) {
         return;
     }
 

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -209,15 +209,11 @@ void avatar::control_npc( npc &np )
     }
     // perception and mutations may have changed, so reset light level caches
     g->reset_light_level();
-    // center the map on the new avatar character
+    // setpos() keeps the loaded map window aligned with the new avatar.
     if( swapped_out_character_was_dead ) {
-        auto map_local_pos = abs_to_map_local( get_map(), controlled_npc_pos );
-        g->vertical_shift( controlled_npc_pos.z() );
-        g->update_map( map_local_pos.x(), map_local_pos.y() );
         setpos( controlled_npc_pos );
     } else {
-        g->vertical_shift( bub_pos().z() );
-        g->update_map( *this );
+        setpos( controlled_npc_pos );
     }
 }
 

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -198,6 +198,11 @@ void avatar::control_npc( npc &np )
     g->remove_npc_follower( getID() );
     // the previous avatar character is now a follower (unless they're dead)
     const bool swapped_out_character_was_dead = avatar_was_dead || np.is_dead_state();
+    // swap_character moved raw position data without running npc::setpos().
+    // Put the NPC object back at its old absolute location first so setpos()
+    // can update overmapbuffer membership when the old avatar body is restored.
+    np.Character::setpos( controlled_npc_pos );
+    np.setpos( previous_avatar_pos );
     if( swapped_out_character_was_dead ) {
         // Keep the newly controlled avatar in the current reality bubble while
         // the swapped-out dead character runs death side effects.
@@ -206,15 +211,14 @@ void avatar::control_npc( npc &np )
     } else {
         g->add_npc_follower( np.getID() );
         np.set_fac( faction_id( "your_followers" ) );
+        // After the swap the avatar already has controlled_npc_pos, so a plain
+        // setpos( controlled_npc_pos ) would be a no-op and skip update_map().
+        Character::setpos( previous_avatar_pos );
     }
     // perception and mutations may have changed, so reset light level caches
     g->reset_light_level();
     // setpos() keeps the loaded map window aligned with the new avatar.
-    if( swapped_out_character_was_dead ) {
-        setpos( controlled_npc_pos );
-    } else {
-        setpos( controlled_npc_pos );
-    }
+    setpos( controlled_npc_pos );
 }
 
 void avatar::toggle_map_memory()

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -629,7 +629,6 @@ void avatar_action::swim( map &m, avatar &you, const tripoint_bub_ms &p )
         add_msg( m_good, _( "You are hiding in the %s." ), m.name( p ) );
     }
     you.setpos( p );
-    g->update_map( you );
 
     cata_event_dispatch::avatar_moves( you, m, you.abs_pos() );
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -6894,14 +6894,12 @@ void cata_tiles::draw_line()
         return;
     }
     static std::string line_overlay = "animation_line";
-    if( !is_target_line || g->u.sees( tripoint_bub_ms( line_pos ) ) ) {
-        for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
-            draw_from_id_string(
-            {line_overlay, C_NONE, empty_string, 0, 0},
-            *it, std::nullopt, std::nullopt,
-            lit_level::LIT, false, 0, false
-            );
-        }
+    for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
+        draw_from_id_string(
+        {line_overlay, C_NONE, empty_string, 0, 0},
+        *it, std::nullopt, std::nullopt,
+        lit_level::LIT, false, 0, false
+        );
     }
 
     draw_from_id_string(

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -841,7 +841,7 @@ tripoint_abs_ms Character::abs_pos() const
 
 auto Character::setpos( const tripoint_bub_ms &p ) -> void
 {
-    position = map_local_to_abs( get_map(), p );
+    position = bub_to_abs( p );
 }
 
 auto Character::setpos( const tripoint_abs_ms &p ) -> void
@@ -1523,7 +1523,6 @@ void Character::forced_dismount()
         if( g->u.is_auto_moving() || g->u.has_destination() || g->u.has_destination_activity() ) {
             g->u.clear_destination();
         }
-        g->update_map( g->u );
     }
     if( activity ) {
         cancel_activity();
@@ -1559,9 +1558,6 @@ void Character::dismount()
         mounted_creature = nullptr;
         critter->mounted_player = nullptr;
         setpos( *pnt );
-        if( is_avatar() ) {
-            g->update_map( g->u );
-        }
         mod_moves( -100 );
         set_movement_mode( CMM_WALK );
     }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1111,7 +1111,6 @@ void character_edit_menu( Character &c )
                     if( p.is_mounted() ) {
                         p.mounted_creature->setpos( *newpos );
                     }
-                    g->update_map( g->u );
                 }
             }
         }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -1213,11 +1213,6 @@ void ExplosionProcess::run()
         }
     }
 
-    // Make sure the map is centered around the player
-    if( player_flung.has_value() ) {
-        g->update_map( *player_flung.value() );
-    }
-
     // Finally, recombine thrown items into full stacks again
     std::sort( recombination_targets.begin(), recombination_targets.end() );
     auto end = std::unique( recombination_targets.begin(), recombination_targets.end() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -16938,14 +16938,16 @@ void game::remove_fake_item( item *it )
 }
 namespace cata_event_dispatch
 {
-void avatar_moves( const avatar &u, const map &m, const tripoint_abs_ms &p )
+void avatar_moves( const avatar &u, const map &m, const tripoint_abs_ms &pos )
 {
     mtype_id mount_type;
     if( u.is_mounted() ) {
         mount_type = u.mounted_creature->type->id;
     }
-    g->events().send<event_type::avatar_moves>( mount_type, m.ter( abs_to_bub( p ) ).id(),
-            u.get_movement_mode(), u.is_underwater(), p.z() );
+    const auto terrain = MAPBUFFER_REGISTRY.get( m.get_bound_dimension() ).get_ter( pos,
+                         { .mode = mapbuffer_lookup_mode::resident_only } ).value_or( t_null );
+    g->events().send<event_type::avatar_moves>( mount_type, terrain, u.get_movement_mode(),
+            u.is_underwater(), pos.z() );
 }
 } // namespace cata_event_dispatch
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5797,8 +5797,8 @@ void game::world_tick()
 }
 
 static auto turn_los_blocker_key( const tripoint_bub_ms &from,
-                                  const tripoint_bub_ms &to )
-- > std::pair<tripoint_bub_ms, tripoint_bub_ms>
+                                  const tripoint_bub_ms &to ) ->
+                                  std::pair<tripoint_bub_ms, tripoint_bub_ms>
 {
     return from < to ? std::make_pair( from, to ) : std::make_pair( to, from );
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -19,6 +19,7 @@
 #include <locale>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <numeric>
 #include <queue>
 #include <ranges>
@@ -210,11 +211,6 @@
 #include "worldfactory.h"
 #include "location_vector.h"
 #include "monfaction.h"
-#if defined( CATA_SDL )
-#include "compute/compute_backend.h"
-#include "compute/gpu_lm.h"
-#include "compute/gpu_platform.h"
-#endif
 class computer;
 
 #if defined(TILES)
@@ -5762,152 +5758,38 @@ void game::world_tick()
     }
 }
 
-struct prepared_sight_query {
-    bool needs_los = false;
-    bool immediate_result = false;
-    tripoint_bub_ms from = tripoint_bub_ms::zero();
-    tripoint_bub_ms to = tripoint_bub_ms::zero();
-    int range = -1;
-};
-
-static auto prepare_terrain_sight_query( const Creature &seer, const tripoint_bub_ms &target,
-        const int range_mod ) -> prepared_sight_query
+static auto turn_los_blocker_key( const tripoint_bub_ms &from,
+                                  const tripoint_bub_ms &to )
+    -> std::pair<tripoint_bub_ms, tripoint_bub_ms>
 {
-    auto &here = get_map();
-    if( seer.get_dimension() != here.get_bound_dimension() ) {
-        return { .immediate_result = false };
-    }
-
-    const auto range_day = seer.sight_range( default_daylight_level() );
-    const auto range_night = seer.sight_range( 0 );
-    const auto range_max = std::max( range_day, range_night );
-    const auto wanted_range = rl_dist( seer.bub_pos(), target );
-    if( wanted_range > range_max ) {
-        return { .immediate_result = false };
-    }
-
-    const auto ambient = here.ambient_light_at( target );
-    const auto range_cur = seer.sight_range( ambient );
-    const auto range_min = std::min( range_cur, range_max );
-    const auto natural_light = g->natural_light_level( target.z() );
-    const auto is_lit = ambient > natural_light;
-    if( wanted_range > range_min && !( wanted_range <= range_max && is_lit ) ) {
-        return { .immediate_result = false };
-    }
-
-    auto range = is_lit ? g_max_view_distance : range_min;
-    if( seer.has_effect( effect_no_sight ) ) {
-        range = 1;
-    }
-    if( range_mod > 0 ) {
-        range = std::min( range, range_mod );
-    }
-    return {
-        .needs_los = true,
-        .from = seer.bub_pos(),
-        .to = target,
-        .range = range,
-    };
+    return from < to ? std::make_pair( from, to ) : std::make_pair( to, from );
 }
 
-static auto prepare_creature_sight_query( const Creature &seer,
-        const Creature &target ) -> prepared_sight_query
+auto game::clear_turn_los_blocker_cache() -> void
 {
-    if( &target == &seer ) {
-        return { .immediate_result = true };
-    }
-    if( target.is_hallucination() ) {
-        return { .immediate_result = seer.is_player() };
-    }
-    if( seer.get_dimension() != target.get_dimension() ) {
-        return { .immediate_result = false };
-    }
-
-    const auto *const target_character = target.as_character();
-    if( target_character != nullptr && target_character->is_invisible() ) {
-        return { .immediate_result = false };
-    }
-
-    auto &here = get_map();
-    const auto seer_pos = seer.bub_pos();
-    const auto target_pos = target.bub_pos();
-    const auto wanted_range = rl_dist( seer_pos, target_pos );
-    if( wanted_range <= 1 && seer_pos.z() == target_pos.z() ) {
-        return {
-            .immediate_result = !here.obscured_by_vehicle_rotation( seer_pos, target_pos ),
-        };
-    }
-    if( wanted_range <= 1 ) {
-        return {
-            .needs_los = true,
-            .from = seer_pos,
-            .to = target_pos,
-            .range = 1,
-        };
-    }
-
-    if( target.digging() ||
-        ( target.has_flag( MF_NIGHT_INVISIBILITY ) &&
-          here.light_at( target_pos ) <= lit_level::LOW ) ||
-        ( target.is_underwater() && !seer.is_underwater() && here.is_divable( target_pos ) ) ||
-        ( here.has_flag_ter_or_furn( TFLAG_HIDE_PLACE, target_pos ) &&
-          !( std::abs( seer_pos.x() - target_pos.x() ) <= 1 &&
-             std::abs( seer_pos.y() - target_pos.y() ) <= 1 &&
-             std::abs( seer_pos.z() - target_pos.z() ) <= 1 ) &&
-          !target.has_flag( MF_FLIES ) &&
-          target.get_size() <= creature_size::medium ) ) {
-        return { .immediate_result = false };
-    }
-
-    if( target_character != nullptr && target_character->movement_mode_is( CMM_CROUCH ) ) {
-        const auto coverage = here.obstacle_coverage( seer_pos, target_pos );
-        if( coverage < 30 ) {
-            return prepare_terrain_sight_query( seer, target_pos, 0 );
-        }
-        auto size_modifier = 1.0;
-        switch( target_character->get_size() ) {
-            case creature_size::tiny:
-                size_modifier = 2.0;
-                break;
-            case creature_size::small:
-                size_modifier = 1.4;
-                break;
-            case creature_size::medium:
-                break;
-            case creature_size::large:
-                size_modifier = 0.6;
-                break;
-            case creature_size::huge:
-                size_modifier = 0.15;
-                break;
-            default:
-                break;
-        }
-        const auto vision_modifier = static_cast<int>( 30 - 0.5 * coverage * size_modifier );
-        if( vision_modifier <= 1 ) {
-            return { .immediate_result = false };
-        }
-        return prepare_terrain_sight_query( seer, target_pos, vision_modifier );
-    }
-
-    return prepare_terrain_sight_query( seer, target_pos, 0 );
+    auto lock = std::unique_lock<std::shared_mutex>( turn_los_blocker_cache_mutex_ );
+    turn_los_blocker_cache_.clear();
 }
 
-#if defined( CATA_SDL )
-static auto make_gpu_sight_pair( const prepared_sight_query &query ) -> cata_gpu::GpuSightPair
+auto game::terrain_los_blocks_sight_between( const tripoint_bub_ms &from,
+        const tripoint_bub_ms &to ) -> bool
 {
-    return {
-        .from_x = query.from.x(),
-        .from_y = query.from.y(),
-        .from_z_idx = query.from.z() + OVERMAP_DEPTH,
-        .to_x = query.to.x(),
-        .to_y = query.to.y(),
-        .to_z_idx = query.to.z() + OVERMAP_DEPTH,
-        .range = query.range,
-        ._pad = 0,
-    };
+    const auto key = turn_los_blocker_key( from, to );
+    {
+        auto lock = std::shared_lock<std::shared_mutex>( turn_los_blocker_cache_mutex_ );
+        const auto it = turn_los_blocker_cache_.find( key );
+        if( it != turn_los_blocker_cache_.end() ) {
+            return it->second;
+        }
+    }
+
+    const auto blocks_sight = !m.sees( from, to, -1 );
+    {
+        auto lock = std::unique_lock<std::shared_mutex>( turn_los_blocker_cache_mutex_ );
+        const auto insert_result = turn_los_blocker_cache_.emplace( key, blocks_sight );
+        return insert_result.first->second;
+    }
 }
-#endif
 
 auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache *cache ) -> void
 {
@@ -5922,11 +5804,11 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
         cleanup_dead();
     }
 
-    // P-8: clear the per-turn sight cache at the top of every monmove() call
-    // so results from the previous turn are not reused.
+    // Clear per-turn terrain LOS blockers so terrain changes from earlier turns
+    // are not reused.
     {
-        ZoneScopedN( "monmove_clear_sight_cache" );
-        turn_sight_cache_.clear();
+        ZoneScopedN( "monmove_clear_los_blocker_cache" );
+        clear_turn_los_blocker_cache();
     }
 
     auto use_activity_cache = cache != nullptr && cache->valid &&
@@ -5958,7 +5840,7 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     // game state (map caches, faction data, creature positions).  The only
     // shared writes are:
     //   - skew_vision_cache (protected by skew_vision_cache_mutex, P-6)
-    //   - turn_sight_cache_ (protected by turn_sight_cache_mutex_, P-8)
+    //   - turn_los_blocker_cache_ (protected by turn_los_blocker_cache_mutex_)
     //   - per-thread RNG (thread-local engine, P-5)
     // This makes the parallel phase data-race-free.
     //
@@ -6106,141 +5988,6 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
         }
     }
 
-    // Pre-warm directed Creature::sees() jobs before the parallel planning phase.
-    // CPU code applies the creature perception rules, then the terrain LOS work
-    // is batched into one GPU dispatch.  The shared turn_sight_cache_ is filled
-    // serially afterward, avoiding cache write-lock contention in compute_plan().
-    auto sight_jobs = std::vector<std::pair<const Creature *, const Creature *>> {};
-    const auto initial_sight_job_capacity =
-        plannable.size() * ( npc_snap->size() + std::min( mon_snap->size(), size_t{ 16 } ) + 1 );
-    sight_jobs.reserve( initial_sight_job_capacity );
-    const auto add_sight_job = [&]( const Creature & seer, const Creature & target ) {
-        sight_jobs.emplace_back( &seer, &target );
-    };
-    {
-        ZoneScopedN( "monmove_build_sight_jobs" );
-        for( auto *mon : plannable ) {
-            const auto mon_max_sight = std::max( mon->type->vision_day, mon->type->vision_night );
-            const auto mon_pos = mon->bub_pos();
-            const auto waiting = mon->has_effect( effect_ai_waiting );
-            const auto docile = mon->friendly != 0 && mon->has_effect( effect_docile );
-            if( !waiting && mon->friendly <= 0 &&
-                rl_dist( mon_pos, u.bub_pos() ) <= mon_max_sight ) {
-                add_sight_job( *mon, u );
-            }
-            for( auto *n : *npc_snap ) {
-                const auto faction_att = mon->faction.obj().attitude( n->get_monster_faction() );
-                if( faction_att == MFA_NEUTRAL || faction_att == MFA_FRIENDLY ) {
-                    continue;
-                }
-                if( rl_dist( mon_pos, n->bub_pos() ) <= mon_max_sight ) {
-                    add_sight_job( *mon, *n );
-                }
-            }
-
-            const auto needs_group_sight =
-                mon->lod_tier <= lod_group_morale_max_tier &&
-                ( ( mon->has_flag( MF_GROUP_MORALE ) && mon->morale < mon->type->morale ) ||
-                  mon->has_flag( MF_SWARMS ) );
-            for( auto *target_mon : *mon_snap ) {
-                if( target_mon == mon ) {
-                    continue;
-                }
-                if( rl_dist( mon_pos, target_mon->bub_pos() ) > mon_max_sight ) {
-                    continue;
-                }
-                if( mon->friendly != 0 && !docile && !waiting && target_mon->friendly == 0 ) {
-                    add_sight_job( *mon, *target_mon );
-                    continue;
-                }
-                if( mon->friendly == 0 ) {
-                    const auto faction_att = mon->faction.obj().attitude( target_mon->faction );
-                    if( faction_att != MFA_NEUTRAL && faction_att != MFA_FRIENDLY ) {
-                        add_sight_job( *mon, *target_mon );
-                        continue;
-                    }
-                    if( needs_group_sight && mon->faction == target_mon->faction ) {
-                        add_sight_job( *mon, *target_mon );
-                    }
-                }
-            }
-        }
-    }
-    TracyPlot( "Monmove Sight Jobs", static_cast<int64_t>( sight_jobs.size() ) );
-    auto sight_results = std::vector<char> {};
-    auto los_jobs = std::vector<std::pair<size_t, prepared_sight_query>> {};
-#if defined( CATA_SDL )
-    auto gpu_pairs = std::vector<cata_gpu::GpuSightPair> {};
-    auto gpu_results = std::vector<uint32_t> {};
-    auto *gpu_sight_device = static_cast<SDL_GPUDevice *>( nullptr );
-    auto gpu_sight_work = cata_gpu::gpu_sight_pairs_work {};
-#endif
-    if( !sight_jobs.empty() ) {
-        sight_results.assign( sight_jobs.size(), 0 );
-        {
-            ZoneScopedN( "monmove_prepare_sight_prewarm" );
-            los_jobs.reserve( sight_jobs.size() );
-            for( const auto index : std::views::iota( size_t{ 0 }, sight_jobs.size() ) ) {
-                const auto &[seer, target] = sight_jobs[index];
-                const auto query = prepare_creature_sight_query( *seer, *target );
-                if( query.needs_los ) {
-                    los_jobs.emplace_back( index, query );
-                } else {
-                    sight_results[index] = query.immediate_result ? 1 : 0;
-                }
-            }
-        }
-        TracyPlot( "Monmove Sight LOS Jobs", static_cast<int64_t>( los_jobs.size() ) );
-        if( !los_jobs.empty() ) {
-#if defined( CATA_SDL )
-            if( cata_compute::uses_sdl_gpu_compute() ) {
-                ZoneScopedN( "monmove_begin_gpu_sight_prewarm" );
-                gpu_pairs.reserve( los_jobs.size() );
-                std::ranges::transform( los_jobs, std::back_inserter( gpu_pairs ),
-                []( const auto & job ) {
-                    return make_gpu_sight_pair( job.second );
-                } );
-                gpu_sight_device = cata_gpu::get_device();
-                if( gpu_sight_device == nullptr ) {
-                    debugmsg( "SDL_GPU sight pair dispatch failed; see debug.log for details" );
-                } else {
-                    const auto sight_inputs_ready = [&]() {
-                        return cata_gpu::resident_lighting_ready_for_sight_pairs( {
-                            .device = gpu_sight_device,
-                            .m = &m,
-                            .pairs = &gpu_pairs,
-                            .zlev = get_levz(),
-                        } );
-                    };
-                    if( !sight_inputs_ready() ) {
-                        ZoneScopedN( "monmove_bootstrap_gpu_sight_inputs" );
-                        m.build_map_cache( get_levz() );
-                    }
-                    if( !sight_inputs_ready() ) {
-                        debugmsg( "SDL_GPU sight pair dispatch failed; see debug.log for details" );
-                    } else {
-                        gpu_sight_work = cata_gpu::begin_gpu_sight_pairs( gpu_sight_device, {
-                            .m = &m,
-                            .pairs = &gpu_pairs,
-                            .zlev = get_levz(),
-                        } );
-                        if( gpu_sight_work.id == 0 ) {
-                            debugmsg( "SDL_GPU sight pair dispatch failed; see debug.log for details" );
-                        }
-                    }
-                }
-            } else
-#endif
-            {
-                ZoneScopedN( "monmove_cpu_sight_prewarm" );
-                auto &here = get_map();
-                for( const auto &[result_index, query] : los_jobs ) {
-                    sight_results[result_index] = here.sees( query.from, query.to, query.range ) ? 1 : 0;
-                }
-            }
-        }
-    }
-
     // Use the actor snapshots for thread-safe compute_plan() access.
     // compute_plan() calls g->all_monsters() / g->all_npcs() to find targets.
     // Those functions iterate weak_ptr_fast<T> objects whose refcounting uses
@@ -6290,35 +6037,6 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
             hostile_fac_map_for_plan = &cache->hostile_fac_map;
         } else {
             hostile_fac_map_for_plan = &hostile_fac_map;
-        }
-    }
-    if( !sight_jobs.empty() ) {
-        if( !los_jobs.empty() ) {
-#if defined( CATA_SDL )
-            if( cata_compute::uses_sdl_gpu_compute() && gpu_sight_work.id != 0 ) {
-                ZoneScopedN( "monmove_finish_gpu_sight_prewarm" );
-                if( !cata_gpu::finish_gpu_sight_pairs( gpu_sight_device, gpu_sight_work,
-                                                       gpu_results ) ) {
-                    debugmsg( "SDL_GPU sight pair completion failed; see debug.log for details" );
-                } else {
-                    auto &here = get_map();
-                    for( const auto gpu_index : std::views::iota( size_t{ 0 }, los_jobs.size() ) ) {
-                        const auto &[result_index, query] = los_jobs[gpu_index];
-                        const auto result = gpu_results[gpu_index] != 0 &&
-                                            !here.obscured_by_vehicle_rotation( query.from, query.to );
-                        sight_results[result_index] = result ? 1 : 0;
-                    }
-                }
-            }
-#endif
-        }
-        {
-            ZoneScopedN( "monmove_insert_sight_prewarm" );
-            auto lock = std::unique_lock<std::shared_mutex>( turn_sight_cache_mutex_ );
-            turn_sight_cache_.reserve( sight_jobs.size() );
-            for( const auto index : std::views::iota( size_t{ 0 }, sight_jobs.size() ) ) {
-                turn_sight_cache_.emplace( sight_jobs[index], sight_results[index] != 0 );
-            }
         }
     }
     const monster::compute_plan_context plan_ctx{ mon_snap, npc_snap, faction_snap_for_plan,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5831,10 +5831,10 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     // -----------------------------------------------------------------------
     // P-7: Parallel planning pass.
     //
-    // Collect Tier-0 and Tier-1 monsters that are alive and eligible for AI
-    // planning this turn, compute their plans in parallel, then apply and
-    // execute serially.  Tier-2 (Macro) monsters are excluded here; they take
-    // a single Manhattan step in the move execution loop below.
+    // Build thread-safe actor/faction snapshots up front, then compute plans
+    // after lifecycle and budget selection so only monsters that actually have
+    // moves this turn are preplanned.  Tier-2 (Macro) monsters are excluded;
+    // they take a single Manhattan step in the move execution loop below.
     //
     // compute_plan() is const w.r.t. *this (monster) and only reads shared
     // game state (map caches, faction data, creature positions).  The only
@@ -5844,9 +5844,8 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     //   - per-thread RNG (thread-local engine, P-5)
     // This makes the parallel phase data-race-free.
     //
-    // Over-collection is intentional: monsters that die during the serial
-    // setup phase (process_turn, creature_in_field) simply have their
-    // pre-computed plan discarded.
+    // The planning pass is intentionally after process_turn(); checking moves
+    // before process_turn() made the preplan list empty for normal monsters.
     // -----------------------------------------------------------------------
 
     // Configurable via Debug → Performance → "Monster LOD" settings.
@@ -5948,45 +5947,6 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     std::unordered_map<monster *, int> plan_index;
 
     std::vector<monster *> plannable;
-    {
-        ZoneScopedN( "monmove_build_plannable" );
-        auto plannable_candidates_local = std::vector<monster *> {};
-        const std::vector<monster *> *plannable_candidates = mon_snap;
-        if( activity_skip_ai ) {
-            if( use_activity_cache ) {
-                plannable_candidates = &cache->plannable_candidates;
-            } else {
-                plannable_candidates_local.reserve( mon_snap->size() );
-                for( monster *critter : *mon_snap ) {
-                    if( !critter->is_dead() &&
-                        !activity_ai_paused->contains( critter ) &&
-                        critter->lod_tier < 2 &&
-                        critter->is_simulated() ) {
-                        plannable_candidates_local.push_back( critter );
-                    }
-                }
-                if( cache != nullptr ) {
-                    cache->plannable_candidates = std::move( plannable_candidates_local );
-                    plannable_candidates = &cache->plannable_candidates;
-                } else {
-                    plannable_candidates = &plannable_candidates_local;
-                }
-            }
-        }
-        plannable.reserve( plannable_candidates->size() );
-        for( monster *critter : *plannable_candidates ) {
-            if( !critter->is_dead() &&
-                !activity_ai_paused->contains( critter ) &&
-                !critter->has_effect( effect_ai_controlled ) &&
-                critter->moves > 0 &&
-                !critter->has_effect( effect_ridden ) &&
-                critter->lod_tier < 2 &&
-                critter->is_simulated() ) {
-                // Tier-2 monsters skip full planning; they use the macro step.
-                plannable.push_back( critter );
-            }
-        }
-    }
 
     // Use the actor snapshots for thread-safe compute_plan() access.
     // compute_plan() calls g->all_monsters() / g->all_npcs() to find targets.
@@ -6042,35 +6002,6 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     const monster::compute_plan_context plan_ctx{ mon_snap, npc_snap, faction_snap_for_plan,
             hostile_fac_map_for_plan };
 
-    // parallel_for_chunked with a small chunk size gives the
-    // pool a queue of fine-grained tasks.  Workers that finish a cheap monster
-    // (no ray traces) immediately pull the next chunk rather than sitting idle
-    // while a thread blocked on a costly monster finishes its oversized slice.
-    std::vector<monster_plan_t> precomputed( plannable.size() );
-    {
-        ZoneScopedN( "monmove_compute_plans" );
-        if( parallel_enabled && parallel_monster_planning ) {
-            ZoneScopedN( "monmove_compute_plans_parallel" );
-            parallel_for_chunked( 0, static_cast<int>( plannable.size() ),
-            monster_plan_chunk_size, [&]( int i ) {
-                precomputed[i] = plannable[i]->compute_plan( plan_ctx );
-            } );
-        } else {
-            ZoneScopedN( "monmove_compute_plans_serial" );
-            for( const auto index : std::views::iota( size_t{ 0 }, plannable.size() ) ) {
-                precomputed[index] = plannable[index]->compute_plan( plan_ctx );
-            }
-        }
-    }
-
-    // Insert plannable entries into plan_index now that precomputed[] is built.
-    {
-        ZoneScopedN( "monmove_build_plan_index" );
-        plan_index.reserve( plannable.size() );
-        for( const auto index : std::views::iota( size_t{ 0 }, plannable.size() ) ) {
-            plan_index[plannable[index]] = static_cast<int>( index );
-        }
-    }
     // -----------------------------------------------------------------------
 
     const auto player_pos = u.bub_pos();
@@ -6234,6 +6165,53 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     // Compare against "LOD Tier 0 (Full AI)" to verify the budget floor is safe.
     TracyPlot( "LOD Eligible (post-cap)", static_cast<int64_t>( eligible.size() ) );
 
+    {
+        ZoneScopedN( "monmove_build_plannable" );
+        plannable.reserve( eligible.size() );
+        for( const auto &entry : eligible ) {
+            auto *critter = entry.second;
+            if( critter != nullptr &&
+                !critter->is_dead() &&
+                !activity_ai_paused->contains( critter ) &&
+                !critter->has_effect( effect_ai_controlled ) &&
+                !critter->has_effect( effect_ridden ) &&
+                critter->moves > 0 &&
+                critter->next_turn <= current_turn &&
+                critter->lod_tier < 2 &&
+                critter->is_simulated() ) {
+                plannable.push_back( critter );
+            }
+        }
+    }
+
+    // parallel_for_chunked with a small chunk size gives the pool a queue of
+    // fine-grained tasks.  Workers that finish a cheap monster immediately pull
+    // the next chunk rather than sitting idle behind a costly monster.
+    std::vector<monster_plan_t> precomputed( plannable.size() );
+    {
+        ZoneScopedN( "monmove_compute_plans" );
+        if( parallel_enabled && parallel_monster_planning ) {
+            ZoneScopedN( "monmove_compute_plans_parallel" );
+            parallel_for_chunked( 0, static_cast<int>( plannable.size() ),
+            monster_plan_chunk_size, [&]( int i ) {
+                precomputed[i] = plannable[i]->compute_plan( plan_ctx );
+            } );
+        } else {
+            ZoneScopedN( "monmove_compute_plans_serial" );
+            for( const auto index : std::views::iota( size_t{ 0 }, plannable.size() ) ) {
+                precomputed[index] = plannable[index]->compute_plan( plan_ctx );
+            }
+        }
+    }
+
+    {
+        ZoneScopedN( "monmove_build_plan_index" );
+        plan_index.reserve( plannable.size() );
+        for( const auto index : std::views::iota( size_t{ 0 }, plannable.size() ) ) {
+            plan_index[plannable[index]] = static_cast<int>( index );
+        }
+    }
+
     // LOD-D: execute each eligible monster's turn.
     // Bio-alarm helper — called after each monster finishes its move loop.
     // static const: string_id hash lookup happens once, not every turn.
@@ -6301,6 +6279,37 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     auto monmove_fallback_plans = int64_t{ 0 };
     auto monmove_serial_replans = int64_t{ 0 };
     auto monmove_controlled_moves = int64_t{ 0 };
+    auto monmove_action_repath_requests = int64_t{ 0 };
+    auto monmove_action_route_candidates = int64_t{ 0 };
+    auto monmove_action_idle = int64_t{ 0 };
+    auto monmove_action_move = int64_t{ 0 };
+    auto monmove_action_attack = int64_t{ 0 };
+    auto monmove_action_other = int64_t{ 0 };
+    const auto record_monmove_action = [&]( const monster & critter,
+    const monster_action_t & action ) {
+        if( action.needs_repath ) {
+            ++monmove_action_repath_requests;
+            if( action.kind == monster_action_kind::idle ) {
+                ++monmove_action_route_candidates;
+            }
+        }
+        switch( action.kind ) {
+            case monster_action_kind::idle:
+            case monster_action_kind::stumble:
+            case monster_action_kind::die:
+                ++monmove_action_idle;
+                break;
+            case monster_action_kind::move:
+                ++monmove_action_move;
+                break;
+            case monster_action_kind::attack:
+                ++monmove_action_attack;
+                break;
+            default:
+                ++monmove_action_other;
+                break;
+        }
+    };
     {
         ZoneScopedN( "monmove_execute_eligible" );
         for( const auto &entry : eligible ) {
@@ -6370,6 +6379,7 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
                         return critter.decide_action();
                     }
                     ();
+                    record_monmove_action( critter, action );
                     {
                         ZoneScopedN( "monmove_execute_action" );
                         critter.execute_action( action );
@@ -6404,6 +6414,12 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     TracyPlot( "Monmove Fallback Plans", monmove_fallback_plans );
     TracyPlot( "Monmove Serial Replans", monmove_serial_replans );
     TracyPlot( "Monmove Controlled Moves", monmove_controlled_moves );
+    TracyPlot( "Monmove Action Repath Requests", monmove_action_repath_requests );
+    TracyPlot( "Monmove Action Route Candidates", monmove_action_route_candidates );
+    TracyPlot( "Monmove Action Idle", monmove_action_idle );
+    TracyPlot( "Monmove Action Move", monmove_action_move );
+    TracyPlot( "Monmove Action Attack", monmove_action_attack );
+    TracyPlot( "Monmove Action Other", monmove_action_other );
 
     if( activity_skip_ai ) {
         ZoneScopedN( "monmove_activity_restore_lod" );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2031,6 +2031,7 @@ bool game::do_turn()
     {
         ZoneScopedN( "do_turn_pre_action_updates" );
         perhaps_add_random_npc();
+        refresh_player_visibility_cache_if_needed();
         process_voluntary_act_interrupt();
         process_activity();
         update_performance_bubble();
@@ -4546,11 +4547,14 @@ void game::draw( ui_adaptor &ui )
         }
         const auto cache_z = is_looking ? u.bub_pos().z() : ter_view_p.z();
         m.build_map_cache( cache_z );
+#if defined( CATA_SDL )
+        const auto player_map_cache_current = m.has_zlevels() || cache_z == u.bub_pos().z();
+        refresh_player_visibility_cache_if_needed( player_map_cache_current );
+#else
         if( m.get_cache_ref( cache_z ).visibility_cache_dirty ) {
-            if( !is_draw_tiles_mode() ) {
-                m.update_visibility_cache( cache_z );
-            }
+            m.update_visibility_cache( cache_z );
         }
+#endif
     }
 
     werase( w_terrain );
@@ -4708,6 +4712,38 @@ void game::draw_ter( const bool draw_sounds )
 auto game::visibility_cache_z() -> int
 {
     return is_looking ? u.bub_pos().z() : ter_view_p.z();
+}
+
+auto game::refresh_player_visibility_cache_if_needed( const bool player_map_cache_current ) -> void
+{
+#if defined( CATA_SDL )
+    ZoneScopedN( "refresh_player_visibility_cache_if_needed" );
+
+    const auto zlev = u.bub_pos().z();
+    const auto minz = m.has_zlevels() ? -OVERMAP_DEPTH : zlev;
+    const auto maxz = m.has_zlevels() ? OVERMAP_HEIGHT : zlev;
+    const auto needs_visibility_refresh = [&]() {
+        if( !m.get_visibility_variables_cache().variables_set ) {
+            return true;
+        }
+        return std::ranges::any_of( std::views::iota( minz, maxz + 1 ), [this]( const int z ) {
+            return m.get_cache_ref( z ).visibility_cache_dirty;
+        } );
+    };
+
+    if( !needs_visibility_refresh() ) {
+        return;
+    }
+
+    if( !player_map_cache_current ) {
+        m.build_map_cache( zlev );
+    }
+    if( needs_visibility_refresh() ) {
+        m.update_visibility_cache( zlev );
+    }
+#else
+    ( void )player_map_cache_current;
+#endif
 }
 
 void game::draw_ter( const tripoint_bub_ms &center, const bool looking, const bool draw_sounds )
@@ -5215,6 +5251,8 @@ void game::mon_info( const catacurses::window &w, int hor_padding )
 void game::mon_info_update( )
 {
     ZoneScoped;
+
+    refresh_player_visibility_cache_if_needed();
 
     int newseen = 0;
     const auto iProxyDist = ( safe_mode_proximity <= 0 ) ? g_max_view_distance : safe_mode_proximity;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5798,7 +5798,7 @@ void game::world_tick()
 
 static auto turn_los_blocker_key( const tripoint_bub_ms &from,
                                   const tripoint_bub_ms &to ) ->
-                                  std::pair<tripoint_bub_ms, tripoint_bub_ms>
+std::pair<tripoint_bub_ms, tripoint_bub_ms>
 {
     return from < to ? std::make_pair( from, to ) : std::make_pair( to, from );
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5829,7 +5829,7 @@ auto game::terrain_los_blocks_sight_between( const tripoint_bub_ms &from,
     }
 }
 
-auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache *cache ) -> void
+void game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache *cache )
 {
     ZoneScopedN( "game::monmove" );
     const auto activity_skip_ai = mode == monster_activity_ai_mode::activity_skip &&
@@ -5850,7 +5850,8 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     }
 
     auto use_activity_cache = cache != nullptr && cache->valid &&
-                              cache->monster_count == static_cast<int>( critter_tracker->size() );
+                              cache->monster_count == static_cast<int>(
+                              critter_tracker->size() );
     if( cache != nullptr && cache->valid && !use_activity_cache ) {
         cache->valid = false;
     }
@@ -5972,7 +5973,8 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
             if( activity_ai_paused->contains( critter ) ) {
                 continue;
             }
-            critter->lod_tier = static_cast<int8_t>( std::min<int>( 2, real_lod_tier + 1 ) );
+            critter->lod_tier = static_cast<int8_t>(
+                                std::min<int>( 2, real_lod_tier + 1 ) );
         }
         TracyPlot( "Activity Skip Monster AI Paused",
                    static_cast<int64_t>( activity_ai_paused->size() ) );
@@ -6064,8 +6066,9 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
             // Critters in impassable tiles get pushed away, unless it's not impassable for them
             if( !critter.is_dead() && m.impassable( critter.bub_pos() ) &&
                 !critter.can_move_to( critter.bub_pos() ) ) {
-                std::string msg = string_format( "%s can't move to its location!  %s  %s", critter.name(),
-                                                 critter.bub_pos().to_string(), m.tername( critter.bub_pos() ) );
+                std::string msg = string_format( "%s can't move to its location! %s %s", critter.name(),
+                                                 critter.bub_pos().to_string(),
+                                                 m.tername( critter.bub_pos() ) );
                 dbg( DL::Error ) << msg;
                 add_msg( m_debug, msg );
                 bool okay = false;
@@ -6131,7 +6134,8 @@ auto game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
                 if( !critter->is_dead() &&
                     !activity_ai_paused->contains( critter ) &&
                     critter->is_simulated() ) {
-                    eligible_order.emplace_back( rl_dist( critter->bub_pos(), player_pos ), critter );
+                    eligible_order.emplace_back( rl_dist(
+                        critter->bub_pos(), player_pos ), critter );
                 }
             }
             std::ranges::sort( eligible_order );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -16945,7 +16945,7 @@ void avatar_moves( const avatar &u, const map &m, const tripoint_abs_ms &pos )
         mount_type = u.mounted_creature->type->id;
     }
     const auto terrain = MAPBUFFER_REGISTRY.get( m.get_bound_dimension() ).get_ter( pos,
-                         { .mode = mapbuffer_lookup_mode::resident_only } ).value_or( t_null );
+    { .mode = mapbuffer_lookup_mode::resident_only } ).value_or( t_null );
     g->events().send<event_type::avatar_moves>( mount_type, terrain, u.get_movement_mode(),
             u.is_underwater(), pos.z() );
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -974,14 +974,15 @@ bool game::start_game()
     // The player is centered in the map, but lev[xyz] refers to the top left point of the map
     lev.x() -= g_half_mapsize;
     lev.y() -= g_half_mapsize;
-    u.setpos( project_to<coords::ms>( lev + tripoint_rel_sm( g_half_mapsize, g_half_mapsize, 0 ) ) );
+    const auto starting_player_pos = project_to<coords::ms>(
+                                         lev + tripoint_rel_sm( g_half_mapsize, g_half_mapsize, 0 ) );
     load_map( lev, /*pump_events=*/true );
+    u.setpos( starting_player_pos );
 
     m.invalidate_map_cache( get_levz() );
     m.build_map_cache( get_levz() );
     // Do this after the map cache has been built!
     start_loc.place_player( u );
-    update_map( u );
     // ...but then rebuild it, because we want visibility cache to avoid spawning monsters in sight
     m.invalidate_map_cache( get_levz() );
     m.build_map_cache( get_levz() );
@@ -1128,8 +1129,6 @@ bool game::start_game()
     for( auto &e : u.inv_dump() ) {
         e->set_owner( g->u );
     }
-    // Now that we're done handling coordinates, ensure the player's submap is in the center of the map
-    update_map( u );
     // Profession pets
     for( const mtype_id &elem : u.starting_pets ) {
         if( monster *const mon = place_critter_around( elem, u.bub_pos(), g_max_view_distance ) ) {
@@ -8857,13 +8856,11 @@ void game::peek( const tripoint_rel_ms &p )
     const auto peek_pos = prev + p;
     auto restore_player_pos = [&]() {
         u.setpos( prev );
-        update_map( u );
         m.invalidate_map_cache( get_levz() );
     };
     auto restore_on_return = on_out_of_scope( restore_player_pos );
 
     u.setpos( peek_pos );
-    update_map( u );
     // Force a full cache rebuild from the peek position so look_around renders
     // correct FOV and lighting.  Without this, lightmap_dirty may already be
     // false (built from the pre-peek player position earlier this turn), causing
@@ -12977,11 +12974,10 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     }
 
     auto oldpos = u.bub_pos();
-    const auto keep_grab = u.get_grab_type() == OBJECT_VEHICLE || allow_furniture_z_move;
     auto submap_shift = point_rel_sm::zero();
     {
         ZoneScopedN( "walk_move_place_player" );
-        submap_shift = place_player( dest_loc, keep_grab );
+        submap_shift = place_player( dest_loc );
     }
     auto ms_shift = project_to<coords::ms>( submap_shift );
     oldpos = oldpos - ms_shift;
@@ -13008,7 +13004,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     return true;
 }
 
-auto game::place_player( const tripoint_bub_ms &dest_loc, const bool keep_grab ) -> point_rel_sm
+auto game::place_player( const tripoint_bub_ms &dest_loc ) -> point_rel_sm
 {
     const auto regular_pit_move = pit_trap_helpers::is_regular_pit_destination_from_pit( m.tr_at(
                                       u.bub_pos() ),
@@ -13134,17 +13130,12 @@ auto game::place_player( const tripoint_bub_ms &dest_loc, const bool keep_grab )
     if( u.in_vehicle ) {
         m.unboard_vehicle( u.bub_pos() );
     }
-    // Move the player
-    // Start with z-level, to make it less likely that old functions (2D ones) freak out
-    if( m.has_zlevels() && dest_loc.z() != get_levz() ) {
-        vertical_shift( dest_loc.z(), keep_grab );
-    }
-
     if( u.is_hauling() && ( !m.can_put_items( dest_loc ) ||
                             m.has_flag( TFLAG_DEEP_WATER, dest_loc ) ||
                             vp1 ) ) {
         u.stop_hauling();
     }
+    const auto origin_before_setpos = m.get_abs_sub();
     u.setpos( dest_loc );
     m.invalidate_visibility_caches();
     if( u.is_mounted() ) {
@@ -13153,15 +13144,7 @@ auto game::place_player( const tripoint_bub_ms &dest_loc, const bool keep_grab )
         mon->process_triggers();
         m.creature_in_field( *mon );
     }
-    auto submap_shift = point_rel_sm::zero();
-    {
-        ZoneScopedN( "place_player_update_map" );
-        submap_shift = update_map( u );
-    }
-    // Important: don't use dest_loc after this line. `update_map` may have shifted the map
-    // and dest_loc was not adjusted and therefore is still in the un-shifted system and probably wrong.
-    // If you must use it you can calculate the position in the new, shifted system with
-    // adjusted_pos = ( old_pos.x - submap_shift.x * SEEX, old_pos.y - submap_shift.y * SEEY, old_pos.z )
+    const auto submap_shift = ( m.get_abs_sub() - origin_before_setpos ).xy();
 
     //Auto pulp or butcher and Auto foraging
     if( get_option<bool>( "AUTO_FEATURES" ) && mostseen == 0  && !u.is_mounted() ) {
@@ -13456,7 +13439,6 @@ bool game::phasing_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
         //tunneling costs 100 moves baseline, 50 per extra tile up to a cap of 500 moves
         u.moves -= ( 50 + ( tunneldist * 50 ) );
         u.setpos( dest );
-        update_map( u );
         m.invalidate_visibility_caches();
 
         if( m.veh_at( u.bub_pos() ).part_with_feature( "BOARDABLE", true ) ) {
@@ -14197,12 +14179,7 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
                 if( p->in_vehicle ) {
                     m.unboard_vehicle( p->bub_pos() );
                 }
-                // If we're flinging the player around, make sure the map stays centered on them.
-                if( is_u ) {
-                    update_map( pt.x(), pt.y() );
-                } else {
-                    p->setpos( pt );
-                }
+                p->setpos( pt );
             } else if( !critter_at( pt ) ) {
                 // Dying monster doesn't always leave an empty tile (blob spawning etc.)
                 // Just don't setpos if it happens - next iteration will do so
@@ -14759,11 +14736,9 @@ void game::vertical_move( int movez, bool force, bool peeking )
     }
 
     const auto old_pos = g->u.bub_pos();
-    point_rel_sm submap_shift;
-    vertical_shift( z_after );
-    if( !force ) {
-        submap_shift = update_map( stairs.x(), stairs.y() );
-    }
+    const auto origin_before_setpos = m.get_abs_sub();
+    u.setpos( map_local_to_abs( m, stairs ) );
+    const auto submap_shift = ( m.get_abs_sub() - origin_before_setpos ).xy();
 
     // if an NPC or monster is on the stiars when player ascends/descends
     // they may end up merged on th esame tile, do some displacement to resolve that.
@@ -15121,9 +15096,10 @@ auto game::travel_to_dimension( const dimension_id &dim_id,
         // Loading at the destination avoids a costly incremental map shift in update_map()
         // when the destination is far from the current position.
         const auto target_load_origin = load_pos.value_or( current_abs_sm );
-        player.setpos( project_to<coords::ms>( target_load_origin + tripoint_rel_sm( g_half_mapsize,
-                                               g_half_mapsize, 0 ) ) );
+        const auto target_player_pos = project_to<coords::ms>(
+                                           target_load_origin + tripoint_rel_sm( g_half_mapsize, g_half_mapsize, 0 ) );
         load_map( target_load_origin, false );
+        player.setpos( target_player_pos );
         debug_assert_player_map_origin( "travel_to_dimension" );
 
         add_msg( m_debug, "[DIM] Loaded new dimension '%s' map", dim_id );
@@ -15367,7 +15343,7 @@ std::optional<tripoint_bub_ms> game::find_or_make_stairs( map &mp, const int z_a
     return stairs;
 }
 
-auto game::vertical_shift( const int z_after, const bool keep_grab ) -> void
+auto game::vertical_shift( const int z_after ) -> void
 {
     if( z_after < -OVERMAP_DEPTH || z_after > OVERMAP_HEIGHT ) {
         debugmsg( "Tried to get z-level %d outside allowed range of %d-%d",
@@ -15375,15 +15351,15 @@ auto game::vertical_shift( const int z_after, const bool keep_grab ) -> void
         return;
     }
 
-    if( !keep_grab ) {
-        u.grab( OBJECT_NONE );
+    const auto z_before = m.get_abs_sub().z();
+    if( z_before == z_after ) {
+        return;
     }
 
     scent.reset();
 
-    const int z_before = get_levz();
-    u.setpos( tripoint_bub_ms( u.bub_pos().xy(), z_after ) );
     if( !m.has_zlevels() ) {
+        const auto loaded_origin = m.get_abs_sub();
         m.clear_vehicle_cache( );
         m.access_cache( z_before ).vehicle_list.clear();
         m.access_cache( z_before ).zone_vehicles.clear();
@@ -15391,7 +15367,7 @@ auto game::vertical_shift( const int z_after, const bool keep_grab ) -> void
         m.set_transparency_cache_dirty( z_before );
         m.set_outside_cache_dirty( z_before );
         m.set_absorption_cache_dirty( z_before );
-        m.load( tripoint_abs_sm( get_levx(), get_levy(), z_after ), true );
+        m.load( tripoint_abs_sm( loaded_origin.xy(), z_after ), true );
         shift_monsters( tripoint_rel_sm( 0, 0, z_after - z_before ) );
         reload_npcs();
     } else {
@@ -15407,6 +15383,7 @@ auto game::vertical_shift( const int z_after, const bool keep_grab ) -> void
     // the critter is unloaded/loaded, and it needs to reconstruct its rider data after being reloaded.
     validate_mounted_npcs();
     vertical_notes( z_before, z_after );
+    update_overmap_seen();
 }
 
 void game::vertical_notes( int z_before, int z_after )
@@ -15451,49 +15428,28 @@ void game::vertical_notes( int z_before, int z_after )
     }
 }
 
-point_rel_sm game::update_map( Character &who )
+auto game::update_map( Character &who ) -> point_rel_sm
 {
-    const auto map_local_pos = abs_to_map_local( m, who.abs_pos() );
-    int x = map_local_pos.x();
-    int y = map_local_pos.y();
-    return update_map( x, y );
+    return update_map( who.abs_pos() );
 }
 
-point_rel_sm game::update_map( int &x, int &y )
+auto game::update_map( int &x, int &y ) -> point_rel_sm
+{
+    const auto target_abs = map_local_to_abs( m, tripoint_bub_ms( x, y, get_levz() ) );
+    return update_map( target_abs );
+}
+
+auto game::update_map( const tripoint_abs_ms &center ) -> point_rel_sm
 {
     ZoneScopedN( "update_map" );
-    const auto target_abs = map_local_to_abs( m, tripoint_bub_ms( x, y, get_levz() ) );
-    point_rel_sm shift;
-
-    {
-        ZoneScopedN( "update_map_compute_shift" );
-        while( x < g_half_mapsize_x ) {
-            x += SEEX;
-            shift.x()--;
-        }
-        while( x >= g_half_mapsize_x + SEEX ) {
-            x -= SEEX;
-            shift.x()++;
-        }
-        while( y < g_half_mapsize_y ) {
-            y += SEEY;
-            shift.y()--;
-        }
-        while( y >= g_half_mapsize_y + SEEY ) {
-            y -= SEEY;
-            shift.y()++;
-        }
-    }
+    const auto target_origin = reality_bubble_origin_from_player( center, g_reality_bubble_size );
+    const auto shift = ( target_origin - m.get_abs_sub() ).xy();
 
     if( shift == point_rel_sm::zero() ) {
-        // adjust player position
-        u.setpos( target_abs );
         // Update what parts of the world map we can see
         // We need this call because even if the map hasn't shifted we may have changed z-level and can now see farther
         // TODO: only make this call if we changed z-level
         update_overmap_seen();
-        // update_map() can run during a pending vertical vehicle transition;
-        // vertical_shift() settles the loaded-grid z anchor afterward.
         debug_assert_player_map_origin( "update_map", false );
         // Not actually shifting the submaps, all the stuff below would do nothing
         return point_rel_sm::zero();
@@ -15511,8 +15467,6 @@ point_rel_sm game::update_map( int &x, int &y )
             remaining_shift -= this_shift;
         }
     }
-
-    u.setpos( target_abs );
 
     // Keep the reality bubble request center in sync with the shifted map.
     // Distribution-grid tracker updates are fully incremental via
@@ -15608,8 +15562,8 @@ point_rel_sm game::update_map( int &x, int &y )
 
     // Update what parts of the world map we can see
     update_overmap_seen();
-    // update_map() is an x/y recentering path; vertical movement settles in
-    // vertical_shift().
+    // update_map() only shifts the loaded x/y window; vertical loaded-state
+    // changes are handled by vertical_shift().
     debug_assert_player_map_origin( "update_map", false );
 
     return shift;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5798,7 +5798,7 @@ void game::world_tick()
 
 static auto turn_los_blocker_key( const tripoint_bub_ms &from,
                                   const tripoint_bub_ms &to )
-    -> std::pair<tripoint_bub_ms, tripoint_bub_ms>
+- > std::pair<tripoint_bub_ms, tripoint_bub_ms>
 {
     return from < to ? std::make_pair( from, to ) : std::make_pair( to, from );
 }
@@ -5851,7 +5851,7 @@ void game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
 
     auto use_activity_cache = cache != nullptr && cache->valid &&
                               cache->monster_count == static_cast<int>(
-                              critter_tracker->size() );
+                                  critter_tracker->size() );
     if( cache != nullptr && cache->valid && !use_activity_cache ) {
         cache->valid = false;
     }
@@ -5974,7 +5974,7 @@ void game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
                 continue;
             }
             critter->lod_tier = static_cast<int8_t>(
-                                std::min<int>( 2, real_lod_tier + 1 ) );
+                                    std::min<int>( 2, real_lod_tier + 1 ) );
         }
         TracyPlot( "Activity Skip Monster AI Paused",
                    static_cast<int64_t>( activity_ai_paused->size() ) );
@@ -6135,7 +6135,7 @@ void game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
                     !activity_ai_paused->contains( critter ) &&
                     critter->is_simulated() ) {
                     eligible_order.emplace_back( rl_dist(
-                        critter->bub_pos(), player_pos ), critter );
+                                                     critter->bub_pos(), player_pos ), critter );
                 }
             }
             std::ranges::sort( eligible_order );
@@ -6328,7 +6328,7 @@ void game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
     auto monmove_action_attack = int64_t{ 0 };
     auto monmove_action_other = int64_t{ 0 };
     const auto record_monmove_action = [&]( const monster & critter,
-    const monster_action_t & action ) {
+    const monster_action_t &action ) {
         if( action.needs_repath ) {
             ++monmove_action_repath_requests;
             if( action.kind == monster_action_kind::idle ) {

--- a/src/game.h
+++ b/src/game.h
@@ -968,6 +968,7 @@ class game : public submap_load_listener
         std::vector<std::string> get_dangerous_tile( const tripoint_bub_ms &dest_loc ) const;
         bool prompt_dangerous_tile( const tripoint_bub_ms &dest_loc ) const;
     private:
+        auto refresh_player_visibility_cache_if_needed( bool player_map_cache_current = false ) -> void;
         void chat(); // Talk to a nearby NPC  'C'
 
         // Internal methods to show "look around" info

--- a/src/game.h
+++ b/src/game.h
@@ -231,6 +231,7 @@ class game : public submap_load_listener
         void draw_ter( bool draw_sounds = true );
         void draw_ter( const tripoint_bub_ms &center, bool looking = false, bool draw_sounds = true );
         auto visibility_cache_z() -> int;
+        auto refresh_player_visibility_cache_if_needed( bool player_map_cache_current = false ) -> void;
 
         class draw_callback_t
         {
@@ -968,7 +969,6 @@ class game : public submap_load_listener
         std::vector<std::string> get_dangerous_tile( const tripoint_bub_ms &dest_loc ) const;
         bool prompt_dangerous_tile( const tripoint_bub_ms &dest_loc ) const;
     private:
-        auto refresh_player_visibility_cache_if_needed( bool player_map_cache_current = false ) -> void;
         void chat(); // Talk to a nearby NPC  'C'
 
         // Internal methods to show "look around" info

--- a/src/game.h
+++ b/src/game.h
@@ -324,7 +324,7 @@ class game : public submap_load_listener
         std::optional<tripoint_bub_ms> find_or_make_stairs( map &mp, int z_after, bool &rope_ladder,
                 bool peeking );
         /** Actual z-level movement part of vertical_move. Doesn't include stair finding, traps etc. */
-        auto vertical_shift( int z_after, bool keep_grab = false ) -> void;
+        auto vertical_shift( int z_after ) -> void;
         /** Add goes up/down auto_notes (if turned on) */
         void vertical_notes( int z_before, int z_after );
         /** Checks to see if a player can use a computer (not illiterate, etc.) and uses if able. */
@@ -665,10 +665,10 @@ class game : public submap_load_listener
         character_id assign_npc_id();
         Creature *is_hostile_nearby();
         Creature *is_hostile_very_close();
-        // Handles shifting coordinates transparently when moving between submaps.
-        // Helper to make calling with a player pointer less verbose.
-        point_rel_sm update_map( Character &who );
-        point_rel_sm update_map( int &x, int &y );
+        // Keeps the loaded map window aligned with an absolute center.
+        auto update_map( Character &who ) -> point_rel_sm;
+        auto update_map( const tripoint_abs_ms &center ) -> point_rel_sm;
+        auto update_map( int &x, int &y ) -> point_rel_sm;
         void update_overmap_seen(); // Update which overmap tiles we can see
 
         void process_artifact( item &it, Character &who );
@@ -951,7 +951,7 @@ class game : public submap_load_listener
         void butcher(); // Butcher a corpse  'B'
     public:
         // Places the player at the specified point; hurts feet, lists items etc.
-        auto place_player( const tripoint_bub_ms &dest, bool keep_grab = false ) -> point_rel_sm;
+        auto place_player( const tripoint_bub_ms &dest ) -> point_rel_sm;
         void place_player_overmap( const tripoint_abs_omt &om_dest );
 
         unsigned int get_seed() const;

--- a/src/game.h
+++ b/src/game.h
@@ -1196,25 +1196,27 @@ class game : public submap_load_listener
 
         int mostseen = 0; // # of mons seen last turn; if this increases, set safe_mode to SAFE_MODE_STOP
 
-        // P-8: per-turn Creature::sees() result cache used during parallel monster
-        // planning (monmove()).  Keyed on directional (seer, target) Creature pointer
-        // pairs; Creature::sees() includes observer and target perception rules, while
-        // map::sees() remains the symmetric LOS cache.  Cleared at the start of
-        // monmove() before the parallel phase begins.  Workers hold a shared_lock for
-        // hits and upgrade to unique_lock on a miss.
-        // Lives in the public section so turn_cached_sees() in monmove.cpp can
-        // access it directly without an additional indirection layer.
-        struct TurnSightPairHash {
-            size_t operator()( const std::pair<const Creature *, const Creature *> &p ) const noexcept {
-                size_t h1 = std::hash<const Creature *> {}( p.first );
-                size_t h2 = std::hash<const Creature *> {}( p.second );
-                return h1 ^ ( h2 * 2654435761ULL );
+        auto clear_turn_los_blocker_cache() -> void;
+        // True means terrain LOS is blocked between these two positions.
+        // The key is canonicalized, so a check from either end warms both directions.
+        // It is not a creature visibility or perception result.
+        auto terrain_los_blocks_sight_between( const tripoint_bub_ms &from,
+                                               const tripoint_bub_ms &to ) -> bool;
+    private:
+        struct TurnLosBlockerPairHash {
+            auto operator()( const std::pair<tripoint_bub_ms, tripoint_bub_ms> &p ) const noexcept
+            -> std::size_t {
+                const auto first_hash = std::hash<tripoint_bub_ms> {}( p.first );
+                const auto second_hash = std::hash<tripoint_bub_ms> {}( p.second );
+                return first_hash ^ ( second_hash * 2654435761ULL );
             }
         };
-        std::unordered_map<std::pair<const Creature *, const Creature *>, bool, TurnSightPairHash>
-        turn_sight_cache_;
-        std::shared_mutex turn_sight_cache_mutex_;
-    private:
+        using turn_los_blocker_cache_t =
+            std::unordered_map<std::pair<tripoint_bub_ms, tripoint_bub_ms>, bool,
+            TurnLosBlockerPairHash>;
+        turn_los_blocker_cache_t turn_los_blocker_cache_;
+        std::shared_mutex turn_los_blocker_cache_mutex_;
+
         shared_ptr_fast<player> u_shared_ptr;
 
         catacurses::window w_terrain_ptr;

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -301,7 +301,7 @@ void defense_game::init_map()
     player_character.setpos( tripoint_bub_ms( SEEX, SEEY, z ) );
 
     monster *const generator = g->place_critter_around(
-                               mtype_id( "mon_generator" ), g->u.bub_pos(), 2 );
+                                   mtype_id( "mon_generator" ), g->u.bub_pos(), 2 );
     assert( generator );
     generator->friendly = -1;
 }

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -300,9 +300,8 @@ void defense_game::init_map()
     const int z = player_character.bub_pos().z();
     player_character.setpos( tripoint_bub_ms( SEEX, SEEY, z ) );
 
-    g->update_map( g-> u );
-    monster *const generator = g->place_critter_around( mtype_id( "mon_generator" ), g->u.bub_pos(),
-                               2 );
+    monster *const generator = g->place_critter_around(
+                               mtype_id( "mon_generator" ), g->u.bub_pos(), 2 );
     assert( generator );
     generator->friendly = -1;
 }

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -151,9 +151,6 @@ bool tutorial_game::init()
     g->load_map( project_to<coords::sm>( lp_abs ) );
     const auto z = you.bub_pos().z();
     you.setpos( tripoint_bub_ms( 2, 4, z ) );
-
-    // This shifts the view to center the players pos
-    g->update_map( you );
     return true;
 }
 

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -223,16 +223,14 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 
         grabbed_vehicle->adjust_zlevel( 1, actual_dir );
 
-        // Put the player on an invalid z-level so they can't collide with the
-        // grabbed vehicle. Moving to an arbitrary x/y no longer hides the avatar
-        // now that player bubble space is derived from avatar position.
-        const auto player_prev = u.abs_pos();
-        auto player_hidden = player_prev;
-        player_hidden.z() = OVERMAP_HEIGHT + 1;
-        u.setpos( player_hidden );
         std::vector<veh_collision> colls;
-        const bool failed = grabbed_vehicle->collision( colls, actual_dir, true );
-        u.setpos( player_prev );
+        const bool failed = grabbed_vehicle->collision( vehicle_collision_options{
+            .colls = colls,
+            .dp = actual_dir,
+            .just_detect = true,
+            .bash_floor = false,
+            .ignored_critter = &u,
+        } );
         if( !colls.empty() ) {
             blocker_name = colls.front().target_name;
         }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1378,9 +1378,6 @@ void iexamine::chainfence( player &p, const tripoint_bub_ms &examp )
         here.unboard_vehicle( p.bub_pos() );
     }
     p.setpos( examp );
-    if( p.is_player() ) {
-        g->update_map( p );
-    }
 }
 
 /**
@@ -1409,9 +1406,6 @@ void iexamine::bars( player &p, const tripoint_bub_ms &examp )
     p.moves -= to_turns<int>( 2_seconds );
     add_msg( _( "You slide right between the bars." ) );
     p.setpos( examp );
-    if( p.is_player() ) {
-        g->update_map( p );
-    }
 }
 
 void iexamine::deployed_furniture( player &p, const tripoint_bub_ms &pos )
@@ -5597,8 +5591,10 @@ void iexamine::pay_gas( player &p, const tripoint_bub_ms &examp )
     }
 }
 
-void iexamine::ledge( player &p, const tripoint_bub_ms &examp )
+void iexamine::ledge( player &p, const tripoint_bub_ms &examp_bub )
 {
+    const auto examp = bub_to_abs( examp_bub );
+    const auto dir = ( examp - p.abs_pos() ).xy();
     enum ledge_action : int { jump_over, climb_down, pull_up_rope, spin_web_bridge };
     if( p.in_vehicle ) {
         if( !character_funcs::can_fly( p ) &&
@@ -5607,19 +5603,25 @@ void iexamine::ledge( player &p, const tripoint_bub_ms &examp )
         }
         get_map().unboard_vehicle( p.bub_pos() );
     }
-    if( get_map().ter( p.bub_pos() ).id().str() == "t_open_air" && !character_funcs::can_fly( p ) ) {
-        auto where = p.bub_pos();
-        auto below = where;
-        below.z()--;
+    auto &buffer = p.get_mapbuffer();
+    const auto player_terrain = buffer.get_ter( p.abs_pos() );
+    if( player_terrain && player_terrain->obj().id.str() == "t_open_air" &&
+        !character_funcs::can_fly( p ) ) {
+        auto where = p.abs_pos();
+        auto below = where + tripoint_rel_ms::below();
 
         // Keep going down until we find a tile that is NOT open air
-        while( get_map().ter( below ).id().str() == "t_open_air" &&
-               get_map().valid_move( where, below, false, true ) ) {
-            where.z()--;
-            below.z()--;
+        while( true ) {
+            const auto below_terrain = buffer.get_ter( below );
+            if( !below_terrain || below_terrain->obj().id.str() != "t_open_air" ||
+                !buffer.valid_move( where, below, { .flying = true, .zlevels = get_map().has_zlevels() } ) ) {
+                break;
+            }
+            where += tripoint_rel_ms::below();
+            below += tripoint_rel_ms::below();
         }
         // where now represents the first NON-open-air tile or the last valid move before hitting one
-        const int height = p.bub_pos().z() - below.z();
+        const int height = p.abs_pos().z() - below.z();
 
         if( height > 0 ) {
             g->vertical_move( -height, true );  // fall onto the solid tile
@@ -5634,32 +5636,30 @@ void iexamine::ledge( player &p, const tripoint_bub_ms &examp )
     //if the tile below has a grappling hook, you can pull it up
     auto below_rope = examp;
     below_rope.z()--;
-    if( get_map().has_flag_furn( "REMOVE_FROM_ABOVE", below_rope ) ) {
+    if( buffer.has_flag_furn( "REMOVE_FROM_ABOVE", below_rope ) ) {
         cmenu.addentry( ledge_action::pull_up_rope, true, 'r', _( "Pull up the %s." ),
-                        get_map().furn( below_rope ).obj().name() );
+                        buffer.get_furn( below_rope )->obj().name() );
     }
     if( p.has_trait( trait_WEB_BRIDGE ) ) {
         cmenu.addentry( ledge_action::spin_web_bridge, true, 'w', _( "Spin Web Bridge." ) );
     }
 
     cmenu.query();
-
-    map &here = get_map();
     switch( cmenu.ret ) {
         case ledge_action::jump_over: {
-            tripoint_bub_ms dest( p.bub_pos().x() + 2 * sgn( examp.x() - p.bub_pos().x() ),
-                                  p.bub_pos().y() + 2 * sgn( examp.y() - p.bub_pos().y() ),
-                                  p.bub_pos().z() );
+            const auto impulse = dir * 2;
+            const auto dest = p.abs_pos() + impulse;
             if( p.get_str() < 4 ) {
                 add_msg( m_warning, _( "You are too weak to jump over an obstacle." ) );
             } else if( 100 * p.weight_carried() / p.weight_capacity() > 25 ) {
                 add_msg( m_warning, _( "You are too burdened to jump over an obstacle." ) );
-            } else if( !here.valid_move( examp, dest, false, true ) ) {
+            } else if( !buffer.valid_move( examp, dest, { .flying = true } ) ) {
                 add_msg( m_warning, _( "You cannot jump over an obstacle - something is blocking the way." ) );
             } else if( g->critter_at( dest ) ) {
                 add_msg( m_warning, _( "You cannot jump over an obstacle - there is %s blocking the way." ),
                          g->critter_at( dest )->disp_name() );
-            } else if( here.ter( dest ).obj().trap == tr_ledge ) {
+            } else if( const auto dest_terrain = buffer.get_ter( dest );
+                       dest_terrain && dest_terrain->obj().trap == tr_ledge ) {
                 add_msg( m_warning, _( "You are not going to jump over an obstacle only to fall down." ) );
             } else {
                 add_msg( m_info, _( "You jump over an obstacle." ) );
@@ -5669,11 +5669,10 @@ void iexamine::ledge( player &p, const tripoint_bub_ms &examp )
         }
         case ledge_action::climb_down: {
             auto where = examp;
-            auto below = examp;
-            below.z()--;
-            while( here.valid_move( where, below, false, true ) ) {
-                where.z()--;
-                below.z()--;
+            auto below = where + tripoint_rel_ms::below();
+            while( buffer.valid_move( where, below, { .flying = true } ) ) {
+                where += tripoint_rel_ms::below();
+                below += tripoint_rel_ms::below();
             }
 
             const int height = examp.z() - where.z();
@@ -5683,7 +5682,7 @@ void iexamine::ledge( player &p, const tripoint_bub_ms &examp )
             }
 
             const bool has_grapnel = p.has_amount( itype_grapnel, 1 );
-            const auto climb_cost = map_funcs::climbing_cost( here, where, examp );
+            const auto climb_cost = map_funcs::climbing_cost( buffer, where, examp );
             const auto fall_mod = p.fall_damage_mod();
             const std::string query_str = vgettext( "Looks like %d story.  Jump down?",
                                                     "Looks like %d stories.  Jump down?",
@@ -5745,22 +5744,18 @@ void iexamine::ledge( player &p, const tripoint_bub_ms &examp )
 
             p.moves -= to_moves<int>( 1_seconds + 1_seconds * fall_mod );
             p.setpos( examp );
-            if( p.is_player() ) {
-                g->update_map( p );
-            }
 
             if( climb_cost > 0 || rng_float( 0.8, 1.0 ) > fall_mod ) {
                 // One tile of falling less (possibly zero)
                 g->vertical_move( -1, true );
             }
-            here.creature_on_trap( p );
+            buffer.creature_on_trap( p );
             break;
         }
         case ledge_action::pull_up_rope: {
-            map &here = get_map();
             p.add_msg_if_player( m_info, _( "You pull up the %s." ),
-                                 here.furn( below_rope ).obj().name() );
-            take_down_deployed_furniture( below_rope, p.bub_pos() );
+                                 buffer.get_furn( below_rope )->obj().name() );
+            take_down_deployed_furniture( buffer, below_rope, p.abs_pos() );
             break;
         }
         case ledge_action::spin_web_bridge: {
@@ -5773,8 +5768,7 @@ void iexamine::ledge( player &p, const tripoint_bub_ms &examp )
             bool success = false;
             for( int i = 2; i <= range; i++ ) {
                 //break at the first non empty space encountered
-                if( g->m.ter( tripoint_bub_ms( p.bub_pos().x() + i * sgn( examp.x() - p.bub_pos().x() ),
-                                               p.bub_pos().y() + i * sgn( examp.y() - p.bub_pos().y() ), p.bub_pos().z() ) ) != t_open_air ) {
+                if( buffer.get_ter( p.abs_pos() + dir * i ) != t_open_air ) {
                     success_range = i;
                     success = true;
                     break;
@@ -5784,11 +5778,7 @@ void iexamine::ledge( player &p, const tripoint_bub_ms &examp )
                 p.add_msg_if_player( _( "There is nothing for your to attach your web to!" ) );
             } else {
                 for( int i = 1; i < success_range; i++ ) {
-                    tripoint_bub_ms dest( p.bub_pos().x() + i * sgn( examp.x() - p.bub_pos().x() ),
-                                          p.bub_pos().y() + i * sgn( examp.y() - p.bub_pos().y() ),
-                                          p.bub_pos().z() );
-
-                    g->m.ter_set( dest, t_web_bridge );
+                    buffer.set_ter( p.abs_pos() + dir * i, t_web_bridge );
                 }
                 p.mutation_spend_resources( trait_WEB_BRIDGE );
             }
@@ -7923,17 +7913,17 @@ void iexamine::portal( player &p, const tripoint_bub_ms &examp )
     g->travel_to_dimension( pt->target_dim_id, wt_id, std::nullopt, dest_sm );
 
     p.setpos( pt->target_pos );
-    g->update_map( p );
 }
 
 void iexamine::migo_nerve_cluster( player &p, const tripoint_bub_ms &examp )
 {
-    map &here = get_map();
     if( query_yn( _( "This looks important.  Tear open nerve cluster?" ) ) ) {
+        auto &buffer = p.get_mapbuffer();
+        const auto pos = p.abs_pos() + ( examp - p.bub_pos() );
         p.mod_moves( -200 );
         add_msg( _( "You grab hold of a sinewy tendril and wrench it loose!" ) );
-        map_funcs::migo_nerve_cage_removal( here, examp, false );
-        here.furn_set( examp, furn_id( "f_alien_scar" ) );
+        map_funcs::migo_nerve_cage_removal( buffer, pos, false );
+        buffer.set_furn( pos, furn_id( "f_alien_scar" ) );
     }
 }
 

--- a/src/iexamine_elevator.cpp
+++ b/src/iexamine_elevator.cpp
@@ -216,11 +216,10 @@ auto move_vehicles( const elevator_vehicles &vehs, const tripoint_bub_ms &sm_ori
     here.reset_vehicle_cache();
 }
 
-auto move_player( player &p, const int movez, tripoint_abs_ms old_abs_pos ) -> void
+auto move_player( player &p, const int /*movez*/, tripoint_abs_ms old_abs_pos ) -> void
 {
     map &here = get_map();
 
-    g->vertical_shift( movez );
     // yes, this is inefficient, but i'm lazy
     elevator::find_elevators_nearby( p.bub_pos() )
     .transform( []( const tripoint_bub_ms & pos ) -> point_rel_sm { return g->place_player( pos ); } );

--- a/src/iexamine_elevator.cpp
+++ b/src/iexamine_elevator.cpp
@@ -65,7 +65,7 @@ auto dest( const elevator::tiles &elevator_here,
 auto find_elevators_nearby( const tripoint_bub_ms &pos ) -> std::optional<tripoint_bub_ms>
 {
     constexpr int max_misalign = 3;
-    map &here = get_map();
+    auto &here = get_map();
 
     for( const auto &p : closest_points_first( pos, max_misalign ) ) {
         if( here.has_flag( TFLAG_ELEVATOR, p ) ) {
@@ -216,15 +216,15 @@ auto move_vehicles( const elevator_vehicles &vehs, const tripoint_bub_ms &sm_ori
     here.reset_vehicle_cache();
 }
 
-auto move_player( player &p, const int /*movez*/, tripoint_abs_ms old_abs_pos ) -> void
+auto move_player( player &p, const int /*movez*/ ) -> void
 {
-    map &here = get_map();
+    auto &here = get_map();
 
     // yes, this is inefficient, but i'm lazy
     elevator::find_elevators_nearby( p.bub_pos() )
     .transform( []( const tripoint_bub_ms & pos ) -> point_rel_sm { return g->place_player( pos ); } );
 
-    cata_event_dispatch::avatar_moves( *p.as_avatar(), here, old_abs_pos );
+    cata_event_dispatch::avatar_moves( *p.as_avatar(), here, p.abs_pos() );
 }
 
 } //namespace elevator
@@ -246,7 +246,6 @@ void iexamine::elevator( player &p, const tripoint_bub_ms &examp )
         return;
     }
 
-    const auto old_abs_pos = p.abs_pos();
     const auto sm_orig = abs_to_bub( project_to<coords::ms>( this_omt ) );
 
     const auto elevator_here = elevator::here( p );
@@ -274,5 +273,5 @@ void iexamine::elevator( player &p, const tripoint_bub_ms &examp )
     elevator::move_items( elevator_here, elevator_dest );
     elevator::move_creatures( elevator_here, elevator_dest );
     elevator::move_vehicles( vehs, sm_orig, movez, turns );
-    elevator::move_player( p, movez, old_abs_pos );
+    elevator::move_player( p, movez );
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -7518,9 +7518,6 @@ void iuse_pocket_dimension::enter_pocket( player &p, item &it ) const
     }
 
     p.setpos( pd.entry_point );
-
-    // Single update_map call at the final position
-    g->update_map( p );
 }
 
 // ---- iuse_portal_link -------------------------------------------------------
@@ -7604,7 +7601,6 @@ auto iuse_portal_link::use( player &p, item &it, bool, const tripoint_bub_ms & )
                                        g_half_mapsize );
             g->travel_to_dimension( origin_dim, wt_id, std::nullopt, preload_point );
             p.setpos( origin_pos );
-            g->update_map( p );
             it.erase_var( "origin_stored" );
             return charges_per_use;
         }
@@ -7631,7 +7627,6 @@ auto iuse_portal_link::use( player &p, item &it, bool, const tripoint_bub_ms & )
                          tripoint_rel_sm( g_half_mapsize, g_half_mapsize, 0 );
     g->travel_to_dimension( linked_dim, wt_id, std::nullopt, dest_sm );
     p.setpos( linked_pos );
-    g->update_map( p );
     return charges_per_use;
 }
 
@@ -7667,9 +7662,6 @@ void iuse_pocket_dimension::exit_pocket( player &p, item &it ) const
     const auto &here = get_map();
     const auto safe = find_safe_spawn( abs_to_map_local( here, return_point ) );
     p.setpos( map_local_to_abs( here, safe ) );
-
-    // Single update_map call at the final position
-    g->update_map( p );
 }
 
 // ---- iuse_paint_stuff -------------------------------------------------------

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -209,7 +209,7 @@ struct legacy_pathfinding_tile {
     optional_vpart_position vehicle_part;
     int move_cost = 0;
 
-    auto vehicle_ptr() const -> vehicle * {
+    auto vehicle_ptr() const -> vehicle * { // *NOPAD*
         if( !vehicle_part ) {
             return nullptr;
         }

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -225,7 +225,7 @@ struct legacy_pathfinding_tile {
 };
 
 auto get_legacy_pathfinding_tile( mapbuffer &buffer, const tripoint_abs_ms &p )
--> std::optional<legacy_pathfinding_tile>
+- > std::optional<legacy_pathfinding_tile>
 {
     const auto terrain = buffer.get_ter( p );
     const auto furniture = buffer.get_furn( p );

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -209,7 +209,7 @@ struct legacy_pathfinding_tile {
     optional_vpart_position vehicle_part;
     int move_cost = 0;
 
-    auto vehicle_ptr() const -> vehicle * {
+    auto vehicle_ptr() const -> vehicle* {
         if( !vehicle_part ) {
             return nullptr;
         }

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -166,7 +166,7 @@ bool vertical_move_destination( const map &m, tripoint_abs_ms &t )
             t = p;
             return true;
         }
-            }
+    }
 
     return false;
 }
@@ -209,16 +209,14 @@ struct legacy_pathfinding_tile {
     optional_vpart_position vehicle_part;
     int move_cost = 0;
 
-    auto vehicle_ptr() const -> vehicle *
-    {
+    auto vehicle_ptr() const -> vehicle * {
         if( !vehicle_part ) {
             return nullptr;
         }
         return &vehicle_part->vehicle();
     }
 
-    auto part_index() const -> int
-    {
+    auto part_index() const -> int {
         if( !vehicle_part ) {
             return -1;
         }
@@ -227,7 +225,7 @@ struct legacy_pathfinding_tile {
 };
 
 auto get_legacy_pathfinding_tile( mapbuffer &buffer, const tripoint_abs_ms &p )
--> std::optional<legacy_pathfinding_tile>
+- > std::optional<legacy_pathfinding_tile>
 {
     const auto terrain = buffer.get_ter( p );
     const auto furniture = buffer.get_furn( p );
@@ -597,7 +595,7 @@ std::vector<tripoint_abs_ms> map::route( const tripoint_abs_ms &f, const tripoin
         }
         if( cur.z() < max.z() && parent_terrain.has_flag( TFLAG_RAMP ) &&
             buffer.valid_move( cur, cur + tripoint_rel_ms::above(),
-                               { .flying = true, .zlevels = has_zlevels() } ) ) {
+        { .flying = true, .zlevels = has_zlevels() } ) ) {
             auto &layer = pf.get_layer( cur.z() + 1 );
             for( size_t it = 0; it < 8; it++ ) {
                 const tripoint_abs_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
@@ -608,7 +606,7 @@ std::vector<tripoint_abs_ms> map::route( const tripoint_abs_ms &f, const tripoin
         }
         if( cur.z() < max.z() && parent_terrain.has_flag( TFLAG_RAMP_UP ) &&
             buffer.valid_move( cur, cur + tripoint_rel_ms::above(),
-                               { .flying = true, .via_ramp = true, .zlevels = has_zlevels() } ) ) {
+        { .flying = true, .via_ramp = true, .zlevels = has_zlevels() } ) ) {
             auto &layer = pf.get_layer( cur.z() + 1 );
             for( size_t it = 0; it < 8; it++ ) {
                 const tripoint_abs_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
@@ -619,7 +617,7 @@ std::vector<tripoint_abs_ms> map::route( const tripoint_abs_ms &f, const tripoin
         }
         if( cur.z() > min.z() && parent_terrain.has_flag( TFLAG_RAMP_DOWN ) &&
             buffer.valid_move( cur, cur + tripoint_rel_ms::below(),
-                               { .flying = true, .via_ramp = true, .zlevels = has_zlevels() } ) ) {
+        { .flying = true, .via_ramp = true, .zlevels = has_zlevels() } ) ) {
             auto &layer = pf.get_layer( cur.z() - 1 );
             for( size_t it = 0; it < 8; it++ ) {
                 const tripoint_abs_ms below( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() - 1 );

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -206,68 +206,63 @@ struct legacy_pathfinding_tile {
     ter_id terrain;
     furn_id furniture;
     trap_id trap;
-    optional_vpart_position vehicle_part;
+    const vehicle *vehicle_ptr_ = nullptr;
+    int vehicle_part = -1;
     int move_cost = 0;
 
-    auto vehicle_ptr() const -> vehicle * { // *NOPAD*
-        if( !vehicle_part ) {
-            return nullptr;
-        }
-        return &vehicle_part->vehicle();
+    auto vehicle_ptr() const -> const vehicle * { // *NOPAD*
+        return vehicle_ptr_;
     }
 
     auto part_index() const -> int {
-        if( !vehicle_part ) {
-            return -1;
-        }
-        return static_cast<int>( vehicle_part->part_index() );
+        return vehicle_part;
     }
 };
 
 // Astyle can snort my carpet dust
-auto get_legacy_pathfinding_tile( mapbuffer &buffer,
+auto get_legacy_pathfinding_tile( const map &here,
                                   const tripoint_abs_ms &p ) -> std::optional<legacy_pathfinding_tile> // *NOPAD*
 {
-    const auto terrain = buffer.get_ter( p );
-    const auto furniture = buffer.get_furn( p );
-    const auto move_cost = buffer.move_cost( p );
-    if( !terrain || !furniture || !move_cost ) {
+    const auto bubble_pos = abs_to_map_local( here, p );
+    if( !here.inbounds( bubble_pos ) ) {
         return std::nullopt;
     }
 
+    const auto tile = here.maptile_at_internal( bubble_pos );
+    auto vehicle_part = -1;
+    const auto *vehicle = here.veh_at_internal( bubble_pos, vehicle_part );
+    const auto &terrain = tile.get_ter_t();
+    const auto &furniture = tile.get_furn_t();
+
     return legacy_pathfinding_tile {
-        .terrain = *terrain,
-        .furniture = *furniture,
-        .trap = buffer.get_trap( p ).value_or( tr_null ),
-        .vehicle_part = buffer.veh_at( p ),
-        .move_cost = *move_cost,
+        .terrain = tile.get_ter(),
+        .furniture = tile.get_furn(),
+        .trap = tile.get_trap(),
+        .vehicle_ptr_ = vehicle,
+        .vehicle_part = vehicle_part,
+        .move_cost = here.move_cost_internal( furniture, terrain, vehicle, vehicle_part ),
     };
 }
 
-auto get_pf_special_abs( mapbuffer &buffer, const tripoint_abs_ms &p ) -> pf_special
+auto get_pf_special_from_tile( const legacy_pathfinding_tile &tile ) -> pf_special
 {
-    const auto tile = get_legacy_pathfinding_tile( buffer, p );
-    if( !tile ) {
-        return PF_WALL;
-    }
-
     auto cur_value = PF_NORMAL;
-    const auto &terrain = tile->terrain.obj();
+    const auto &terrain = tile.terrain.obj();
 
-    if( tile->move_cost > 2 ) {
+    if( tile.move_cost > 2 ) {
         cur_value |= PF_SLOW;
-    } else if( tile->move_cost <= 0 ) {
+    } else if( tile.move_cost <= 0 ) {
         cur_value |= PF_WALL;
         if( terrain.has_flag( TFLAG_CLIMBABLE ) ) {
             cur_value |= PF_CLIMBABLE;
         }
     }
 
-    if( tile->vehicle_part ) {
+    if( tile.vehicle_ptr() != nullptr ) {
         cur_value |= PF_VEHICLE;
     }
 
-    if( !tile->trap.obj().is_benign() || !terrain.trap.obj().is_benign() ) {
+    if( !tile.trap.obj().is_benign() || !terrain.trap.obj().is_benign() ) {
         cur_value |= PF_TRAP;
     }
 
@@ -282,6 +277,12 @@ auto get_pf_special_abs( mapbuffer &buffer, const tripoint_abs_ms &p ) -> pf_spe
     }
 
     return cur_value;
+}
+
+auto get_pf_special_abs( const map &here, const tripoint_abs_ms &p ) -> pf_special
+{
+    const auto tile = get_legacy_pathfinding_tile( here, p );
+    return tile ? get_pf_special_from_tile( *tile ) : PF_WALL;
 }
 
 std::vector<tripoint_abs_ms> map::route( const tripoint_abs_ms &f, const tripoint_abs_ms &t,
@@ -307,9 +308,9 @@ std::vector<tripoint_abs_ms> map::route( const tripoint_abs_ms &f, const tripoin
     if( f.z() == t.z() ) {
         const auto line_path = line_to( f, t );
         // Check all points for any special case (including just hard terrain)
-        if( !( get_pf_special_abs( buffer, f ) & non_normal ) &&
-        std::ranges::all_of( line_path, [&buffer]( const tripoint_abs_ms & p ) {
-        return !( get_pf_special_abs( buffer, p ) & non_normal );
+        if( !( get_pf_special_abs( *this, f ) & non_normal ) &&
+        std::ranges::all_of( line_path, [this]( const tripoint_abs_ms & p ) {
+        return !( get_pf_special_abs( *this, p ) & non_normal );
         } ) ) {
             const std::set<tripoint_abs_ms> sorted_line( line_path.begin(), line_path.end() );
 
@@ -390,10 +391,12 @@ std::vector<tripoint_abs_ms> map::route( const tripoint_abs_ms &f, const tripoin
 
         cur_state = ASL_CLOSED;
 
-        const auto cur_special = get_pf_special_abs( buffer, cur );
-
-        const auto cur_tile = get_legacy_pathfinding_tile( buffer, cur );
-        const auto *cur_veh = cur_tile ? cur_tile->vehicle_ptr() : nullptr;
+        const auto cur_tile = get_legacy_pathfinding_tile( *this, cur );
+        if( !cur_tile ) {
+            continue;
+        }
+        const auto cur_special = get_pf_special_from_tile( *cur_tile );
+        const auto *cur_veh = cur_tile->vehicle_ptr();
 
         // 7 3 5
         // 1 . 2
@@ -413,7 +416,7 @@ std::vector<tripoint_abs_ms> map::route( const tripoint_abs_ms &f, const tripoin
                 continue;
             }
 
-            const auto p_tile = get_legacy_pathfinding_tile( buffer, p );
+            const auto p_tile = get_legacy_pathfinding_tile( *this, p );
             if( !p_tile ) {
                 layer.state[index] = ASL_CLOSED;
                 continue;
@@ -438,7 +441,7 @@ std::vector<tripoint_abs_ms> map::route( const tripoint_abs_ms &f, const tripoin
             // Penalize for diagonals or the path will look "unnatural"
             int newg = layer.gscore[parent_index] + ( ( cur.x() != p.x() && cur.y() != p.y() ) ? 1 : 0 );
 
-            const auto p_special = get_pf_special_abs( buffer, p );
+            const auto p_special = get_pf_special_from_tile( *p_tile );
             // TODO: De-uglify, de-huge-n
             if( !( p_special & non_normal ) ) {
                 // Boring flat dirt - the most common case above the ground

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -225,7 +225,7 @@ struct legacy_pathfinding_tile {
 };
 
 auto get_legacy_pathfinding_tile( mapbuffer &buffer, const tripoint_abs_ms &p )
-- > std::optional<legacy_pathfinding_tile>
+-> std::optional<legacy_pathfinding_tile>
 {
     const auto terrain = buffer.get_ter( p );
     const auto furniture = buffer.get_furn( p );

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -26,6 +26,8 @@
 #include "vehicle_part.h"
 #include "vpart_position.h"
 #include "line.h"
+#include "mapbuffer.h"
+#include "mapbuffer_registry.h"
 #include "type_id.h"
 #include "point.h"
 
@@ -37,9 +39,10 @@ enum astar_state {
 
 // Turns two coordinates into an index into the 1D backing array.
 // stride_y is the total tile height of the loaded map.
-static int flat_index( const tripoint_bub_ms &p, int stride_y )
+static int flat_index( const tripoint_abs_ms &p, const point_abs_ms &origin, int stride_y )
 {
-    return ( p.x() * stride_y ) + p.y();
+    const auto offset = p.xy() - origin;
+    return ( offset.x() * stride_y ) + offset.y();
 }
 
 // Flattened 2D array representing a single z-level worth of pathfinding data.
@@ -47,15 +50,17 @@ static int flat_index( const tripoint_bub_ms &p, int stride_y )
 // so that they scale correctly with any REALITY_BUBBLE_SIZE setting.
 struct path_data_layer {
     const int stride_y; // = g_mapsize_y at construction time
+    const point_abs_ms origin;
 
     // State is accessed way more often than all other values here.
     std::vector<astar_state> state;
     std::vector<int> score;
     std::vector<int> gscore;
-    std::vector<tripoint_bub_ms> parent;
+    std::vector<tripoint_abs_ms> parent;
 
-    explicit path_data_layer() :
+    explicit path_data_layer( const point_abs_ms &_origin ) :
         stride_y( g_mapsize_y ),
+        origin( _origin ),
         state( static_cast<std::size_t>( g_mapsize_x * g_mapsize_y ), ASL_NONE ),
         score( static_cast<std::size_t>( g_mapsize_x * g_mapsize_y ), 0 ),
         gscore( static_cast<std::size_t>( g_mapsize_x * g_mapsize_y ), 0 ),
@@ -64,26 +69,27 @@ struct path_data_layer {
 
     // All elements are initialised to ASL_NONE in the constructor; init() is kept
     // for compatibility but is a no-op when the vector is already zeroed.
-    void init( point_bub_ms min, point_bub_ms max ) {
+    void init( point_abs_ms min, point_abs_ms max ) {
         std::ranges::for_each(
             cata::views::cartesian_product(
                 std::views::iota( min.x(), max.x() + 1 ),
                 std::views::iota( min.y(), max.y() + 1 ) ),
         [this]( auto xy ) {
             const auto &[x, y] = xy;
-            state[flat_index( tripoint_bub_ms{ x, y, 0 }, stride_y )] = ASL_NONE;
+            state[flat_index( tripoint_abs_ms{ x, y, 0 }, origin, stride_y )] = ASL_NONE;
         } );
     }
 };
 
 struct pathfinder {
-    point_bub_ms min;
-    point_bub_ms max;
-    pathfinder( point_bub_ms _min, point_bub_ms _max ) :
-        min( _min ), max( _max ) {
+    point_abs_ms min;
+    point_abs_ms max;
+    point_abs_ms origin;
+    pathfinder( point_abs_ms _min, point_abs_ms _max, point_abs_ms _origin ) :
+        min( _min ), max( _max ), origin( _origin ) {
     }
 
-    std::priority_queue<std::pair<int, tripoint_bub_ms>, std::vector< std::pair<int, tripoint_bub_ms>>, pair_greater_cmp_first>
+    std::priority_queue<std::pair<int, tripoint_abs_ms>, std::vector< std::pair<int, tripoint_abs_ms>>, pair_greater_cmp_first>
             open;
     std::array< std::unique_ptr<path_data_layer>, OVERMAP_LAYERS > path_data;
 
@@ -93,7 +99,7 @@ struct pathfinder {
             return *ptr;
         }
 
-        ptr = std::make_unique<path_data_layer>();
+        ptr = std::make_unique<path_data_layer>( origin );
         ptr->init( min, max );
         return *ptr;
     }
@@ -102,16 +108,16 @@ struct pathfinder {
         return open.empty();
     }
 
-    tripoint_bub_ms get_next() {
+    tripoint_abs_ms get_next() {
         const auto pt = open.top();
         open.pop();
         return pt.second;
     }
 
-    void add_point( const int gscore, const int score, const tripoint_bub_ms &from,
-                    const tripoint_bub_ms &to ) {
+    void add_point( const int gscore, const int score, const tripoint_abs_ms &from,
+                    const tripoint_abs_ms &to ) {
         auto &layer = get_layer( to.z() );
-        const int index = flat_index( to, layer.stride_y );
+        const int index = flat_index( to, origin, layer.stride_y );
         if( ( layer.state[index] == ASL_OPEN && gscore >= layer.gscore[index] ) ||
             layer.state[index] == ASL_CLOSED ) {
             return;
@@ -124,15 +130,15 @@ struct pathfinder {
         open.emplace( score, to );
     }
 
-    void close_point( const tripoint_bub_ms &p ) {
+    void close_point( const tripoint_abs_ms &p ) {
         auto &layer = get_layer( p.z() );
-        const int index = flat_index( p, layer.stride_y );
+        const int index = flat_index( p, origin, layer.stride_y );
         layer.state[index] = ASL_CLOSED;
     }
 
-    void unclose_point( const tripoint_bub_ms &p ) {
+    void unclose_point( const tripoint_abs_ms &p ) {
         auto &layer = get_layer( p.z() );
-        const int index = flat_index( p, layer.stride_y );
+        const int index = flat_index( p, origin, layer.stride_y );
         layer.state[index] = ASL_NONE;
     }
 };
@@ -140,45 +146,27 @@ struct pathfinder {
 // Modifies `t` to be a tile with `flag` in the overmap tile that `t` was originally on
 // return false if it could not find a suitable point
 template<ter_bitflags flag>
-bool vertical_move_destination( const map &m, tripoint_bub_ms &t )
+bool vertical_move_destination( const map &m, tripoint_abs_ms &t )
 {
     if( !m.has_zlevels() ) {
         return false;
     }
 
     // Align to OMT boundaries
-    const auto origin = project_to<coords::ms>( m.get_abs_sub().xy() );
-    const auto target_abs = origin + t.xy().reinterpret_as<point_rel_ms>();
-    const auto omt_origin = project_to<coords::ms>( project_to<coords::omt>( target_abs ) );
-    auto start = ( omt_origin - origin ).reinterpret_as<point_bub_ms>();
-    auto end = start + point_rel_ms( SEEX * 2, SEEY * 2 );
+    const auto omt_origin = project_to<coords::ms>( project_to<coords::omt>( t ) );
+    const auto end = omt_origin + point_rel_ms( SEEX * 2, SEEY * 2 );
+    auto &buffer = MAPBUFFER_REGISTRY.get( m.get_bound_dimension() );
 
-    // Exclude submaps not loaded into bubble
-    if( start.x() < 0 ) {
-        start.x() = 0;
-    }
-    if( start.y() < 0 ) {
-        start.y() = 0;
-    }
-    const auto &rend_cache = m.get_cache_ref( t.z() );
-    if( end.x() >= rend_cache.cache_x ) {
-        end.x() = rend_cache.cache_x - 1;
-    }
-    if( end.y() >= rend_cache.cache_y ) {
-        end.y() = rend_cache.cache_y - 1;
-    }
-
-    for( int x = start.x(); x < end.x(); x++ ) {
-        for( int y = start.y(); y < end.y(); y++ ) {
-            const auto p = tripoint_bub_ms( x, y, t.z() );
-            if( m.get_pf_special( p ) & PF_UPDOWN ) {
-                if( m.has_flag( flag, p ) ) {
-                    t = p;
-                    return true;
-                }
-            }
+    for( const auto [x, y] : cata::views::cartesian_product(
+             std::views::iota( omt_origin.x(), end.x() ),
+             std::views::iota( omt_origin.y(), end.y() ) ) ) {
+        const auto p = tripoint_abs_ms( x, y, t.z() );
+        const auto terrain = buffer.get_ter( p );
+        if( terrain && terrain->obj().has_flag( flag ) ) {
+            t = p;
+            return true;
         }
-    }
+            }
 
     return false;
 }
@@ -214,23 +202,105 @@ bool is_disjoint( const Set1 &set1, const Set2 &set2 )
     return true;
 }
 
-std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoint_bub_ms &t,
+struct legacy_pathfinding_tile {
+    ter_id terrain;
+    furn_id furniture;
+    trap_id trap;
+    optional_vpart_position vehicle_part;
+    int move_cost = 0;
+
+    auto vehicle_ptr() const -> vehicle *
+    {
+        if( !vehicle_part ) {
+            return nullptr;
+        }
+        return &vehicle_part->vehicle();
+    }
+
+    auto part_index() const -> int
+    {
+        if( !vehicle_part ) {
+            return -1;
+        }
+        return static_cast<int>( vehicle_part->part_index() );
+    }
+};
+
+auto get_legacy_pathfinding_tile( mapbuffer &buffer, const tripoint_abs_ms &p )
+-> std::optional<legacy_pathfinding_tile>
+{
+    const auto terrain = buffer.get_ter( p );
+    const auto furniture = buffer.get_furn( p );
+    const auto move_cost = buffer.move_cost( p );
+    if( !terrain || !furniture || !move_cost ) {
+        return std::nullopt;
+    }
+
+    return legacy_pathfinding_tile {
+        .terrain = *terrain,
+        .furniture = *furniture,
+        .trap = buffer.get_trap( p ).value_or( tr_null ),
+        .vehicle_part = buffer.veh_at( p ),
+        .move_cost = *move_cost,
+    };
+}
+
+auto get_pf_special_abs( mapbuffer &buffer, const tripoint_abs_ms &p ) -> pf_special
+{
+    const auto tile = get_legacy_pathfinding_tile( buffer, p );
+    if( !tile ) {
+        return PF_WALL;
+    }
+
+    auto cur_value = PF_NORMAL;
+    const auto &terrain = tile->terrain.obj();
+
+    if( tile->move_cost > 2 ) {
+        cur_value |= PF_SLOW;
+    } else if( tile->move_cost <= 0 ) {
+        cur_value |= PF_WALL;
+        if( terrain.has_flag( TFLAG_CLIMBABLE ) ) {
+            cur_value |= PF_CLIMBABLE;
+        }
+    }
+
+    if( tile->vehicle_part ) {
+        cur_value |= PF_VEHICLE;
+    }
+
+    if( !tile->trap.obj().is_benign() || !terrain.trap.obj().is_benign() ) {
+        cur_value |= PF_TRAP;
+    }
+
+    if( terrain.has_flag( TFLAG_GOES_DOWN ) || terrain.has_flag( TFLAG_GOES_UP ) ||
+        terrain.has_flag( TFLAG_RAMP ) || terrain.has_flag( TFLAG_RAMP_UP ) ||
+        terrain.has_flag( TFLAG_RAMP_DOWN ) ) {
+        cur_value |= PF_UPDOWN;
+    }
+
+    if( terrain.has_flag( TFLAG_SHARP ) ) {
+        cur_value |= PF_SHARP;
+    }
+
+    return cur_value;
+}
+
+std::vector<tripoint_abs_ms> map::route( const tripoint_abs_ms &f, const tripoint_abs_ms &t,
         const pathfinding_settings &settings,
-        const std::set<tripoint_bub_ms> &pre_closed ) const
+        const std::set<tripoint_abs_ms> &pre_closed ) const
 {
     /* TODO: If the origin or destination is out of bound, figure out the closest
      * in-bounds point and go to that, then to the real origin/destination.
      */
-    std::vector<tripoint_bub_ms> ret;
+    std::vector<tripoint_abs_ms> ret;
+    auto &buffer = MAPBUFFER_REGISTRY.get( get_bound_dimension() );
 
-    if( f == t || !inbounds( f ) ) {
+    if( f == t || !inbounds( abs_to_map_local( *this, f ) ) ) {
         return ret;
     }
 
-    if( !inbounds( t ) ) {
-        tripoint_bub_ms clipped = t;
-        clip_to_bounds( clipped );
-        return route( f, clipped, settings, pre_closed );
+    if( !inbounds( abs_to_map_local( *this, t ) ) ) {
+        return ret;
     }
     // First, check for a simple straight line on flat ground
     // Except when the line contains a pre-closed tile - we need to do regular pathing then
@@ -238,11 +308,11 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
     if( f.z() == t.z() ) {
         const auto line_path = line_to( f, t );
         // Check all points for any special case (including just hard terrain)
-        if( !( get_pf_special( f ) & non_normal ) &&
-        std::ranges::all_of( line_path, [this]( const tripoint_bub_ms & p ) {
-        return !( get_pf_special( p ) & non_normal );
+        if( !( get_pf_special_abs( buffer, f ) & non_normal ) &&
+        std::ranges::all_of( line_path, [&buffer]( const tripoint_abs_ms & p ) {
+        return !( get_pf_special_abs( buffer, p ) & non_normal );
         } ) ) {
-            const std::set<tripoint_bub_ms> sorted_line( line_path.begin(), line_path.end() );
+            const std::set<tripoint_abs_ms> sorted_line( line_path.begin(), line_path.end() );
 
             if( is_disjoint( sorted_line, pre_closed ) ) {
                 return line_path;
@@ -270,18 +340,24 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
     // Search-area inflation: at least 16 tiles, scaled with bubble radius so pathfinders
     // can route around obstacles near the bubble boundary at large bubble sizes.
     const int pad = std::max( 16, 4 * g_half_mapsize );
-    auto min = tripoint_bub_ms( std::min( f.x(), t.x() ) - pad, std::min( f.y(), t.y() ) - pad,
+    auto min = tripoint_abs_ms( std::min( f.x(), t.x() ) - pad, std::min( f.y(), t.y() ) - pad,
                                 std::min( f.z(), t.z() ) );
-    auto max = tripoint_bub_ms( std::max( f.x(), t.x() ) + pad, std::max( f.y(), t.y() ) + pad,
+    auto max = tripoint_abs_ms( std::max( f.x(), t.x() ) + pad, std::max( f.y(), t.y() ) + pad,
                                 std::max( f.z(), t.z() ) );
-    clip_to_bounds( min );
-    clip_to_bounds( max );
+    const auto origin = project_to<coords::ms>( get_abs_sub() ).xy();
+    const auto bounds_max = origin + point_rel_ms( g_mapsize_x - 1, g_mapsize_y - 1 );
+    min.x() = std::max( min.x(), origin.x() );
+    min.y() = std::max( min.y(), origin.y() );
+    max.x() = std::min( max.x(), bounds_max.x() );
+    max.y() = std::min( max.y(), bounds_max.y() );
+    min.z() = std::max( min.z(), -OVERMAP_DEPTH );
+    max.z() = std::min( max.z(), OVERMAP_HEIGHT );
 
-    pathfinder pf( min.xy(), max.xy() );
+    pathfinder pf( min.xy(), max.xy(), origin );
     // Make NPCs not want to path through player
     // But don't make player pathing stop working
     for( const auto &p : pre_closed ) {
-        if( p.x() >= min.x() && p.x() < max.x() && p.y() >= min.y() && p.y() < max.y() ) {
+        if( p.x() >= min.x() && p.x() <= max.x() && p.y() >= min.y() && p.y() <= max.y() ) {
             pf.close_point( p );
         }
     }
@@ -297,7 +373,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
         auto cur = pf.get_next();
 
         auto &layer = pf.get_layer( cur.z() );
-        const int parent_index = flat_index( cur, layer.stride_y );
+        const int parent_index = flat_index( cur, pf.origin, layer.stride_y );
         auto &cur_state = layer.state[parent_index];
         if( cur_state == ASL_CLOSED ) {
             continue;
@@ -305,7 +381,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
 
         if( layer.gscore[parent_index] > max_length ) {
             // Shortest path would be too long, return empty vector
-            return std::vector<tripoint_bub_ms>();
+            return std::vector<tripoint_abs_ms>();
         }
 
         if( cur == t ) {
@@ -315,10 +391,10 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
 
         cur_state = ASL_CLOSED;
 
-        const auto cur_special = get_pf_special( cur );
+        const auto cur_special = get_pf_special_abs( buffer, cur );
 
-        int cur_part;
-        const vehicle *cur_veh = veh_at_internal( tripoint_bub_ms( cur ), cur_part );
+        const auto cur_tile = get_legacy_pathfinding_tile( buffer, cur );
+        const auto *cur_veh = cur_tile ? cur_tile->vehicle_ptr() : nullptr;
 
         // 7 3 5
         // 1 . 2
@@ -326,11 +402,11 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
         constexpr std::array<int, 8> x_offset{{ -1,  1,  0,  0,  1, -1, -1, 1 }};
         constexpr std::array<int, 8> y_offset{{  0,  0, -1,  1, -1,  1, -1, 1 }};
         for( size_t i = 0; i < 8; i++ ) {
-            const tripoint_bub_ms p( cur.x() + x_offset[i], cur.y() + y_offset[i], cur.z() );
-            const int index = flat_index( p, layer.stride_y );
+            const tripoint_abs_ms p( cur.x() + x_offset[i], cur.y() + y_offset[i], cur.z() );
+            const int index = flat_index( p, pf.origin, layer.stride_y );
 
             // TODO: Remove this and instead have sentinels at the edges
-            if( p.x() < min.x() || p.x() >= max.x() || p.y() < min.y() || p.y() >= max.y() ) {
+            if( p.x() < min.x() || p.x() > max.x() || p.y() < min.y() || p.y() > max.y() ) {
                 continue;
             }
 
@@ -338,19 +414,24 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                 continue;
             }
 
-            int part = -1;
-            const vehicle *veh = veh_at_internal( tripoint_bub_ms( p ), part );
-            // TODO: migrate pathfinding positions to abs so these conversions can use abs_to_mount
+            const auto p_tile = get_legacy_pathfinding_tile( buffer, p );
+            if( !p_tile ) {
+                layer.state[index] = ASL_CLOSED;
+                continue;
+            }
+
+            int part = p_tile->part_index();
+            const vehicle *veh = p_tile->vehicle_ptr();
             if( cur_veh &&
-                !cur_veh->allowed_move( cur_veh->bubble_to_mount( tripoint_bub_ms( cur ) ),
-                                        cur_veh->bubble_to_mount( tripoint_bub_ms( p ) ) ) ) {
+                !cur_veh->allowed_move( cur_veh->abs_to_mount( cur ),
+                                        cur_veh->abs_to_mount( p ) ) ) {
                 //Trying to squeeze through a vehicle hole, skip this movement but don't close the tile as other paths may lead to it
                 continue;
             }
 
             if( veh && veh != cur_veh &&
-                !veh->allowed_move( veh->bubble_to_mount( tripoint_bub_ms( cur ) ),
-                                    veh->bubble_to_mount( tripoint_bub_ms( p ) ) ) ) {
+                !veh->allowed_move( veh->abs_to_mount( cur ),
+                                    veh->abs_to_mount( p ) ) ) {
                 //Same as above but moving into rather than out of a vehicle
                 continue;
             }
@@ -358,7 +439,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
             // Penalize for diagonals or the path will look "unnatural"
             int newg = layer.gscore[parent_index] + ( ( cur.x() != p.x() && cur.y() != p.y() ) ? 1 : 0 );
 
-            const auto p_special = get_pf_special( p );
+            const auto p_special = get_pf_special_abs( buffer, p );
             // TODO: De-uglify, de-huge-n
             if( !( p_special & non_normal ) ) {
                 // Boring flat dirt - the most common case above the ground
@@ -369,11 +450,10 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                     continue;
                 }
 
-                const maptile &tile = maptile_at_internal( tripoint_bub_ms( p ) );
-                const auto &terrain = tile.get_ter_t();
-                const auto &furniture = tile.get_furn_t();
+                const auto &terrain = p_tile->terrain.obj();
+                const auto &furniture = p_tile->furniture.obj();
 
-                const int cost = move_cost_internal( furniture, terrain, veh, part );
+                const int cost = p_tile->move_cost;
                 // Don't calculate bash rating unless we intend to actually use it
                 const int rating = ( bash == 0 || cost != 0 ) ? -1 :
                                    bash_rating_internal( bash, furniture, terrain, false, veh, part );
@@ -391,17 +471,16 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                         newg += climb_cost;
                     } else if( doors && ( terrain.open || furniture.open ) &&
                                ( !terrain.has_flag( "OPENCLOSE_INSIDE" ) || !furniture.has_flag( "OPENCLOSE_INSIDE" ) ||
-                                 !is_outside( cur ) ) ) {
+                                 !is_outside( abs_to_map_local( *this, cur ) ) ) ) {
                         // Only try to open INSIDE doors from the inside
                         // To open and then move onto the tile
                         newg += 4;
                     } else if( veh != nullptr ) {
                         const auto vpobst = vpart_position( const_cast<vehicle &>( *veh ), part ).obstacle_at_part();
                         part = vpobst ? vpobst->part_index() : -1;
-                        int dummy = -1;
                         if( doors && veh->part_flag( part, VPFLAG_OPENABLE ) &&
                             ( !veh->part_flag( part, "OPENCLOSE_INSIDE" ) ||
-                              veh_at_internal( tripoint_bub_ms( cur ), dummy ) == veh ) ) {
+                              cur_veh == veh ) ) {
                             // Handle car doors, but don't try to path through curtains
                             newg += 10; // One turn to open, 4 to move there
                         } else if( part >= 0 && bash > 0 ) {
@@ -446,15 +525,16 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
 
                 if( trapavoid && p_special & PF_TRAP ) {
                     const auto &ter_trp = terrain.trap.obj();
-                    const auto &trp = ter_trp.is_benign() ? tile.get_trap_t() : ter_trp;
+                    const auto &trp = ter_trp.is_benign() ? p_tile->trap.obj() : ter_trp;
                     if( !trp.is_benign() ) {
                         // For now make them detect all traps
                         if( has_zlevels() && terrain.has_flag( TFLAG_NO_FLOOR ) ) {
                             // Special case - ledge in z-levels
                             // Warning: really expensive, needs a cache
-                            if( valid_move( p, tripoint_bub_ms( p.xy(), p.z() - 1 ), false, true ) ) {
-                                tripoint_bub_ms below( p.xy(), p.z() - 1 );
-                                if( !has_flag( TFLAG_NO_FLOOR, below ) ) {
+                            const auto below = p + tripoint_rel_ms::below();
+                            if( buffer.valid_move( p, below, { .flying = true, .zlevels = has_zlevels() } ) ) {
+                                const auto below_terrain = buffer.get_ter( below );
+                                if( below_terrain && !below_terrain->obj().has_flag( TFLAG_NO_FLOOR ) ) {
                                     // Otherwise this would have been a huge fall
                                     auto &layer = pf.get_layer( p.z() - 1 );
                                     // From cur, not p, because we won't be walking on air
@@ -492,11 +572,13 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
             continue;
         }
 
-        const maptile &parent_tile = maptile_at_internal( tripoint_bub_ms( cur ) );
-        const auto &parent_terrain = parent_tile.get_ter_t();
+        if( !cur_tile ) {
+            continue;
+        }
+        const auto &parent_terrain = cur_tile->terrain.obj();
         if( settings.allow_climb_stairs && cur.z() > min.z() &&
             parent_terrain.has_flag( TFLAG_GOES_DOWN ) ) {
-            tripoint_bub_ms dest( cur.xy(), cur.z() - 1 );
+            tripoint_abs_ms dest( cur.xy(), cur.z() - 1 );
             if( vertical_move_destination<TFLAG_GOES_UP>( *this, dest ) ) {
                 auto &layer = pf.get_layer( dest.z() );
                 pf.add_point( layer.gscore[parent_index] + 2,
@@ -505,7 +587,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
             }
         }
         if( settings.allow_climb_stairs && cur.z() < max.z() && parent_terrain.has_flag( TFLAG_GOES_UP ) ) {
-            tripoint_bub_ms dest( cur.xy(), cur.z() + 1 );
+            tripoint_abs_ms dest( cur.xy(), cur.z() + 1 );
             if( vertical_move_destination<TFLAG_GOES_DOWN>( *this, dest ) ) {
                 auto &layer = pf.get_layer( dest.z() );
                 pf.add_point( layer.gscore[parent_index] + 2,
@@ -514,30 +596,33 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
             }
         }
         if( cur.z() < max.z() && parent_terrain.has_flag( TFLAG_RAMP ) &&
-            valid_move( cur, tripoint_bub_ms( cur.xy(), cur.z() + 1 ), false, true ) ) {
+            buffer.valid_move( cur, cur + tripoint_rel_ms::above(),
+                               { .flying = true, .zlevels = has_zlevels() } ) ) {
             auto &layer = pf.get_layer( cur.z() + 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint_bub_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
+                const tripoint_abs_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
                 pf.add_point( layer.gscore[parent_index] + 4,
                               layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
                               cur, above );
             }
         }
         if( cur.z() < max.z() && parent_terrain.has_flag( TFLAG_RAMP_UP ) &&
-            valid_move( cur, tripoint_bub_ms( cur.xy(), cur.z() + 1 ), false, true, true ) ) {
+            buffer.valid_move( cur, cur + tripoint_rel_ms::above(),
+                               { .flying = true, .via_ramp = true, .zlevels = has_zlevels() } ) ) {
             auto &layer = pf.get_layer( cur.z() + 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint_bub_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
+                const tripoint_abs_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
                 pf.add_point( layer.gscore[parent_index] + 4,
                               layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
                               cur, above );
             }
         }
         if( cur.z() > min.z() && parent_terrain.has_flag( TFLAG_RAMP_DOWN ) &&
-            valid_move( cur, tripoint_bub_ms( cur.xy(), cur.z() - 1 ), false, true, true ) ) {
+            buffer.valid_move( cur, cur + tripoint_rel_ms::below(),
+                               { .flying = true, .via_ramp = true, .zlevels = has_zlevels() } ) ) {
             auto &layer = pf.get_layer( cur.z() - 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint_bub_ms below( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() - 1 );
+                const tripoint_abs_ms below( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() - 1 );
                 pf.add_point( layer.gscore[parent_index] + 4,
                               layer.score[parent_index] + 4 + 2 * rl_dist( below, t ),
                               cur, below );
@@ -552,8 +637,8 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
         // Just to limit max distance, in case something weird happens
         for( int fdist = max_length; fdist != 0; fdist-- ) {
             const auto &layer = pf.get_layer( cur.z() );
-            const int cur_index = flat_index( cur, layer.stride_y );
-            const tripoint_bub_ms &par = layer.parent[cur_index];
+            const int cur_index = flat_index( cur, pf.origin, layer.stride_y );
+            const tripoint_abs_ms &par = layer.parent[cur_index];
             if( cur == f ) {
                 break;
             }
@@ -574,4 +659,29 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
     }
 
     return ret;
+}
+
+std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoint_bub_ms &t,
+        const pathfinding_settings &settings,
+        const std::set<tripoint_bub_ms> &pre_closed ) const
+{
+    auto clipped_f = f;
+    auto clipped_t = t;
+    clip_to_bounds( clipped_f );
+    clip_to_bounds( clipped_t );
+
+    std::set<tripoint_abs_ms> pre_closed_abs;
+    for( const tripoint_bub_ms &p : pre_closed ) {
+        pre_closed_abs.insert( map_local_to_abs( *this, p ) );
+    }
+
+    const auto abs_route = route( map_local_to_abs( *this, clipped_f ),
+                                  map_local_to_abs( *this, clipped_t ),
+                                  settings, pre_closed_abs );
+    std::vector<tripoint_bub_ms> result;
+    result.reserve( abs_route.size() );
+    for( const tripoint_abs_ms &p : abs_route ) {
+        result.push_back( abs_to_map_local( *this, p ) );
+    }
+    return result;
 }

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -224,8 +224,9 @@ struct legacy_pathfinding_tile {
     }
 };
 
-auto get_legacy_pathfinding_tile( mapbuffer &buffer, const tripoint_abs_ms &p )
-- > std::optional<legacy_pathfinding_tile>
+// Astyle can snort my carpet dust
+auto get_legacy_pathfinding_tile( mapbuffer &buffer,
+const tripoint_abs_ms &p ) -> std::optional<legacy_pathfinding_tile> // *NOPAD*
 {
     const auto terrain = buffer.get_ter( p );
     const auto furniture = buffer.get_furn( p );

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -209,7 +209,7 @@ struct legacy_pathfinding_tile {
     optional_vpart_position vehicle_part;
     int move_cost = 0;
 
-    auto vehicle_ptr() const -> vehicle* {
+    auto vehicle_ptr() const -> vehicle * {
         if( !vehicle_part ) {
             return nullptr;
         }

--- a/src/legacy_pathfinding.cpp
+++ b/src/legacy_pathfinding.cpp
@@ -226,7 +226,7 @@ struct legacy_pathfinding_tile {
 
 // Astyle can snort my carpet dust
 auto get_legacy_pathfinding_tile( mapbuffer &buffer,
-const tripoint_abs_ms &p ) -> std::optional<legacy_pathfinding_tile> // *NOPAD*
+                                  const tripoint_abs_ms &p ) -> std::optional<legacy_pathfinding_tile> // *NOPAD*
 {
     const auto terrain = buffer.get_ter( p );
     const auto furniture = buffer.get_furn( p );

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1900,8 +1900,8 @@ bool map::pl_sees( const tripoint_bub_ms &t, const int max_range ) const
         return get_visibility( ll, visibility_variables_cache ) == VIS_CLEAR;
     }
 
-    // Normal SDL gameplay should consume GPU-generated visibility_cache.
-    // If a caller asks before draw refreshes that cache, avoid geometry-only
+    // Normal SDL gameplay should consume the pre-refreshed visibility_cache.
+    // If a caller asks before the game/UI refresh point, avoid geometry-only
     // visibility because it produces false safe-mode and monster-info warnings.
     return false;
 #else

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -137,8 +137,6 @@ static void swap_pos( Creature &caster, const tripoint_bub_ms &target )
         critter->setpos( caster.bub_pos() );
     }
     caster.setpos( target );
-    //update map in case a monster swapped positions with the player
-    g->update_map( get_avatar() );
 }
 
 void spell_effect::pain_split( const spell &sp, Creature &caster, const tripoint_bub_ms & )

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3063,7 +3063,7 @@ bool map::valid_move( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
                       const bool bash, const bool flying, const bool via_ramp ) const
 {
     return MAPBUFFER_REGISTRY.get( bound_dimension_ ).valid_move(
-               map_local_to_abs( *this, from ), map_local_to_abs( *this, to ), {
+    map_local_to_abs( *this, from ), map_local_to_abs( *this, to ), {
         .bash = bash,
         .flying = flying,
         .via_ramp = via_ramp,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1485,7 +1485,10 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
     size_t collision_attempts = 10;
     do {
         collisions.clear();
-        veh.collision( collisions, dp1, false );
+        veh.collision( vehicle_collision_options{
+            .colls = collisions,
+            .dp = dp1,
+        } );
 
         // Vehicle collisions
         std::map<vehicle *, std::vector<veh_collision> > veh_collisions;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2062,9 +2062,6 @@ void map::board_vehicle( const tripoint_bub_ms &pos, Character *who )
 
     who->setpos( pos );
     who->in_vehicle = true;
-    if( who->is_avatar() ) {
-        g->update_map( g->u );
-    }
 }
 
 void map::unboard_vehicle( const vpart_reference &vp, Character *passenger, bool dead_passenger )
@@ -2161,7 +2158,6 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp )
 
     bool need_update = false;
     bool z_change = false;
-    int z_to = 0;
     // Move passengers and pets
     bool complete = false;
     // loop until everyone has moved or for each passenger
@@ -2202,10 +2198,8 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp )
                 continue;
             }
             if( psg->is_avatar() ) {
-                // If passenger is you, we need to update the map
                 need_update = true;
                 z_change = psgp.z() != part_pos.z();
-                z_to = psgp.z();
             }
 
             psg->setpos( psgp );
@@ -2320,15 +2314,10 @@ bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp )
     if( need_update && !z_change && src.z() == dest.z() ) {
         mark_vehicle_moved();
     }
-
-    if( need_update ) {
-        g->update_map( g->u );
-    }
     add_vehicle_to_cache( &veh );
 
     if( z_change || src.z() != dest.z() ) {
         if( z_change ) {
-            g->vertical_shift( z_to );
             // vertical moves can flush the caches, so make sure we're still in the cache
             add_vehicle_to_cache( &veh );
         }
@@ -3070,96 +3059,13 @@ int map::combined_movecost( const tripoint_bub_ms &from, const tripoint_bub_ms &
 bool map::valid_move( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
                       const bool bash, const bool flying, const bool via_ramp ) const
 {
-    // Used to account for the fact that older versions of GCC can trip on the if statement here.
-    assert( to.z() > std::numeric_limits<int>::min() );
-    if( std::abs( from.x() - to.x() ) > 1 || std::abs( from.y() - to.y() ) > 1 ||
-        std::abs( from.z() - to.z() ) > 1 ) {
-        return false;
-    }
-
-    if( from.z() == to.z() ) {
-        // But here we need to, to prevent bashing critters
-        return passable( to ) || ( bash && inbounds( to ) );
-    } else if( !zlevels ) {
-        return false;
-    }
-
-    const bool going_up = from.z() < to.z();
-
-    const auto &up_p = tripoint_bub_ms( going_up ? to : from );
-    const auto &down_p = tripoint_bub_ms( going_up ? from : to );
-
-    const maptile up = maptile_at( up_p );
-    const ter_t &up_ter = up.get_ter_t();
-    if( up_ter.id.is_null() ) {
-        return false;
-    }
-    // Checking for ledge is a workaround for the case when mapgen doesn't
-    // actually make a valid ledge drop location with zlevels on, this forces
-    // at least one zlevel drop and if down_ter is impassible it's probably
-    // inside a wall, we could workaround that further but it's unnecessary.
-    const bool up_is_ledge = tr_at( up_p ).loadid == tr_ledge;
-
-    if( up_ter.movecost == 0 ) {
-        // Unpassable tile
-        return false;
-    }
-
-    const maptile down = maptile_at( down_p );
-    const ter_t &down_ter = down.get_ter_t();
-    if( down_ter.id.is_null() ) {
-        return false;
-    }
-
-    if( !up_is_ledge && down_ter.movecost == 0 ) {
-        // Unpassable tile
-        return false;
-    }
-
-    if( !up_ter.has_flag( TFLAG_NO_FLOOR ) && !up_ter.has_flag( TFLAG_GOES_DOWN ) && !up_is_ledge &&
-        !via_ramp ) {
-        // Can't move from up to down
-        if( std::abs( from.x() - to.x() ) == 1 || std::abs( from.y() - to.y() ) == 1 ) {
-            // Break the move into two - vertical then horizontal
-            tripoint_bub_ms midpoint( down_p.xy(), up_p.z() );
-            return valid_move( down_p, midpoint, bash, flying, via_ramp ) &&
-                   valid_move( midpoint, up_p, bash, flying, via_ramp );
-        }
-        return false;
-    }
-
-    if( !flying && !down_ter.has_flag( TFLAG_GOES_UP ) && !down_ter.has_flag( TFLAG_RAMP ) &&
-        !up_is_ledge && !via_ramp ) {
-        // Can't safely reach the lower tile
-        return false;
-    }
-
-    if( bash ) {
-        return true;
-    }
-    // get_cache() has no bounds check on z, and maptile_at's mapbuffer fallback
-    // can return non-null terrain for positions outside the reality bubble.
-    if( !inbounds( down_p ) || !inbounds_z( up_p.z() ) ) {
-        return up.get_furn_t().movecost >= 0;
-    }
-
-    int part_up;
-    const vehicle *veh_up = veh_at_internal( up_p, part_up );
-    if( veh_up != nullptr && !veh_at( up_p ).part_with_feature( VPFLAG_NOCOLLIDEBELOW, false ) ) {
-        // TODO: Hatches below the vehicle
-        return false;
-    }
-
-    int part_down;
-    const vehicle *veh_down = veh_at_internal( down_p, part_down );
-    if( veh_down != nullptr && veh_down->roof_at_part( part_down ) >= 0 ) {
-        // TODO: OPEN (and only open) hatches from above
-        return false;
-    }
-
-    // Currently only furniture can block movement if everything else is OK
-    // TODO: Vehicles with boards in the given spot
-    return up.get_furn_t().movecost >= 0;
+    return MAPBUFFER_REGISTRY.get( bound_dimension_ ).valid_move(
+               map_local_to_abs( *this, from ), map_local_to_abs( *this, to ), {
+        .bash = bash,
+        .flying = flying,
+        .via_ramp = via_ramp,
+        .zlevels = zlevels,
+    } );
 }
 
 // End of move cost
@@ -3185,35 +3091,8 @@ int map::climb_difficulty( const tripoint_bub_ms &p ) const
         return INT_MAX;
     }
 
-    int best_difficulty = INT_MAX;
-    int blocks_movement = 0;
-    if( has_flag( "LADDER", p ) ) {
-        // Really easy, but you have to stand on the tile
-        return 1;
-    } else if( has_flag( TFLAG_RAMP, p ) || has_flag( TFLAG_RAMP_UP, p ) ||
-               has_flag( TFLAG_RAMP_DOWN, p ) ) {
-        // We're on something stair-like, so halfway there already
-        best_difficulty = 7;
-    }
-
-    for( const auto &pt : points_in_radius( p, 1 ) ) {
-        if( impassable_ter_furn( pt ) ) {
-            // TODO: Non-hardcoded climbability
-            best_difficulty = std::min( best_difficulty, 10 );
-            blocks_movement++;
-        } else if( veh_at( pt ) ) {
-            // Vehicle tiles are quite good for climbing
-            // TODO: Penalize spiked parts?
-            best_difficulty = std::min( best_difficulty, 7 );
-        }
-
-        if( best_difficulty > 5 && has_flag( "CLIMBABLE", pt ) ) {
-            best_difficulty = 5;
-        }
-    }
-
-    // TODO: Make this more sensible - check opposite sides, not just movement blocker count
-    return std::max( 0, best_difficulty - blocks_movement );
+    return MAPBUFFER_REGISTRY.get( bound_dimension_ ).climb_difficulty(
+               map_local_to_abs( *this, p ) ).value_or( INT_MAX );
 }
 
 bool map::has_floor( const tripoint_bub_ms &p, bool visible_only ) const
@@ -11271,20 +11150,7 @@ field &map::get_field( const tripoint_bub_ms &p )
 
 void map::creature_on_trap( Creature &c, const bool may_avoid )
 {
-    const auto &tr = tr_at( c.bub_pos() );
-    if( tr.is_null() ) {
-        return;
-    }
-    // boarded in a vehicle means the player is above the trap, like a flying monster and can
-    // never trigger the trap.
-    const player *const p = dynamic_cast<const player *>( &c );
-    if( p != nullptr && p->in_vehicle ) {
-        return;
-    }
-    if( may_avoid && c.avoid_trap( c.bub_pos(), tr ) ) {
-        return;
-    }
-    tr.trigger( c.bub_pos(), &c );
+    MAPBUFFER_REGISTRY.get( bound_dimension_ ).creature_on_trap( c, may_avoid );
 }
 
 template<typename Functor>

--- a/src/map.h
+++ b/src/map.h
@@ -1138,6 +1138,9 @@ class map : public submap_load_listener
         std::vector<tripoint_bub_ms> route( const tripoint_bub_ms &f, const tripoint_bub_ms &t,
                                             const pathfinding_settings &settings,
         const std::set<tripoint_bub_ms> &pre_closed = {{ }} ) const;
+        std::vector<tripoint_abs_ms> route( const tripoint_abs_ms &f, const tripoint_abs_ms &t,
+                                            const pathfinding_settings &settings,
+        const std::set<tripoint_abs_ms> &pre_closed = {{ }} ) const;
 
         // Vehicles: Common to 2D and 3D
         VehicleList get_vehicles();

--- a/src/map_functions.cpp
+++ b/src/map_functions.cpp
@@ -3,6 +3,8 @@
 #include "character.h"
 #include "game.h"
 #include "map.h"
+#include "mapbuffer.h"
+#include "mapbuffer_registry.h"
 #include "map_iterator.h"
 #include "messages.h"
 #include "monster.h"
@@ -10,32 +12,24 @@
 
 static const mtype_id mon_mi_go_myrmidon( "mon_mi_go_myrmidon" );
 
-namespace map_funcs
+namespace
 {
 
-auto climbing_cost( const map &m, const tripoint_bub_ms &from,
-                    const tripoint_bub_ms &to ) -> std::optional<int>
+auto remove_migo_nerve_cage_terrain( mapbuffer &buffer, const tripoint_abs_ms &p ) -> bool
 {
-    // TODO: All sorts of mutations, equipment weight etc. for characters
-    if( !m.valid_move( from, to, false, true ) ) {
-        return {};
-    }
-    const int diff = m.climb_difficulty( from );
-    if( diff > 5 ) {
-        return {};
-    }
-    return 50 + diff * 100;
-}
-
-void migo_nerve_cage_removal( map &m, const tripoint_bub_ms &p, bool spawn_damaged )
-{
-    bool open = false;
-    for( const tripoint_bub_ms &tmp : m.points_in_radius( p, 12 ) ) {
-        if( m.ter( tmp ) == ter_id( "t_wall_resin_cage" ) ) {
-            m.ter_set( tmp, ter_id( "t_floor_resin" ) );
+    auto open = false;
+    for( const auto &tmp : points_in_radius( p, 12 ) ) {
+        if( buffer.get_ter( tmp ) == ter_id( "t_wall_resin_cage" ) ) {
+            buffer.set_ter( tmp, ter_id( "t_floor_resin" ) );
             open = true;
         }
     }
+    return open;
+}
+
+auto finish_migo_nerve_cage_removal( const tripoint_bub_ms &p, const bool spawn_damaged,
+                                     const bool open ) -> void
+{
     if( open ) {
         add_msg( m_good, _( "The nerve cluster collapses in on itself, and the nearby cages open!" ) );
     } else {
@@ -58,6 +52,53 @@ void migo_nerve_cage_removal( map &m, const tripoint_bub_ms &p, bool spawn_damag
     if( get_player_character().sees( p ) ) {
         add_msg( m_bad, _( "Something stirs and clambers out of the ruined mass of flesh and nerves!" ) );
     }
+}
+
+} // namespace
+
+namespace map_funcs
+{
+
+auto climbing_cost( mapbuffer &buffer, const tripoint_abs_ms &from,
+                    const tripoint_abs_ms &to ) -> std::optional<int>
+{
+    // TODO: All sorts of mutations, equipment weight etc. for characters
+    const auto move_options = mapbuffer_valid_move_options {
+        .flying = true,
+    };
+    if( !buffer.valid_move( from, to, move_options ) ) {
+        return {};
+    }
+
+    const auto diff = buffer.climb_difficulty( from );
+    if( !diff || *diff > 5 ) {
+        return {};
+    }
+    return 50 + *diff * 100;
+}
+
+auto climbing_cost( const map &m, const tripoint_bub_ms &from,
+                    const tripoint_bub_ms &to ) -> std::optional<int>
+{
+    if( from.z() != to.z() && !m.has_zlevels() ) {
+        return {};
+    }
+    return climbing_cost( MAPBUFFER_REGISTRY.get( m.get_bound_dimension() ),
+                          map_local_to_abs( m, from ), map_local_to_abs( m, to ) );
+}
+
+auto migo_nerve_cage_removal( mapbuffer &buffer, const tripoint_abs_ms &p,
+                              const bool spawn_damaged ) -> void
+{
+    finish_migo_nerve_cage_removal( abs_to_bub( p ), spawn_damaged,
+                                    remove_migo_nerve_cage_terrain( buffer, p ) );
+}
+
+void migo_nerve_cage_removal( map &m, const tripoint_bub_ms &p, bool spawn_damaged )
+{
+    auto &buffer = MAPBUFFER_REGISTRY.get( m.get_bound_dimension() );
+    finish_migo_nerve_cage_removal( p, spawn_damaged,
+                                    remove_migo_nerve_cage_terrain( buffer, map_local_to_abs( m, p ) ) );
 }
 
 } // namespace map_funcs

--- a/src/map_functions.h
+++ b/src/map_functions.h
@@ -5,6 +5,7 @@
 #include "coordinates.h"
 
 class map;
+class mapbuffer;
 
 namespace map_funcs
 {
@@ -14,11 +15,13 @@ namespace map_funcs
  * returns move cost of climbing from `from` to `to`.
  * Return value can depend on the orientation of the terrain.
  */
+auto climbing_cost( mapbuffer &buffer, const tripoint_abs_ms &from,
+                    const tripoint_abs_ms &to ) -> std::optional<int>;
 auto climbing_cost( const map &m, const tripoint_bub_ms &from,
                     const tripoint_bub_ms &to ) -> std::optional<int>;
 
+auto migo_nerve_cage_removal( mapbuffer &buffer, const tripoint_abs_ms &p,
+                              bool spawn_damaged ) -> void;
 void migo_nerve_cage_removal( map &m, const tripoint_bub_ms &p, bool spawn_damaged );
 
 } // namespace map_funcs
-
-

--- a/src/map_utils.cpp
+++ b/src/map_utils.cpp
@@ -30,6 +30,17 @@ auto get_items_at( const tripoint_abs_ms &loc ) -> location_subrange
     }
 }
 
+auto take_down_deployed_furniture( mapbuffer &buffer,
+                                   const tripoint_abs_ms &furniture_pos,
+                                   const tripoint_abs_ms &drop_pos ) -> void
+{
+    const auto furn_item = buffer.get_furn( furniture_pos )->obj().deployed_item;
+    auto dropped_item = item::spawn( furn_item, calendar::turn );
+    dropped_item->item_vars().merge( *buffer.furn_vars( furniture_pos ) );
+    buffer.add_item_or_charges( drop_pos, std::move( dropped_item ) );
+    buffer.set_furn( furniture_pos, f_null );
+}
+
 auto take_down_deployed_furniture( const tripoint_bub_ms &furniture_pos,
                                    const tripoint_bub_ms &drop_pos ) -> void
 {

--- a/src/map_utils.h
+++ b/src/map_utils.h
@@ -14,5 +14,8 @@ using location_subrange =
 auto get_items_at( const tripoint_abs_ms &loc ) -> location_subrange;
 
 /// Take down deployed furniture and drop its item form.
+auto take_down_deployed_furniture( mapbuffer &buffer,
+                                   const tripoint_abs_ms &furniture_pos,
+                                   const tripoint_abs_ms &drop_pos ) -> void;
 auto take_down_deployed_furniture( const tripoint_bub_ms &furniture_pos,
                                    const tripoint_bub_ms &drop_pos ) -> void;

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <chrono>
+#include <cstdlib>
 #include <exception>
 #include <functional>
 #include <memory>
@@ -16,6 +18,7 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "cata_utility.h"
+#include "creature.h"
 #include "debug.h"
 #include "detached_ptr.h"
 #include "distribution_grid.h"
@@ -30,6 +33,7 @@
 #include "json.h"
 #include "map.h"
 #include "mapdata.h"
+#include "map_iterator.h"
 #include "map_mutation_hooks.h"
 #include "overmapbuffer.h"
 #include "output.h"
@@ -143,6 +147,29 @@ auto move_cost_from_tile_parts( const ter_id &terrain_id, const furn_id &furnitu
     }
 
     return std::max( terrain.movecost, 0 );
+}
+
+auto move_cost_ter_furn_from_tile( const mapbuffer_tile_lookup &tile ) -> int
+{
+    const auto &terrain = tile.sm->get_ter( tile.local ).obj();
+    if( terrain.movecost == 0 ) {
+        return 0;
+    }
+
+    const auto &furniture = tile.sm->get_furn( tile.local ).obj();
+    if( furniture.movecost < 0 ) {
+        return 0;
+    }
+
+    const auto cost = terrain.movecost + furniture.movecost;
+    return cost > 0 ? cost : 0;
+}
+
+auto passable_ter_furn_at( mapbuffer &buffer, const tripoint_abs_ms &p,
+                           const mapbuffer_lookup_options options ) -> bool
+{
+    const auto tile = lookup_tile( buffer, p, options );
+    return tile && move_cost_ter_furn_from_tile( *tile ) != 0;
 }
 
 } // namespace
@@ -541,6 +568,202 @@ auto mapbuffer::passable( const tripoint_abs_ms &p,
     return *cost != 0;
 }
 
+auto mapbuffer::valid_move( const tripoint_abs_ms &from, const tripoint_abs_ms &to,
+                            const mapbuffer_valid_move_options options ) -> bool
+{
+    assert( to.z() > std::numeric_limits<int>::min() );
+    if( std::abs( from.x() - to.x() ) > 1 || std::abs( from.y() - to.y() ) > 1 ||
+        std::abs( from.z() - to.z() ) > 1 ) {
+        return false;
+    }
+
+    if( from.z() == to.z() ) {
+        const auto target_passable = passable( to, options.lookup );
+        if( !target_passable ) {
+            return false;
+        }
+        return *target_passable || ( options.bash && get_ter( to, options.lookup ).has_value() );
+    }
+    if( !options.zlevels ) {
+        return false;
+    }
+
+    const auto going_up = from.z() < to.z();
+    const auto up_p = going_up ? to : from;
+    const auto down_p = going_up ? from : to;
+
+    const auto up_ter_id = get_ter( up_p, options.lookup );
+    const auto up_furn_id = get_furn( up_p, options.lookup );
+    if( !up_ter_id || !up_furn_id ) {
+        return false;
+    }
+    const auto &up_ter = up_ter_id->obj();
+    if( up_ter.id.is_null() ) {
+        return false;
+    }
+    const auto &up_furn = up_furn_id->obj();
+    const auto up_trap_id = get_trap( up_p, options.lookup ).value_or( tr_null );
+    const auto up_is_ledge = up_ter.trap == tr_ledge || up_trap_id == tr_ledge;
+
+    if( up_ter.movecost == 0 ) {
+        return false;
+    }
+
+    const auto down_ter_id = get_ter( down_p, options.lookup );
+    if( !down_ter_id ) {
+        return false;
+    }
+    const auto &down_ter = down_ter_id->obj();
+    if( down_ter.id.is_null() ) {
+        return false;
+    }
+
+    if( !up_is_ledge && down_ter.movecost == 0 ) {
+        return false;
+    }
+
+    if( !up_ter.has_flag( TFLAG_NO_FLOOR ) && !up_ter.has_flag( TFLAG_GOES_DOWN ) &&
+        !up_is_ledge && !options.via_ramp ) {
+        if( std::abs( from.x() - to.x() ) == 1 || std::abs( from.y() - to.y() ) == 1 ) {
+            const auto midpoint = tripoint_abs_ms( down_p.xy(), up_p.z() );
+            return valid_move( down_p, midpoint, options ) && valid_move( midpoint, up_p, options );
+        }
+        return false;
+    }
+
+    if( !options.flying && !down_ter.has_flag( TFLAG_GOES_UP ) &&
+        !down_ter.has_flag( TFLAG_RAMP ) && !up_is_ledge && !options.via_ramp ) {
+        return false;
+    }
+
+    if( options.bash ) {
+        return true;
+    }
+
+    const auto up_vehicle = veh_at( up_p, options.lookup );
+    if( up_vehicle && !up_vehicle.part_with_feature( VPFLAG_NOCOLLIDEBELOW, false ) ) {
+        return false;
+    }
+
+    const auto down_vehicle = veh_at( down_p, options.lookup );
+    if( down_vehicle &&
+        down_vehicle->vehicle().roof_at_part( static_cast<int>( down_vehicle->part_index() ) ) >= 0 ) {
+        return false;
+    }
+
+    return up_furn.movecost >= 0;
+}
+
+auto mapbuffer::climb_difficulty( const tripoint_abs_ms &p,
+                                  const mapbuffer_lookup_options options ) -> std::optional<int>
+{
+    if( p.z() > OVERMAP_HEIGHT || p.z() < -OVERMAP_DEPTH ) {
+        return std::nullopt;
+    }
+
+    const auto center_tile = lookup_tile( *this, p, options );
+    if( !center_tile ) {
+        return std::nullopt;
+    }
+
+    auto best_difficulty = std::numeric_limits<int>::max();
+    auto blocks_movement = 0;
+    if( has_flag_ter_or_furn( "LADDER", p, options ) ) {
+        return 1;
+    }
+    if( has_flag_ter_or_furn( TFLAG_RAMP, p, options ) ||
+        has_flag_ter_or_furn( TFLAG_RAMP_UP, p, options ) ||
+        has_flag_ter_or_furn( TFLAG_RAMP_DOWN, p, options ) ) {
+        best_difficulty = 7;
+    }
+
+    for( const auto &pt : points_in_radius( p, 1 ) ) {
+        if( !passable_ter_furn_at( *this, pt, options ) ) {
+            best_difficulty = std::min( best_difficulty, 10 );
+            blocks_movement++;
+        } else if( veh_at( pt, options ) ) {
+            best_difficulty = std::min( best_difficulty, 7 );
+        }
+
+        if( best_difficulty > 5 && has_flag_ter_or_furn( "CLIMBABLE", pt, options ) ) {
+            best_difficulty = 5;
+        }
+    }
+
+    return std::max( 0, best_difficulty - blocks_movement );
+}
+
+auto mapbuffer::has_flag( const std::string &flag, const tripoint_abs_ms &p,
+                          const mapbuffer_lookup_options options ) -> bool
+{
+    return has_flag_ter_or_furn( flag, p, options );
+}
+
+auto mapbuffer::has_flag_ter( const std::string &flag, const tripoint_abs_ms &p,
+                              const mapbuffer_lookup_options options ) -> bool
+{
+    const auto tile = lookup_tile( *this, p, options );
+    return tile && tile->sm->get_ter( tile->local ).obj().has_flag( flag );
+}
+
+auto mapbuffer::has_flag_furn( const std::string &flag, const tripoint_abs_ms &p,
+                               const mapbuffer_lookup_options options ) -> bool
+{
+    const auto tile = lookup_tile( *this, p, options );
+    return tile && tile->sm->get_furn( tile->local ).obj().has_flag( flag );
+}
+
+auto mapbuffer::has_flag_vpart( const std::string &flag, const tripoint_abs_ms &p,
+                                const mapbuffer_lookup_options options ) -> bool
+{
+    const auto vp = veh_at( p, options );
+    return static_cast<bool>( vp.part_with_feature( flag, true ) );
+}
+
+auto mapbuffer::has_flag_furn_or_vpart( const std::string &flag, const tripoint_abs_ms &p,
+                                        const mapbuffer_lookup_options options ) -> bool
+{
+    return has_flag_furn( flag, p, options ) || has_flag_vpart( flag, p, options );
+}
+
+auto mapbuffer::has_flag_ter_or_furn( const std::string &flag, const tripoint_abs_ms &p,
+                                      const mapbuffer_lookup_options options ) -> bool
+{
+    const auto tile = lookup_tile( *this, p, options );
+    return tile &&
+           ( tile->sm->get_ter( tile->local ).obj().has_flag( flag ) ||
+             tile->sm->get_furn( tile->local ).obj().has_flag( flag ) );
+}
+
+auto mapbuffer::has_flag( const ter_bitflags flag, const tripoint_abs_ms &p,
+                          const mapbuffer_lookup_options options ) -> bool
+{
+    return has_flag_ter_or_furn( flag, p, options );
+}
+
+auto mapbuffer::has_flag_ter( const ter_bitflags flag, const tripoint_abs_ms &p,
+                              const mapbuffer_lookup_options options ) -> bool
+{
+    const auto tile = lookup_tile( *this, p, options );
+    return tile && tile->sm->get_ter( tile->local ).obj().has_flag( flag );
+}
+
+auto mapbuffer::has_flag_furn( const ter_bitflags flag, const tripoint_abs_ms &p,
+                               const mapbuffer_lookup_options options ) -> bool
+{
+    const auto tile = lookup_tile( *this, p, options );
+    return tile && tile->sm->get_furn( tile->local ).obj().has_flag( flag );
+}
+
+auto mapbuffer::has_flag_ter_or_furn( const ter_bitflags flag, const tripoint_abs_ms &p,
+                                      const mapbuffer_lookup_options options ) -> bool
+{
+    const auto tile = lookup_tile( *this, p, options );
+    return tile &&
+           ( tile->sm->get_ter( tile->local ).obj().has_flag( flag ) ||
+             tile->sm->get_furn( tile->local ).obj().has_flag( flag ) );
+}
+
 auto mapbuffer::ter_vars( const tripoint_abs_ms &p,
                           const mapbuffer_lookup_options options ) -> data_vars::data_set *
 {
@@ -596,6 +819,35 @@ auto mapbuffer::set_trap( const tripoint_abs_ms &p, const trap_id trap,
     tile->sm->set_trap( tile->local, trap );
     sync_active_trap_change_side_tables( p, tile->local, old_id, trap );
     return true;
+}
+
+auto mapbuffer::creature_on_trap( Creature &critter, const bool may_avoid ) -> void
+{
+    const auto pos = critter.abs_pos();
+    const auto terrain = get_ter( pos );
+    if( !terrain ) {
+        return;
+    }
+
+    auto trap_here = terrain->obj().trap;
+    if( trap_here == tr_null ) {
+        trap_here = get_trap( pos ).value_or( tr_null );
+    }
+
+    const auto &tr = trap_here.obj();
+    if( tr.is_null() ) {
+        return;
+    }
+    const player *const pl = critter.as_player();
+    if( pl != nullptr && pl->in_vehicle ) {
+        return;
+    }
+
+    const auto bubble_pos = abs_to_bub( pos );
+    if( may_avoid && critter.avoid_trap( bubble_pos, tr ) ) {
+        return;
+    }
+    tr.trigger( bubble_pos, &critter );
 }
 
 auto mapbuffer::get_radiation( const tripoint_abs_ms &p,

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -24,10 +24,12 @@
 
 class submap;
 class computer;
+class Creature;
 class field;
 class field_entry;
 class item;
 class JsonIn;
+enum ter_bitflags : int;
 struct partial_con;
 template<typename T>
 class location_vector;
@@ -54,6 +56,14 @@ enum class mapbuffer_lookup_mode : int {
 
 struct mapbuffer_lookup_options {
     mapbuffer_lookup_mode mode = mapbuffer_lookup_mode::simulated_only;
+};
+
+struct mapbuffer_valid_move_options {
+    bool bash = false;
+    bool flying = false;
+    bool via_ramp = false;
+    bool zlevels = true;
+    mapbuffer_lookup_options lookup;
 };
 
 struct mapbuffer_field_age_options {
@@ -171,6 +181,30 @@ class mapbuffer
         mapbuffer_lookup_options options = {} ) -> std::optional<int>;
         auto passable( const tripoint_abs_ms &p,
         mapbuffer_lookup_options options = {} ) -> std::optional<bool>;
+        auto valid_move( const tripoint_abs_ms &from, const tripoint_abs_ms &to,
+                         mapbuffer_valid_move_options options = {} ) -> bool;
+        auto climb_difficulty( const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> std::optional<int>;
+        auto has_flag( const std::string &flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
+        auto has_flag_ter( const std::string &flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
+        auto has_flag_furn( const std::string &flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
+        auto has_flag_vpart( const std::string &flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
+        auto has_flag_furn_or_vpart( const std::string &flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
+        auto has_flag_ter_or_furn( const std::string &flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
+        auto has_flag( ter_bitflags flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
+        auto has_flag_ter( ter_bitflags flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
+        auto has_flag_furn( ter_bitflags flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
+        auto has_flag_ter_or_furn( ter_bitflags flag, const tripoint_abs_ms &p,
+        mapbuffer_lookup_options options = {} ) -> bool;
         auto ter_vars( const tripoint_abs_ms &p,
         mapbuffer_lookup_options options = {} ) -> data_vars::data_set *;
         auto furn_vars( const tripoint_abs_ms &p,
@@ -180,6 +214,7 @@ class mapbuffer
         mapbuffer_lookup_options options = {} ) -> std::optional<trap_id>;
         auto set_trap( const tripoint_abs_ms &p, trap_id trap,
         mapbuffer_lookup_options options = {} ) -> bool;
+        auto creature_on_trap( Creature &critter, bool may_avoid = true ) -> void;
 
         auto get_radiation( const tripoint_abs_ms &p,
         mapbuffer_lookup_options options = {} ) -> std::optional<int>;

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -182,7 +182,7 @@ class mapbuffer
         auto passable( const tripoint_abs_ms &p,
         mapbuffer_lookup_options options = {} ) -> std::optional<bool>;
         auto valid_move( const tripoint_abs_ms &from, const tripoint_abs_ms &to,
-                         mapbuffer_valid_move_options options = {} ) -> bool;
+        mapbuffer_valid_move_options options = {} ) -> bool;
         auto climb_difficulty( const tripoint_abs_ms &p,
         mapbuffer_lookup_options options = {} ) -> std::optional<int>;
         auto has_flag( const std::string &flag, const tripoint_abs_ms &p,

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2857,11 +2857,6 @@ bool mattack::ranged_pull( monster *z )
             if( foe->in_vehicle ) {
                 here.unboard_vehicle( foe->bub_pos() );
             }
-
-            if( target->is_player() && ( pt.x() < g_half_mapsize_x || pt.y() < g_half_mapsize_y ||
-                                         pt.x() >= g_half_mapsize_x + SEEX || pt.y() >= g_half_mapsize_y + SEEY ) ) {
-                g->update_map( pt.x(), pt.y() );
-            }
         }
 
         target->setpos( pt );
@@ -3002,11 +2997,6 @@ bool mattack::grab_drag( monster *z )
         z->move_to( target_square );
         if( !g->is_empty( zpt ) ) { //Cancel the grab if the space is occupied by something
             return false;
-        }
-        if( target->is_player() && ( zpt.x() < g_half_mapsize_x ||
-                                     zpt.y() < g_half_mapsize_y ||
-                                     zpt.x() >= g_half_mapsize_x + SEEX || zpt.y() >= g_half_mapsize_y + SEEY ) ) {
-            g->update_map( zpt.x(), zpt.y() );
         }
         if( foe != nullptr ) {
             if( foe->in_vehicle ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -455,22 +455,30 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
     const auto for_each_monster = [&]( auto &&fn ) {
         if( ctx.monsters ) {
             for( monster *mp : *ctx.monsters ) {
-                fn( *mp );
+                if( mp != nullptr && !mp->is_dead() ) {
+                    fn( *mp );
+                }
             }
         } else {
             for( monster &tmp : g->all_monsters() ) {
-                fn( tmp );
+                if( !tmp.is_dead() ) {
+                    fn( tmp );
+                }
             }
         }
     };
     const auto for_each_npc = [&]( auto &&fn ) {
         if( ctx.npcs ) {
             for( npc *np : *ctx.npcs ) {
-                fn( *np );
+                if( np != nullptr && !np->is_dead() ) {
+                    fn( *np );
+                }
             }
         } else {
             for( npc &who : g->all_npcs() ) {
-                fn( who );
+                if( !who.is_dead() ) {
+                    fn( who );
+                }
             }
         }
     };
@@ -491,6 +499,9 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
     int local_morale  = morale;
     int local_friendly = friendly;
     tripoint_bub_ms local_goal = goal;
+    auto local_goal_kind = monster_plan_goal_kind::none;
+    auto *local_observed_target = static_cast<Creature *>( nullptr );
+    auto local_observed_target_pos = tripoint_bub_ms::zero();
 
     const auto &factions = g->critter_tracker->factions();
 
@@ -632,6 +643,7 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
         result.anger   = local_anger;
         result.morale  = local_morale;
         result.friendly = local_friendly;
+        result.goal_kind = monster_plan_goal_kind::none;
         return result;
     }
 
@@ -755,7 +767,9 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
                         const auto sit = ctx.faction_snap->find( hostile_id );
                         if( sit != ctx.faction_snap->end() ) {
                             std::ranges::for_each( sit->second, [&]( monster * mon_ptr ) {
-                                process_sight( *mon_ptr );
+                                if( mon_ptr != nullptr && !mon_ptr->is_dead() ) {
+                                    process_sight( *mon_ptr );
+                                }
                             } );
                         }
                     }
@@ -814,7 +828,9 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
                 const auto it = ctx.faction_snap->find( actual_faction );
                 if( it != ctx.faction_snap->end() ) {
                     std::ranges::for_each( it->second, [&]( monster * mon_ptr ) {
-                        process_faction_member( *mon_ptr );
+                        if( mon_ptr != nullptr && !mon_ptr->is_dead() ) {
+                            process_faction_member( *mon_ptr );
+                        }
                     } );
                 }
             } else {
@@ -872,8 +888,10 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
             if( !found_path_to_couch ) {
                 local_anger = 0;
                 result.effects_to_remove.push_back( effect_dragging );
+                local_goal_kind = monster_plan_goal_kind::none;
             } else {
                 local_goal = couch_loc;
+                local_goal_kind = monster_plan_goal_kind::none;
             }
         }
 
@@ -881,8 +899,11 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
 
         const auto dest = target->bub_pos();
         const auto att_to_target = attitude_to( *target );
+        local_observed_target = target;
+        local_observed_target_pos = dest;
         if( att_to_target == Attitude::A_HOSTILE && !fleeing ) {
             local_goal = dest;
+            local_goal_kind = monster_plan_goal_kind::target_last_known;
         } else if( fleeing ) {
             const auto current_pos = bub_pos();
             const auto away = current_pos - dest;
@@ -899,6 +920,7 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
                 flee_goal.z() = current_pos.z();
             }
             local_goal = flee_goal;
+            local_goal_kind = monster_plan_goal_kind::none;
         }
         if( angers_hostile_weak && att_to_target != Attitude::A_FRIENDLY ) {
             int hp_per = target->hp_percentage();
@@ -932,11 +954,14 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
         if( allow_follow_player && !has_flag( MF_PET_WONT_FOLLOW ) ) {
             if( rl_dist( bub_pos(), g->u.bub_pos() ) > 2 ) {
                 local_goal = g->u.bub_pos();
+                local_goal_kind = monster_plan_goal_kind::none;
             } else {
                 local_goal = bub_pos(); // unset_dest
+                local_goal_kind = monster_plan_goal_kind::none;
             }
         } else if( allow_follow_player ) {
             local_goal = bub_pos(); // unset_dest
+            local_goal_kind = monster_plan_goal_kind::none;
         }
         const auto &u = g->u;
         const int distance_from_friend = rl_dist( bub_pos(), u.bub_pos() );
@@ -960,15 +985,21 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
             target->attitude_to( g->u ) == Attitude::A_HOSTILE && !fleeing ) {
             if( rl_dist( bub_pos(), g->u.bub_pos() ) > 5 ) {
                 local_goal = g->u.bub_pos();
+                local_goal_kind = monster_plan_goal_kind::none;
             }
         } else if( rl_dist( bub_pos(), g->u.bub_pos() ) > 1 ) {
             local_goal = g->u.bub_pos();
+            local_goal_kind = monster_plan_goal_kind::none;
         } else {
             local_goal = bub_pos(); // unset_dest
+            local_goal_kind = monster_plan_goal_kind::none;
         }
     }
 
     result.goal     = local_goal;
+    result.goal_kind = local_goal_kind;
+    result.observed_target = local_observed_target;
+    result.observed_target_pos = local_observed_target_pos;
     result.anger    = local_anger;
     result.morale   = local_morale;
     result.friendly = local_friendly;
@@ -978,11 +1009,17 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
 
 void monster::apply_plan( const monster_plan_t &plan )
 {
-    // Apply movement goal.
-    // LOGIC-1: set_goal(plan.goal) correctly implements the unset_dest()
-    // semantic when plan.goal == bub_pos(), because unset_dest() is defined as
-    // set_goal(pos()).  No special-case handling for the "unset" value is needed.
-    set_goal( plan.goal );
+    // Target movement updates last-known position; it does not by itself mean
+    // the monster's current movement path is broken.
+    if( plan.goal_kind == monster_plan_goal_kind::target_last_known ) {
+        const auto &here = get_map();
+        if( here.inbounds( plan.goal ) ) {
+            goal = plan.goal;
+        }
+    } else {
+        // set_goal(bub_pos()) preserves unset_dest() semantics.
+        set_goal( plan.goal );
+    }
 
     // Apply stat changes.
     anger   = plan.anger;
@@ -1178,11 +1215,8 @@ monster_action_t monster::decide_action() const
             }
         }
 
-        // Signal A* repath if needed (execute_action will do the actual call).
-        // Tier-0: always repath when requested.
-        // Tier-1: also repath when repath_requested is already set (monster was
-        //   stuck last turn), breaking the perpetual stuck loop where a blocked
-        //   Tier-1 monster spends 100 moves per turn and never replans.
+        // Signal stale path/request state.  execute_action only routes from
+        // no-step idle actions; a valid greedy step is taken directly.
         if( repath_requested && lod_tier <= 1 && !action.needs_repath ) {
             action.needs_repath = true;
         }
@@ -1405,10 +1439,6 @@ monster_action_t monster::decide_action() const
         action.kind          = monster_action_kind::idle;
         action.move_cost     = 100;
         action.needs_stumble = true;
-        if( !is_wandering() ) {
-            // Flag that the path is stale; execute_action will clear it.
-            action.needs_repath = true;
-        }
     }
 
     return action;
@@ -1437,13 +1467,18 @@ void monster::execute_action( const monster_action_t &action )
     // move_effects) that happen before the movement execution.
     map &here = g->m;
 
-    behavior::monster_oracle_t oracle( this );
-    behavior::tree goals;
-    goals.add( type->get_goals() );
-    std::string beh_action = goals.tick( &oracle );
+    std::string beh_action;
+    {
+        ZoneScopedN( "mon_execute_behavior" );
+        behavior::monster_oracle_t oracle( this );
+        behavior::tree goals;
+        goals.add( type->get_goals() );
+        beh_action = goals.tick( &oracle );
+    }
     // The monster can consume objects it stands on.
     if( beh_action == "consume_items" &&
         ( !has_effect( effect_mon_mitosis ) || hp < type->hp * 3 ) ) {
+        ZoneScopedN( "mon_execute_consume_items" );
         if( g->u.sees( *this ) ) {
             add_msg( _( "The %s flows around the objects on the floor and they are quickly dissolved!" ),
                      name() );
@@ -1484,6 +1519,7 @@ void monster::execute_action( const monster_action_t &action )
     //     loop: if all call()s failed the cooldown was never reset, decide_action()
     //     saw cooldown==0 again next iteration, and moves were never consumed.
     if( !( pacified || is_hallucination() ) ) {
+        ZoneScopedN( "mon_execute_special_attacks" );
         std::vector<const std::pair<const std::string, mtype_special_attack> *> spec_list;
         for( const auto &sp_type : type->special_attacks ) {
             const auto it = special_attacks.find( sp_type.first );
@@ -1511,11 +1547,16 @@ void monster::execute_action( const monster_action_t &action )
     // Fall through: execute the movement action regardless of whether a special fired.
 
     // Dragging foe / nursebot.
-    player *dragged_foe = find_dragged_foe();
-    nursebot_operate( dragged_foe );
+    auto *dragged_foe = static_cast<player *>( nullptr );
+    {
+        ZoneScopedN( "mon_execute_drag_setup" );
+        dragged_foe = find_dragged_foe();
+        nursebot_operate( dragged_foe );
+    }
 
     // Floor / drowning / moves-negative guards.
     if( !flies() && g->m.has_flag( TFLAG_NO_FLOOR, bub_pos() ) ) {
+        ZoneScopedN( "mon_execute_floor_trap" );
         g->m.creature_on_trap( *this, false );
         if( is_dead() ) {
             return;
@@ -1533,9 +1574,12 @@ void monster::execute_action( const monster_action_t &action )
     // move_effects — may prevent movement this tick.
     // TODO: Move this to attack_at/move_to/etc. functions
     bool attacking = false;
-    if( !move_effects( attacking ) ) {
-        moves = 0;
-        return;
+    {
+        ZoneScopedN( "mon_execute_move_effects" );
+        if( !move_effects( attacking ) ) {
+            moves = 0;
+            return;
+        }
     }
 
     // Friendly decrement — runs unconditionally here so idle-path exits
@@ -1545,19 +1589,96 @@ void monster::execute_action( const monster_action_t &action )
         --friendly;
     }
 
+    // Movement execution phase.
+    auto dest = resolved_action.dest;
+
+    const auto reclassify_destination = [&]() {
+        resolved_action.target = nullptr;
+        resolved_action.stagger_adjust = get_stagger_adjust( bub_pos().raw(),
+                                         dest.raw(), dest.raw() );
+
+        const Creature *critter_here = g->critter_at( dest, is_hallucination() );
+        if( !pacified && critter_here != nullptr &&
+            attitude_to( *critter_here ) == Attitude::A_HOSTILE ) {
+            resolved_action.kind = monster_action_kind::attack;
+            resolved_action.target = const_cast<Creature *>( critter_here );
+        } else if( !pacified && has_flag( MF_CAN_OPEN_DOORS ) &&
+                   here.can_open_door( this, dest, !here.is_outside( bub_pos() ) ) ) {
+            resolved_action.kind = monster_action_kind::open_door;
+        } else if( !pacified && bash_skill() > 0 && !can_move_to( dest ) ) {
+            resolved_action.kind = monster_action_kind::bash;
+        } else if( !pacified && critter_here != nullptr &&
+                   attitude_to( *critter_here ) != Attitude::A_HOSTILE &&
+                   has_flag( MF_PUSH_MON ) ) {
+            resolved_action.kind = monster_action_kind::push;
+        } else if( has_flag( MF_STATIONARY ) ) {
+            resolved_action.kind = monster_action_kind::idle;
+            resolved_action.move_cost = 100;
+        } else {
+            resolved_action.kind = monster_action_kind::move;
+        }
+    };
+
+    auto route_attempted = false;
+    const auto try_repath = [&]() -> bool {
+        if( !resolved_action.needs_repath ||
+            is_wandering() ||
+            lod_tier > 1 ) {
+            return false;
+        }
+        route_attempted = true;
+        ZoneScopedN( "mon_execute_repath" );
+        std::vector<tripoint_bub_ms> maybe_new_path;
+        if( get_option<bool>( "USE_LEGACY_PATHFINDING" ) ) {
+            ZoneScopedN( "mon_execute_route_legacy" );
+            auto pf_settings = get_legacy_pathfinding_settings();
+            maybe_new_path = g->m.route( bub_pos(), goal, pf_settings,
+                                         get_legacy_path_avoid() );
+        } else {
+            ZoneScopedN( "mon_execute_route_pf" );
+            auto pair = get_pathfinding_pair();
+            maybe_new_path = Pathfinding::route( bub_pos(), goal,
+                                                 pair.first, pair.second );
+        }
+        assert( maybe_new_path.empty() ? true : maybe_new_path.back() == this->goal );
+        if( maybe_new_path.empty() ) {
+            path.clear();
+            return false;
+        }
+        path = maybe_new_path;
+        auto path_it = path.cbegin();
+        while( path_it != path.cend() && *path_it == bub_pos() ) {
+            ++path_it;
+        }
+        if( path_it == path.cend() ) {
+            return false;
+        }
+        {
+            ZoneScopedN( "mon_execute_repath_reclassify" );
+            dest = *path_it;
+            resolved_action.dest = dest;
+            reclassify_destination();
+        }
+        return true;
+    };
+
     // Idle / stumble actions (immobile, stunned, ai_waiting, attitude-stumble,
     //     no-viable-step).  These are checked AFTER move_effects to preserve the
     //     original ordering.
     if( resolved_action.kind == monster_action_kind::idle ) {
-        moves -= resolved_action.move_cost;
-        if( resolved_action.needs_stumble ) {
-            stumble();
+        if( resolved_action.needs_repath && try_repath() ) {
+            // A route supplied an executable step; continue into movement.
+        } else {
+            moves -= resolved_action.move_cost;
+            if( resolved_action.needs_stumble ) {
+                stumble();
+            }
+            if( resolved_action.needs_repath && !is_wandering() ) {
+                this->path.clear();
+                this->repath_requested = !route_attempted;
+            }
+            return;
         }
-        if( resolved_action.needs_repath && !is_wandering() ) {
-            this->path.clear();
-            this->repath_requested = true;
-        }
-        return;
     }
 
     if( resolved_action.kind == monster_action_kind::stumble ) {
@@ -1583,69 +1704,19 @@ void monster::execute_action( const monster_action_t &action )
         }
     }
 
-    // Movement execution phase.
-    auto dest = resolved_action.dest;
+    const auto immediate_action =
+        rl_dist( bub_pos(), resolved_action.dest ) <= 1 &&
+        ( resolved_action.kind == monster_action_kind::attack ||
+          resolved_action.kind == monster_action_kind::open_door ||
+          resolved_action.kind == monster_action_kind::bash ||
+          resolved_action.kind == monster_action_kind::push );
 
-    // Path trimming: remove front elements that equal current position.
-    while( !path.empty() && path.front() == bub_pos() ) {
-        path.erase( path.begin() );
-    }
-
-    // A* repath if flagged by decide_action.
-    //      Tier 0: always.  Tier 1: when genuinely stuck (see LOGIC-E note in
-    //      decide_action).  Tier 2: never — macro step has no path.
-    if( resolved_action.needs_repath && !is_wandering() ) {
-        if( lod_tier <= 1 ) {
-            std::vector<tripoint_bub_ms> maybe_new_path;
-            if( get_option<bool>( "USE_LEGACY_PATHFINDING" ) ) {
-                auto pf_settings = get_legacy_pathfinding_settings();
-                maybe_new_path = g->m.route( bub_pos(), goal, pf_settings,
-                                             get_legacy_path_avoid() );
-            } else {
-                auto pair = get_pathfinding_pair();
-                maybe_new_path = Pathfinding::route( bub_pos(), goal,
-                                                     pair.first, pair.second );
-            }
-            assert( maybe_new_path.empty() ? true : maybe_new_path.back() == this->goal );
-            if( !maybe_new_path.empty() ) {
-                path = maybe_new_path;
-            } else {
-                path.clear();
-            }
-        }
-        // Tier 2: path unchanged; macro step does not use the A* path.
-        auto path_it = path.cbegin();
-        while( path_it != path.cend() && *path_it == bub_pos() ) {
-            ++path_it;
-        }
-        if( path_it != path.cend() ) {
-            dest = *path_it;
-            resolved_action.dest = dest;
-            resolved_action.target = nullptr;
-            resolved_action.stagger_adjust = get_stagger_adjust( bub_pos().raw(),
-                                             dest.raw(), dest.raw() );
-
-            const Creature *critter_here = g->critter_at( dest, is_hallucination() );
-            if( !pacified && critter_here != nullptr &&
-                attitude_to( *critter_here ) == Attitude::A_HOSTILE ) {
-                resolved_action.kind = monster_action_kind::attack;
-                resolved_action.target = const_cast<Creature *>( critter_here );
-            } else if( !pacified && has_flag( MF_CAN_OPEN_DOORS ) &&
-                       here.can_open_door( this, dest, !here.is_outside( bub_pos() ) ) ) {
-                resolved_action.kind = monster_action_kind::open_door;
-            } else if( !pacified && bash_skill() > 0 && !can_move_to( dest ) ) {
-                resolved_action.kind = monster_action_kind::bash;
-            } else if( !pacified && critter_here != nullptr &&
-                       attitude_to( *critter_here ) != Attitude::A_HOSTILE &&
-                       has_flag( MF_PUSH_MON ) ) {
-                resolved_action.kind = monster_action_kind::push;
-            } else if( has_flag( MF_STATIONARY ) ) {
-                resolved_action.kind = monster_action_kind::idle;
-                resolved_action.move_cost = 100;
-            } else {
-                resolved_action.kind = monster_action_kind::move;
-            }
-        }
+    if( !immediate_action && !path.empty() ) {
+        ZoneScopedN( "mon_execute_path_trim" );
+        const auto path_it = std::ranges::find_if( path, [&]( const tripoint_bub_ms & p ) {
+            return p != bub_pos();
+        } );
+        path.erase( path.begin(), path_it );
     }
 
     // Facing direction update.
@@ -1681,6 +1752,7 @@ void monster::execute_action( const monster_action_t &action )
     //      remote_destination = monster's movement goal (may be many tiles away);
     //      nearby_destination = the immediate step being taken (action.dest).
     if( resolved_action.kind == monster_action_kind::move ) {
+        ZoneScopedN( "mon_execute_shove_vehicle" );
         shove_vehicle( goal, dest );
     }
 
@@ -1689,22 +1761,32 @@ void monster::execute_action( const monster_action_t &action )
     bool did_something = false;
 
     switch( resolved_action.kind ) {
-        case monster_action_kind::attack:
+        case monster_action_kind::attack: {
+            ZoneScopedN( "mon_execute_attack_at" );
             did_something = !pacified && attack_at( dest );
             break;
-        case monster_action_kind::open_door:
+        }
+        case monster_action_kind::open_door: {
+            ZoneScopedN( "mon_execute_open_door" );
             did_something = !pacified && can_open_doors &&
                             here.open_door( this, dest, !here.is_outside( bub_pos() ) );
             break;
-        case monster_action_kind::bash:
+        }
+        case monster_action_kind::bash: {
+            ZoneScopedN( "mon_execute_bash_at" );
             did_something = !pacified && bash_at( dest );
             break;
-        case monster_action_kind::push:
+        }
+        case monster_action_kind::push: {
+            ZoneScopedN( "mon_execute_push_to" );
             did_something = !pacified && push_to( dest, 0, 0 );
             break;
-        case monster_action_kind::move:
+        }
+        case monster_action_kind::move: {
+            ZoneScopedN( "mon_execute_move_to" );
             did_something = move_to( dest, false, false, resolved_action.stagger_adjust );
             break;
+        }
         default:
             break;
     }
@@ -1716,6 +1798,7 @@ void monster::execute_action( const monster_action_t &action )
 
     // Dragging update.
     if( has_effect( effect_dragging ) && dragged_foe != nullptr ) {
+        ZoneScopedN( "mon_execute_drag_update" );
         if( !dragged_foe->has_effect( effect_grabbed ) ) {
             dragged_foe = nullptr;
             remove_effect( effect_dragging );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -3,6 +3,7 @@
 #include "monster.h" // IWYU pragma: associated
 
 #include <algorithm>
+#include <array>
 #include <cfloat>
 #include <cmath>
 #include <cstdlib>
@@ -1104,14 +1105,17 @@ bool monster::die_if_drowning( const tripoint_bub_ms &at_pos, const int chance )
 //   4) Movement: destination → candidate selection → action kind
 monster_action_t monster::decide_action() const
 {
-    monster_action_t action;
+    auto action = monster_action_t {};
+    const auto pos = bub_pos();
+    const auto hallucination = is_hallucination();
+    const auto wandering = goal == pos;
 
     // (1) Hallucination: chance to vanish each tick.
-    if( is_hallucination() && one_in( 25 ) ) {
+    if( hallucination && one_in( 25 ) ) {
         action.kind = monster_action_kind::die;
         return action;
     }
-    const bool pacified = has_effect( effect_pacified );
+    const auto pacified = has_effect( effect_pacified );
 
     // (2) [Special attacks are detected and fired as a side effect inside
     //     execute_action(), matching the original move() fall-through behaviour.
@@ -1150,7 +1154,7 @@ monster_action_t monster::decide_action() const
 
     // Vehicle harness / pet-in-moving-vehicle checks (reads only).
     // execute_action() handles the remove_effect(effect_harnessed) write.
-    const auto vp = g->m.veh_at( bub_pos() );
+    const auto vp = g->m.veh_at( pos );
     if( vp && vp->vehicle().is_moving() && vp->vehicle().get_pet( vp->part_index() ) ) {
         action.kind      = monster_action_kind::idle;
         action.move_cost = moves;
@@ -1163,98 +1167,95 @@ monster_action_t monster::decide_action() const
     }
 
     // (4) Attitude check — read-only.
-    monster_attitude current_attitude = attitude( nullptr );
-    if( !is_wandering() ) {
-        if( goal == g->u.bub_pos() ) {
-            current_attitude = attitude( &g->u );
-        } else {
-            for( const npc &guy : g->all_npcs() ) {
-                if( goal == guy.bub_pos() ) {
-                    current_attitude = attitude( &guy );
-                }
-            }
+    if( wandering ) {
+        auto current_attitude = MATT_NULL;
+        {
+            ZoneScopedN( "mon_decide_attitude" );
+            current_attitude = attitude( nullptr );
         }
-    }
-
-    const auto allow_manual_goal = !is_wandering();
-    if( ( current_attitude == MATT_IGNORE && !allow_manual_goal ) ||
-        ( current_attitude == MATT_FOLLOW && !allow_manual_goal &&
-          rl_dist( bub_pos(), goal ) <= MONSTER_FOLLOW_DIST ) ) {
-        // Consume 100 moves and stumble; execute_action handles the writes.
-        action.kind          = monster_action_kind::idle;
-        action.move_cost     = 100;
-        action.needs_stumble = true;
-        return action;
+        if( current_attitude == MATT_IGNORE ||
+            ( current_attitude == MATT_FOLLOW &&
+              rl_dist( pos, goal ) <= MONSTER_FOLLOW_DIST ) ) {
+            // Consume 100 moves and stumble; execute_action handles the writes.
+            action.kind          = monster_action_kind::idle;
+            action.move_cost     = 100;
+            action.needs_stumble = true;
+            return action;
+        }
     }
 
     // (5) Destination determination — reads only.
     //     Path trimming (erase of front==pos() elements), path.clear(),
     //     repath_requested flag, and actual A* are all deferred to execute_action.
-    const map &here = g->m;
-    auto destination = bub_pos();
+    const auto &here = g->m;
+    auto destination = pos;
 
-    if( !is_wandering() ) {
-        // Simulate the path trimming without erasing: find the first element
-        // that is not our current position.
-        auto path_it = path.cbegin();
-        while( path_it != path.cend() && *path_it == bub_pos() ) {
-            ++path_it;
-        }
+    {
+        ZoneScopedN( "mon_decide_destination" );
+        if( !wandering ) {
+            // Simulate the path trimming without erasing: find the first element
+            // that is not our current position.
+            auto path_it = path.cbegin();
+            while( path_it != path.cend() && *path_it == pos ) {
+                ++path_it;
+            }
 
-        if( path_it == path.cend() ) {
-            // Path is empty (or all-current-pos): go straight to goal.
-            destination = goal;
-        } else {
-            auto candidate_dest = *path_it;
-            if( !here.valid_move( bub_pos(), candidate_dest, true, true, true ) ) {
-                // Path is stale / blocked.  Signal execute_action to clear path and repath.
-                action.needs_repath = true;
-                destination         = bub_pos(); // no viable step; have_destination = false
+            if( path_it == path.cend() ) {
+                // Path is empty (or all-current-pos): go straight to goal.
+                destination = goal;
             } else {
-                destination = candidate_dest;
+                auto candidate_dest = *path_it;
+                if( !here.valid_move( pos, candidate_dest, true, true, true ) ) {
+                    // Path is stale / blocked.  Signal execute_action to clear path and repath.
+                    action.needs_repath = true;
+                    destination         = pos; // no viable step; have_destination = false
+                } else {
+                    destination = candidate_dest;
+                }
             }
-        }
 
-        // Signal stale path/request state.  execute_action only routes from
-        // no-step idle actions; a valid greedy step is taken directly.
-        if( repath_requested && lod_tier <= 1 && !action.needs_repath ) {
-            action.needs_repath = true;
-        }
-    } else {
-        // Wandering: scent -> sound fall-backs (reads only).
-        // LOD Tier 1: reduce scent-tracking frequency to save CPU.
-        const bool do_scent = lod_tier == 0 ||
-                              ( to_turn<int>( calendar::turn ) + bub_pos().x() + bub_pos().y() ) % lod_coarse_scent_interval == 0;
-        if( has_flag( MF_SMELLS ) && do_scent ) {
-            // scent_move() is const -- reads scent map, returns a tripoint.
-            // unset_dest() (a write) is deferred to execute_action.
-            auto tmp = tripoint_bub_ms( scent_move() );
-            if( tmp.x() != -1 ) {
-                destination = tmp;
+            // Signal stale path/request state.  execute_action only routes from
+            // no-step idle actions; a valid greedy step is taken directly.
+            if( repath_requested && lod_tier <= 1 && !action.needs_repath ) {
+                action.needs_repath = true;
             }
-        }
+        } else {
+            // Wandering: scent -> sound fall-backs (reads only).
+            // LOD Tier 1: reduce scent-tracking frequency to save CPU.
+            const auto do_scent = lod_tier == 0 ||
+                                  ( to_turn<int>( calendar::turn ) + pos.x() + pos.y() ) % lod_coarse_scent_interval == 0;
+            if( has_flag( MF_SMELLS ) && do_scent ) {
+                // scent_move() is const -- reads scent map, returns a tripoint.
+                // unset_dest() (a write) is deferred to execute_action.
+                ZoneScopedN( "mon_decide_scent_move" );
+                auto tmp = tripoint_bub_ms( scent_move() );
+                if( tmp.x() != -1 ) {
+                    destination = tmp;
+                }
+            }
 
-        // wandf and friendly are both decremented in execute_action, so simulate
-        // their post-decrement values for these checks.
-        const int effective_wandf    = wandf > 0 ? wandf - 1 : 0;
-        const int effective_friendly = friendly > 0 ? friendly - 1 : friendly;
-        if( effective_wandf > 0 && effective_friendly == 0 ) {
-            // Follow sound as a fall-back (unset_dest write deferred).
-            if( wander_pos != bub_pos() ) {
-                destination = wander_pos;
+            // wandf and friendly are both decremented in execute_action, so simulate
+            // their post-decrement values for these checks.
+            const auto effective_wandf = wandf > 0 ? wandf - 1 : 0;
+            const auto effective_friendly = friendly > 0 ? friendly - 1 : friendly;
+            if( effective_wandf > 0 && effective_friendly == 0 ) {
+                // Follow sound as a fall-back (unset_dest write deferred).
+                if( wander_pos != pos ) {
+                    destination = wander_pos;
+                }
             }
+            // path.clear() deferred to execute_action.
         }
-        // path.clear() deferred to execute_action.
     }
 
-    const bool have_destination = destination != bub_pos();
+    const auto have_destination = destination != pos;
 
     // pathed_to_goal: true if the effective path front and back confirm we are
     // on a valid A*-computed route.
-    bool pathed_to_goal = false;
-    if( !is_wandering() && !path.empty() ) {
+    auto pathed_to_goal = false;
+    if( !wandering && !path.empty() ) {
         auto path_first = path.cbegin();
-        while( path_first != path.cend() && *path_first == bub_pos() ) {
+        while( path_first != path.cend() && *path_first == pos ) {
             ++path_first;
         }
         if( path_first != path.cend() &&
@@ -1265,37 +1266,42 @@ monster_action_t monster::decide_action() const
     }
 
     if( !g->m.has_zlevels() ) {
-        destination.z() = bub_pos().z();
+        destination.z() = pos.z();
     }
 
     // -----------------------------------------------------------------------
     // (6) Candidate selection — reads only.
     //     shove_vehicle() is a write; deferred to execute_action.
     // -----------------------------------------------------------------------
-    const bool can_open_doors = has_flag( MF_CAN_OPEN_DOORS );
-    const bool is_stumbling   = has_flag( MF_STUMBLES );
+    const auto can_open_doors = has_flag( MF_CAN_OPEN_DOORS );
+    const auto is_stumbling = has_flag( MF_STUMBLES );
+    const auto can_bash = bash_skill() > 0;
+    const auto can_attack_mon = has_flag( MF_ATTACKMON );
+    const auto can_push_mon = has_flag( MF_PUSH_MON );
+    const auto stationary = has_flag( MF_STATIONARY );
 
-    tripoint_bub_ms next_step;
-    bool has_next_step = false;
+    auto next_step = tripoint_bub_ms::zero();
+    auto has_next_step = false;
 
     if( have_destination ) {
-        const float distance_to_target = trig_dist( bub_pos(), destination );
-        std::vector<tripoint> candidates;
+        ZoneScopedN( "mon_decide_candidates" );
+        const auto distance_to_target = trig_dist( pos, destination );
+        auto candidates = std::vector<tripoint> {};
         if( pathed_to_goal ) {
             candidates.push_back( destination.raw() );
         } else {
-            candidates = squares_closer_to( bub_pos().raw(), destination.raw() );
+            candidates = squares_closer_to( pos.raw(), destination.raw() );
         }
 
-        for( tripoint can_raw : candidates ) {
+        for( const auto &can_raw : candidates ) {
             auto candidate = tripoint_bub_ms( can_raw );
             // rare scenario when monster is on the border of the map
             if( !here.inbounds( candidate ) ) {
                 continue;
             }
 
-            bool via_ramp        = false;
-            tripoint ramp_offset = tripoint_zero;
+            auto via_ramp = false;
+            auto ramp_offset = tripoint_zero;
             if( here.has_flag( TFLAG_RAMP_UP, candidate ) ) {
                 via_ramp = true;
                 candidate.z() += 1;
@@ -1306,25 +1312,25 @@ monster_action_t monster::decide_action() const
                 ramp_offset = tripoint_above;
             }
 
-            bool can_z_move  = true;
-            const bool is_z_move = candidate.z() != bub_pos().z();
+            auto can_z_move = true;
+            const auto is_z_move = candidate.z() != pos.z();
             if( is_z_move ) {
-                bool can_z_attack = true;
-                if( !here.valid_move( bub_pos(), candidate, false, true, via_ramp ) ) {
+                auto can_z_attack = true;
+                if( !here.valid_move( pos, candidate, false, true, via_ramp ) ) {
                     can_z_move   = false;
                     can_z_attack = false;
                 }
 
-                if( can_z_move && candidate.z() > bub_pos().z() && !( via_ramp || flies() ) &&
+                if( can_z_move && candidate.z() > pos.z() && !( via_ramp || flies() ) &&
                     ( !can_climb() || !here.has_floor_or_support( candidate ) ) ) {
                     can_z_move = false;
                 }
 
                 if( !can_z_move &&
-                    bub_pos().x() / ( SEEX * 2 ) == candidate.x() / ( SEEX * 2 ) &&
-                    bub_pos().y() / ( SEEY * 2 ) == candidate.y() / ( SEEY * 2 ) ) {
-                    const auto &upper = candidate.z() > bub_pos().z() ? candidate : bub_pos();
-                    const auto &lower = candidate.z() > bub_pos().z() ? bub_pos() : candidate;
+                    pos.x() / ( SEEX * 2 ) == candidate.x() / ( SEEX * 2 ) &&
+                    pos.y() / ( SEEY * 2 ) == candidate.y() / ( SEEY * 2 ) ) {
+                    const auto &upper = candidate.z() > pos.z() ? candidate : pos;
+                    const auto &lower = candidate.z() > pos.z() ? pos : candidate;
                     if( g->m.has_flag( TFLAG_GOES_DOWN, upper ) &&
                         g->m.has_flag( TFLAG_GOES_UP, lower ) ) {
                         can_z_move = true;
@@ -1340,11 +1346,11 @@ monster_action_t monster::decide_action() const
                 continue;
             }
 
-            bool bad_choice = false;
+            auto bad_choice = false;
 
-            const Creature *critter_here = g->critter_at( candidate, is_hallucination() );
+            const auto *critter_here = g->critter_at( candidate, hallucination );
             if( critter_here != nullptr ) {
-                const Attitude att = attitude_to( *critter_here );
+                const auto att = attitude_to( *critter_here );
                 if( att == Attitude::A_HOSTILE ) {
                     // When attacking an adjacent enemy, we're direct.
                     next_step     = candidate;
@@ -1354,7 +1360,7 @@ monster_action_t monster::decide_action() const
                 } else if( att == Attitude::A_FRIENDLY &&
                            ( critter_here->is_player() || critter_here->is_npc() ) ) {
                     continue; // Friendly-firing the player or an NPC is illegal.
-                } else if( !has_flag( MF_ATTACKMON ) && !has_flag( MF_PUSH_MON ) ) {
+                } else if( !can_attack_mon && !can_push_mon ) {
                     continue; // Non-hostile monster in the way; not pushy.
                 }
                 bad_choice = true;
@@ -1362,7 +1368,7 @@ monster_action_t monster::decide_action() const
 
             // Openable door?
             if( can_open_doors &&
-                here.can_open_door( this, candidate, !here.is_outside( bub_pos() ) ) ) {
+                here.can_open_door( this, candidate, !here.is_outside( pos ) ) ) {
                 next_step     = candidate;
                 has_next_step = true;
                 continue;
@@ -1370,15 +1376,14 @@ monster_action_t monster::decide_action() const
 
             // shove_vehicle() is a write -- deferred to execute_action.
 
-            const bool can_bash = bash_skill() > 0;
             if( !pathed_to_goal && ( !can_move_to( candidate ) || !can_squeeze_to( candidate ) ) ) {
                 if( !can_bash ) {
                     continue;
                 }
-                if( is_wandering() && destination == wander_pos ) {
+                if( wandering && destination == wander_pos ) {
                     continue;
                 }
-                const int estimate = here.bash_rating( bash_estimate( candidate ), candidate );
+                const auto estimate = here.bash_rating( bash_estimate( candidate ), candidate );
                 if( estimate <= 0 ) {
                     continue;
                 }
@@ -1387,8 +1392,8 @@ monster_action_t monster::decide_action() const
                 }
             }
 
-            float switch_chance = 0.0f;
-            const float progress =
+            auto switch_chance = 0.0f;
+            const auto progress =
                 distance_to_target - trig_dist( candidate + ramp_offset, destination );
             switch_chance += progress * 2;
             if( progress > 0 && ( !has_next_step || x_in_y( progress, switch_chance ) ) ) {
@@ -1404,41 +1409,44 @@ monster_action_t monster::decide_action() const
     // -----------------------------------------------------------------------
     // (7) Build the action descriptor from the selected step.
     // -----------------------------------------------------------------------
-    if( has_next_step ) {
-        action.dest           = next_step;
-        action.stagger_adjust = get_stagger_adjust( bub_pos().raw(), destination.raw(), next_step.raw() );
+    {
+        ZoneScopedN( "mon_decide_action_kind" );
+        if( has_next_step ) {
+            action.dest           = next_step;
+            action.stagger_adjust = get_stagger_adjust( pos.raw(), destination.raw(), next_step.raw() );
 
-        // Determine action kind by what occupies next_step.
-        // Re-use action.target if set by the hostile-break in the candidate loop —
-        // avoids a redundant critter_at lookup for the attack case.
-        const Creature *critter_here = action.target != nullptr
+            // Determine action kind by what occupies next_step.
+            // Re-use action.target if set by the hostile-break in the candidate loop —
+            // avoids a redundant critter_at lookup for the attack case.
+            const auto *critter_here = action.target != nullptr
                                        ? action.target
-                                       : g->critter_at( next_step, is_hallucination() );
-        if( !pacified && critter_here != nullptr &&
-            attitude_to( *critter_here ) == Attitude::A_HOSTILE ) {
-            action.kind   = monster_action_kind::attack;
-            action.target = const_cast<Creature *>( critter_here );
-        } else if( !pacified && can_open_doors &&
-                   here.can_open_door( this, next_step, !here.is_outside( bub_pos() ) ) ) {
-            action.kind = monster_action_kind::open_door;
-        } else if( !pacified && bash_skill() > 0 && !can_move_to( next_step ) ) {
-            action.kind = monster_action_kind::bash;
-        } else if( !pacified && critter_here != nullptr &&
-                   attitude_to( *critter_here ) != Attitude::A_HOSTILE &&
-                   has_flag( MF_PUSH_MON ) ) {
-            action.kind = monster_action_kind::push;
-        } else if( has_flag( MF_STATIONARY ) ) {
-            // Stationary monsters can't move but can take any other action, unlike MF_IMMOBILE
-            action.kind = monster_action_kind::idle;
-            action.move_cost     = 100;
+                                       : g->critter_at( next_step, hallucination );
+            if( !pacified && critter_here != nullptr &&
+                attitude_to( *critter_here ) == Attitude::A_HOSTILE ) {
+                action.kind   = monster_action_kind::attack;
+                action.target = const_cast<Creature *>( critter_here );
+            } else if( !pacified && can_open_doors &&
+                       here.can_open_door( this, next_step, !here.is_outside( pos ) ) ) {
+                action.kind = monster_action_kind::open_door;
+            } else if( !pacified && can_bash && !can_move_to( next_step ) ) {
+                action.kind = monster_action_kind::bash;
+            } else if( !pacified && critter_here != nullptr &&
+                       attitude_to( *critter_here ) != Attitude::A_HOSTILE &&
+                       can_push_mon ) {
+                action.kind = monster_action_kind::push;
+            } else if( stationary ) {
+                // Stationary monsters can't move but can take any other action, unlike MF_IMMOBILE
+                action.kind = monster_action_kind::idle;
+                action.move_cost     = 100;
+            } else {
+                action.kind = monster_action_kind::move;
+            }
         } else {
-            action.kind = monster_action_kind::move;
+            // No viable step: stumble in place (matches original else branch).
+            action.kind          = monster_action_kind::idle;
+            action.move_cost     = 100;
+            action.needs_stumble = true;
         }
-    } else {
-        // No viable step: stumble in place (matches original else branch).
-        action.kind          = monster_action_kind::idle;
-        action.move_cost     = 100;
-        action.needs_stumble = true;
     }
 
     return action;
@@ -1510,7 +1518,7 @@ void monster::execute_action( const monster_action_t &action )
     // Record position before moving (for dragging update at end).
     auto drag_to = abs_pos();
 
-    const bool pacified = has_effect( effect_pacified );
+    const auto pacified = has_effect( effect_pacified );
 
     // Special attacks: fire any ready specials, then fall through to movement.
     //     This matches the original move() behaviour where specials were a side
@@ -1518,9 +1526,11 @@ void monster::execute_action( const monster_action_t &action )
     //     out into a separate action kind (with an early return) caused an infinite
     //     loop: if all call()s failed the cooldown was never reset, decide_action()
     //     saw cooldown==0 again next iteration, and moves were never consumed.
-    if( !( pacified || is_hallucination() ) ) {
+    if( !pacified && !is_hallucination() &&
+        !type->special_attacks.empty() && !special_attacks.empty() ) {
         ZoneScopedN( "mon_execute_special_attacks" );
-        std::vector<const std::pair<const std::string, mtype_special_attack> *> spec_list;
+        auto spec_list = std::vector<const std::pair<const std::string, mtype_special_attack> *> {};
+        spec_list.reserve( type->special_attacks.size() );
         for( const auto &sp_type : type->special_attacks ) {
             const auto it = special_attacks.find( sp_type.first );
             if( it != special_attacks.end() &&
@@ -1528,10 +1538,10 @@ void monster::execute_action( const monster_action_t &action )
                 spec_list.push_back( &sp_type );
             }
         }
-        bool sp_atk_used = false;
+        auto sp_atk_used = false;
         while( !sp_atk_used && !spec_list.empty() ) {
-            int spec_iter = spec_list.size() == 1 ? 0 :
-                            rng( 0, static_cast<int>( spec_list.size() ) - 1 );
+            const auto spec_iter = spec_list.size() == 1 ? 0 :
+                                   rng( 0, static_cast<int>( spec_list.size() ) - 1 );
             const auto &sp_type = spec_list[spec_iter];
             if( sp_type->second->call( *this ) ) {
                 sp_atk_used = true;
@@ -1983,89 +1993,103 @@ void monster::footsteps( const tripoint_bub_ms &p )
 
 tripoint_bub_ms monster::scent_move() const
 {
+    const auto pos = bub_pos();
+    const auto &here = g->m;
+
     // TODO: Remove when scentmap is 3D
-    if( std::abs( bub_pos().z() - g->get_levz() ) > SCENT_MAP_Z_REACH ) {
+    if( std::abs( pos.z() - g->get_levz() ) > SCENT_MAP_Z_REACH ) {
         return { -1, -1, INT_MIN };
     }
 
-    const std::set<scenttype_id> &tracked_scents = type->scents_tracked;
-    const std::set<scenttype_id> &ignored_scents = type->scents_ignored;
+    const auto &tracked_scents = type->scents_tracked;
+    const auto &ignored_scents = type->scents_ignored;
 
-    std::vector<tripoint_bub_ms> smoves;
-
-    int bestsmell = 10; // Squares with smell 0 are not eligible targets.
-    int smell_threshold = 200; // Squares at or above this level are ineligible.
+    auto bestsmell = 10; // Squares with smell 0 are not eligible targets.
+    auto smell_threshold = 200; // Squares at or above this level are ineligible.
     if( has_flag( MF_KEENNOSE ) ) {
         bestsmell = 1;
         smell_threshold = 400;
     }
 
-    const bool fleeing = is_fleeing( g->u );
-    if( fleeing ) {
-        bestsmell = g->scent.get( bub_pos() );
+    auto next = tripoint_bub_ms( -1, -1, pos.z() );
+    const auto current_smell = g->scent.get( pos );
+    if( current_smell <= 0 ) {
+        return next;
     }
 
-    const scenttype_id player_scent = g->u.get_type_of_scent();
-    // The main purpose of scent_move() is to either move toward scents or away from scents depending on the value of the fleeing flag.
-    // However, if the monster is a pet who is not actively fleeing and has the WONT_FOLLOW flag, we'd rather let it stumble instead of
-    // vaguely follow the player's scent.
-    const bool ignore_player_scent = !fleeing && is_pet() && has_flag( MF_PET_WONT_FOLLOW );
+    const auto fleeing = is_fleeing( g->u );
+    if( fleeing ) {
+        bestsmell = current_smell;
+    }
 
-    tripoint_bub_ms next( -1, -1, bub_pos().z() );
-    if( ( !fleeing && g->scent.get( bub_pos() ) > smell_threshold ) ||
+    if( ( !fleeing && ( current_smell < bestsmell || current_smell > smell_threshold ) ) ||
         ( fleeing && bestsmell == 0 ) ) {
         return next;
     }
-    const bool can_bash = bash_skill() > 0;
-    for( const auto &dest : g->m.points_in_radius( bub_pos(), 1, SCENT_MAP_Z_REACH ) ) {
-        int smell = g->scent.get( dest );
-        const scenttype_id &type_scent = g->scent.get_type( dest );
 
-        bool right_scent = false;
-        // is the monster tracking this scent
+    const auto player_scent = g->u.get_type_of_scent();
+    const auto ignore_player_scent = !fleeing && is_pet() && has_flag( MF_PET_WONT_FOLLOW );
+    const auto can_smell_scent_type = [&]( const scenttype_id & type_scent ) -> bool {
+        auto right_scent = false;
         if( !tracked_scents.empty() ) {
             right_scent = tracked_scents.contains( type_scent );
         }
-        //is this scent recognised by the monster species
         if( !type_scent.is_empty() ) {
-            const std::set<species_id> &receptive_species = type_scent->receptive_species;
-            const std::set<species_id> &monster_species = type->species;
-            std::vector<species_id> v_intersection;
-            std::set_intersection( receptive_species.begin(), receptive_species.end(), monster_species.begin(),
-                                   monster_species.end(), std::back_inserter( v_intersection ) );
-            if( !v_intersection.empty() ) {
-                right_scent = true;
-            }
+            const auto &receptive_species = type_scent->receptive_species;
+            right_scent = right_scent || std::ranges::any_of( type->species,
+            [&]( const species_id & species ) {
+                return receptive_species.contains( species );
+            } );
         }
-        // is the monster actually ignoring this scent
-        if( !ignored_scents.empty() && ( ignored_scents.contains( type_scent ) ) ) {
+        if( !ignored_scents.empty() && ignored_scents.contains( type_scent ) ) {
             right_scent = false;
         }
-
         if( ignore_player_scent && type_scent == player_scent ) {
             right_scent = false;
         }
+        return right_scent;
+    };
 
-        if( ( !fleeing && smell < bestsmell ) || ( fleeing && smell > bestsmell ) || !right_scent ) {
+    if( !can_smell_scent_type( g->scent.get_type( pos ) ) ) {
+        return next;
+    }
+    const auto can_bash = bash_skill() > 0;
+    auto smoves = std::array<tripoint_bub_ms, 27> {};
+    auto smove_count = size_t{ 0 };
+    for( const auto &dest : here.points_in_radius( pos, 1, SCENT_MAP_Z_REACH ) ) {
+        const auto smell = g->scent.get( dest );
+        if( ( !fleeing && smell < bestsmell ) || ( fleeing && smell > bestsmell ) ) {
             continue;
         }
-        if( g->m.valid_move( bub_pos(), dest, can_bash, true ) &&
+
+        const auto type_scent = g->scent.get_type( dest );
+        if( !can_smell_scent_type( type_scent ) ) {
+            continue;
+        }
+        if( here.valid_move( pos, dest, can_bash, true ) &&
             // Waterbound monsters can only smell you if you're in deep water.
-            ( !has_flag( MF_AQUATIC ) || g->m.is_divable( dest ) ) &&
-            ( ( can_move_to( dest ) && !get_map().obstructed_by_vehicle_rotation( bub_pos(), dest ) ) ||
+            ( !has_flag( MF_AQUATIC ) || here.is_divable( dest ) ) &&
+            ( ( can_move_to( dest ) && !here.obstructed_by_vehicle_rotation( pos, dest ) ) ||
               ( dest == g->u.bub_pos() ) ||
-              ( can_bash && g->m.bash_rating( bash_estimate( dest ), dest ) > 0 ) ) ) {
+              ( can_bash && here.is_bashable( dest ) &&
+                here.bash_rating( bash_estimate( dest ), dest ) > 0 ) ) ) {
             if( ( !fleeing && smell > bestsmell ) || ( fleeing && smell < bestsmell ) ) {
-                smoves.clear();
-                smoves.push_back( dest );
+                smove_count = 0;
+                smoves[smove_count++] = dest;
                 bestsmell = smell;
             } else if( ( !fleeing && smell == bestsmell ) || ( fleeing && smell == bestsmell ) ) {
-                smoves.push_back( dest );
+                smoves[smove_count++] = dest;
             }
         }
     }
 
-    return random_entry( smoves, next );
+    if( smove_count == 0 ) {
+        return next;
+    }
+
+    const auto selected = smove_count == 1 ? size_t{ 0 } :
+                          static_cast<size_t>( rng( 0, static_cast<int>( smove_count ) - 1 ) );
+    return smoves[selected];
 }
 
 int monster::calc_movecost( const tripoint_bub_ms &f, const tripoint_bub_ms &t ) const

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -13,7 +13,6 @@
 #include <optional>
 #include <ostream>
 #include <ranges>
-#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -383,10 +382,9 @@ void monster::wander_to( const tripoint_bub_ms &p, int f )
     }
 }
 
-// P-8: per-turn Creature::sees() result cache wrapper.
-// Checks g->turn_sight_cache_ before invoking the full Creature::sees() chain.
-// Key is directional because Creature::sees() includes observer and target
-// perception rules.  The symmetric LOS part is handled by map::sees().
+// Per-turn terrain LOS blocker cache.  This is keyed only by the current
+// positions, and a true result means the real sight check can be rejected early.
+// A false result is not visibility; callers still have to run Creature::sees().
 //
 // LOGIC-2 / P-5 note: x_in_y aggro-chance rolls inside compute_plan() run on
 // worker-thread RNG (tl_worker_engine).  This is data-race-free (P-5), but it
@@ -394,22 +392,10 @@ void monster::wander_to( const tripoint_bub_ms &p, int f )
 // sequence, silently breaking save-file determinism and shifting all subsequent
 // main-thread RNG draws.  If determinism is required, move the x_in_y calls
 // into apply_plan() so they execute on the main thread with the shared engine.
-static bool turn_cached_sees( const Creature &seer, const Creature &target )
+static auto terrain_los_cache_blocks_current_positions( const Creature &seer,
+        const Creature &target ) -> bool
 {
-    const auto key = std::make_pair( &seer, &target );
-    {
-        std::shared_lock<std::shared_mutex> lock( g->turn_sight_cache_mutex_ );
-        const auto it = g->turn_sight_cache_.find( key );
-        if( it != g->turn_sight_cache_.end() ) {
-            return it->second;
-        }
-    }
-    const bool result = seer.sees( target );
-    {
-        std::unique_lock<std::shared_mutex> lock( g->turn_sight_cache_mutex_ );
-        g->turn_sight_cache_.emplace( key, result );
-    }
-    return result;
+    return g->terrain_los_blocks_sight_between( seer.bub_pos(), target.bub_pos() );
 }
 
 float monster::rate_target( Creature &c, float best, bool smart, int precalc_dist ) const
@@ -427,9 +413,11 @@ float monster::rate_target( Creature &c, float best, bool smart, int precalc_dis
         return FLT_MAX;
     }
 
-    // P-8: use the per-turn cache for repeated Creature::sees() checks in this
-    // direction.  Symmetric LOS reuse happens inside map::sees().
-    if( !turn_cached_sees( *this, c ) ) {
+    if( terrain_los_cache_blocks_current_positions( *this, c ) ) {
+        return FLT_MAX;
+    }
+
+    if( !sees( c ) ) {
         return FLT_MAX;
     }
 
@@ -532,8 +520,8 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
     bool swarms       = lod_tier <= lod_group_morale_max_tier && has_flag( MF_SWARMS );
     auto mood   = attitude();
 
-    // GAIN-B: call rate_target once (which internally calls turn_cached_sees).
-    // The redundant outer turn_cached_sees guard has been removed; player
+    // GAIN-B: call rate_target once.  It applies the terrain LOS blocker cache,
+    // then runs the real sight check; player
     // visibility is determined by the rate_target return value (FLT_MAX = not visible).
     {
         ZoneScopedN( "cp_initial_target" );
@@ -550,7 +538,7 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
                         local_anger += angers_hostile_near;
                     }
                     if( angers_hostile_near ) {
-                        // LOGIC-2: worker-thread RNG — see P-5 note above turn_cached_sees().
+                        // LOGIC-2: worker-thread RNG; see P-5 note above the LOS blocker cache.
                         if( x_in_y( local_anger, 100 ) ) {
                             result.aggro_triggers.push_back( "proximity" );
                         }
@@ -575,7 +563,7 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
                             } else {
                                 local_anger += angers_mating_season;
                             }
-                            // LOGIC-2: worker-thread RNG — see P-5 note above turn_cached_sees().
+                            // LOGIC-2: worker-thread RNG; see P-5 note above the LOS blocker cache.
                             if( x_in_y( local_anger, 100 ) ) {
                                 result.aggro_triggers.push_back( "mating season" );
                             }
@@ -705,7 +693,7 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
                         } else {
                             local_anger += angers_mating_season;
                         }
-                        // LOGIC-2: worker-thread RNG — see P-5 note above turn_cached_sees().
+                        // LOGIC-2: worker-thread RNG; see P-5 note above the LOS blocker cache.
                         if( x_in_y( local_anger, 100 ) ) {
                             result.aggro_triggers.push_back( "mating season" );
                         }
@@ -928,7 +916,7 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
                     local_anger += anger_amount;
                 }
                 if( local_anger <= 40 ) {
-                    // LOGIC-2: worker-thread RNG — see P-5 note above turn_cached_sees().
+                    // LOGIC-2: worker-thread RNG; see P-5 note above the LOS blocker cache.
                     if( x_in_y( local_anger, 100 ) ) {
                         result.aggro_triggers.push_back( "weakness" );
                     }
@@ -937,7 +925,9 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
         }
     } else if( local_friendly > 0 && one_in( 3 ) ) {
         local_friendly--;
-    } else if( local_friendly < 0 && turn_cached_sees( *this, g->u ) ) {
+    } else if( local_friendly < 0 &&
+               !terrain_los_cache_blocks_current_positions( *this, g->u ) &&
+               sees( g->u ) ) {
         const auto allow_follow_player = local_goal == bub_pos();
         if( allow_follow_player && !has_flag( MF_PET_WONT_FOLLOW ) ) {
             if( rl_dist( bub_pos(), g->u.bub_pos() ) > 2 ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1633,34 +1633,40 @@ void monster::execute_action( const monster_action_t &action )
     const auto try_repath = [&]() -> bool {
         if( !resolved_action.needs_repath ||
             is_wandering() ||
-            lod_tier > 1 ) {
+            lod_tier > 1 )
+        {
             return false;
         }
         route_attempted = true;
         ZoneScopedN( "mon_execute_repath" );
         std::vector<tripoint_bub_ms> maybe_new_path;
-        if( get_option<bool>( "USE_LEGACY_PATHFINDING" ) ) {
+        if( get_option<bool>( "USE_LEGACY_PATHFINDING" ) )
+        {
             ZoneScopedN( "mon_execute_route_legacy" );
             auto pf_settings = get_legacy_pathfinding_settings();
             maybe_new_path = g->m.route( bub_pos(), goal, pf_settings,
                                          get_legacy_path_avoid() );
-        } else {
+        } else
+        {
             ZoneScopedN( "mon_execute_route_pf" );
             auto pair = get_pathfinding_pair();
             maybe_new_path = Pathfinding::route( bub_pos(), goal,
                                                  pair.first, pair.second );
         }
         assert( maybe_new_path.empty() ? true : maybe_new_path.back() == this->goal );
-        if( maybe_new_path.empty() ) {
+        if( maybe_new_path.empty() )
+        {
             path.clear();
             return false;
         }
         path = maybe_new_path;
         auto path_it = path.cbegin();
-        while( path_it != path.cend() && *path_it == bub_pos() ) {
+        while( path_it != path.cend() && *path_it == bub_pos() )
+        {
             ++path_it;
         }
-        if( path_it == path.cend() ) {
+        if( path_it == path.cend() )
+        {
             return false;
         }
         {
@@ -2031,20 +2037,24 @@ tripoint_bub_ms monster::scent_move() const
     const auto ignore_player_scent = !fleeing && is_pet() && has_flag( MF_PET_WONT_FOLLOW );
     const auto can_smell_scent_type = [&]( const scenttype_id & type_scent ) -> bool {
         auto right_scent = false;
-        if( !tracked_scents.empty() ) {
+        if( !tracked_scents.empty() )
+        {
             right_scent = tracked_scents.contains( type_scent );
         }
-        if( !type_scent.is_empty() ) {
+        if( !type_scent.is_empty() )
+        {
             const auto &receptive_species = type_scent->receptive_species;
             right_scent = right_scent || std::ranges::any_of( type->species,
             [&]( const species_id & species ) {
                 return receptive_species.contains( species );
             } );
         }
-        if( !ignored_scents.empty() && ignored_scents.contains( type_scent ) ) {
+        if( !ignored_scents.empty() && ignored_scents.contains( type_scent ) )
+        {
             right_scent = false;
         }
-        if( ignore_player_scent && type_scent == player_scent ) {
+        if( ignore_player_scent && type_scent == player_scent )
+        {
             right_scent = false;
         }
         return right_scent;

--- a/src/monster_action.h
+++ b/src/monster_action.h
@@ -51,9 +51,9 @@ struct monster_action_t {
     /// Stagger multiplier passed to move_to().  1.0 = no stagger.
     float               stagger_adjust = 1.0f;
 
-    /// Path is stale; execute_action must call Pathfinding::route() before stepping.
-    /// Set for Tier-0 whenever requested; set for Tier-1 when genuinely stuck
-    /// (repath_requested was already true, i.e. stuck for 2+ turns — LOGIC-E).
+    /// Path is stale; execute_action may call Pathfinding::route() before stepping.
+    /// Set when an existing path/request is stale, not merely because greedy
+    /// movement failed to find a step.
     /// Tier-2 never sets this flag (macro step does not use the path).
     bool                needs_repath   = false;
 
@@ -61,4 +61,5 @@ struct monster_action_t {
     /// Used for the MATT_IGNORE / MATT_FOLLOW-at-range idle action that pairs
     /// a stumble with a partial move deduction (100 moves, not all moves).
     bool                needs_stumble  = false;
+
 };

--- a/src/monster_plan.h
+++ b/src/monster_plan.h
@@ -1,10 +1,18 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "coordinates.h"
 #include "point.h"
 #include "type_id.h"
+
+class Creature;
+
+enum class monster_plan_goal_kind : uint8_t {
+    none,
+    target_last_known,
+};
 
 /**
  * Captures the complete output of monster::compute_plan().
@@ -26,9 +34,15 @@ struct monster_plan_t {
     //
     // LOGIC-1: setting local_goal = pos() inside compute_plan() is equivalent
     // to unset_dest(), because unset_dest() is defined as set_goal(pos()) and
-    // apply_plan() commits via set_goal(plan.goal).  No separate
-    // "unset_dest_requested" flag is necessary.
+    // apply_plan() commits with set_goal().  No separate unset flag is needed.
     tripoint_bub_ms goal;
+    monster_plan_goal_kind goal_kind = monster_plan_goal_kind::none;
+
+    // Same-turn memory from the planning pass.  This is not live visibility:
+    // callers may use it to preserve movement intent, but attacks still
+    // revalidate against current state.
+    Creature *observed_target = nullptr;
+    tripoint_bub_ms observed_target_pos = tripoint_bub_ms::zero();
 
     // Wander state.  Only written when swarm dispersal logic fires;
     // apply_plan only updates wander_pos/wandf when this flag is set.

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3390,7 +3390,7 @@ const
 std::pair<PathfindingSettings, RouteSettings> npc::get_pathfinding_pair(
     bool no_bashing ) const
 {
-    PathfindingSettings path_settings;
+    auto path_settings = PathfindingSettings();
 
     path_settings.door_open_cost = rules.has_flag( ally_rule::avoid_doors ) ? INFINITY : 2.0;
     path_settings.mob_presence_penalty =
@@ -3410,16 +3410,24 @@ std::pair<PathfindingSettings, RouteSettings> npc::get_pathfinding_pair(
         path_settings.climb_cost = 5 / climb_success_prob;
     }
 
-    RouteSettings route_settings;
+    auto route_settings = RouteSettings();
     // TODO: Make it assign a stockfish preset instead
-    route_settings.alpha = 1.0;
-    route_settings.h_coeff = 1.0;
+    route_settings.alpha = get_option<float>( "PATHFINDING_ALPHA_DEFAULT" );
+    route_settings.h_coeff = get_option<float>( "PATHFINDING_H_COEFF_DEFAULT" );
     route_settings.max_dist = INFINITY;
-    route_settings.max_f_coeff = INFINITY;
+    route_settings.max_f_coeff = get_option<float>( "PATHFINDING_MAX_F_COEFF_DEFAULT" );
     route_settings.max_s_coeff = INFINITY;
     route_settings.f_limit_based_on_max_dist = false;
-    route_settings.search_cone_angle = 180.0;
-    route_settings.search_radius_coeff = INFINITY;
+    route_settings.search_cone_angle =
+        get_option<float>( "PATHFINDING_SEARCH_CONE_ANGLE_DEFAULT" );
+    route_settings.search_radius_coeff =
+        get_option<float>( "PATHFINDING_SEARCH_RADIUS_COEFF_DEFAULT" );
+    if( route_settings.max_f_coeff < 0.0f ) {
+        route_settings.max_f_coeff = INFINITY;
+    }
+    if( route_settings.search_radius_coeff < 0.0f ) {
+        route_settings.search_radius_coeff = INFINITY;
+    }
 
     return { path_settings, route_settings };
 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2500,7 +2500,7 @@ bool npc::enough_time_to_reload( const item &gun ) const
         auto &c = dynamic_cast<const Character &>( *target );
         if( sees( c ) && c.primary_weapon().is_gun() && rltime > 200 &&
             c.primary_weapon().gun_range( true ) >
-                distance + turns_til_reloaded / target_speed ) {
+            distance + turns_til_reloaded / target_speed ) {
             // Don't take longer than 2 turns if player has a gun
             return false;
         }
@@ -2550,7 +2550,7 @@ bool npc::update_path( const tripoint_bub_ms &p, const bool no_bashing, bool for
     if( !path.empty() ) {
         const auto &last = path[path.size() - 1];
         if( last == p && ( path[0].z() != bub_pos().z()
-            || rl_dist( path[0], bub_pos() ) <= 1 ) ) {
+                           || rl_dist( path[0], bub_pos() ) <= 1 ) ) {
             // Our path already leads to that point, no need to recalculate
             return true;
         }
@@ -2560,7 +2560,8 @@ bool npc::update_path( const tripoint_bub_ms &p, const bool no_bashing, bool for
         ZoneScopedN( "npc_update_path_route" );
         return get_map().route( bub_pos(), p, get_legacy_pathfinding_settings( no_bashing ),
                                 get_legacy_path_avoid() );
-    }();
+    }
+    ();
     if( new_path.empty() ) {
         if( !ai_cache.sound_alerts.empty() ) {
             ai_cache.sound_alerts.erase( ai_cache.sound_alerts.begin() );
@@ -3196,8 +3197,8 @@ void npc::find_item()
     // Harvest item doesn't exist, so we'll be checking by its name
     std::string wanted_name;
     const auto consider_terrain =
-    [ this, whitelisting, volume_allowed, &wanted,
-            &wanted_name, &here ]( const tripoint_bub_ms & p ) {
+        [ this, whitelisting, volume_allowed, &wanted,
+          &wanted_name, &here ]( const tripoint_bub_ms & p ) {
         // We only want to pick plants when there are no items to pick
         if( !whitelisting || wanted != nullptr ||
             !wanted_name.empty() || volume_allowed < 250_ml ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -65,6 +65,7 @@
 #include "overmapbuffer.h"
 #include "overmapbuffer_registry.h"
 #include "calendar.h"
+#include "pathfinding.h"
 #include "player_activity.h"
 #include "pldata.h"
 #include "profile.h"
@@ -1166,13 +1167,17 @@ void npc::move()
 
 void npc::execute_action( npc_action action )
 {
-    int oldmoves = moves;
-    tripoint_bub_ms tar = bub_pos();
-    Creature *cur = current_target();
-    if( action == npc_flee ) {
-        tar = good_escape_direction( false );
-    } else if( cur != nullptr ) {
-        tar = cur->bub_pos();
+    const auto oldmoves = moves;
+    auto tar = bub_pos();
+    auto *cur = static_cast<Creature *>( nullptr );
+    {
+        ZoneScopedN( "npc_exec_target_setup" );
+        cur = current_target();
+        if( action == npc_flee ) {
+            tar = good_escape_direction( false );
+        } else if( cur != nullptr ) {
+            tar = cur->bub_pos();
+        }
     }
     /*
       debugmsg("%s ran execute_action() with target = %d! Action %s",
@@ -1182,15 +1187,19 @@ void npc::execute_action( npc_action action )
     Character &player_character = get_player_character();
     map &here = get_map();
     switch( action ) {
-        case npc_pause:
+        case npc_pause: {
+            ZoneScopedN( "npc_exec_pause" );
             move_pause();
             break;
+        }
         case npc_reload: {
+            ZoneScopedN( "npc_exec_reload" );
             do_reload( primary_weapon() );
         }
         break;
 
         case npc_investigate_sound: {
+            ZoneScopedN( "npc_exec_investigate_sound" );
             auto cur_pos = bub_pos();
             update_path( abs_to_bub( ai_cache.s_abs_pos ) );
             move_to_next();
@@ -1201,6 +1210,7 @@ void npc::execute_action( npc_action action )
         break;
 
         case npc_return_to_guard_pos: {
+            ZoneScopedN( "npc_exec_return_to_guard_pos" );
             const auto local_guard_pos = abs_to_bub( *ai_cache.guard_pos );
             update_path( local_guard_pos );
             if( bub_pos() == local_guard_pos || path.empty() ) {
@@ -1214,6 +1224,7 @@ void npc::execute_action( npc_action action )
         break;
 
         case npc_sleep: {
+            ZoneScopedN( "npc_exec_sleep" );
             // TODO: Allow stims when not too tired
             // Find a nice spot to sleep
             int best_sleepy = character_funcs::rate_sleep_spot( *this, bub_pos() );
@@ -1250,19 +1261,26 @@ void npc::execute_action( npc_action action )
         }
         break;
 
-        case npc_pickup:
+        case npc_pickup: {
+            ZoneScopedN( "npc_exec_pickup" );
             pick_up_item();
             break;
+        }
 
-        case npc_heal:
+        case npc_heal: {
+            ZoneScopedN( "npc_exec_heal" );
             heal_self();
             break;
+        }
 
-        case npc_use_painkiller:
+        case npc_use_painkiller: {
+            ZoneScopedN( "npc_exec_use_painkiller" );
             use_painkiller();
             break;
+        }
 
-        case npc_drop_items:
+        case npc_drop_items: {
+            ZoneScopedN( "npc_exec_drop_items" );
             /* NPCs can't choose this action anymore, but at least it works */
             drop_invalid_inventory();
             /* drop_items is still broken
@@ -1271,22 +1289,28 @@ void npc::execute_action( npc_action action )
              */
             move_pause();
             break;
+        }
 
-        case npc_flee:
+        case npc_flee: {
+            ZoneScopedN( "npc_exec_flee" );
             if( path.empty() ) {
                 move_to( tar );
             } else {
                 move_to_next();
             }
             break;
+        }
 
-        case npc_reach_attack:
+        case npc_reach_attack: {
+            ZoneScopedN( "npc_exec_reach_attack" );
             if( can_use_offensive_cbm() ) {
                 activate_bionic_by_id( bio_hydraulics );
             }
             reach_attack( tar );
             break;
-        case npc_melee:
+        }
+        case npc_melee: {
+            ZoneScopedN( "npc_exec_melee" );
             update_path( tar );
             if( path.size() > 1 ) {
                 move_to_next();
@@ -1301,8 +1325,10 @@ void npc::execute_action( npc_action action )
                 look_for_player( player_character );
             }
             break;
+        }
 
         case npc_aim: {
+            ZoneScopedN( "npc_exec_aim" );
             gun_mode mode = cbm_active.is_null() ? primary_weapon().gun_current_mode() :
                             cbm_fake_active->gun_current_mode();
             if( !mode ) {
@@ -1320,6 +1346,7 @@ void npc::execute_action( npc_action action )
         break;
 
         case npc_shoot: {
+            ZoneScopedN( "npc_exec_shoot" );
             gun_mode mode = cbm_active.is_null() ? primary_weapon().gun_current_mode() :
                             cbm_fake_active->gun_current_mode();
             if( !mode ) {
@@ -1345,7 +1372,8 @@ void npc::execute_action( npc_action action )
             break;
         }
 
-        case npc_look_for_player:
+        case npc_look_for_player: {
+            ZoneScopedN( "npc_exec_look_for_player" );
             if( saw_player_recently() && last_player_seen_pos && sees( *last_player_seen_pos ) ) {
                 update_path( *last_player_seen_pos );
                 move_to_next();
@@ -1353,8 +1381,10 @@ void npc::execute_action( npc_action action )
                 look_for_player( player_character );
             }
             break;
+        }
 
         case npc_heal_player: {
+            ZoneScopedN( "npc_exec_heal_player" );
             player *patient = dynamic_cast<player *>( current_ally() );
             if( patient ) {
                 update_path( patient->bub_pos() );
@@ -1369,7 +1399,8 @@ void npc::execute_action( npc_action action )
             }
             break;
         }
-        case npc_follow_player:
+        case npc_follow_player: {
+            ZoneScopedN( "npc_exec_follow_player" );
             update_path( player_character.bub_pos() );
             move_mode = rules.has_flag( ally_rule::move_own_pace ) ?
                         ( ( static_cast<int>( path.size() ) > follow_distance() * 4 ) ? CMM_RUN : CMM_WALK ) :
@@ -1385,8 +1416,10 @@ void npc::execute_action( npc_action action )
             // TODO: Make it only happen when it's safe
             complain();
             break;
+        }
 
         case npc_follow_embarked: {
+            ZoneScopedN( "npc_exec_follow_embarked" );
             move_mode = rules.has_flag( ally_rule::move_own_pace ) ?
                         ( ( static_cast<int>( path.size() ) > follow_distance() * 4 ) ? CMM_RUN : CMM_WALK ) :
                         player_character.get_movement_mode();
@@ -1494,16 +1527,21 @@ void npc::execute_action( npc_action action )
         }
 
         break;
-        case npc_talk_to_player:
+        case npc_talk_to_player: {
+            ZoneScopedN( "npc_exec_talk_to_player" );
             talk_to_u();
             moves = 0;
             break;
+        }
 
-        case npc_mug_player:
+        case npc_mug_player: {
+            ZoneScopedN( "npc_exec_mug_player" );
             mug_player( player_character );
             break;
+        }
 
         case npc_goto_to_this_pos: {
+            ZoneScopedN( "npc_exec_goto_to_this_pos" );
             if( !goto_to_this_pos.has_value() ) {
                 debugmsg( "npc_goto_to_this_pos set to true, but no target set" );
                 break;
@@ -1518,33 +1556,47 @@ void npc::execute_action( npc_action action )
             break;
         }
 
-        case npc_goto_destination:
+        case npc_goto_destination: {
+            ZoneScopedN( "npc_exec_goto_destination" );
             go_to_omt_destination();
             break;
+        }
 
-        case npc_avoid_friendly_fire:
+        case npc_avoid_friendly_fire: {
+            ZoneScopedN( "npc_exec_avoid_friendly_fire" );
             avoid_friendly_fire();
             break;
+        }
 
-        case npc_escape_explosion:
+        case npc_escape_explosion: {
+            ZoneScopedN( "npc_exec_escape_explosion" );
             escape_explosion();
             break;
+        }
 
-        case npc_player_activity:
+        case npc_player_activity: {
+            ZoneScopedN( "npc_exec_player_activity" );
             do_player_activity();
             break;
+        }
 
-        case npc_undecided:
+        case npc_undecided: {
+            ZoneScopedN( "npc_exec_undecided" );
             complain();
             move_pause();
             break;
+        }
 
-        case npc_noop:
+        case npc_noop: {
+            ZoneScopedN( "npc_exec_noop" );
             add_msg( m_debug, "%s skips turn (noop)", disp_name() );
             return;
+        }
 
-        default:
+        default: {
+            ZoneScopedN( "npc_exec_unknown" );
             debugmsg( "Unknown NPC action (%d)", action );
+        }
     }
 
     if( oldmoves == moves ) {
@@ -2482,6 +2534,9 @@ bool npc::aim()
 
 bool npc::update_path( const tripoint_bub_ms &p, const bool no_bashing, bool force )
 {
+    ZoneScopedN( "npc_update_path" );
+    ZoneValue( rl_dist( bub_pos(), p ) );
+
     if( p == bub_pos() ) {
         path.clear();
         return true;
@@ -2499,8 +2554,11 @@ bool npc::update_path( const tripoint_bub_ms &p, const bool no_bashing, bool for
         }
     }
 
-    auto new_path = get_map().route( bub_pos(), p, get_legacy_pathfinding_settings( no_bashing ),
-                                     get_legacy_path_avoid() );
+    auto new_path = [&]() {
+        ZoneScopedN( "npc_update_path_route" );
+        return get_map().route( bub_pos(), p, get_legacy_pathfinding_settings( no_bashing ),
+                                get_legacy_path_avoid() );
+    }();
     if( new_path.empty() ) {
         if( !ai_cache.sound_alerts.empty() ) {
             ai_cache.sound_alerts.erase( ai_cache.sound_alerts.begin() );
@@ -3615,7 +3673,9 @@ bool npc::do_pulp()
 
 bool npc::do_player_activity()
 {
-    int old_moves = moves;
+    ZoneScopedN( "npc_do_player_activity" );
+
+    const auto old_moves = moves;
     if( moves > 200 && activity && ( activity->is_multi_type() ||
                                      activity->id() == activity_id( "ACT_TIDY_UP" ) ) ) {
         // a huge backlog of a multi-activity type can forever loop
@@ -3634,13 +3694,20 @@ bool npc::do_player_activity()
     // ( even if other move-using things occur inbetween )
     // so here - if no moves are used in a multi-type activity do_turn(), then subtract a nominal amount
     // to satisfy the infinite loop counter.
-    const bool multi_type = activity ? activity->is_multi_type() : false;
-    const int moves_before = moves;
-    while( moves > 0 && activity && *activity ) {
-        activity->do_turn( *this );
-        if( !is_active() ) {
-            return true;
+    const auto multi_type = activity ? activity->is_multi_type() : false;
+    const auto moves_before = moves;
+    {
+        ZoneScopedN( "npc_do_player_activity_loop" );
+        auto activity_turns = 0;
+        while( moves > 0 && activity && *activity ) {
+            activity->do_turn( *this );
+            activity_turns++;
+            if( !is_active() ) {
+                ZoneValue( activity_turns );
+                return true;
+            }
         }
+        ZoneValue( activity_turns );
     }
     if( multi_type && moves == moves_before ) {
         moves -= 1;
@@ -4499,6 +4566,8 @@ void npc::set_omt_destination()
 
 void npc::go_to_omt_destination()
 {
+    ZoneScopedN( "npc_go_to_omt_destination" );
+
     map &here = get_map();
     if( ai_cache.guard_pos ) {
         if( abs_pos() == *ai_cache.guard_pos ) {
@@ -4547,6 +4616,7 @@ void npc::go_to_omt_destination()
     auto sm_tri =
         abs_to_bub( project_to<coords::ms>( omt_path.back() ) );
     auto centre_sub = sm_tri + point( SEEX, SEEY );
+    here.clip_to_bounds( centre_sub );
     if( !here.passable( centre_sub ) ) {
         auto candidates = here.points_in_radius( centre_sub, 2 );
         for( const auto &elem : candidates ) {
@@ -4556,8 +4626,19 @@ void npc::go_to_omt_destination()
             }
         }
     }
-    path = here.route( bub_pos(), centre_sub, get_legacy_pathfinding_settings(),
-                       get_legacy_path_avoid() );
+    {
+        ZoneScopedN( "npc_goto_destination_route" );
+        if( get_option<bool>( "USE_LEGACY_PATHFINDING" ) ) {
+            path = here.route( bub_pos(), centre_sub, get_legacy_pathfinding_settings(),
+                               get_legacy_path_avoid() );
+        } else {
+            const auto pf_pair = get_pathfinding_pair();
+            path = Pathfinding::route( bub_pos(), centre_sub, pf_pair.first, pf_pair.second );
+        }
+    }
+    while( !path.empty() && path.front() == bub_pos() ) {
+        path.erase( path.begin() );
+    }
     add_msg( m_debug, "%s going %s->%s", name, omt_pos.to_string(), goal.to_string() );
 
     if( !path.empty() ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -446,26 +446,6 @@ static bool too_close( const tripoint_bub_ms &critter_pos, const tripoint_bub_ms
     return rl_dist( critter_pos, ally_pos ) <= def_radius;
 }
 
-// Per-turn Creature::sees() cache wrapper — mirrors turn_cached_sees() in monmove.cpp.
-// Key is directional; map::sees() handles symmetric LOS reuse below this layer.
-static auto npc_turn_cached_sees( const Creature &seer, const Creature &target ) -> bool
-{
-    const auto key = std::make_pair( &seer, &target );
-    {
-        std::shared_lock<std::shared_mutex> lock( g->turn_sight_cache_mutex_ );
-        const auto it = g->turn_sight_cache_.find( key );
-        if( it != g->turn_sight_cache_.end() ) {
-            return it->second;
-        }
-    }
-    const bool result = seer.sees( target );
-    {
-        std::unique_lock<std::shared_mutex> lock( g->turn_sight_cache_mutex_ );
-        g->turn_sight_cache_.emplace( key, result );
-    }
-    return result;
-}
-
 void npc::assess_danger()
 {
     ZoneScoped;
@@ -663,7 +643,9 @@ void npc::assess_danger()
             if( att != Attitude::A_HOSTILE ) {
                 continue;
             }
-            if( !npc_turn_cached_sees( *this, critter ) ) {
+            // Character::sees() includes short-range special senses; do not replace it
+            // with a terrain-only LOS cache here.
+            if( !sees( critter ) ) {
                 continue;
             }
             float critter_threat = evaluate_enemy( critter );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -65,7 +65,6 @@
 #include "overmapbuffer.h"
 #include "overmapbuffer_registry.h"
 #include "calendar.h"
-#include "pathfinding.h"
 #include "player_activity.h"
 #include "pldata.h"
 #include "profile.h"
@@ -4635,13 +4634,8 @@ void npc::go_to_omt_destination()
     }
     {
         ZoneScopedN( "npc_goto_destination_route" );
-        if( get_option<bool>( "USE_LEGACY_PATHFINDING" ) ) {
-            path = here.route( bub_pos(), centre_sub, get_legacy_pathfinding_settings(),
-                               get_legacy_path_avoid() );
-        } else {
-            const auto pf_pair = get_pathfinding_pair();
-            path = Pathfinding::route( bub_pos(), centre_sub, pf_pair.first, pf_pair.second );
-        }
+        path = here.route( bub_pos(), centre_sub, get_legacy_pathfinding_settings(),
+                           get_legacy_path_avoid() );
     }
     while( !path.empty() && path.front() == bub_pos() ) {
         path.erase( path.begin() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2499,7 +2499,8 @@ bool npc::enough_time_to_reload( const item &gun ) const
     if( target->is_player() || target->is_npc() ) {
         auto &c = dynamic_cast<const Character &>( *target );
         if( sees( c ) && c.primary_weapon().is_gun() && rltime > 200 &&
-            c.primary_weapon().gun_range( true ) > distance + turns_til_reloaded / target_speed ) {
+            c.primary_weapon().gun_range( true ) >
+                distance + turns_til_reloaded / target_speed ) {
             // Don't take longer than 2 turns if player has a gun
             return false;
         }
@@ -2548,7 +2549,8 @@ bool npc::update_path( const tripoint_bub_ms &p, const bool no_bashing, bool for
 
     if( !path.empty() ) {
         const auto &last = path[path.size() - 1];
-        if( last == p && ( path[0].z() != bub_pos().z() || rl_dist( path[0], bub_pos() ) <= 1 ) ) {
+        if( last == p && ( path[0].z() != bub_pos().z()
+            || rl_dist( path[0], bub_pos() ) <= 1 ) ) {
             // Our path already leads to that point, no need to recalculate
             return true;
         }
@@ -2863,7 +2865,8 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         }
 
         // Close doors behind self (if you can)
-        if( ( rules.has_flag( ally_rule::close_doors ) && is_player_ally() ) && !is_hallucination() ) {
+        if( ( rules.has_flag( ally_rule::close_doors ) &&
+              is_player_ally() ) && !is_hallucination() ) {
             doors::close_door( here, *this, old_pos );
         }
 
@@ -3168,7 +3171,8 @@ void npc::find_item()
         for( auto &elem : followers ) {
             if( !it.is_owned_by( *this, true ) && ( player_character.sees( bub_pos() ) ||
                                                     player_character.sees( wanted_item_pos ) ||
-                                                    elem->sees( bub_pos() ) || elem->sees( wanted_item_pos ) ) ) {
+                                                    elem->sees( bub_pos() ) ||
+                                                    elem->sees( wanted_item_pos ) ) ) {
                 return;
             }
         }
@@ -3192,9 +3196,11 @@ void npc::find_item()
     // Harvest item doesn't exist, so we'll be checking by its name
     std::string wanted_name;
     const auto consider_terrain =
-    [ this, whitelisting, volume_allowed, &wanted, &wanted_name, &here ]( const tripoint_bub_ms & p ) {
+    [ this, whitelisting, volume_allowed, &wanted,
+            &wanted_name, &here ]( const tripoint_bub_ms & p ) {
         // We only want to pick plants when there are no items to pick
-        if( !whitelisting || wanted != nullptr || !wanted_name.empty() || volume_allowed < 250_ml ) {
+        if( !whitelisting || wanted != nullptr ||
+            !wanted_name.empty() || volume_allowed < 250_ml ) {
             return;
         }
 

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -72,16 +72,14 @@ struct pathfinding_tile {
     optional_vpart_position vehicle_part;
     int move_cost = 0;
 
-    auto vehicle_ptr() const -> vehicle *
-    {
+    auto vehicle_ptr() const -> vehicle * {
         if( !vehicle_part ) {
             return nullptr;
         }
         return &vehicle_part->vehicle();
     }
 
-    auto part_index() const -> int
-    {
+    auto part_index() const -> int {
         if( !vehicle_part ) {
             return -1;
         }
@@ -432,20 +430,20 @@ void Pathfinding::update_z_caches( bool update_open_air )
                 // We won't do vehicle checks for simplicity
 
                 const ZLevelChange going_to_below = ZLevelChange{
-                                   .from = abs_pos, .to = below_us_abs, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
+                    .from = abs_pos, .to = below_us_abs, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
                 const ZLevelChange reach_from_below = ZLevelChange{
-                                   .from = below_us_abs, .to = abs_pos, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
+                    .from = below_us_abs, .to = abs_pos, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
 
                 // This is stored separately from other changes because it requires a different type of processing
                 Pathfinding::get_z_cache_open_air( z ).emplace( abs_pos.xy(), Pathfinding::ZLevelChangeOpenAirPair{
-                                                                .reach_from_below = reach_from_below, .reach_from_above = std::nullopt } );
+                    .reach_from_below = reach_from_below, .reach_from_above = std::nullopt } );
 
                 auto &lower_level = Pathfinding::get_z_cache_open_air( z - 1 );
                 if( lower_level.contains( abs_pos.xy() ) ) {
                     lower_level[abs_pos.xy()].reach_from_above = going_to_below;
                 } else {
                     lower_level.emplace( abs_pos.xy(), Pathfinding::ZLevelChangeOpenAirPair{
-                                         .reach_from_below = std::nullopt, .reach_from_above = going_to_below } );
+                        .reach_from_below = std::nullopt, .reach_from_above = going_to_below } );
                 }
             } else if( cur_ter.has_flag( TFLAG_GOES_UP ) ) {
                 // Stair bullshitery
@@ -460,7 +458,7 @@ void Pathfinding::update_z_caches( bool update_open_air )
                 const auto above_us_abs = abs_pos + tripoint_rel_ms::above();
                 for( const auto &maybe_stairs_abs : closest_points_first( above_us_abs, 10 ) ) {
                     const auto maybe_stairs_ter = buffer.get_ter( maybe_stairs_abs,
-                                                    pathfinding_lookup_options() );
+                                                  pathfinding_lookup_options() );
                     if( !maybe_stairs_ter ) {
                         continue;
                     }
@@ -488,7 +486,7 @@ void Pathfinding::update_z_caches( bool update_open_air )
                 const auto below_us_abs = abs_pos + tripoint_rel_ms::below();
                 for( const tripoint_abs_ms &maybe_stairs_abs : closest_points_first( below_us_abs, 10 ) ) {
                     const auto maybe_stairs_ter = buffer.get_ter( maybe_stairs_abs,
-                                                    pathfinding_lookup_options() );
+                                                  pathfinding_lookup_options() );
                     if( !maybe_stairs_ter ) {
                         continue;
                     }
@@ -821,7 +819,7 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
                         const bool door_opens_from_inside = terrain.has_flag( "OPENCLOSE_INSIDE" ) ||
                                                             furniture.has_flag( "OPENCLOSE_INSIDE" );
                         const bool is_cur_point_inside = !here.is_outside( abs_to_map_local( here,
-                                                           cur_point_with_z ) );
+                                                         cur_point_with_z ) );
                         const bool valid_to_open = door_opens_from_inside ? is_cur_point_inside : true;
                         if( valid_to_open ) {
                             obstacle_g = this->settings.door_open_cost;

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -431,18 +431,21 @@ void Pathfinding::update_z_caches( bool update_open_air )
                 };
                 // We won't do vehicle checks for simplicity
 
-                const ZLevelChange going_to_below = ZLevelChange{ .from = abs_pos, .to = below_us_abs, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
-                const ZLevelChange reach_from_below = ZLevelChange{ .from = below_us_abs, .to = abs_pos, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
+                const ZLevelChange going_to_below = ZLevelChange{
+                                   .from = abs_pos, .to = below_us_abs, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
+                const ZLevelChange reach_from_below = ZLevelChange{
+                                   .from = below_us_abs, .to = abs_pos, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
 
                 // This is stored separately from other changes because it requires a different type of processing
-                Pathfinding::get_z_cache_open_air( z ).emplace( abs_pos.xy(),
-                        Pathfinding::ZLevelChangeOpenAirPair{ .reach_from_below = reach_from_below, .reach_from_above = std::nullopt } );
+                Pathfinding::get_z_cache_open_air( z ).emplace( abs_pos.xy(), Pathfinding::ZLevelChangeOpenAirPair{
+                                                                .reach_from_below = reach_from_below, .reach_from_above = std::nullopt } );
 
                 auto &lower_level = Pathfinding::get_z_cache_open_air( z - 1 );
                 if( lower_level.contains( abs_pos.xy() ) ) {
                     lower_level[abs_pos.xy()].reach_from_above = going_to_below;
                 } else {
-                    lower_level.emplace( abs_pos.xy(),  Pathfinding::ZLevelChangeOpenAirPair{ .reach_from_below = std::nullopt, .reach_from_above = going_to_below } );
+                    lower_level.emplace( abs_pos.xy(), Pathfinding::ZLevelChangeOpenAirPair{
+                                         .reach_from_below = std::nullopt, .reach_from_above = going_to_below } );
                 }
             } else if( cur_ter.has_flag( TFLAG_GOES_UP ) ) {
                 // Stair bullshitery
@@ -463,8 +466,10 @@ void Pathfinding::update_z_caches( bool update_open_air )
                     }
 
                     if( maybe_stairs_ter->obj().has_flag( TFLAG_GOES_DOWN ) ) {
-                        const ZLevelChange stairs_up = ZLevelChange{ .from = abs_pos, .to = maybe_stairs_abs, .type = Pathfinding::ZLevelChange::Type::STAIRS };
-                        const ZLevelChange stairs_down = ZLevelChange{ .from = maybe_stairs_abs, .to = abs_pos, .type = Pathfinding::ZLevelChange::Type::STAIRS };
+                        const ZLevelChange stairs_up = ZLevelChange{ .from = abs_pos, .to = maybe_stairs_abs,
+                                                                     .type = Pathfinding::ZLevelChange::Type::STAIRS };
+                        const ZLevelChange stairs_down = ZLevelChange{ .from = maybe_stairs_abs, .to = abs_pos,
+                                                                       .type = Pathfinding::ZLevelChange::Type::STAIRS };
                         Pathfinding::get_z_cache( z ).push_back( stairs_down );
                         Pathfinding::get_z_cache( z + 1 ).push_back( stairs_up );
                         break;
@@ -489,8 +494,10 @@ void Pathfinding::update_z_caches( bool update_open_air )
                     }
 
                     if( maybe_stairs_ter->obj().has_flag( TFLAG_GOES_UP ) ) {
-                        const ZLevelChange stairs_down = ZLevelChange{ .from = abs_pos, .to = maybe_stairs_abs, .type = Pathfinding::ZLevelChange::Type::STAIRS };
-                        const ZLevelChange stairs_up = ZLevelChange{ .from = maybe_stairs_abs, .to = abs_pos, .type = Pathfinding::ZLevelChange::Type::STAIRS };
+                        const ZLevelChange stairs_down = ZLevelChange{ .from = abs_pos, .to = maybe_stairs_abs,
+                                                                       .type = Pathfinding::ZLevelChange::Type::STAIRS };
+                        const ZLevelChange stairs_up = ZLevelChange{ .from = maybe_stairs_abs, .to = abs_pos,
+                                                                     .type = Pathfinding::ZLevelChange::Type::STAIRS };
                         Pathfinding::get_z_cache( z ).push_back( stairs_up );
                         Pathfinding::get_z_cache( z - 1 ).push_back( stairs_down );
                         break;
@@ -503,7 +510,8 @@ void Pathfinding::update_z_caches( bool update_open_air )
                     continue;
                 }
 
-                const ZLevelChange ramp_up = ZLevelChange{ .from = abs_pos, .to = abs_pos + tripoint_rel_ms::above(), .type = Pathfinding::ZLevelChange::Type::RAMP };
+                const ZLevelChange ramp_up = ZLevelChange{ .from = abs_pos, .to = abs_pos + tripoint_rel_ms::above(),
+                                                           .type = Pathfinding::ZLevelChange::Type::RAMP };
                 Pathfinding::get_z_cache( z + 1 ).push_back( ramp_up );
             } else if( cur_ter.has_flag( TFLAG_RAMP_DOWN ) ) {
                 const auto below_us = cur + tripoint_below;
@@ -512,7 +520,8 @@ void Pathfinding::update_z_caches( bool update_open_air )
                     continue;
                 }
 
-                const ZLevelChange ramp_down = ZLevelChange{ .from = abs_pos, .to = abs_pos + tripoint_rel_ms::below(), .type = Pathfinding::ZLevelChange::Type::RAMP };
+                const ZLevelChange ramp_down = ZLevelChange{ .from = abs_pos, .to = abs_pos + tripoint_rel_ms::below(),
+                                                             .type = Pathfinding::ZLevelChange::Type::RAMP };
                 Pathfinding::get_z_cache( z - 1 ).push_back( ramp_down );
             }
         }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -72,7 +72,7 @@ struct pathfinding_tile {
     optional_vpart_position vehicle_part;
     int move_cost = 0;
 
-    auto vehicle_ptr() const -> vehicle * {
+    auto vehicle_ptr() const -> vehicle* {
         if( !vehicle_part ) {
             return nullptr;
         }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -72,7 +72,7 @@ struct pathfinding_tile {
     optional_vpart_position vehicle_part;
     int move_cost = 0;
 
-    auto vehicle_ptr() const -> vehicle * {
+    auto vehicle_ptr() const -> vehicle * { // *NOPAD*
         if( !vehicle_part ) {
             return nullptr;
         }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -4,12 +4,15 @@
 #include <memory>
 #include <optional>
 #include <queue>
+#include <ranges>
 #include <vector>
 
 #include "coordinates.h"
 #include "game.h"
 #include "game_constants.h"
 #include "map.h"
+#include "mapbuffer.h"
+#include "mapbuffer_registry.h"
 #include "map_iterator.h"
 #include "point.h"
 #include "submap.h"
@@ -33,6 +36,8 @@ static constexpr std::array<point_rel_ms, 8> DIRS_2D = {
 decltype( Pathfinding::d_maps_store ) Pathfinding::d_maps_store = {};
 decltype( Pathfinding::d_maps ) Pathfinding::d_maps = {};
 decltype( Pathfinding::z_area ) Pathfinding::z_area = {};
+decltype( Pathfinding::z_caches_dirty ) Pathfinding::z_caches_dirty = true;
+decltype( Pathfinding::z_caches_include_open_air ) Pathfinding::z_caches_include_open_air = false;
 decltype( Pathfinding::z_caches ) Pathfinding::z_caches = {};
 decltype( Pathfinding::z_caches_open_air ) Pathfinding::z_caches_open_air = {};
 decltype( Pathfinding::cached_closest_z_changes ) Pathfinding::cached_closest_z_changes = {};
@@ -57,6 +62,87 @@ static constexpr bool is_inf( float x )
 #endif
 }
 
+namespace
+{
+
+struct pathfinding_tile {
+    ter_id terrain;
+    furn_id furniture;
+    trap_id trap;
+    optional_vpart_position vehicle_part;
+    int move_cost = 0;
+
+    auto vehicle_ptr() const -> vehicle *
+    {
+        if( !vehicle_part ) {
+            return nullptr;
+        }
+        return &vehicle_part->vehicle();
+    }
+
+    auto part_index() const -> int
+    {
+        if( !vehicle_part ) {
+            return -1;
+        }
+        return static_cast<int>( vehicle_part->part_index() );
+    }
+};
+
+auto pathfinding_lookup_options() -> mapbuffer_lookup_options
+{
+    return { .mode = mapbuffer_lookup_mode::simulated_only };
+}
+
+auto get_pathfinding_tile( mapbuffer &buffer, const tripoint_abs_ms &pos )
+-> std::optional<pathfinding_tile>
+{
+    const auto options = pathfinding_lookup_options();
+    const auto terrain = buffer.get_ter( pos, options );
+    const auto furniture = buffer.get_furn( pos, options );
+    const auto move_cost = buffer.move_cost( pos, options );
+    if( !terrain || !furniture || !move_cost ) {
+        return std::nullopt;
+    }
+
+    return pathfinding_tile {
+        .terrain = *terrain,
+        .furniture = *furniture,
+        .trap = buffer.get_trap( pos, options ).value_or( tr_null ),
+        .vehicle_part = buffer.veh_at( pos, options ),
+        .move_cost = *move_cost,
+    };
+}
+
+auto passable_ter_furn( const ter_id &terrain_id, const furn_id &furniture_id ) -> bool
+{
+    const auto &terrain = terrain_id.obj();
+    if( terrain.movecost == 0 ) {
+        return false;
+    }
+
+    const auto &furniture = furniture_id.obj();
+    if( furniture.movecost < 0 ) {
+        return false;
+    }
+
+    return terrain.movecost + furniture.movecost > 0;
+}
+
+auto passable_ter_furn_at( mapbuffer &buffer, const tripoint_abs_ms &pos ) -> bool
+{
+    const auto options = pathfinding_lookup_options();
+    const auto terrain = buffer.get_ter( pos, options );
+    const auto furniture = buffer.get_furn( pos, options );
+    if( !terrain || !furniture ) {
+        return false;
+    }
+
+    return passable_ter_furn( *terrain, *furniture );
+}
+
+} // namespace
+
 // PathfindingSettings impls
 int PathfindingSettings::z_move_type() const
 {
@@ -71,9 +157,9 @@ constexpr bool RouteSettings::is_relative_search_domain() const
     return !( this->search_cone_angle >= 180. ||
               is_inf( this->search_radius_coeff ) );
 }
-constexpr bool RouteSettings::is_in_search_cone( const point_bub_ms start,
-        const point_bub_ms pos,
-        const point_bub_ms end ) const
+constexpr bool RouteSettings::is_in_search_cone( const point_abs_ms start,
+        const point_abs_ms pos,
+        const point_abs_ms end ) const
 {
     assert( 0.0 <= this->search_cone_angle );
 
@@ -100,22 +186,22 @@ constexpr bool RouteSettings::is_in_search_cone( const point_bub_ms start,
 
     return -max_cone_angle <= deviation && deviation <= max_cone_angle;
 }
-constexpr bool RouteSettings::is_in_search_radius( const point_bub_ms start,
-        const point_bub_ms pos,
-        const point_bub_ms end ) const
+constexpr bool RouteSettings::is_in_search_radius( const point_abs_ms start,
+        const point_abs_ms pos,
+        const point_abs_ms end ) const
 {
     if( is_inf( search_radius_coeff ) ) {
         return true;
     }
 
-    const auto midpoint = point_bub_ms( ( end.raw() + start.raw() ) / 2 );
+    const auto midpoint = point_abs_ms( ( end.raw() + start.raw() ) / 2 );
 
     const float objective_distance =
-        rl_dist_exact( tripoint_bub_ms( start, 0 ), tripoint_bub_ms( end, 0 ) );
+        rl_dist_exact( tripoint_abs_ms( start, 0 ), tripoint_abs_ms( end, 0 ) );
     const float search_radius =
         ( objective_distance * this->search_radius_coeff ) / 2;
     const float distance_to_objective =
-        rl_dist_exact( tripoint_bub_ms( pos, 0 ), tripoint_bub_ms( midpoint, 0 ) );
+        rl_dist_exact( tripoint_abs_ms( pos, 0 ), tripoint_abs_ms( midpoint, 0 ) );
 
     return distance_to_objective <= search_radius;
 }
@@ -145,19 +231,24 @@ unsigned int RouteSettings::rank_weighted_rng( const unsigned int n ) const
     return selected_n % n;
 }
 /// Pathfinding: verifications
-bool Pathfinding::in_bounds( const point_bub_ms &p )
+bool Pathfinding::in_bounds( const point_abs_ms &p )
 {
     // Specialized for pathfinding
+    const auto offset = this->map_pos_offset( p );
+    if( offset.x() < -1 || offset.x() > this->map_x_ || offset.y() < -1 ||
+        offset.y() > this->map_y_ ) {
+        return false;
+    }
     return this->tile_state_at( p ) != State::BOUNDS;
 }
 bool Pathfinding::is_in_limited_domain(
-    const point_bub_ms &start, const point_bub_ms &p, const RouteSettings &route_settings )
+    const point_abs_ms &start, const point_abs_ms &p, const RouteSettings &route_settings )
 {
     // Could be NaN if max_f_coeff = INFINITY * 0
     const float max_f = route_settings.max_f_coeff * (
                             route_settings.f_limit_based_on_max_dist ?
                             route_settings.max_dist :
-                            rl_dist_exact( tripoint_bub_ms( start, this->z ), tripoint_bub_ms( this->dest, this->z ) )
+                            rl_dist_exact( tripoint_abs_ms( start, this->z ), tripoint_abs_ms( this->dest, this->z ) )
                         );
 
     const bool is_in_f_limited_area = is_nan( max_f ) || this->get_f_unbiased( p ) <= max_f;
@@ -176,30 +267,38 @@ Pathfinding::Pathfinding( int mx, int my )
 {}
 
 /// Pathfinding: map indexing
-float &Pathfinding::p_at( const point_bub_ms &p )
+point_rel_ms Pathfinding::map_pos_offset( const point_abs_ms &p ) const
 {
-    return this->p_map[p.y() * this->map_x_ + p.x()];
-};
-float &Pathfinding::g_at( const point_bub_ms &p )
+    return p - this->origin;
+}
+
+float &Pathfinding::p_at( const point_abs_ms &p )
 {
-    return this->g_map[p.y() * this->map_x_ + p.x()];
+    const auto offset = this->map_pos_offset( p );
+    return this->p_map[offset.y() * this->map_x_ + offset.x()];
 };
-float Pathfinding::get_f_unbiased( const point_bub_ms &p )
+float &Pathfinding::g_at( const point_abs_ms &p )
+{
+    const auto offset = this->map_pos_offset( p );
+    return this->g_map[offset.y() * this->map_x_ + offset.x()];
+};
+float Pathfinding::get_f_unbiased( const point_abs_ms &p )
 {
     return this->p_at( p ) + this->g_at( p );
 }
-float Pathfinding::get_f_biased( const point_bub_ms &p, const point_bub_ms &start,
+float Pathfinding::get_f_biased( const point_abs_ms &p, const point_abs_ms &start,
                                  float h_coeff )
 {
     return this->get_f_unbiased( p ) + ( h_coeff * rl_dist_exact(
-            tripoint_bub_ms( p, 0 ), tripoint_bub_ms( start, 0 ) ) );
+            tripoint_abs_ms( p, 0 ), tripoint_abs_ms( start, 0 ) ) );
 }
-Pathfinding::State &Pathfinding::tile_state_at( const point_bub_ms &p )
+Pathfinding::State &Pathfinding::tile_state_at( const point_abs_ms &p )
 {
-    return this->tile_state[( p.y() + 1 ) * ( this->map_x_ + 2 ) + ( p.x() + 1 )];
+    const auto offset = this->map_pos_offset( p );
+    return this->tile_state[( offset.y() + 1 ) * ( this->map_x_ + 2 ) + ( offset.x() + 1 )];
 }
 /// Pathfinding: d-map wide changes
-void Pathfinding::produce_d_map( point_bub_ms dest, int z, PathfindingSettings settings )
+void Pathfinding::produce_d_map( point_abs_ms dest, int z, PathfindingSettings settings )
 {
     if( Pathfinding::d_maps_store.empty() ) {
         std::unique_ptr<Pathfinding> d_map = std::make_unique<Pathfinding>( g_mapsize_x, g_mapsize_y );
@@ -211,6 +310,7 @@ void Pathfinding::produce_d_map( point_bub_ms dest, int z, PathfindingSettings s
 
     d_map->dest = dest;
     d_map->z = z;
+    d_map->origin = project_to<coords::ms>( get_map().get_abs_sub() ).xy();
     d_map->settings = settings;
 
     Pathfinding::d_maps.push_back( std::move( d_map ) );
@@ -234,12 +334,18 @@ void Pathfinding::clear_pool()
     clear_d_maps();
     Pathfinding::d_maps_store.clear();
 }
+void Pathfinding::mark_dirty_z_cache()
+{
+    Pathfinding::z_caches_dirty = true;
+    Pathfinding::z_caches_include_open_air = false;
+    Pathfinding::cached_closest_z_changes.clear();
+}
 void Pathfinding::reset_maps()
 {
     this->p_at( this->dest ) = 0.0;
     this->g_at( this->dest ) = 0.0;
 
-    for( const point_bub_ms &p : this->map_modify_set ) {
+    for( const point_abs_ms &p : this->map_modify_set ) {
         this->p_at( p ) = 0.0;
         this->g_at( p ) = 0.0;
     }
@@ -249,7 +355,7 @@ void Pathfinding::reset_tile_state()
 {
     this->tile_state_at( this->dest ) = State::UNVISITED;
 
-    for( const point_bub_ms &p : this->tile_state_modify_set ) {
+    for( const point_abs_ms &p : this->tile_state_modify_set ) {
         this->tile_state_at( p ) = State::UNVISITED;
     }
 
@@ -266,7 +372,7 @@ void Pathfinding::reset_tile_state()
     }
 }
 /// Pathfinding: Z-levels
-std::unordered_map<point_bub_ms, Pathfinding::ZLevelChangeOpenAirPair>
+std::unordered_map<point_abs_ms, Pathfinding::ZLevelChangeOpenAirPair>
 &Pathfinding::get_z_cache_open_air( const int z )
 {
     assert( -OVERMAP_DEPTH <= z && z <= OVERMAP_HEIGHT );
@@ -284,98 +390,59 @@ std::vector<Pathfinding::ZLevelChange> &Pathfinding::get_z_cache( const int z )
 void Pathfinding::update_z_caches( bool update_open_air )
 {
     const map &here = get_map();
+    auto &buffer = MAPBUFFER_REGISTRY.get( here.get_bound_dimension() );
 
     auto cur_z_area = project_to<coords::ms>( here.get_abs_sub().xy() );
 
-    if( cur_z_area == Pathfinding::z_area ) {
+    if( !Pathfinding::z_caches_dirty && cur_z_area == Pathfinding::z_area &&
+        ( !update_open_air || Pathfinding::z_caches_include_open_air ) ) {
         return;
     }
 
-    const auto anti_shift = tripoint_rel_ms( Pathfinding::z_area - cur_z_area, 0 );
-    const auto prev_z_area_local = ( Pathfinding::z_area - cur_z_area ).reinterpret_as<point_bub_ms>();
-    const auto prev_z_area_end_local = ( Pathfinding::z_area + point_rel_ms( g_mapsize_x,
-                                         g_mapsize_y ) - cur_z_area ).reinterpret_as<point_bub_ms>();
-    // This cuboid will contain negative values, it's fine
-    half_open_cuboid<tripoint_bub_ms> prev_z_volume_local(
-        tripoint_bub_ms( prev_z_area_local, -OVERMAP_DEPTH ),
-        tripoint_bub_ms( prev_z_area_end_local, OVERMAP_HEIGHT + 1 )
-    );
-
-    for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
-        std::vector<Pathfinding::ZLevelChange> &target = Pathfinding::get_z_cache( z );
-
-        // Shift Z-changes to match new coordinate system
-        for( Pathfinding::ZLevelChange &c : target ) {
-            c.from = c.from + anti_shift;
-            c.to = c.to + anti_shift;
-        }
-
-        // Remove Z-level changes that have gone out of bounds into unloaded regions
-        std::erase_if( target, [&here]( const auto & pair ) {
-            return !( here.inbounds( pair.from ) && here.inbounds( pair.to ) );
-        } );
-
-        if( update_open_air ) {
-            std::unordered_map<point_bub_ms, Pathfinding::ZLevelChangeOpenAirPair> &open_air_target =
-                Pathfinding::get_z_cache_open_air( z );
-            std::unordered_map<point_bub_ms, Pathfinding::ZLevelChangeOpenAirPair> new_z_cache_open_air;
-            for( auto pair : open_air_target ) {
-                auto shifted = pair.first + anti_shift;
-                // Remove open air Z-level changes that have gone out of bounds into unloaded regions
-                if( !here.inbounds( shifted ) ) {
-                    continue;
-                }
-                if( pair.second.reach_from_above.has_value() ) {
-                    pair.second.reach_from_above->from += anti_shift;
-                    pair.second.reach_from_above->to += anti_shift;
-                }
-                if( pair.second.reach_from_below.has_value() ) {
-                    pair.second.reach_from_below->from += anti_shift;
-                    pair.second.reach_from_below->to += anti_shift;
-                }
-
-                new_z_cache_open_air.emplace( shifted.xy(), pair.second );
-            }
-            open_air_target.swap( new_z_cache_open_air );
-        }
+    for( auto &target : Pathfinding::z_caches ) {
+        target.clear();
     }
+    for( auto &target : Pathfinding::z_caches_open_air ) {
+        target.clear();
+    }
+    Pathfinding::cached_closest_z_changes.clear();
 
-    // Finally, append newly loaded points
-    for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+    for( const int z : std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ) ) {
         for( const tripoint_bub_ms &cur : here.points_on_zlevel( z ) ) {
             const auto bubble_pos = tripoint_bub_ms( cur );
-            if( prev_z_volume_local.contains( cur ) ) {
+            const auto abs_pos = map_local_to_abs( here, bubble_pos );
+            const auto cur_ter_id = buffer.get_ter( abs_pos, pathfinding_lookup_options() );
+            if( !cur_ter_id ) {
                 continue;
             }
-
-            const maptile &cur_tile = here.maptile_at( bubble_pos );
-            const auto &cur_ter = cur_tile.get_ter_t();
+            const auto &cur_ter = cur_ter_id->obj();
 
             if( update_open_air && cur_ter.has_flag( TFLAG_NO_FLOOR ) ) {
                 // Open air
                 const auto below_us = bubble_pos + tripoint_rel_ms::below();
+                const auto below_us_abs = abs_pos + tripoint_rel_ms::below();
 
                 if( !here.inbounds_z( below_us.z() ) ) {
                     continue;
                 }
 
-                if( here.impassable_ter_furn( below_us ) ) {
+                if( !passable_ter_furn_at( buffer, below_us_abs ) ) {
                     continue;
                 };
                 // We won't do vehicle checks for simplicity
 
-                const ZLevelChange going_to_below = ZLevelChange{ .from = cur, .to = below_us, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
-                const ZLevelChange reach_from_below = ZLevelChange{ .from = below_us, .to = cur, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
+                const ZLevelChange going_to_below = ZLevelChange{ .from = abs_pos, .to = below_us_abs, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
+                const ZLevelChange reach_from_below = ZLevelChange{ .from = below_us_abs, .to = abs_pos, .type = Pathfinding::ZLevelChange::Type::OPEN_AIR };
 
                 // This is stored separately from other changes because it requires a different type of processing
-                Pathfinding::get_z_cache_open_air( z ).emplace( bubble_pos.xy(),
+                Pathfinding::get_z_cache_open_air( z ).emplace( abs_pos.xy(),
                         Pathfinding::ZLevelChangeOpenAirPair{ .reach_from_below = reach_from_below, .reach_from_above = std::nullopt } );
 
                 auto &lower_level = Pathfinding::get_z_cache_open_air( z - 1 );
-                if( lower_level.contains( bubble_pos.xy() ) ) {
-                    lower_level[bubble_pos.xy()].reach_from_above = going_to_below;
+                if( lower_level.contains( abs_pos.xy() ) ) {
+                    lower_level[abs_pos.xy()].reach_from_above = going_to_below;
                 } else {
-                    lower_level.emplace( bubble_pos.xy(),  Pathfinding::ZLevelChangeOpenAirPair{ .reach_from_below = std::nullopt, .reach_from_above = going_to_below } );
+                    lower_level.emplace( abs_pos.xy(),  Pathfinding::ZLevelChangeOpenAirPair{ .reach_from_below = std::nullopt, .reach_from_above = going_to_below } );
                 }
             } else if( cur_ter.has_flag( TFLAG_GOES_UP ) ) {
                 // Stair bullshitery
@@ -387,13 +454,17 @@ void Pathfinding::update_z_caches( bool update_open_air )
 
                 // 10 to maintain parity with legacy A*
                 // closest_points_first will ensure stairs above us directly will be hit first
-                for( const auto &maybe_stairs_p : closest_points_first( above_us, 10 ) ) {
-                    const maptile &maybe_stairs_tile = here.maptile_at( maybe_stairs_p );
-                    const auto &maybe_stair_ter = maybe_stairs_tile.get_ter_t();
+                const auto above_us_abs = abs_pos + tripoint_rel_ms::above();
+                for( const auto &maybe_stairs_abs : closest_points_first( above_us_abs, 10 ) ) {
+                    const auto maybe_stairs_ter = buffer.get_ter( maybe_stairs_abs,
+                                                    pathfinding_lookup_options() );
+                    if( !maybe_stairs_ter ) {
+                        continue;
+                    }
 
-                    if( maybe_stair_ter.has_flag( TFLAG_GOES_DOWN ) ) {
-                        const ZLevelChange stairs_up = ZLevelChange{ .from = cur, .to = maybe_stairs_p, .type = Pathfinding::ZLevelChange::Type::STAIRS };
-                        const ZLevelChange stairs_down = ZLevelChange{ .from = maybe_stairs_p, .to = cur, .type = Pathfinding::ZLevelChange::Type::STAIRS };
+                    if( maybe_stairs_ter->obj().has_flag( TFLAG_GOES_DOWN ) ) {
+                        const ZLevelChange stairs_up = ZLevelChange{ .from = abs_pos, .to = maybe_stairs_abs, .type = Pathfinding::ZLevelChange::Type::STAIRS };
+                        const ZLevelChange stairs_down = ZLevelChange{ .from = maybe_stairs_abs, .to = abs_pos, .type = Pathfinding::ZLevelChange::Type::STAIRS };
                         Pathfinding::get_z_cache( z ).push_back( stairs_down );
                         Pathfinding::get_z_cache( z + 1 ).push_back( stairs_up );
                         break;
@@ -409,13 +480,17 @@ void Pathfinding::update_z_caches( bool update_open_air )
 
                 // 10 to maintain parity with legacy A*
                 // closest_points_first will ensure stairs below us directly will be hit first
-                for( const tripoint_bub_ms &maybe_stairs_p : closest_points_first( below_us, 10 ) ) {
-                    const maptile &maybe_stairs_tile = here.maptile_at( maybe_stairs_p );
-                    const auto &maybe_stairs_ter = maybe_stairs_tile.get_ter_t();
+                const auto below_us_abs = abs_pos + tripoint_rel_ms::below();
+                for( const tripoint_abs_ms &maybe_stairs_abs : closest_points_first( below_us_abs, 10 ) ) {
+                    const auto maybe_stairs_ter = buffer.get_ter( maybe_stairs_abs,
+                                                    pathfinding_lookup_options() );
+                    if( !maybe_stairs_ter ) {
+                        continue;
+                    }
 
-                    if( maybe_stairs_ter.has_flag( TFLAG_GOES_UP ) ) {
-                        const ZLevelChange stairs_down = ZLevelChange{ .from = cur, .to = maybe_stairs_p, .type = Pathfinding::ZLevelChange::Type::STAIRS };
-                        const ZLevelChange stairs_up = ZLevelChange{ .from = maybe_stairs_p, .to = cur, .type = Pathfinding::ZLevelChange::Type::STAIRS };
+                    if( maybe_stairs_ter->obj().has_flag( TFLAG_GOES_UP ) ) {
+                        const ZLevelChange stairs_down = ZLevelChange{ .from = abs_pos, .to = maybe_stairs_abs, .type = Pathfinding::ZLevelChange::Type::STAIRS };
+                        const ZLevelChange stairs_up = ZLevelChange{ .from = maybe_stairs_abs, .to = abs_pos, .type = Pathfinding::ZLevelChange::Type::STAIRS };
                         Pathfinding::get_z_cache( z ).push_back( stairs_up );
                         Pathfinding::get_z_cache( z - 1 ).push_back( stairs_down );
                         break;
@@ -428,7 +503,7 @@ void Pathfinding::update_z_caches( bool update_open_air )
                     continue;
                 }
 
-                const ZLevelChange ramp_up = ZLevelChange{ .from = cur, .to = above_us, .type = Pathfinding::ZLevelChange::Type::RAMP };
+                const ZLevelChange ramp_up = ZLevelChange{ .from = abs_pos, .to = abs_pos + tripoint_rel_ms::above(), .type = Pathfinding::ZLevelChange::Type::RAMP };
                 Pathfinding::get_z_cache( z + 1 ).push_back( ramp_up );
             } else if( cur_ter.has_flag( TFLAG_RAMP_DOWN ) ) {
                 const auto below_us = cur + tripoint_below;
@@ -437,32 +512,34 @@ void Pathfinding::update_z_caches( bool update_open_air )
                     continue;
                 }
 
-                const ZLevelChange ramp_down = ZLevelChange{ .from = cur, .to = below_us, .type = Pathfinding::ZLevelChange::Type::RAMP };
+                const ZLevelChange ramp_down = ZLevelChange{ .from = abs_pos, .to = abs_pos + tripoint_rel_ms::below(), .type = Pathfinding::ZLevelChange::Type::RAMP };
                 Pathfinding::get_z_cache( z - 1 ).push_back( ramp_down );
             }
         }
     }
 
     Pathfinding::z_area = cur_z_area;
+    Pathfinding::z_caches_dirty = false;
+    Pathfinding::z_caches_include_open_air = update_open_air;
 }
 /// Pathfinding: main loops
 void Pathfinding::detect_culled_frontier(
-    const point_bub_ms &start, const RouteSettings &route_settings,
-    std::unordered_set<point_bub_ms> &out )
+    const point_abs_ms &start, const RouteSettings &route_settings,
+    std::unordered_set<point_abs_ms> &out )
 {
-    std::unordered_set<point_bub_ms> flood_fill;
-    std::vector<point_bub_ms> stack;
+    std::unordered_set<point_abs_ms> flood_fill;
+    std::vector<point_abs_ms> stack;
 
     flood_fill.insert( start );
     stack.push_back( start );
 
     // This is deliberately a depth-first search in order to fail quickly upon reaching map edge
     while( !stack.empty() ) {
-        const point_bub_ms p = stack.back();
+        const point_abs_ms p = stack.back();
         stack.pop_back();
 
         for( const auto &dir : DIRS_2D ) {
-            const point_bub_ms next = p + dir;
+            const point_abs_ms next = p + dir;
             if( !this->in_bounds( next ) ) {
                 // If we reached map edge, this means we're in an unclosed area
                 return;
@@ -492,7 +569,7 @@ void Pathfinding::detect_culled_frontier(
 }
 
 Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
-    const point_bub_ms &start,
+    const point_abs_ms &start,
     const RouteSettings &route_settings )
 {
     using Frontier = std::priority_queue<val_pair, std::vector<val_pair>, pair_greater_cmp_first>;
@@ -527,7 +604,7 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
                 if( this->is_explored ) {
                     return ExpansionOutcome::NO_PATH_EXISTS;
                 }
-                for( const point_bub_ms &p : this->unbiased_frontier ) {
+                for( const point_abs_ms &p : this->unbiased_frontier ) {
                     biased_frontier.emplace( this->get_f_biased( p, start, route_settings.h_coeff ), p );
                 }
                 break;
@@ -552,9 +629,9 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
 
     // If this is not empty, we have encircled our target so don't bother expanding
     //   to tiles outside this area
-    std::unordered_set<point_bub_ms> unculled_area;
+    std::unordered_set<point_abs_ms> unculled_area;
     // If we happen to cull our search area, we'll store culled points here
-    std::unordered_set<point_bub_ms> culled_frontier;
+    std::unordered_set<point_abs_ms> culled_frontier;
     ExpansionOutcome result = ExpansionOutcome::UNSET;
 
     const bool can_open_doors = !is_inf( this->settings.door_open_cost );
@@ -563,6 +640,7 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
     const bool care_about_mobs = this->settings.mob_presence_penalty > 0;
     const bool care_about_traps = this->settings.trap_cost > 0;
     const map &here = get_map();
+    auto &buffer = MAPBUFFER_REGISTRY.get( here.get_bound_dimension() );
 
     while( !biased_frontier.empty() ) {
         // Periodically check if `start` is enclosed
@@ -571,7 +649,7 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
         if( ++it % 200 == 0 ) {
             this->detect_culled_frontier( start, route_settings, unculled_area );
         }
-        const point_bub_ms next_point = biased_frontier.top().second;
+        const point_abs_ms next_point = biased_frontier.top().second;
 
         biased_frontier.pop();
 
@@ -588,16 +666,14 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
             continue;
         }
 
-        const tripoint_bub_ms next_point_with_z = tripoint_bub_ms( next_point, this->z );
-
-        int _;
-        const vehicle *next_vehicle;
-        next_vehicle = here.veh_at_internal( tripoint_bub_ms( next_point_with_z ), _ );
+        const tripoint_abs_ms next_point_with_z = tripoint_abs_ms( next_point, this->z );
+        const auto next_vp = buffer.veh_at( next_point_with_z, pathfinding_lookup_options() );
+        const auto *next_vehicle = next_vp ? &next_vp->vehicle() : nullptr;
 
         for( const auto &dir : DIRS_2D ) {
             // It's cur_point because we're working backwards from destination
-            const point_bub_ms cur_point = next_point + dir;
-            const tripoint_bub_ms cur_point_with_z = tripoint_bub_ms( cur_point, this->z );
+            const point_abs_ms cur_point = next_point + dir;
+            const tripoint_abs_ms cur_point_with_z = tripoint_abs_ms( cur_point, this->z );
 
             if( !this->in_bounds( cur_point ) ) {
                 continue;
@@ -607,25 +683,30 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
                 continue;
             }
 
-            int cur_vehicle_part;
-            const vehicle *cur_vehicle;
-            cur_vehicle = here.veh_at_internal( tripoint_bub_ms( cur_point_with_z ), cur_vehicle_part );
+            const auto maybe_new_tile = get_pathfinding_tile( buffer, cur_point_with_z );
+            if( !maybe_new_tile ) {
+                this->tile_state_at( cur_point ) = Pathfinding::State::INACCESSIBLE;
+                this->tile_state_modify_set.push_back( cur_point );
+                continue;
+            }
+            const auto &new_tile = *maybe_new_tile;
+            auto *const cur_vehicle = new_tile.vehicle_ptr();
+            const auto cur_vehicle_part = new_tile.part_index();
 
             {
                 bool is_move_valid = true;
 
-                // TODO: migrate pathfinding positions to abs so these conversions can use abs_to_mount
                 const bool is_valid_to_step_into_veh =
                     cur_vehicle == nullptr ?
                     true :
-                    cur_vehicle->allowed_move( cur_vehicle->bubble_to_mount( tripoint_bub_ms( cur_point_with_z ) ),
-                                               cur_vehicle->bubble_to_mount( tripoint_bub_ms( next_point_with_z ) ) );
+                    cur_vehicle->allowed_move( cur_vehicle->abs_to_mount( cur_point_with_z ),
+                                               cur_vehicle->abs_to_mount( next_point_with_z ) );
 
                 const bool is_valid_to_step_out_of_veh =
                     next_vehicle == nullptr ?
                     true :
-                    next_vehicle->allowed_move( next_vehicle->bubble_to_mount( tripoint_bub_ms( cur_point_with_z ) ),
-                                                next_vehicle->bubble_to_mount( tripoint_bub_ms( next_point_with_z ) ) );
+                    next_vehicle->allowed_move( next_vehicle->abs_to_mount( cur_point_with_z ),
+                                                next_vehicle->abs_to_mount( next_point_with_z ) );
 
                 is_move_valid &= is_valid_to_step_into_veh;
                 is_move_valid &= is_valid_to_step_out_of_veh;
@@ -636,10 +717,9 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
                 }
             }
 
-            const maptile &new_tile = here.maptile_at_internal( tripoint_bub_ms( cur_point_with_z ) );
-            const auto &terrain = new_tile.get_ter_t();
-            const auto &furniture = new_tile.get_furn_t();
-            const int move_cost = here.move_cost_internal( furniture, terrain, cur_vehicle, cur_vehicle_part );
+            const auto &terrain = new_tile.terrain.obj();
+            const auto &furniture = new_tile.furniture.obj();
+            const auto move_cost = new_tile.move_cost;
 
             float cur_g = this->g_at( cur_point );
             // May be false for relative search, so we'll reuse g-values there
@@ -665,7 +745,7 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
 
                 if( care_about_traps && !std::isinf( cur_g ) ) {
                     const trap &maybe_ter_trap = terrain.trap.obj();
-                    const trap &maybe_trap = maybe_ter_trap.is_benign() ? new_tile.get_trap_t() : maybe_ter_trap;
+                    const trap &maybe_trap = maybe_ter_trap.is_benign() ? new_tile.trap.obj() : maybe_ter_trap;
                     const bool is_trap = !maybe_trap.is_benign();
 
                     cur_g += is_trap ? this->settings.trap_cost : 0.0;
@@ -696,11 +776,9 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
                         const int obstacle_part = vpobst ? vpobst->part_index() : -1;
 
                         if( obstacle_part >= 0 ) {
-                            int _;
                             const bool part_is_door = cur_vehicle->part_flag( obstacle_part, VPFLAG_OPENABLE );
                             const bool part_opens_from_inside = cur_vehicle->part_flag( obstacle_part, "OPENCLOSE_INSIDE" );
-                            const bool is_cur_point_inside = here.veh_at_internal( tripoint_bub_ms( cur_point_with_z ),
-                                                             _ ) == next_vehicle;
+                            const bool is_cur_point_inside = cur_vehicle == next_vehicle;
                             const bool valid_to_open = part_is_door && ( part_opens_from_inside ? is_cur_point_inside : true );
 
                             if( can_open_doors && valid_to_open ) {
@@ -733,7 +811,8 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
                         // Doors that can only be open from the inside
                         const bool door_opens_from_inside = terrain.has_flag( "OPENCLOSE_INSIDE" ) ||
                                                             furniture.has_flag( "OPENCLOSE_INSIDE" );
-                        const bool is_cur_point_inside = !here.is_outside( cur_point );
+                        const bool is_cur_point_inside = !here.is_outside( abs_to_map_local( here,
+                                                           cur_point_with_z ) );
                         const bool valid_to_open = door_opens_from_inside ? is_cur_point_inside : true;
                         if( valid_to_open ) {
                             obstacle_g = this->settings.door_open_cost;
@@ -801,12 +880,12 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
     // We will be rebuilding on next search anyway if we had a relative search this time
     if( this->domain == MapDomain::ABSOLUTE_DOMAIN ) {
         while( !biased_frontier.empty() ) {
-            const point_bub_ms p = biased_frontier.top().second;
+            const point_abs_ms p = biased_frontier.top().second;
             biased_frontier.pop();
 
             this->unbiased_frontier.push_back( p );
         }
-        for( const point_bub_ms &p : culled_frontier ) {
+        for( const point_abs_ms &p : culled_frontier ) {
             this->unbiased_frontier.push_back( p );
         }
     }
@@ -823,13 +902,13 @@ Pathfinding::ExpansionOutcome Pathfinding::expand_2d_up_to(
 }
 
 
-std::vector<tripoint_bub_ms> Pathfinding::get_route_2d(
-    const point_bub_ms from, const point_bub_ms to, const int z,
+std::vector<tripoint_abs_ms> Pathfinding::get_route_2d(
+    const point_abs_ms from, const point_abs_ms to, const int z,
     const PathfindingSettings path_settings,
     const RouteSettings route_settings )
 {
     if( from == to ) {
-        return std::vector<tripoint_bub_ms> { tripoint_bub_ms( from, z ), tripoint_bub_ms( to, z ) };
+        return std::vector<tripoint_abs_ms> { tripoint_abs_ms( from, z ), tripoint_abs_ms( to, z ) };
     }
 
     auto d_map_it = std::ranges::find_if(
@@ -848,29 +927,29 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_2d(
 
     if( !d_map->is_in_limited_domain( from, from, route_settings ) ) {
         // This should only fail if max f-limit is failed
-        return std::vector<tripoint_bub_ms>();
+        return std::vector<tripoint_abs_ms>();
     }
 
     if( d_map->expand_2d_up_to( from, route_settings ) != ExpansionOutcome::PATH_FOUND ) {
-        return std::vector<tripoint_bub_ms>();
+        return std::vector<tripoint_abs_ms>();
     }
 
     const int chebyshev_distance = square_dist_fast(
-                                       tripoint_bub_ms( from, d_map->z ),
-                                       tripoint_bub_ms( d_map->dest, d_map->z ) );
+                                       tripoint_abs_ms( from, d_map->z ),
+                                       tripoint_abs_ms( d_map->dest, d_map->z ) );
     const float max_s = route_settings.max_s_coeff * chebyshev_distance;
 
-    std::vector<tripoint_bub_ms> result;
-    result.push_back( tripoint_bub_ms( from, d_map->z ) );
+    std::vector<tripoint_abs_ms> result;
+    result.push_back( tripoint_abs_ms( from, d_map->z ) );
 
-    point_bub_ms cur_point = from;
+    point_abs_ms cur_point = from;
     float cur_cost = d_map->get_f_unbiased( cur_point );
 
     while( cur_point != d_map->dest ) {
-        std::vector<std::pair<float, point_bub_ms>> candidates;
+        std::vector<std::pair<float, point_abs_ms>> candidates;
 
         for( const auto &dir : DIRS_2D ) {
-            const point_bub_ms next_point = cur_point + dir;
+            const point_abs_ms next_point = cur_point + dir;
             const bool is_in_bounds = d_map->in_bounds( next_point );
             if( !is_in_bounds ) {
                 continue;
@@ -906,7 +985,7 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_2d(
 
         const auto selected_pair = &candidates[route_settings.rank_weighted_rng( candidates.size() )];
 
-        result.push_back( tripoint_bub_ms( selected_pair->second, d_map->z ) );
+        result.push_back( tripoint_abs_ms( selected_pair->second, d_map->z ) );
         cur_point = selected_pair->second;
         cur_cost = selected_pair->first;
 
@@ -922,8 +1001,8 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_2d(
     return result;
 }
 
-std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
-    const tripoint_bub_ms from, const tripoint_bub_ms to,
+std::vector<tripoint_abs_ms> Pathfinding::get_route_3d(
+    const tripoint_abs_ms from, const tripoint_abs_ms to,
     const PathfindingSettings path_settings,
     const RouteSettings route_settings )
 {
@@ -936,12 +1015,12 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
     // Determine our Z-path
     std::vector<ZLevelChange> z_path;
     {
-        tripoint_bub_ms cur_origin = to;
-        point_bub_ms cur_origin_point = to.xy();
+        tripoint_abs_ms cur_origin = to;
+        point_abs_ms cur_origin_point = to.xy();
 
         while( cur_origin.z() != from.z() ) {
             Pathfinding::ZLevelChange best_z_change;
-            std::tuple<bool, int, tripoint_bub_ms> cache_pair{ we_go_up, path_settings.z_move_type(), cur_origin };
+            std::tuple<bool, int, tripoint_abs_ms> cache_pair{ we_go_up, path_settings.z_move_type(), cur_origin };
 
             if( Pathfinding::cached_closest_z_changes.contains( cache_pair ) ) {
                 best_z_change = Pathfinding::cached_closest_z_changes.at( cache_pair );
@@ -997,14 +1076,14 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
 
                 // Open air processing
                 if( path_settings.can_fly ) {
-                    std::unordered_map<point_bub_ms, ZLevelChangeOpenAirPair> &target =
+                    std::unordered_map<point_abs_ms, ZLevelChangeOpenAirPair> &target =
                         Pathfinding::get_z_cache_open_air( cur_origin.z() );
 
                     // There's a rare case where no valid non-open-air way exists to this Z-level
                     //   in which case `closest_points_first` would return a INT_MAX radius of points
                     //   causing an oopsie
                     // If that's the case, we have to iterate over open airs directly instead
-                    std::vector<point_bub_ms> source;
+                    std::vector<point_abs_ms> source;
                     const bool source_is_closest_points = !std::isinf( best_distance );
                     if( source_is_closest_points ) {
                         source = closest_points_first( cur_origin_point, static_cast<int>( best_distance ) );
@@ -1014,7 +1093,7 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
                         }
                     }
 
-                    for( const point_bub_ms &p : source ) {
+                    for( const point_abs_ms &p : source ) {
                         // Are we considering open airs that are already beyond our best known move?
                         //   only valid for closest_point movement since they're ordered
                         if( source_is_closest_points && square_dist( cur_origin_point, p ) > best_distance ) {
@@ -1025,13 +1104,13 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
                         }
                         Pathfinding::ZLevelChangeOpenAirPair z_pair = target[p];
                         if( we_go_up && z_pair.reach_from_below.has_value() ) {
-                            const float dist = rl_dist_exact( tripoint_bub_ms( cur_origin_point, 0 ), tripoint_bub_ms( p, 0 ) );
+                            const float dist = rl_dist_exact( tripoint_abs_ms( cur_origin_point, 0 ), tripoint_abs_ms( p, 0 ) );
                             if( dist < best_distance ) {
                                 best_z_change = *z_pair.reach_from_below;
                                 best_distance = dist;
                             }
                         } else if( !we_go_up && z_pair.reach_from_above.has_value() ) {
-                            const float dist = rl_dist_exact( tripoint_bub_ms( cur_origin_point, 0 ), tripoint_bub_ms( p, 0 ) );
+                            const float dist = rl_dist_exact( tripoint_abs_ms( cur_origin_point, 0 ), tripoint_abs_ms( p, 0 ) );
                             if( dist < best_distance ) {
                                 best_z_change = *z_pair.reach_from_above;
                                 best_distance = dist;
@@ -1043,7 +1122,7 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
                 if( is_inf( best_distance ) ) {
                     // No trivial Z path exists, give up
                     debugmsg_of( DL::Debug, "Failed to find a trivial path across z-levels" );
-                    return std::vector<tripoint_bub_ms>();
+                    return std::vector<tripoint_abs_ms>();
                 }
 
                 Pathfinding::cached_closest_z_changes.insert_or_assign( cache_pair, best_z_change );
@@ -1054,7 +1133,7 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
             constexpr auto unreasonable_z_hops = 1000;
             if( z_path.size() > unreasonable_z_hops ) {
                 debugmsg( "Failed to find a path with less than %d z-level changes", unreasonable_z_hops );
-                return std::vector<tripoint_bub_ms>();
+                return std::vector<tripoint_abs_ms>();
             }
 
             cur_origin = best_z_change.from;
@@ -1062,15 +1141,15 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
         }
     }
 
-    std::unordered_set<tripoint_bub_ms> ramp_excluded;
-    std::vector<tripoint_bub_ms> result;
+    std::unordered_set<tripoint_abs_ms> ramp_excluded;
+    std::vector<tripoint_abs_ms> result;
     // Now try to construct path
     {
-        point_bub_ms cur_pos = from.xy();
+        point_abs_ms cur_pos = from.xy();
         while( !z_path.empty() ) {
             const Pathfinding::ZLevelChange next = z_path.back();
 
-            const std::vector<tripoint_bub_ms> path_segment = Pathfinding::get_route_2d(
+            const std::vector<tripoint_abs_ms> path_segment = Pathfinding::get_route_2d(
                         cur_pos, next.from.xy(), next.from.z(),
                         path_settings, route_settings );
             if( path_segment.empty() ) {
@@ -1091,7 +1170,7 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
         }
 
         // We arrived to final Z level
-        const std::vector<tripoint_bub_ms> final_segment = Pathfinding::get_route_2d(
+        const std::vector<tripoint_abs_ms> final_segment = Pathfinding::get_route_2d(
                     cur_pos, to.xy(), to.z(),
                     path_settings, route_settings );
         if( final_segment.empty() ) {
@@ -1101,12 +1180,40 @@ std::vector<tripoint_bub_ms> Pathfinding::get_route_3d(
         result.insert( result.end(), final_segment.begin(), final_segment.end() );
 
         // Finally, remove ramp tiles
-        std::erase_if( result, [&ramp_excluded]( const tripoint_bub_ms & p ) {
+        std::erase_if( result, [&ramp_excluded]( const tripoint_abs_ms & p ) {
             return ramp_excluded.contains( p );
         } );
     }
     return result;
 }
+
+std::vector<tripoint_abs_ms> Pathfinding::route(
+    tripoint_abs_ms from, tripoint_abs_ms to,
+    const std::optional<PathfindingSettings> maybe_path_settings,
+    const std::optional<RouteSettings> maybe_route_settings )
+{
+    const map &here = get_map();
+
+    PathfindingSettings path_settings = maybe_path_settings.has_value() ? *maybe_path_settings :
+                                        PathfindingSettings();
+    RouteSettings route_settings = maybe_route_settings.has_value() ? *maybe_route_settings :
+                                   RouteSettings();
+
+    if( rl_dist_exact( from.raw(), to.raw() ) > route_settings.max_dist ) {
+        return std::vector<tripoint_abs_ms>();
+    }
+
+    if( !here.inbounds( abs_to_map_local( here, from ) ) ||
+        !here.inbounds( abs_to_map_local( here, to ) ) ) {
+        return std::vector<tripoint_abs_ms>();
+    }
+
+    if( from.z() == to.z() ) {
+        return Pathfinding::get_route_2d( from.xy(), to.xy(), from.z(),
+                                          path_settings, route_settings );
+    }
+    return Pathfinding::get_route_3d( from, to, path_settings, route_settings );
+};
 
 std::vector<tripoint_bub_ms> Pathfinding::route(
     tripoint_bub_ms from, tripoint_bub_ms to,
@@ -1118,18 +1225,12 @@ std::vector<tripoint_bub_ms> Pathfinding::route(
     here.clip_to_bounds( from );
     here.clip_to_bounds( to );
 
-    PathfindingSettings path_settings = maybe_path_settings.has_value() ? *maybe_path_settings :
-                                        PathfindingSettings();
-    RouteSettings route_settings = maybe_route_settings.has_value() ? *maybe_route_settings :
-                                   RouteSettings();
-
-    if( rl_dist_exact( from.raw(), to.raw() ) > route_settings.max_dist ) {
-        return std::vector<tripoint_bub_ms>();
+    const auto abs_route = Pathfinding::route( bub_to_abs( from ), bub_to_abs( to ),
+                           maybe_path_settings, maybe_route_settings );
+    std::vector<tripoint_bub_ms> result;
+    result.reserve( abs_route.size() );
+    for( const tripoint_abs_ms &p : abs_route ) {
+        result.push_back( abs_to_bub( p ) );
     }
-
-    if( from.z() == to.z() ) {
-        return Pathfinding::get_route_2d( from.xy(), to.xy(), from.z(),
-                                          path_settings, route_settings );
-    }
-    return Pathfinding::get_route_3d( from, to, path_settings, route_settings );
-};
+    return result;
+}

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -253,7 +253,7 @@ bool Pathfinding::is_in_limited_domain(
     const bool is_in_search_radius = route_settings.is_in_search_radius( start, p, this->dest );
     const bool is_in_search_cone = route_settings.is_in_search_cone( start, p, this->dest );
 
-    return is_in_f_limited_area || is_in_search_radius || is_in_search_cone;
+    return is_in_f_limited_area && is_in_search_radius && is_in_search_cone;
 }
 
 /// Pathfinding: constructor

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -72,7 +72,7 @@ struct pathfinding_tile {
     optional_vpart_position vehicle_part;
     int move_cost = 0;
 
-    auto vehicle_ptr() const -> vehicle* {
+    auto vehicle_ptr() const -> vehicle * {
         if( !vehicle_part ) {
             return nullptr;
         }

--- a/src/pathfinding.h
+++ b/src/pathfinding.h
@@ -61,7 +61,7 @@ struct PathfindingSettings {
     bool can_climb_stairs = false;
 
     // A map of tiles that have an extra G-cost assigned to them. Used for potential fields, preclosed tiles, etc.
-    std::unordered_map<point_bub_ms, float> extra_g_costs;
+    std::unordered_map<point_abs_ms, float> extra_g_costs;
 
     bool operator==( const PathfindingSettings &rhs ) const = default;
     int z_move_type() const;
@@ -117,8 +117,8 @@ struct RouteSettings {
     */
     float search_radius_coeff = INFINITY;
     // Test if `pos` is in the circle of radius distance from `start` to `end` by `search_radius_coeff` centered at `end`
-    constexpr bool is_in_search_radius( const point_bub_ms start, const point_bub_ms pos,
-                                        const point_bub_ms end ) const;
+    constexpr bool is_in_search_radius( const point_abs_ms start, const point_abs_ms pos,
+                                        const point_abs_ms end ) const;
 
     /*
     ```plain
@@ -143,8 +143,8 @@ struct RouteSettings {
     */
     float search_cone_angle = 180.0;
     // Test if `pos` is in the cone of `search_cone_angle` projected from `start` to `end`
-    constexpr bool is_in_search_cone( const point_bub_ms start, const point_bub_ms pos,
-                                      const point_bub_ms end ) const;
+    constexpr bool is_in_search_cone( const point_abs_ms start, const point_abs_ms pos,
+                                      const point_abs_ms end ) const;
 
     /* Limit our search area such that a path will contain steps only up to this coefficient multiplied by chebyshev distance between start and end.
     In other words, it limits the amount of tiles to step through for any given path.
@@ -175,7 +175,7 @@ struct RouteSettings {
 class Pathfinding
 {
     private:
-        using val_pair = std::pair<float, point_bub_ms>;
+        using val_pair = std::pair<float, point_abs_ms>;
 
         enum class State {
             UNVISITED, // Tile has not been expanded to yet
@@ -204,8 +204,8 @@ class Pathfinding
                 OPEN_AIR
             };
 
-            tripoint_bub_ms from;
-            tripoint_bub_ms to;
+            tripoint_abs_ms from;
+            tripoint_abs_ms to;
             Type type;
         };
         struct ZLevelChangeOpenAirPair {
@@ -219,29 +219,18 @@ class Pathfinding
         // Global state: memoized dijikstra d_maps. Transfer to `d_maps_store` every game turn.
         static std::vector<std::unique_ptr<Pathfinding>> d_maps;
 
-        // We store the area covered by last Z-scan (in global coords, top left loaded submap)
-        // ```
-        // -----
-        // |1  |
-        // | --+---
-        // | | |  |
-        // --+--  |
-        //   |   2|
-        //   ------
-        // ```
-        // If we moved our area from square 1 to square 2, then
-        // `ZLevelChange`s that only remain in 1 will be removed
-        // `ZLevelChange`s that remain in both 1 and 2 will be shifted so their local coords match square 2
-        // and points that are only in 2 will be scanned for new Z-changes.
+        // Top-left absolute map square of the last loaded area scanned for Z-level transitions.
         static point_abs_ms z_area;
+        static bool z_caches_dirty;
+        static bool z_caches_include_open_air;
 
         // Global state: Z-level transitions for each z-level (does not include OPEN_AIR due to being numerous, requiring a different approach)
         static std::array<std::vector<ZLevelChange>, OVERMAP_LAYERS> z_caches;
         // Global state: OPEN_AIR type z-level transitions for each z-level
-        static std::array<std::unordered_map<point_bub_ms, ZLevelChangeOpenAirPair>, OVERMAP_LAYERS>
+        static std::array<std::unordered_map<point_abs_ms, ZLevelChangeOpenAirPair>, OVERMAP_LAYERS>
         z_caches_open_air;
         // Global state: We cache `z_path` information taken to prevent multiple iterations for the same target
-        static std::map<std::tuple<bool, int, tripoint_bub_ms>, ZLevelChange> cached_closest_z_changes;
+        static std::map<std::tuple<bool, int, tripoint_abs_ms>, ZLevelChange> cached_closest_z_changes;
 
         // Runtime map dimensions (default MAPSIZE_X / MAPSIZE_Y; updated when bubble size changes)
         int map_x_;
@@ -256,14 +245,16 @@ class Pathfinding
         std::vector<State> tile_state;
 
         // Which points in maps have we modified thus far? Used for resetting.
-        std::vector<point_bub_ms> map_modify_set;
+        std::vector<point_abs_ms> map_modify_set;
         // Which points in tile state have we modified thus far? Used for resetting.
-        std::vector<point_bub_ms> tile_state_modify_set;
+        std::vector<point_abs_ms> tile_state_modify_set;
 
         // `dest`ination of this map [2D]
-        point_bub_ms dest;
+        point_abs_ms dest;
         // `z` level of this map
         int z;
+        // Absolute origin used to index the dense pathfinding arrays.
+        point_abs_ms origin;
         // `settings` which were used to spawn this map
         PathfindingSettings settings;
 
@@ -274,10 +265,10 @@ class Pathfinding
 
         // We don't want to calculate dijikstra of the whole map every time,
         //   so we store wave `frontier` to proceed from later if needed
-        std::vector<point_bub_ms> unbiased_frontier;
+        std::vector<point_abs_ms> unbiased_frontier;
 
         // Moves we don't allow to happen
-        std::set<std::pair<point_bub_ms, point_bub_ms>> forbidden_moves;
+        std::set<std::pair<point_abs_ms, point_abs_ms>> forbidden_moves;
 
         // Possibly shift or move all Z-changes if our `z_area` moved
         //   and scan for new changes.
@@ -287,55 +278,59 @@ class Pathfinding
 
         // Get a reference to ZCache for this level
         static std::vector<ZLevelChange> &get_z_cache( const int z );
-        static std::unordered_map<point_bub_ms, ZLevelChangeOpenAirPair> &get_z_cache_open_air(
+        static std::unordered_map<point_abs_ms, ZLevelChangeOpenAirPair> &get_z_cache_open_air(
             const int z );
 
-        static void produce_d_map( point_bub_ms dest, int z, PathfindingSettings settings );
+        static void produce_d_map( point_abs_ms dest, int z, PathfindingSettings settings );
 
         // Get `p`-value at `p`
-        float &p_at( const point_bub_ms &p );
+        float &p_at( const point_abs_ms &p );
         // Get `g`-value at `p`
-        float &g_at( const point_bub_ms &p );
+        float &g_at( const point_abs_ms &p );
         // f0 = p + g
-        float get_f_unbiased( const point_bub_ms &p );
+        float get_f_unbiased( const point_abs_ms &p );
         // f1 = p + g + `h_coeff` * [distance between `start` and `p`]
-        float get_f_biased( const point_bub_ms &p, const point_bub_ms &start, float h_coeff );
+        float get_f_biased( const point_abs_ms &p, const point_abs_ms &start, float h_coeff );
 
         void reset_maps();
         void reset_tile_state();
-        State &tile_state_at( const point_bub_ms &p );
-        bool in_bounds( const point_bub_ms &p );
+        point_rel_ms map_pos_offset( const point_abs_ms &p ) const;
+        State &tile_state_at( const point_abs_ms &p );
+        bool in_bounds( const point_abs_ms &p );
 
         // Determine if `start` is surrounded by already visited tiles in `d_map` or tiles allowed by `route_settings`
         //   and if so, clear and fill `out` with all unexplored tiles left.
-        void detect_culled_frontier( const point_bub_ms &start,
+        void detect_culled_frontier( const point_abs_ms &start,
                                      const RouteSettings &route_settings,
-                                     std::unordered_set<point_bub_ms> &out );
+                                     std::unordered_set<point_abs_ms> &out );
 
         // Test if `p` is in our limited domain defined by `route_settings` relative to `start`
-        bool is_in_limited_domain( const point_bub_ms &start, const point_bub_ms &p,
+        bool is_in_limited_domain( const point_abs_ms &start, const point_abs_ms &p,
                                    const RouteSettings &route_settings );
 
         // See `Pathfinding::route`
-        static std::vector<tripoint_bub_ms> get_route_2d(
-            const point_bub_ms from, const point_bub_ms to, const int z,
+        static std::vector<tripoint_abs_ms> get_route_2d(
+            const point_abs_ms from, const point_abs_ms to, const int z,
             const PathfindingSettings path_settings,
             const RouteSettings route_settings );
         // See `Pathfinding::route`
-        static std::vector<tripoint_bub_ms> get_route_3d(
-            const tripoint_bub_ms from, const tripoint_bub_ms to,
+        static std::vector<tripoint_abs_ms> get_route_3d(
+            const tripoint_abs_ms from, const tripoint_abs_ms to,
             const PathfindingSettings path_settings,
             const RouteSettings route_settings
         );
 
         // Continue expanding the dijikstra map until we reach `origin` or nothing remains of the frontier. Returns whether a route is present.
-        ExpansionOutcome expand_2d_up_to( const point_bub_ms &start, const RouteSettings &route_settings );
+        ExpansionOutcome expand_2d_up_to( const point_abs_ms &start, const RouteSettings &route_settings );
     public:
         // Allocates flat arrays for a map of size mx × my.
         explicit Pathfinding( int mx, int my );
 
         // get `route` from `from` to `to` if available in accordance to `route_settings` while `path_settings` defines our capabilities, otherwise empty vector.
         // Found route will include `from` and `to`.
+        static std::vector<tripoint_abs_ms> route( tripoint_abs_ms from, tripoint_abs_ms to,
+                const std::optional<PathfindingSettings> path_settings = std::nullopt,
+                const std::optional<RouteSettings> route_settings = std::nullopt );
         static std::vector<tripoint_bub_ms> route( tripoint_bub_ms from, tripoint_bub_ms to,
                 const std::optional<PathfindingSettings> path_settings = std::nullopt,
                 const std::optional<RouteSettings> route_settings = std::nullopt );
@@ -352,4 +347,3 @@ class Pathfinding
         //   such as change in terrain
         static void mark_dirty_z_cache();
 };
-

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -7,10 +7,34 @@
 #include "enums.h"
 #include "flag.h"
 #include "game.h"
+#include "map.h"
 #include "messages.h"
 #include "output.h"
 #include "string_id.h"
 #include "vitamin.h"
+
+static auto update_map_after_player_setpos( player &who,
+        const tripoint_abs_ms &old_pos ) -> void
+{
+    if( g == nullptr || !who.is_avatar() ) {
+        return;
+    }
+
+    const auto new_pos = who.abs_pos();
+    if( old_pos == new_pos ) {
+        return;
+    }
+
+    const auto old_sm = project_to<coords::sm>( old_pos );
+    const auto new_sm = project_to<coords::sm>( new_pos );
+
+    if( old_sm.xy() != new_sm.xy() ) {
+        g->update_map( who );
+    }
+    if( old_pos.z() != new_pos.z() ) {
+        g->vertical_shift( new_pos.z() );
+    }
+}
 
 player::player()
 {
@@ -59,6 +83,18 @@ player::player()
 player::~player() = default;
 player::player( player && )  noexcept = default;
 player &player::operator=( player && )  noexcept = default;
+
+auto player::setpos( const tripoint_bub_ms &p ) -> void
+{
+    setpos( map_local_to_abs( get_map(), p ) );
+}
+
+auto player::setpos( const tripoint_abs_ms &p ) -> void
+{
+    const auto old_pos = position;
+    position = p;
+    update_map_after_player_setpos( *this, old_pos );
+}
 
 
 //message related stuff

--- a/src/player.h
+++ b/src/player.h
@@ -34,6 +34,9 @@ class player : public Character
             return false;    // Overloaded for NPCs in npc.h
         }
 
+        void setpos( const tripoint_bub_ms &p ) override;
+        void setpos( const tripoint_abs_ms &p ) override;
+
         // populate variables, inventory items, and misc from json object
         virtual void deserialize( JsonIn &jsin ) = 0;
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3112,7 +3112,7 @@ target_handler::trajectory target_ui::run()
             activity->action = timed_out_action;
             activity->snap_to_target = snap_to_target;
             activity->shifting_view = shifting_view;
-            activity->aiming_at_critter = !!dst_critter;
+            activity->aiming_at_critter = dst_critter != nullptr || you->last_target.lock() != nullptr;
             break;
         }
         case ExitCode::Reload: {
@@ -3266,7 +3266,17 @@ bool target_ui::handle_cursor_movement( const std::string &action, bool &skip_re
 
 bool target_ui::set_cursor_pos( const tripoint_bub_ms &new_pos )
 {
+    const auto refresh_dst_critter = [this]() {
+        if( src != dst ) {
+            Creature *const cr = g->critter_at( dst, true );
+            dst_critter = cr && pl_sees( *cr ) ? cr : nullptr;
+        } else {
+            dst_critter = nullptr;
+        }
+    };
+
     if( dst == new_pos ) {
+        refresh_dst_critter();
         return false;
     }
     if( status == Status::OutOfAmmo && new_pos != src ) {
@@ -3350,16 +3360,7 @@ bool target_ui::set_cursor_pos( const tripoint_bub_ms &new_pos )
     }
 
     // Cache creature under cursor
-    if( src != dst ) {
-        Creature *cr = g->critter_at( dst, true );
-        if( cr && pl_sees( *cr ) ) {
-            dst_critter = cr;
-        } else {
-            dst_critter = nullptr;
-        }
-    } else {
-        dst_critter = nullptr;
-    }
+    refresh_dst_critter();
 
     // Update mode-specific stuff
     if( mode == TargetMode::Fire ) {
@@ -3463,13 +3464,12 @@ tripoint_bub_ms target_ui::choose_initial_target()
 
 bool target_ui::try_reacquire_target( bool critter, tripoint_bub_ms &new_dst )
 {
-    if( critter ) {
-        // Try to re-acquire the creature
-        shared_ptr_fast<Creature> cr = you->last_target.lock();
-        if( cr && pl_sees( *cr ) && dist_fn( cr->bub_pos() ) <= range ) {
-            new_dst = cr->bub_pos();
-            return true;
-        }
+    // Prefer creature identity over the saved tile.  If aiming_at_critter was
+    // lost for one UI pass, last_target still tells us what the aim was tracking.
+    const auto cr = you->last_target.lock();
+    if( cr && pl_sees( *cr ) && dist_fn( cr->bub_pos() ) <= range ) {
+        new_dst = cr->bub_pos();
+        return true;
     }
 
     if( !you->last_target_pos.has_value() ) {
@@ -3925,14 +3925,11 @@ void target_ui::draw_terrain_overlay()
     if( mode != TargetMode::Turrets && dst != src ) {
         std::vector<tripoint_bub_ms> this_z = filter_this_z( traj );
 
-        // Draw a highlighted trajectory only if we can see the endpoint.
-        // Provides feedback to the player, but avoids leaking information
-        // about tiles they can't see.
-        g->draw_line( dst, center, this_z );
+        g->draw_line( dst, center, this_z, true );
     }
 
-    // Since draw_line does nothing if destination is not visible,
-    // cursor also disappears. Draw it explicitly.
+    // TILES draw_line uses a target endpoint sprite.  Keep the cursor explicit
+    // so aiming at empty tiles and z-level edges has the normal cursor marker.
     if( dst.z() == center.z() ) {
         g->draw_cursor( dst );
     }

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -344,19 +344,19 @@ auto game::unserialize( std::istream &fin ) -> bool
         const auto saved_origin = tripoint_abs_sm( lev.x + com.x * OMAPX * 2,
                                   lev.y + com.y * OMAPY * 2, lev.z );
         auto load_origin = saved_origin;
+        auto player_pos = project_to<coords::ms>(
+                              saved_origin + tripoint_rel_sm( g_half_mapsize, g_half_mapsize, 0 ) );
         if( has_saved_player_abs ) {
-            u.setpos( saved_player_abs );
-            load_origin = player_reality_bubble_origin();
+            player_pos = saved_player_abs;
+            load_origin = reality_bubble_origin_from_player( player_pos, g_reality_bubble_size );
         } else if( has_saved_reality_bubble_size ) {
             const auto saved_player_sm = reality_bubble_center_from_origin( saved_origin,
                                          saved_reality_bubble_size );
-            u.setpos( project_to<coords::ms>( saved_player_sm ) );
-            load_origin = player_reality_bubble_origin();
-        } else {
-            u.setpos( project_to<coords::ms>( saved_origin + tripoint_rel_sm( g_half_mapsize,
-                                              g_half_mapsize, 0 ) ) );
+            player_pos = project_to<coords::ms>( saved_player_sm );
+            load_origin = reality_bubble_origin_from_player( player_pos, g_reality_bubble_size );
         }
         load_map( load_origin, /*pump_events=*/true );
+        u.setpos( player_pos );
 
         safe_mode = static_cast<safe_mode_type>( tmprun );
         if( get_option<bool>( "SAFEMODE" ) && safe_mode == SAFE_MODE_OFF ) {

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -147,8 +147,13 @@ void scent_map::draw( const catacurses::window &win, const int div,
 
 int scent_map::get( const tripoint_bub_ms &p ) const
 {
-    if( inbounds( p ) && raw_scent_at( p.x(), p.y(), p.z() ) > 0 ) {
-        return get_unsafe( p );
+    if( !inbounds( p ) ) {
+        return 0;
+    }
+
+    const auto raw_scent = raw_scent_at( p.x(), p.y(), p.z() );
+    if( raw_scent > 0 ) {
+        return raw_scent - std::abs( gm.get_levz() - p.z() );
     }
     return 0;
 }

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -111,9 +111,6 @@ bool teleport::teleport( Creature &critter, int min_distance, int max_distance, 
             p->add_effect( effect_teleglow, 30_minutes );
         }
     }
-    if( c_is_u ) {
-        g->update_map( *p );
-    }
     critter.remove_effect( effect_grabbed );
     here.creature_on_trap( critter );
     return true;

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -322,7 +322,6 @@ bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
                 z->setpos( g->u.bub_pos() );
             }
             g->u.moves -= 150;
-            g->update_map( g->u );
         } else {
             z->stumble();
         }
@@ -340,9 +339,6 @@ bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
             n->setpos( random_entry( valid ) );
         }
         n->moves -= 150;
-        if( c == &g->u ) {
-            g->update_map( g->u );
-        }
         if( !n->is_mounted() ) {
             ///\EFFECT_DEX decreases chance of taking damage from a tripwire trap
             if( rng( 5, 20 ) > n->dex_cur ) {
@@ -1134,9 +1130,6 @@ static bool sinkhole_safety_roll( player *p, const itype_id &itemname, const int
         p->add_msg_player_or_npc( m_good, _( "You pull yourself to safety!" ),
                                   _( "<npcname> steps on a sinkhole, but manages to pull themselves to safety." ) );
         p->setpos( random_entry( safe ) );
-        if( p == &g->u ) {
-            g->update_map( *p );
-        }
 
         return true;
     }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -120,12 +120,21 @@ struct veh_collision {
     veh_collision() = default;
 };
 
+struct vehicle_collision_options {
+    std::vector<veh_collision> &colls;
+    tripoint_rel_ms dp;
+    bool just_detect = false;
+    bool bash_floor = false;
+    const Creature *ignored_critter = nullptr;
+};
+
 struct vehicle_part_collision_options {
     int part = 0;
     tripoint_bub_ms pos;
     bool just_detect = false;
     bool bash_floor = false;
     bool vertical = false;
+    const Creature *ignored_critter = nullptr;
 };
 //TODO!: location stuffs here
 class vehicle_stack : public item_stack
@@ -1280,9 +1289,7 @@ class vehicle
         }
 
         // Returns if any collision occurred
-        bool collision( std::vector<veh_collision> &colls,
-                        const tripoint_rel_ms &dp,
-                        bool just_detect, bool bash_floor = false );
+        auto collision( const vehicle_collision_options &options ) -> bool;
 
         // Handle given part collision with vehicle, monster/NPC/player or terrain obstacle
         // Returns collision, which has type, impulse, part, & target.

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -385,10 +385,13 @@ void vehicle::stop( bool update_cache )
     }
 }
 
-bool vehicle::collision( std::vector<veh_collision> &colls,
-                         const tripoint_rel_ms &dp,
-                         bool just_detect, bool bash_floor )
+auto vehicle::collision( const vehicle_collision_options &options ) -> bool
 {
+    auto &colls = options.colls;
+    const auto &dp = options.dp;
+    auto just_detect = options.just_detect;
+    const auto bash_floor = options.bash_floor;
+    const auto *ignored_critter = options.ignored_critter;
 
     /*
      * Big TODO:
@@ -406,14 +409,32 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
 
     if( dp.z() != 0 && ( dp.x() != 0 || dp.y() != 0 ) ) {
         // Split into horizontal + vertical
-        return collision( colls, tripoint_rel_ms( dp.xy(), 0 ), just_detect, bash_floor ) ||
-               collision( colls, tripoint_rel_ms( 0,    0,    dp.z() ), just_detect, bash_floor );
+        return collision( vehicle_collision_options{
+            .colls = colls,
+            .dp = tripoint_rel_ms( dp.xy(), 0 ),
+            .just_detect = just_detect,
+            .bash_floor = bash_floor,
+            .ignored_critter = ignored_critter,
+        } ) ||
+        collision( vehicle_collision_options{
+            .colls = colls,
+            .dp = tripoint_rel_ms( 0, 0, dp.z() ),
+            .just_detect = just_detect,
+            .bash_floor = bash_floor,
+            .ignored_critter = ignored_critter,
+        } );
     }
 
     if( dp.z() == -1 && !bash_floor ) {
         // First check current level, then the one below if current had no collisions
         // Bash floors on the current one, but not on the one below.
-        if( collision( colls, tripoint_rel_ms::zero(), just_detect, true ) ) {
+        if( collision( vehicle_collision_options{
+            .colls = colls,
+            .dp = tripoint_rel_ms::zero(),
+            .just_detect = just_detect,
+            .bash_floor = true,
+            .ignored_critter = ignored_critter,
+        } ) ) {
             return true;
         }
     }
@@ -448,6 +469,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
             .just_detect = just_detect,
             .bash_floor = bash_floor,
             .vertical = vertical,
+            .ignored_critter = ignored_critter,
         } );
         if( coll.type == veh_coll_nothing ) {
             continue;
@@ -528,6 +550,9 @@ auto vehicle::part_collision( const vehicle_part_collision_options &options ) ->
     Character &player_character = get_player_character();
     const bool pl_ctrl = player_in_control( player_character );
     Creature *critter = g->critter_at( p, true );
+    if( critter == options.ignored_critter ) {
+        critter = nullptr;
+    }
     player *ph = dynamic_cast<player *>( critter );
 
     Creature *driver = pl_ctrl ? &player_character : nullptr;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -429,8 +429,8 @@ auto vehicle::collision( const vehicle_collision_options &options ) -> bool
         // First check current level, then the one below if current had no collisions
         // Bash floors on the current one, but not on the one below.
         if( collision( vehicle_collision_options{
-            .colls = colls,
-            .dp = tripoint_rel_ms::zero(),
+        .colls = colls,
+        .dp = tripoint_rel_ms::zero(),
             .just_detect = just_detect,
             .bash_floor = true,
             .ignored_critter = ignored_critter,

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -273,7 +273,6 @@ TEST_CASE( "minirose can be disarmed after switching to an npc and back", "[bion
     auto &you = get_avatar();
     const auto minirose_id = bionic_id( "bio_minirose" );
     const auto cleanup_test_state = on_out_of_scope( []() {
-        g->vertical_shift( 0 );
         clear_all_state();
         get_avatar().setID( character_id(), true );
     } );
@@ -426,7 +425,7 @@ TEST_CASE( "lua_place_monster_pins_upgrade_time", "[lua][monster]" )
 {
     const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
     clear_map();
-    put_player_underground();
+    move_player_out_of_the_way();
     calendar::turn = calendar::start_of_cataclysm + 2 * calendar::season_length();
 
     const auto monster_id = mtype_id( "mon_test_lua_upgrade_zombie" );

--- a/tests/electric_grid_test.cpp
+++ b/tests/electric_grid_test.cpp
@@ -120,11 +120,12 @@ static grid_setup set_up_grid( map &m )
     // TODO: clear_grids()
     clear_grid_connections( m );
 
-    const tripoint_bub_ms vehicle_local_pos = tripoint_bub_ms( 10, 10, 0 );
-    const tripoint_bub_ms connector_local_pos = tripoint_bub_ms( 13, 10, 0 );
-    const tripoint_bub_ms battery_local_pos = tripoint_bub_ms( 14, 10, 0 );
-    const tripoint_abs_ms connector_abs_pos( map_local_to_abs( m, connector_local_pos ) );
-    const tripoint_abs_ms battery_abs_pos( map_local_to_abs( m, battery_local_pos ) );
+    const auto z = m.get_abs_sub().z();
+    const auto vehicle_local_pos = tripoint_bub_ms( 10, 10, z );
+    const auto connector_local_pos = tripoint_bub_ms( 13, 10, z );
+    const auto battery_local_pos = tripoint_bub_ms( 14, 10, z );
+    const auto connector_abs_pos = tripoint_abs_ms( map_local_to_abs( m, connector_local_pos ) );
+    const auto battery_abs_pos = tripoint_abs_ms( map_local_to_abs( m, battery_local_pos ) );
     m.furn_set( connector_local_pos, f_cable_connector );
     m.furn_set( battery_local_pos, f_battery );
     vehicle *veh = m.add_vehicle( vproto_id( "car" ), vehicle_local_pos, 0_degrees, 0, 0, false );
@@ -149,7 +150,7 @@ static grid_setup set_up_grid( map &m )
 TEST_CASE( "grid_and_vehicle_in_bubble", "[grids][vehicle]" )
 {
     clear_all_state();
-    put_player_underground();
+    move_player_out_of_the_way();
     GIVEN( "vehicle and battery are on one grid" ) {
         auto setup = set_up_grid( get_map() );
         test_grid_veh( setup.grid, setup.veh, setup.battery );
@@ -159,7 +160,7 @@ TEST_CASE( "grid_and_vehicle_in_bubble", "[grids][vehicle]" )
 TEST_CASE( "grid_and_vehicle_outside_bubble", "[grids][vehicle]" )
 {
     clear_all_state();
-    put_player_underground();
+    move_player_out_of_the_way();
     map &m = get_map();
     const auto old_abs_sub = m.get_abs_sub();
     // Ugly: we move the real map instead of the tinymap to reuse clear_map() results
@@ -192,10 +193,11 @@ static S set_up_grid_with_consumer( map &m, const furn_str_id &act_tile_id )
     // TODO: clear_grids()
     clear_grid_connections( m );
 
-    const tripoint_bub_ms act_local_pos = tripoint_bub_ms( 13, 10, 0 );
-    const tripoint_bub_ms battery_local_pos = tripoint_bub_ms( 14, 10, 0 );
-    const tripoint_abs_ms act_abs_pos( map_local_to_abs( m, act_local_pos ) );
-    const tripoint_abs_ms battery_abs_pos( map_local_to_abs( m, battery_local_pos ) );
+    const auto z = m.get_abs_sub().z();
+    const auto act_local_pos = tripoint_bub_ms( 13, 10, z );
+    const auto battery_local_pos = tripoint_bub_ms( 14, 10, z );
+    const auto act_abs_pos = tripoint_abs_ms( map_local_to_abs( m, act_local_pos ) );
+    const auto battery_abs_pos = tripoint_abs_ms( map_local_to_abs( m, battery_local_pos ) );
     m.furn_set( act_local_pos, act_tile_id );
     m.furn_set( battery_local_pos, f_battery );
     T *act_tile = active_tiles::furn_at<T>( act_abs_pos );
@@ -363,7 +365,7 @@ TEST_CASE( "steady_consumer_in_bubble", "[grids]" )
 {
     clear_all_state();
     calendar::turn = calendar::turn_zero;
-    put_player_underground();
+    move_player_out_of_the_way();
 
     GIVEN( "consumer and battery are on one grid" ) {
         grid_setup_consumer setup = set_up_grid_with_consumer<steady_consumer_tile, grid_setup_consumer>
@@ -376,7 +378,7 @@ TEST_CASE( "charge_watcher_in_bubble", "[grids]" )
 {
     clear_all_state();
     calendar::turn = calendar::turn_zero;
-    put_player_underground();
+    move_player_out_of_the_way();
 
     GIVEN( "watcher and battery are on one grid" ) {
         grid_setup_watcher setup = set_up_grid_with_consumer<charge_watcher_tile, grid_setup_watcher>
@@ -389,10 +391,11 @@ TEST_CASE( "grid_furn_transform_queue_in_bubble", "[grids]" )
 {
     clear_all_state();
     calendar::turn = calendar::turn_zero;
-    put_player_underground();
+    move_player_out_of_the_way();
 
-    tripoint_bub_ms pos_local( 22, 7, 0 );
-    tripoint_abs_ms pos_abs( map_local_to_abs( get_map(), pos_local ) );
+    const auto z = get_map().get_abs_sub().z();
+    const auto pos_local = tripoint_bub_ms( 22, 7, z );
+    const auto pos_abs = tripoint_abs_ms( map_local_to_abs( get_map(), pos_local ) );
 
     grid_furn_transform_queue tf_queue;
     tf_queue.add( pos_abs, f_floor_lamp_on, "" );
@@ -411,10 +414,11 @@ TEST_CASE( "grid_furn_transform_queue_outside_bubble", "[grids]" )
 {
     clear_all_state();
     calendar::turn = calendar::turn_zero;
-    put_player_underground();
+    move_player_out_of_the_way();
 
-    tripoint_bub_ms pos_local( 22, 7, 0 );
-    tripoint_abs_ms pos_abs( map_local_to_abs( get_map(), pos_local ) );
+    const auto z = get_map().get_abs_sub().z();
+    const auto pos_local = tripoint_bub_ms( 22, 7, z );
+    const auto pos_abs = tripoint_abs_ms( map_local_to_abs( get_map(), pos_local ) );
     tripoint_abs_sm pos_abs_sm;
     point_sm_ms pos_in_sm;
     std::tie( pos_abs_sm, pos_in_sm ) = project_remain<coords::sm>( pos_abs );
@@ -446,13 +450,14 @@ TEST_CASE( "grid_furn_transform_queue_outside_bubble", "[grids]" )
 TEST_CASE( "grid_power_stats", "[grids]" )
 {
     clear_all_state();
-    put_player_underground();
+    move_player_out_of_the_way();
     clear_grid_connections( get_map() );
 
     GIVEN( "battery, solar panel and consumer on one grid" ) {
-        const auto solar_local = tripoint_bub_ms( 15, 10, 0 );
-        const auto consumer_local = tripoint_bub_ms( 13, 10, 0 );
-        const auto battery_local = tripoint_bub_ms( 14, 10, 0 );
+        const auto z = get_map().get_abs_sub().z();
+        const auto solar_local = tripoint_bub_ms( 15, 10, z );
+        const auto consumer_local = tripoint_bub_ms( 13, 10, z );
+        const auto battery_local = tripoint_bub_ms( 14, 10, z );
         const auto solar_abs = tripoint_abs_ms( map_local_to_abs( get_map(), solar_local ) );
         const auto consumer_abs = tripoint_abs_ms( map_local_to_abs( get_map(), consumer_local ) );
 

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -56,9 +56,9 @@ void check_lethality( const std::string &explosive_id, const int range, float le
     do {
         // Clear map
         clear_map();
-        put_player_underground();
+        move_player_out_of_the_way();
         // Spawn some monsters in a circle.
-        tripoint_bub_ms origin( 30, 30, 0 );
+        const auto origin = tripoint_bub_ms( 30, 30, 0 );
         int num_subjects_this_time = 0;
         for( const tripoint_bub_ms &monster_position : closest_points_first( origin, range ) ) {
             if( rl_dist( monster_position, origin ) != range ) {
@@ -119,8 +119,8 @@ auto get_part_hp( vehicle *veh ) -> std::vector<int>
 void check_vehicle_damage( const std::string &explosive_id, const std::string &vehicle_id,
                            const int range )
 {
-    put_player_underground();
-    tripoint_bub_ms origin( 30, 30, 0 );
+    move_player_out_of_the_way();
+    auto origin = tripoint_bub_ms( 30, 30, 0 );
 
     vehicle *target_vehicle = get_map().add_vehicle( vproto_id( vehicle_id ), origin, 0_degrees,
                               -1, 0 );
@@ -169,8 +169,8 @@ TEST_CASE( "grenade_vs_vehicle", "[grenade][explosion][balance]" )
 TEST_CASE( "shrapnel behind wall", "[grenade][explosion][balance]" )
 {
     clear_all_state();
-    put_player_underground();
-    tripoint_bub_ms origin( 30, 30, 0 );
+    move_player_out_of_the_way();
+    const auto origin = tripoint_bub_ms( 30, 30, 0 );
 
     item &grenade = *item::spawn_temporary( "test_shrapnel_blast" );
     REQUIRE( grenade.get_use( "explosion" ) != nullptr );
@@ -201,8 +201,8 @@ TEST_CASE( "shrapnel behind wall", "[grenade][explosion][balance]" )
 TEST_CASE( "shrapnel at huge range", "[grenade][explosion]" )
 {
     clear_all_state();
-    put_player_underground();
-    tripoint_bub_ms origin;
+    move_player_out_of_the_way();
+    const auto origin = tripoint_bub_ms( 0, 0, 0 );
 
     item &grenade = *item::spawn_temporary( "test_long_shrapnel_blast" );
     REQUIRE( grenade.get_use( "explosion" ) != nullptr );
@@ -226,8 +226,8 @@ TEST_CASE( "shrapnel at huge range", "[grenade][explosion]" )
 TEST_CASE( "shrapnel at max grenade range", "[grenade][explosion]" )
 {
     clear_all_state();
-    put_player_underground();
-    tripoint_bub_ms origin( 60, 60, 0 );
+    move_player_out_of_the_way();
+    const auto origin = tripoint_bub_ms( 60, 60, 0 );
 
     item &grenade = *item::spawn_temporary( "test_shrapnel_blast" );
     REQUIRE( grenade.get_use( "explosion" ) != nullptr );
@@ -261,8 +261,8 @@ TEST_CASE( "shrapnel at max grenade range", "[grenade][explosion]" )
 TEST_CASE( "rotated_vehicle_walls_block_explosions" )
 {
     clear_all_state();
-    put_player_underground();
-    tripoint_bub_ms origin( 60, 60, 0 );
+    move_player_out_of_the_way();
+    const auto origin = tripoint_bub_ms( 60, 60, 0 );
 
     item &grenade = *item::spawn_temporary( "test_shrapnel_blast" );
 

--- a/tests/explosion_fling_damage_test.cpp
+++ b/tests/explosion_fling_damage_test.cpp
@@ -24,11 +24,10 @@ TEST_CASE( "post_death_explosion_does_not_move_avatar_before_follower_takeover",
     clear_all_state();
     override_option opt( "OLD_EXPLOSIONS", "false" );
     clear_map();
-    put_player_underground();
+    move_player_out_of_the_way();
 
     avatar &you = get_avatar();
     const auto cleanup_test_state = on_out_of_scope( []() {
-        g->vertical_shift( 0 );
         clear_all_state();
         get_avatar().setID( character_id(), true );
     } );
@@ -74,7 +73,7 @@ TEST_CASE( "explosion_flung_items_damage_creatures", "[explosion][damage]" )
 {
     clear_all_state();
     override_option opt( "OLD_EXPLOSIONS", "false" );
-    put_player_underground();
+    move_player_out_of_the_way();
     map &here = get_map();
 
     const tripoint_bub_ms explosion_center( 30, 30, 0 );

--- a/tests/ground_destroy_test.cpp
+++ b/tests/ground_destroy_test.cpp
@@ -25,7 +25,7 @@ TEST_CASE( "pavement_destroy", "[.]" )
     const ter_id flat_roof_id = ter_id( "t_flat_roof" );
     REQUIRE( flat_roof_id != t_null );
 
-    put_player_underground();
+    move_player_out_of_the_way();
     map &here = get_map();
     // Populate the map with pavement.
     here.ter_set( tripoint_bub_ms::zero(), ter_id( "t_pavement" ) );
@@ -49,7 +49,7 @@ TEST_CASE( "explosion_on_ground", "[.]" )
     ter_id flat_roof_id = ter_id( "t_flat_roof" );
     REQUIRE( flat_roof_id != t_null );
 
-    put_player_underground();
+    move_player_out_of_the_way();
     std::vector<ter_id> test_terrain_id = {
         ter_id( "t_dirt" ), ter_id( "t_grass" )
     };
@@ -100,7 +100,7 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
     REQUIRE( rock_floor_id != t_null );
     REQUIRE( open_air_id != t_null );
 
-    put_player_underground();
+    move_player_out_of_the_way();
 
     map &here = get_map();
     const int area_dim = 24;
@@ -158,7 +158,7 @@ TEST_CASE( "collapse_checks", "[.]" )
     REQUIRE( wall_id != t_null );
     REQUIRE( open_air_id != t_null );
 
-    put_player_underground();
+    move_player_out_of_the_way();
 
     map &here = get_map();
     // build a structure

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -43,9 +43,9 @@ void clear_vehicles()
 
 void wipe_map_terrain()
 {
-    map &here = get_map();
+    auto &here = get_map();
     const int mapsize = here.getmapsize() * SEEX;
-    for( int z = -1; z <= OVERMAP_HEIGHT; ++z ) {
+    for( int z = -2; z <= OVERMAP_HEIGHT; ++z ) {
         const ter_id terrain = z == 0 ? t_grass : z < 0 ? t_rock : t_open_air;
         for( int x = 0; x < mapsize; ++x ) {
             for( int y = 0; y < mapsize; ++y ) {
@@ -76,7 +76,7 @@ void clear_npcs()
 
 void clear_fields( const int zlevel )
 {
-    map &here = get_map();
+    auto &here = get_map();
     const int mapsize = here.getmapsize();
     for( int x = 0; x < mapsize; ++x ) {
         for( int y = 0; y < mapsize; ++y ) {
@@ -157,7 +157,16 @@ void put_player_underground()
 {
     // Make sure the player doesn't block the path of the monster being tested.
     g->u.setpos( map_local_to_abs( get_map(),
-                                   tripoint_bub_ms( g_half_mapsize_x, g_half_mapsize_y, -2 ) ) );
+                                   tripoint_bub_ms( g_half_mapsize_x + SEEX - 1,
+                                           g_half_mapsize_y + SEEY - 1, -2 ) ) );
+}
+
+auto move_player_out_of_the_way() -> void
+{
+    auto &here = get_map();
+    g->u.setpos( map_local_to_abs( here,
+                                   tripoint_bub_ms( g_half_mapsize_x + SEEX - 1,
+                                           g_half_mapsize_y + SEEY - 1, here.get_abs_sub().z() ) ) );
 }
 
 monster &spawn_test_monster( const std::string &monster_type, const tripoint_bub_ms &start )

--- a/tests/map_helpers.h
+++ b/tests/map_helpers.h
@@ -18,6 +18,7 @@ void clear_items( int zlevel );
 void clear_map();
 void clear_overmap();
 void put_player_underground();
+auto move_player_out_of_the_way() -> void;
 monster &spawn_test_monster( const std::string &monster_type, const tripoint_bub_ms &start );
 void clear_vehicles();
 void build_test_map( const ter_id &terrain );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -604,7 +604,7 @@ TEST_CASE( "reality_bubble_origin_helpers_use_explicit_size" )
     CHECK( reality_bubble_center_from_origin( size_zero_origin, 0 ) == player_sm );
 }
 
-TEST_CASE( "update_map_uses_avatar_absolute_position" )
+TEST_CASE( "avatar_setpos_updates_map_from_absolute_position" )
 {
     clear_all_state();
 
@@ -615,13 +615,12 @@ TEST_CASE( "update_map_uses_avatar_absolute_position" )
     const auto destination_abs = map_local_to_abs( here, destination );
 
     you.setpos( destination_abs );
-    const auto shift = g->update_map( you );
 
-    CHECK( shift == point_rel_sm( 1, 0 ) );
     CHECK( here.get_abs_sub() == old_origin + tripoint_rel_sm( 1, 0, 0 ) );
     CHECK( here.get_abs_sub() == player_reality_bubble_origin() );
     CHECK( you.abs_pos() == destination_abs );
     CHECK( you.bub_pos() == tripoint_bub_ms( g_half_mapsize_x, g_half_mapsize_y, 0 ) );
+    CHECK( g->update_map( you ) == point_rel_sm::zero() );
 }
 
 TEST_CASE( "monster_tracker_uses_absolute_positions" )

--- a/tests/monster_faction_anger_test.cpp
+++ b/tests/monster_faction_anger_test.cpp
@@ -32,7 +32,7 @@ TEST_CASE( "unauthorized_robofac_turrets_attack_player", "[monster][faction]" )
     auto &you = get_avatar();
     you.remove_value( "npctalk_var_dialogue_intercom_completed_robofac_intercom_3" );
     auto &turret = spawn_test_monster( "mon_robofac_turret_light", tripoint_bub_ms( 5, 5, 0 ) );
-    put_player_underground();
+    move_player_out_of_the_way();
 
     CHECK( turret.attitude( &you ) == MATT_ATTACK );
 }
@@ -49,7 +49,7 @@ TEST_CASE( "authorized_robofac_turrets_use_faction_attitude", "[monster][faction
     authorized_turret.friendly = 0;
 
     auto &you = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
 
     CHECK( authorized_turret.attitude( &you ) == MATT_FRIEND );
     CHECK( authorized_turret.attitude_to( robofac_turret ) == Attitude::A_FRIENDLY );
@@ -80,7 +80,7 @@ TEST_CASE( "authorized_robofac_turrets_alert_visible_security", "[monster][facti
     }
 
     auto &you = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
     const auto player_faction = mfaction_id( "player" );
 
     REQUIRE( east_turret.sees( attacked_turret ) );
@@ -147,7 +147,7 @@ TEST_CASE( "monster_faction_memory_anger", "[monster][faction][anger]" )
     monster &hazmat = spawn_test_monster( "mon_eyebot", hazmat_pos );
 
     avatar &p = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
     tank.friendly = 0;
     tank.anger = 0;
     // We can't clear faction_anger directly as it is private, but a new monster should be clean.
@@ -189,7 +189,7 @@ TEST_CASE( "monster_faction_memory_zombie_attacks_tank", "[monster][faction][ang
     monster &zombie = spawn_test_monster( "mon_zombie", zombie_pos );
 
     avatar &p = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
 
     // Ensure initial state
     tank.friendly = 0;
@@ -255,7 +255,7 @@ TEST_CASE( "monster_faction_memory_friend_attacked", "[monster][faction][anger]"
     monster &zombie = spawn_test_monster( "mon_zombie", zombie_pos );
 
     avatar &p = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
 
     // Ensure initial state
     tank1.friendly = 0;

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -335,7 +335,7 @@ static void monster_check()
 TEST_CASE( "write_slope_to_speed_map_trig", "[.][!mayfail]" )
 {
     clear_all_state();
-    put_player_underground();
+    move_player_out_of_the_way();
     override_option opt( "CIRCLEDIST", "true" );
     trigdist = true;
     test_moves_to_squares( "mon_zombie_dog", true );
@@ -345,7 +345,7 @@ TEST_CASE( "write_slope_to_speed_map_trig", "[.][!mayfail]" )
 TEST_CASE( "write_slope_to_speed_map_square", "[.][!mayfail]" )
 {
     clear_all_state();
-    put_player_underground();
+    move_player_out_of_the_way();
     override_option opt( "CIRCLEDIST", "false" );
     trigdist = false;
     test_moves_to_squares( "mon_zombie_dog", true );
@@ -357,7 +357,7 @@ TEST_CASE( "write_slope_to_speed_map_square", "[.][!mayfail]" )
 TEST_CASE( "monster_speed_square", "[speed][.][!mayfail]" )
 {
     clear_all_state();
-    put_player_underground();
+    move_player_out_of_the_way();
     override_option opt( "CIRCLEDIST", "false" );
     trigdist = false;
     monster_check();
@@ -367,7 +367,7 @@ TEST_CASE( "monster_speed_square", "[speed][.][!mayfail]" )
 TEST_CASE( "monster_speed_trig", "[speed][.][!mayfail]" )
 {
     clear_all_state();
-    put_player_underground();
+    move_player_out_of_the_way();
     override_option opt( "CIRCLEDIST", "true" );
     trigdist = true;
     monster_check();
@@ -376,7 +376,7 @@ TEST_CASE( "monster_speed_trig", "[speed][.][!mayfail]" )
 TEST_CASE( "monster_move_through_vehicle_holes" )
 {
     clear_all_state();
-    put_player_underground();
+    move_player_out_of_the_way();
     tripoint_bub_ms origin( 60, 60, 0 );
 
     get_map().add_vehicle( vproto_id( "apc" ), origin, -45_degrees, 0, 0 );

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -78,7 +78,7 @@ TEST_CASE( "monsters_dont_see_through_vehicle_holes", "[vision]" )
 {
     clear_all_state();
     calendar::turn = midday;
-    put_player_underground();
+    move_player_out_of_the_way();
     tripoint_bub_ms origin( 60, 60, 0 );
 
     get_map().add_vehicle( vproto_id( "apc" ), origin, -45_degrees, 0, 0 );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -40,13 +40,13 @@ static const efftype_id effect_infected( "infected" );
 static const trait_id trait_PROF_FED( "PROF_FED" );
 static const trait_id trait_PROF_SWAT( "PROF_SWAT" );
 
-static npc &create_test_talker()
+static auto create_test_talker( const point_bub_ms &talker_pos ) -> npc &
 {
     const string_id<npc_template> test_talker( "test_talker" );
-    const character_id model_id = get_map().place_npc( point_bub_ms( 25, 25 ), test_talker, true );
+    const auto model_id = get_map().place_npc( talker_pos, test_talker, true );
     g->load_npcs();
 
-    npc *model_npc = g->find_npc( model_id );
+    auto *model_npc = g->find_npc( model_id );
     REQUIRE( model_npc != nullptr );
 
     for( const trait_id &tr : model_npc->get_mutations() ) {
@@ -90,18 +90,19 @@ static void change_om_type( const std::string &new_type )
     ACTIVE_OVERMAP_BUFFER.ter_set( omt_pos, oter_id( new_type ) );
 }
 
-static npc &prep_test( dialogue &d )
+static auto prep_test( dialogue &d ) -> npc &
 {
     clear_vehicles();
-    avatar &player_character = get_avatar();
+    auto &player_character = get_avatar();
     REQUIRE_FALSE( player_character.in_vehicle );
 
-    const tripoint_bub_ms test_origin( 15, 15, 0 );
+    const auto test_origin = tripoint_bub_ms( g_half_mapsize_x, g_half_mapsize_y,
+                             get_map().get_abs_sub().z() );
     player_character.setpos( test_origin );
 
     g->faction_manager_ptr->create_if_needed();
 
-    npc &talker_npc = create_test_talker();
+    auto &talker_npc = create_test_talker( player_character.bub_pos().xy() + point( 5, 0 ) );
 
     d.alpha = &player_character;
     d.beta = &talker_npc;

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "avatar.h"
 #include "calendar.h"
 #include "coordinates.h"
 #include "faction.h"
@@ -439,6 +440,31 @@ TEST_CASE( "npc-movement" )
 
         check_npc_movement( origin );
     }
+}
+
+TEST_CASE( "control_npc_updates_positions_and_reality_bubble", "[npc][control]" )
+{
+    clear_all_state();
+
+    avatar &you = get_avatar();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    npc &follower = spawn_npc( point_bub_ms( 10, 10 ), "test_talker" );
+    follower.set_fac( faction_id( "your_followers" ) );
+    follower.set_attitude( NPCATT_FOLLOW );
+    REQUIRE( follower.is_player_ally() );
+
+    const auto previous_avatar_pos = you.abs_pos();
+    const auto controlled_npc_pos = follower.abs_pos();
+    const auto old_map_origin = get_map().get_abs_sub();
+    REQUIRE( previous_avatar_pos != controlled_npc_pos );
+
+    you.control_npc( follower );
+
+    CHECK( you.abs_pos() == controlled_npc_pos );
+    CHECK( follower.abs_pos() == previous_avatar_pos );
+    CHECK( get_map().get_abs_sub() == player_reality_bubble_origin() );
+    CHECK( get_map().get_abs_sub() != old_map_origin );
+    CHECK( get_map().inbounds( you.bub_pos() ) );
 }
 
 TEST_CASE( "npc_can_target_player" )

--- a/tests/pet_system_test.cpp
+++ b/tests/pet_system_test.cpp
@@ -27,7 +27,7 @@ static const mtype_id mon_dog( "mon_dog" );
 
 static const skill_id skill_survival( "survival" );
 
-// A position well away from the player's underground test location so
+// A position well away from the player's test location so
 // the monster's line-of-sight checks do not interfere with tests.
 static const tripoint_bub_ms mon_pos( 10, 10, 0 );
 
@@ -239,7 +239,7 @@ TEST_CASE( "train_pet_finish removes effect_well_fed", "[pet][monster][training]
     REQUIRE( mon.has_effect( effect_well_fed ) );
 
     avatar &p = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
     // Ensure skill meets the minimum so we don't early-return before consuming well_fed.
     REQUIRE( mon.type->pet_training.has_value() );
     p.set_skill_level( skill_survival, mon.type->pet_training->min_skill );
@@ -262,7 +262,7 @@ TEST_CASE( "train_pet_finish increments training_level on success",
     mon.training_level = 0;
 
     avatar &p = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
     // Skill 25 guarantees success: 4*25=100 >= rng(0,100) always.
     p.set_skill_level( skill_survival, 25 );
 
@@ -286,7 +286,7 @@ TEST_CASE( "train_pet_finish does not exceed max_level", "[pet][monster][trainin
     mon.add_effect( effect_well_fed, 24_hours );
 
     avatar &p = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
     p.set_skill_level( skill_survival, 25 );
 
     player_activity act( ACT_TRAIN_PET );
@@ -307,7 +307,7 @@ TEST_CASE( "train_pet_finish with insufficient skill does not increment training
     mon.training_level = 0;
 
     avatar &p = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
     REQUIRE( mon.type->pet_training.has_value() );
     // Set skill below the minimum required for this pet.
     p.set_skill_level( skill_survival, mon.type->pet_training->min_skill - 1 );
@@ -349,7 +349,7 @@ TEST_CASE( "train_pet_finish removes effect_ai_waiting so pet is not stuck after
     REQUIRE( mon.has_effect( effect_ai_waiting ) );
 
     avatar &p = get_avatar();
-    put_player_underground();
+    move_player_out_of_the_way();
     REQUIRE( mon.type->pet_training.has_value() );
     p.set_skill_level( skill_survival, mon.type->pet_training->min_skill );
 

--- a/tests/reload_on_location_test.cpp
+++ b/tests/reload_on_location_test.cpp
@@ -22,10 +22,10 @@
 TEST_CASE( "reload_on_vehicle_cargo", "[magazine] [visitable] [item] [item_location]" )
 {
     clear_all_state();
-    const tripoint_bub_ms vehicle_center = tripoint_bub_ms( 65, 65, 0 );
-    put_player_underground();
+    move_player_out_of_the_way();
 
     map &here = get_map();
+    const auto vehicle_center = tripoint_bub_ms( 65, 65, here.get_abs_sub().z() );
     const vproto_id car_id( "car" );
     const itype_id ups_id( "UPS_off" );
     vehicle *veh = here.add_vehicle( car_id, vehicle_center, 0_radians, 0, 0, false );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -72,7 +72,7 @@ auto make_horde_vehicle_spawn_fixture(
     const auto target_submap_end = target_submap_origin + tripoint( SEEX - 1, SEEY - 1, 0 );
     const auto vehicle_origin = target_submap_origin + tripoint( SEEX / 2, SEEY / 2, 0 );
 
-    you.setpos( vehicle_origin + tripoint( 0, 0, -2 ) );
+    you.setpos( map_local_to_abs( here, target_submap_origin ) );
     const auto veh = here.add_vehicle( vproto_id( "car" ), vehicle_origin, 0_degrees, 0, 0 );
     REQUIRE( veh != nullptr );
 

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -32,7 +32,6 @@ TEST_CASE( "avatar diving", "[diving][!mayfail]" )
     GIVEN( "avatar is above water at z0" ) {
         dummy.set_underwater( false );
         dummy.setpos( test_origin );
-        g->vertical_shift( 0 );
 
         WHEN( "avatar dives down" ) {
             g->vertical_move( -1, false );
@@ -58,7 +57,6 @@ TEST_CASE( "avatar diving", "[diving][!mayfail]" )
     GIVEN( "avatar is underwater at z0" ) {
         dummy.set_underwater( true );
         dummy.setpos( test_origin );
-        g->vertical_shift( 0 );
 
         WHEN( "avatar dives down" ) {
             g->vertical_move( -1, false );
@@ -84,7 +82,6 @@ TEST_CASE( "avatar diving", "[diving][!mayfail]" )
     GIVEN( "avatar is underwater at z-1" ) {
         dummy.set_underwater( true );
         dummy.setpos( test_origin + tripoint_below );
-        g->vertical_shift( -1 );
 
         WHEN( "avatar dives down" ) {
             g->vertical_move( -1, false );
@@ -110,7 +107,6 @@ TEST_CASE( "avatar diving", "[diving][!mayfail]" )
     GIVEN( "avatar is underwater at z-2" ) {
         dummy.set_underwater( true );
         dummy.setpos( test_origin + tripoint( 0, 0, -2 ) );
-        g->vertical_shift( -2 );
 
         WHEN( "avatar dives down" ) {
             g->vertical_move( -1, false );
@@ -133,7 +129,5 @@ TEST_CASE( "avatar diving", "[diving][!mayfail]" )
         }
     }
 
-    // Put us back at 0. We shouldn't have to do this but other tests are
-    // making assumptions about what z-level they're on.
-    g->vertical_shift( 0 );
+    dummy.setpos( test_origin );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

Continuation of #9398
resolves #9489
resolves #9495
resolves #9499
may fix #9339
may fix #9498

## Describe the solution (The How)

Continue migration of bubble space & map class referencing functions that should be absolute spaced mapbuffer calls.
This includes swapping player::set_pos into the source of map::shift instead of requiring individual call sites to care about it.
Pathfinding is now absolute coordinate space truth.

## Testing

Moving around, checking that monsters still look sane and pathfind around properly.
Checked aiming, and performance tested many situations.

## AI Disclosure

I used gpt-5.5 as an assistant.
It was used heavily to handle automated tests.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e96b6a0](https://github.com/cataclysmbn/Cataclysm-BN/commit/e96b6a04210cfd778d55796a2abc2b4d6912bcc7) (Make pathfinding not explode performance *again*) on 2026-06-15 14:27:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27547656277/artifacts/7639923009)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27547656277)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27547656277/artifacts/7639833800)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27547656277/artifacts/7639454992)
<!-- END artifact comment -->