### PR TITLE
feat(balance): let night vision help with fine-detail tasks

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -33,6 +33,7 @@
 #include "character_functions.h"
 #include "character_martial_arts.h"
 #include "character_stat.h"
+#include "character_vision.h"
 #include "clothing_utils.h"
 #include "clzones.h"
 #include "craft_command.h"
@@ -2023,19 +2024,16 @@ void Character::recalc_sight_limits()
     for( const mutation_branch *mut : cached_mutations ) {
         best_bonus_nv = std::max( best_bonus_nv, mut->night_vision_range );
     }
-    if( worn_with_flag( flag_RECON_VISION ) ||
-        ( is_mounted() && mounted_creature->has_flag( MF_MECH_RECON_VISION ) ) ) {
-        best_bonus_nv = std::max( best_bonus_nv, 10.0f );
-    }
+    const auto night_vision_level = character_vision::active_night_vision_bonus_level( *this );
+    best_bonus_nv = std::max( best_bonus_nv,
+                              character_vision::sight_range_bonus( night_vision_level ) );
     if( worn_with_flag( flag_GNV_EFFECT ) ||
         has_active_bionic( bio_night_vision ) ||
         has_effect_with_flag( flag_EFFECT_NIGHT_VISION ) ) {
         vision_mode_cache.set( NV_GOGGLES );
-        best_bonus_nv = std::max( best_bonus_nv, 10.0f );
     }
     if( worn_with_flag( flag_GNVE_EFFECT ) ) {
         vision_mode_cache.set( ENV_GOGGLES );
-        best_bonus_nv = std::max( best_bonus_nv, 18.0f );
     }
     if( has_trait( trait_BIRD_EYE ) ) {
         vision_mode_cache.set( BIRD_EYE );

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -10,6 +10,7 @@
 #include "calendar.h"
 #include "character_martial_arts.h"
 #include "character.h"
+#include "character_vision.h"
 #include "creature.h"
 #include "flag.h"
 #include "game.h"
@@ -247,6 +248,16 @@ float fine_detail_vision_mod( const Character &who, const tripoint_bub_ms &p )
         ( ( who.has_effect( effect_boomered ) || who.has_effect( effect_darkness ) ) &&
           !who.has_trait( trait_PER_SLIME_OK ) ) ) {
         return 11.0;
+    }
+    const auto night_vision_level = character_vision::active_night_vision_bonus_level( who );
+    switch( night_vision_level ) {
+        case night_vision_bonus_level::enhanced:
+        case night_vision_bonus_level::standard:
+            return FINE_VISION_PERFECT;
+        case night_vision_bonus_level::standard_goggles:
+            return FINE_VISION_THRESHOLD;
+        case night_vision_bonus_level::none:
+            break;
     }
     // Regular NV trait isn't enough to help at all, while Full Night Vision allows reading at a penalty
     float nvbonus = who.mutation_value( "night_vision_range" ) >= 8 ? 4 : 0;

--- a/src/character_vision.cpp
+++ b/src/character_vision.cpp
@@ -1,0 +1,54 @@
+#include "character_vision.h"
+
+#include "bionics.h"
+#include "character.h"
+#include "flag.h"
+#include "monster.h"
+#include "mtype.h"
+
+static const bionic_id bio_night_vision( "bio_night_vision" );
+
+namespace
+{
+
+auto has_mounted_recon_vision( const Character &who ) -> bool
+{
+    return who.is_mounted() && who.mounted_creature->has_flag( MF_MECH_RECON_VISION );
+}
+
+} // namespace
+
+namespace character_vision
+{
+
+auto active_night_vision_bonus_level( const Character &who ) -> night_vision_bonus_level
+{
+    if( who.worn_with_flag( flag_GNVE_EFFECT ) ) {
+        return night_vision_bonus_level::enhanced;
+    }
+    if( who.worn_with_flag( flag_RECON_VISION ) || has_mounted_recon_vision( who ) ||
+        who.has_active_bionic( bio_night_vision ) ||
+        who.has_effect_with_flag( flag_EFFECT_NIGHT_VISION ) ) {
+        return night_vision_bonus_level::standard;
+    }
+    if( who.worn_with_flag( flag_GNV_EFFECT ) ) {
+        return night_vision_bonus_level::standard_goggles;
+    }
+    return night_vision_bonus_level::none;
+}
+
+auto sight_range_bonus( const night_vision_bonus_level level ) -> float
+{
+    switch( level ) {
+        case night_vision_bonus_level::enhanced:
+            return 18.0f;
+        case night_vision_bonus_level::standard:
+        case night_vision_bonus_level::standard_goggles:
+            return 10.0f;
+        case night_vision_bonus_level::none:
+            return 0.0f;
+    }
+    return 0.0f;
+}
+
+} // namespace character_vision

