### PR TITLE
fix(UI): move only the selected number of items in a trade

### DIFF
--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -41,8 +41,9 @@ void npc_trading::transfer_items( std::vector<item_pricing> &stuff, Character &,
 
             receiver.i_add( std::move( to_give ) );
         } else {
+            const auto count = npc_gives ? ip.u_has : ip.npc_has;
             gift.set_owner( receiver );
-            std::ranges::for_each( ip.locs, [&]( auto * it ) {
+            std::ranges::for_each( std::views::take(ip.locs, count), [&]( auto * it ) {
                 receiver.i_add( it->detach() );
             } );
         }

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -43,7 +43,7 @@ void npc_trading::transfer_items( std::vector<item_pricing> &stuff, Character &,
         } else {
             const auto count = npc_gives ? ip.u_has : ip.npc_has;
             gift.set_owner( receiver );
-            std::ranges::for_each( std::views::take(ip.locs, count), [&]( auto * it ) {
+            std::ranges::for_each( std::views::take( ip.locs, count ), [&]( auto * it ) {
                 receiver.i_add( it->detach() );
             } );
         }


### PR DESCRIPTION
Trading stackable (but not charge-based stacks) items would move the entire stack even if a smaller number of items in the stack was selected in the trade window

<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

fixes #4372
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Changed `npc_trading::transfer_items()` to take into account the count of items selected in the trading window

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
Traded with follower NPCs, merchants. Selecting a number of items in a stack only transfers that number, selecting a whole stack without a number transfers the whole stack.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b075278](https://github.com/cataclysmbn/Cataclysm-BN/commit/b07527853de32f7bbe3f23f33d4be2b1cae7baa7) (style(autofix.ci): automated formatting) on 2026-06-15 21:35:13

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27552268272/artifacts/7649047081)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27552268272)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27552268272/artifacts/7641668278)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27552268272/artifacts/7641638334)
<!-- END artifact comment -->