--- a/src/character_vision.h
+++ b/src/character_vision.h
@@ -1,0 +1,18 @@
+#pragma once
+
+class Character;
+
+enum class night_vision_bonus_level {
+    none,
+    standard_goggles,
+    standard,
+    enhanced,
+};
+
+namespace character_vision
+{
+
+auto active_night_vision_bonus_level( const Character &who ) -> night_vision_bonus_level;
+auto sight_range_bonus( night_vision_bonus_level level ) -> float;
+
+} // namespace character_vision

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -14,6 +14,7 @@
 #include "item.h"
 #include "itype.h"
 #include "flag.h"
+#include "game.h"
 #include "map.h"
 #include "map_selector.h"
 #include "map_helpers.h"
@@ -26,10 +27,12 @@
 #include "skill.h"
 #include "state_helpers.h"
 #include "type_id.h"
+#include "units.h"
 #include "value_ptr.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
 #include "vehicle_selector.h"
+#include "weather.h"
 
 class player;
 
@@ -447,6 +450,51 @@ static void destroyed_book_test_helper( avatar &u, item *loc )
                 }
             }
         }
+    }
+}
+
+TEST_CASE( "active night vision tiers allow fine detail vision in darkness", "[reading][vision]" )
+{
+    clear_all_state();
+    clear_avatar();
+    set_time( calendar::turn_zero );
+    get_weather().weather_id = weather_type_id( "clear" );
+
+    auto &dummy = get_avatar();
+    constexpr auto pos = tripoint_bub_ms( 60, 60, 0 );
+    g->place_player( pos );
+
+    auto &here = get_map();
+    here.ter_set( pos, ter_id( "t_floor" ) );
+    here.furn_set( pos, furn_id( "f_null" ) );
+    here.ter_set( pos + tripoint_above, ter_id( "t_flat_roof" ) );
+    here.invalidate_map_cache( pos.z() );
+    here.build_map_cache( pos.z() );
+    here.update_visibility_cache( pos.z() );
+
+    REQUIRE_FALSE( character_funcs::can_see_fine_details( dummy ) );
+
+    SECTION( "standard light amp goggles provide poor fine detail vision" ) {
+        REQUIRE( !dummy.wear_item( item::spawn( "goggles_nv_on" ), false ) );
+
+        CHECK( character_funcs::fine_detail_vision_mod( dummy ) == character_funcs::FINE_VISION_THRESHOLD );
+        CHECK( character_funcs::can_see_fine_details( dummy ) );
+    }
+
+    SECTION( "enhanced light amp goggles provide perfect fine detail vision" ) {
+        REQUIRE( !dummy.wear_item( item::spawn( "goggles_nv_enhanced_on" ), false ) );
+
+        CHECK( character_funcs::fine_detail_vision_mod( dummy ) == character_funcs::FINE_VISION_PERFECT );
+        CHECK( character_funcs::can_see_fine_details( dummy ) );
+    }
+
+    SECTION( "bionic night vision provides perfect fine detail vision" ) {
+        dummy.set_max_power_level( 1_kJ );
+        dummy.set_power_level( 1_kJ );
+        give_and_activate_bionic( dummy, bionic_id( "bio_night_vision" ) );
+
+        CHECK( character_funcs::fine_detail_vision_mod( dummy ) == character_funcs::FINE_VISION_PERFECT );
+        CHECK( character_funcs::can_see_fine_details( dummy ) );
     }
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

resolves #9513

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/509898a5-b7fe-4279-9bf8-623a5f42864a" />

tacticool™
the very idea of trying to read a book wearing NV goggle is highly funni so

## Describe the solution (The How)

- Share one night-vision tier helper between sight range and fine-detail vision.
- Treat standard light amp goggles as poor fine-detail lighting.
- Treat enhanced/recon/bionic/effect night vision as good fine-detail lighting.
- Add regression coverage for standard, enhanced, and bionic night vision in an unlit room.

## Testing

1. debug time to night
2. wear NV goggle
3. you can read books

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ac227ca](https://github.com/cataclysmbn/Cataclysm-BN/commit/ac227caee953277e9a4813660e9438eadc4ab262) (feat: let night vision help with fine-detail tasks) on 2026-06-17 02:15:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27657959906/artifacts/7683587606)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27657959906/artifacts/7684474405)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27657959906/artifacts/7683639134)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27657959906/artifacts/7683641968)
<!-- END artifact comment -->