### PR TITLE
ci: speed up linux tests with sharding, part 1

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -230,7 +230,7 @@ jobs:
           sleep 1
 
           test_bin="build/tests/cata_test${{ matrix.tiles == 1 && '-tiles' || '' }}"
-          build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 4 --non-slow-shards 8 "$test_bin" -- \
+          build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 2 --non-slow-shards 8 "$test_bin" -- \
             --min-duration 20 \
             --use-colour yes \
             --rng-seed time \

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -229,11 +229,12 @@ jobs:
           sleep 1
 
           test_bin="build/tests/cata_test${{ matrix.tiles == 1 && '-tiles' || '' }}"
-          test_opts="--min-duration 20 --use-colour yes --rng-seed time --error-format=github-action --gpu-backend=software"
-
-          parallel --verbose --linebuffer \
-            "$test_bin $test_opts --user-dir=test_user_dir_{#} {}" \
-            ::: "[slow] ~starting_items" "~[slow] ~[.],starting_items"
+          build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 6 --non-slow-shards 8 "$test_bin" -- \
+            --min-duration 20 \
+            --use-colour yes \
+            --rng-seed time \
+            --error-format=github-action \
+            --gpu-backend=software
 
           # Run test with all mods (test-stage only)
           if [ "${{ env.TEST_STAGE }}" = "1" ]; then

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -229,7 +229,7 @@ jobs:
           sleep 1
 
           test_bin="build/tests/cata_test${{ matrix.tiles == 1 && '-tiles' || '' }}"
-          build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 6 --non-slow-shards 8 "$test_bin" -- \
+          build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 4 --non-slow-shards 8 "$test_bin" -- \
             --min-duration 20 \
             --use-colour yes \
             --rng-seed time \

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -230,7 +230,7 @@ jobs:
           sleep 1
 
           test_bin="build/tests/cata_test${{ matrix.tiles == 1 && '-tiles' || '' }}"
-          build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 2 --non-slow-shards 8 "$test_bin" -- \
+          build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 4 --non-slow-shards 8 "$test_bin" -- \
             --min-duration 20 \
             --use-colour yes \
             --rng-seed time \

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -226,6 +226,7 @@ jobs:
           xvfb_pid=$!
           trap 'kill "$xvfb_pid" 2>/dev/null || true' EXIT
           export DISPLAY=:99
+          export LP_NUM_THREADS=2
           sleep 1
 
           test_bin="build/tests/cata_test${{ matrix.tiles == 1 && '-tiles' || '' }}"

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -230,7 +230,7 @@ jobs:
           sleep 1
 
           test_bin="build/tests/cata_test${{ matrix.tiles == 1 && '-tiles' || '' }}"
-          build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 4 --non-slow-shards 8 "$test_bin" -- \
+          build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 4 --non-slow-shards 16 "$test_bin" -- \
             --min-duration 20 \
             --use-colour yes \
             --rng-seed time \

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -3,6 +3,7 @@
 Sources:
 - Baseline: old Linux non-slow shard from successful PR run: `706.837s`.
 - CI profile: PR #9515 run 27586856606, `clang, tiles, i18n` job 81560362204.
+- CI resource check: PR #9515 run 27596058861 showed llvmpipe-backed shards stalling under four unrestricted software-GPU processes.
 - Local profile: rebased branch at 69d0c9ec6d9, `cata_test-tiles --filenames-as-tags --rng-seed 1 --gpu-backend=software`.
 
 ## CI profile before fixes
@@ -21,7 +22,8 @@ The job failed before every shard completed.
 ## Local shard profile after vehicle/map fixture fixes
 
 `#` bars are scaled at about 10 seconds each. Local GNU `parallel` was unavailable, so shards
-were run sequentially; CI runs them with `--jobs 4` to avoid overloading llvmpipe-backed test runners.
+were run sequentially. CI runs them with `--jobs 4` and `LP_NUM_THREADS=2` to avoid unrestricted
+llvmpipe thread oversubscription.
 
 | Time | Graph | Shard |
 | ---: | :--- | --- |
@@ -55,9 +57,10 @@ were run sequentially; CI runs them with `--jobs 4` to avoid overloading llvmpip
 
 ## Prioritized plan
 
-1. Wait for PR CI timings from the rebased branch before changing shard weights again.
+1. Wait for PR CI timings with `LP_NUM_THREADS=2` before changing shard weights again.
 2. If CI still has a >180s shard, split `04-non-slow` first.
-3. Benchmark `--option_overrides=REALITY_BUBBLE_SIZE:2` only on map/visibility-heavy shards;
+3. If runner shutdown continues, reduce CI to `--jobs 3` or isolate `[#map_test]` / `[#vehicle_efficiency_test]`.
+4. Benchmark `--option_overrides=REALITY_BUBBLE_SIZE:2` only on map/visibility-heavy shards;
    keep failing or reality-bubble-sensitive tags on the default bubble.
-4. Avoid `REALITY_BUBBLE_SIZE:1` until a focused compatibility pass proves it does not change
+5. Avoid `REALITY_BUBBLE_SIZE:1` until a focused compatibility pass proves it does not change
    test contracts.

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -1,10 +1,13 @@
 # Linux test shard profile
 
-Source: PR #9515 run 27586856606, `clang, tiles, i18n` job 81560362204.
+Sources:
+- Baseline: old Linux non-slow shard from successful PR run: `706.837s`.
+- CI profile: PR #9515 run 27586856606, `clang, tiles, i18n` job 81560362204.
+- Local profile: rebased branch at 69d0c9ec6d9, `cata_test-tiles --filenames-as-tags --rng-seed 1 --gpu-backend=software`.
 
-## Observed shard timings
+## CI profile before fixes
 
-`#` bars are scaled at about 10 seconds each. The job failed before every shard completed.
+The job failed before every shard completed.
 
 | Time | Graph | Filter summary |
 | ---: | :--- | --- |
@@ -15,23 +18,43 @@ Source: PR #9515 run 27586856606, `clang, tiles, i18n` job 81560362204.
 | 132s | ############# | non-slow shard: algo/melee/vehicle_collision/etc. |
 | >90s | #########... | non-slow shard: calendar/map/projectile/vehicle_part/etc. (canceled) |
 
-## Failure blocker
+## Local shard profile after vehicle/map fixture fixes
 
-`[#vehicle_test]` fails when run independently or in a shard. The failing case is
-`horde_spawns_skip_owned_vehicle_tiles`; the horde spawn fixture does not leave a valid
-vehicle tile for the expected monster spawn/requeue behavior.
+`#` bars are scaled at about 10 seconds each. Local GNU `parallel` was unavailable, so shards
+were run sequentially; CI still runs them with `--jobs 6`.
 
-PR #9519 changes absolute-space/mapbuffer vehicle lookup paths, but this failing assertion
-uses the active `map::veh_at( tripoint_bub_ms )` horde-spawn path, so #9519 is not expected
-to fix this specific failure.
+| Time | Graph | Shard |
+| ---: | :--- | --- |
+| 138s | ############## | `04-non-slow` |
+| 88s | ######### | `08-non-slow` |
+| 80s | ######## | `00-vehicle-rails` |
+| 58s | ###### | `05-non-slow` |
+| 57s | ###### | `06-non-slow` |
+| 53s | ##### | `07-non-slow` |
+| 39s | #### | `03-non-slow` |
+| 38s | #### | `01-non-slow` |
+| 38s | #### | `21-vehicle-efficiency` |
+| 30s | ### | `31-slow` |
+| 29s | ### | `22-starting-items` |
+| 29s | ### | `02-non-slow` |
+| 28s | ### | `20-visibility` |
+| 10s | # | `34-slow` |
+| 5s | # | `32-slow` |
+| 3s | # | `33-slow` |
+
+## Resolved blockers
+
+- `[#vehicle_test] ~[.]` now passes standalone with CI flags.
+- `[#map_test] ~[.]` now passes standalone with CI flags after refreshing the active vehicle
+  cache in the manual part-install fixture.
+- Local verification covered the previously failing `06-non-slow` shard and remaining shards
+  `07`, `08`, `20`, `21`, `22`, `31`, `32`, `33`, and `34`.
 
 ## Prioritized plan
 
-1. Fix or quarantine `horde_spawns_skip_owned_vehicle_tiles` so `[#vehicle_test] ~[.]` passes
-   standalone with the CI flags.
-2. Re-profile file-tag shards after the vehicle fix; keep the actual CI command and flags.
-3. Split the remaining >180s file-tag shards before adding more parallelism.
-4. Benchmark `--option_overrides=REALITY_BUBBLE_SIZE:2` only on map/visibility-heavy shards;
+1. Wait for PR CI timings from the rebased branch before changing shard weights again.
+2. If CI still has a >180s shard, split `04-non-slow` first.
+3. Benchmark `--option_overrides=REALITY_BUBBLE_SIZE:2` only on map/visibility-heavy shards;
    keep failing or reality-bubble-sensitive tags on the default bubble.
-5. Avoid `REALITY_BUBBLE_SIZE:1` until a focused compatibility pass proves it does not change
+4. Avoid `REALITY_BUBBLE_SIZE:1` until a focused compatibility pass proves it does not change
    test contracts.

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -64,9 +64,10 @@ Result before the `vehicle_drag` fixture reuse: all shards passed in `6:52.40` l
 After reusing a single map in `vehicle_drag`, standalone `[#vehicle_drag_test] ~[.]` with CPU
 compute dropped from `121s` to `16.33s` wall time locally.
 
-For local runs, the shard runner defaults `--jobs` to the detected CPU count and defaults generated
-non-slow shards to `jobs * 2`, clamped to `6..16`. CI still passes explicit `--jobs 4
---non-slow-shards 16` for runner stability.
+For local runs, `build-scripts/run-linux-test-shards.sh` defaults to the linux-full tiles test
+binary, standard CI-like test options, detected CPU-count `--jobs`, and generated non-slow shards as
+`jobs * 2` clamped to `6..16`. CI still passes explicit `--jobs 4 --non-slow-shards 16` for runner
+stability.
 
 ## Resolved blockers
 

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -21,9 +21,9 @@ The job failed before every shard completed.
 
 ## Local shard profile after vehicle/map fixture fixes
 
-`#` bars are scaled at about 10 seconds each. Local GNU `parallel` was unavailable, so shards
-were run sequentially. CI runs most shards with CPU compute and keeps software-GPU compute for
-`20-visibility`, so `--jobs 4` does not start multiple llvmpipe-heavy test processes.
+`#` bars are scaled at about 10 seconds each. CI runs most shards with CPU compute, keeps
+software-GPU compute for `20-visibility`, and uses 16 generated non-slow shards to shorten
+individual Linux test processes.
 
 | Time | Graph | Shard |
 | ---: | :--- | --- |
@@ -47,6 +47,20 @@ were run sequentially. CI runs most shards with CPU compute and keeps software-G
 | 5s | # | `32-slow` |
 | 3s | # | `33-slow` |
 
+## Local full sharded validation after CI shard-size reduction
+
+Command: `build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 4 --non-slow-shards 16 ./out/build/linux-full/tests/cata_test-tiles -- --min-duration 20 --use-colour no --rng-seed 1 --error-format=github-action --gpu-backend=software`
+
+Result: all shards passed in `6:52.40` locally. Longest shards:
+
+| Time | Shard |
+| ---: | --- |
+| 165s | `12-non-slow` |
+| 123s | `16-non-slow` |
+| 98s | `21-vehicle-efficiency` |
+| 71s | `06-non-slow` |
+| 67s | `15-non-slow` |
+
 ## Resolved blockers
 
 - `[#vehicle_test] ~[.]` now passes standalone with CI flags.
@@ -57,8 +71,8 @@ were run sequentially. CI runs most shards with CPU compute and keeps software-G
 
 ## Prioritized plan
 
-1. Wait for PR CI timings with CPU-by-default shards before changing shard weights again.
-2. If CI still has a >180s shard, split `04-non-slow` first.
+1. Wait for PR CI timings with 16 generated non-slow shards before changing shard weights again.
+2. If CI still has a >180s shard, split the longest generated non-slow shard first.
 3. If runner shutdown continues, isolate `[#map_test]` / `[#vehicle_efficiency_test]`.
 4. Benchmark `--option_overrides=REALITY_BUBBLE_SIZE:2` only on map/visibility-heavy shards;
    keep failing or reality-bubble-sensitive tags on the default bubble.

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -51,7 +51,7 @@ individual Linux test processes.
 
 Command: `build-scripts/run-linux-test-shards.sh --mode file-tags --jobs 4 --non-slow-shards 16 ./out/build/linux-full/tests/cata_test-tiles -- --min-duration 20 --use-colour no --rng-seed 1 --error-format=github-action --gpu-backend=software`
 
-Result: all shards passed in `6:52.40` locally. Longest shards:
+Result before the `vehicle_drag` fixture reuse: all shards passed in `6:52.40` locally. Longest shards:
 
 | Time | Shard |
 | ---: | --- |
@@ -60,6 +60,9 @@ Result: all shards passed in `6:52.40` locally. Longest shards:
 | 98s | `21-vehicle-efficiency` |
 | 71s | `06-non-slow` |
 | 67s | `15-non-slow` |
+
+After reusing a single map in `vehicle_drag`, standalone `[#vehicle_drag_test] ~[.]` with CPU
+compute dropped from `121s` to `16.33s` wall time locally.
 
 ## Resolved blockers
 

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -27,7 +27,6 @@ were run sequentially; CI runs them with `--jobs 4` to avoid overloading llvmpip
 | ---: | :--- | --- |
 | 138s | ############## | `04-non-slow` |
 | 88s | ######### | `08-non-slow` |
-| 80s | ######## | `00-vehicle-rails` |
 | 58s | ###### | `05-non-slow` |
 | 57s | ###### | `06-non-slow` |
 | 53s | ##### | `07-non-slow` |
@@ -35,9 +34,13 @@ were run sequentially; CI runs them with `--jobs 4` to avoid overloading llvmpip
 | 38s | #### | `01-non-slow` |
 | 38s | #### | `21-vehicle-efficiency` |
 | 30s | ### | `31-slow` |
+| 30s | ### | `00-vehicle-rails-basic` |
 | 29s | ### | `22-starting-items` |
 | 29s | ### | `02-non-slow` |
 | 28s | ### | `20-visibility` |
+| 24s | ## | `19-vehicle-rails-shifting` |
+| 18s | ## | `09-vehicle-rails-fork` |
+| 13s | # | `29-vehicle-rails-other` |
 | 10s | # | `34-slow` |
 | 5s | # | `32-slow` |
 | 3s | # | `33-slow` |
@@ -47,8 +50,8 @@ were run sequentially; CI runs them with `--jobs 4` to avoid overloading llvmpip
 - `[#vehicle_test] ~[.]` now passes standalone with CI flags.
 - `[#map_test] ~[.]` now passes standalone with CI flags after refreshing the active vehicle
   cache in the manual part-install fixture.
-- Local verification covered the previously failing `06-non-slow` shard and remaining shards
-  `07`, `08`, `20`, `21`, `22`, `31`, `32`, `33`, and `34`.
+- Local verification covered the previously failing `06-non-slow` shard, the split vehicle-rails
+  shards, and remaining shards `07`, `08`, `20`, `21`, `22`, `31`, `32`, `33`, and `34`.
 
 ## Prioritized plan
 

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -1,0 +1,37 @@
+# Linux test shard profile
+
+Source: PR #9515 run 27586856606, `clang, tiles, i18n` job 81560362204.
+
+## Observed shard timings
+
+`#` bars are scaled at about 10 seconds each. The job failed before every shard completed.
+
+| Time | Graph | Filter summary |
+| ---: | :--- | --- |
+| 217s | ###################### | `[#vehicle_rails_test]` |
+| 184s | ################## | non-slow shard: bionics/crafting/overmap/etc. |
+| 146s | ############### | non-slow shard: active_item/cata_utility/player_activities/etc. |
+| 141s | ############## | non-slow shard containing `[#vehicle_test]` (failed) |
+| 132s | ############# | non-slow shard: algo/melee/vehicle_collision/etc. |
+| >90s | #########... | non-slow shard: calendar/map/projectile/vehicle_part/etc. (canceled) |
+
+## Failure blocker
+
+`[#vehicle_test]` fails when run independently or in a shard. The failing case is
+`horde_spawns_skip_owned_vehicle_tiles`; the horde spawn fixture does not leave a valid
+vehicle tile for the expected monster spawn/requeue behavior.
+
+PR #9519 changes absolute-space/mapbuffer vehicle lookup paths, but this failing assertion
+uses the active `map::veh_at( tripoint_bub_ms )` horde-spawn path, so #9519 is not expected
+to fix this specific failure.
+
+## Prioritized plan
+
+1. Fix or quarantine `horde_spawns_skip_owned_vehicle_tiles` so `[#vehicle_test] ~[.]` passes
+   standalone with the CI flags.
+2. Re-profile file-tag shards after the vehicle fix; keep the actual CI command and flags.
+3. Split the remaining >180s file-tag shards before adding more parallelism.
+4. Benchmark `--option_overrides=REALITY_BUBBLE_SIZE:2` only on map/visibility-heavy shards;
+   keep failing or reality-bubble-sensitive tags on the default bubble.
+5. Avoid `REALITY_BUBBLE_SIZE:1` until a focused compatibility pass proves it does not change
+   test contracts.

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -22,8 +22,8 @@ The job failed before every shard completed.
 ## Local shard profile after vehicle/map fixture fixes
 
 `#` bars are scaled at about 10 seconds each. Local GNU `parallel` was unavailable, so shards
-were run sequentially. CI runs them with `--jobs 2` and `LP_NUM_THREADS=2` to keep concurrent
-software-GPU test processes under the runner's resource limit.
+were run sequentially. CI runs most shards with CPU compute and keeps software-GPU compute for
+`20-visibility`, so `--jobs 4` does not start multiple llvmpipe-heavy test processes.
 
 | Time | Graph | Shard |
 | ---: | :--- | --- |
@@ -57,7 +57,7 @@ software-GPU test processes under the runner's resource limit.
 
 ## Prioritized plan
 
-1. Wait for PR CI timings with `--jobs 2` / `LP_NUM_THREADS=2` before changing shard weights again.
+1. Wait for PR CI timings with CPU-by-default shards before changing shard weights again.
 2. If CI still has a >180s shard, split `04-non-slow` first.
 3. If runner shutdown continues, isolate `[#map_test]` / `[#vehicle_efficiency_test]`.
 4. Benchmark `--option_overrides=REALITY_BUBBLE_SIZE:2` only on map/visibility-heavy shards;

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -64,6 +64,10 @@ Result before the `vehicle_drag` fixture reuse: all shards passed in `6:52.40` l
 After reusing a single map in `vehicle_drag`, standalone `[#vehicle_drag_test] ~[.]` with CPU
 compute dropped from `121s` to `16.33s` wall time locally.
 
+For local runs, the shard runner defaults `--jobs` to the detected CPU count and defaults generated
+non-slow shards to `jobs * 2`, clamped to `6..16`. CI still passes explicit `--jobs 4
+--non-slow-shards 16` for runner stability.
+
 ## Resolved blockers
 
 - `[#vehicle_test] ~[.]` now passes standalone with CI flags.

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -21,7 +21,7 @@ The job failed before every shard completed.
 ## Local shard profile after vehicle/map fixture fixes
 
 `#` bars are scaled at about 10 seconds each. Local GNU `parallel` was unavailable, so shards
-were run sequentially; CI still runs them with `--jobs 6`.
+were run sequentially; CI runs them with `--jobs 4` to avoid overloading llvmpipe-backed test runners.
 
 | Time | Graph | Shard |
 | ---: | :--- | --- |

--- a/build-scripts/linux-test-profile.md
+++ b/build-scripts/linux-test-profile.md
@@ -22,8 +22,8 @@ The job failed before every shard completed.
 ## Local shard profile after vehicle/map fixture fixes
 
 `#` bars are scaled at about 10 seconds each. Local GNU `parallel` was unavailable, so shards
-were run sequentially. CI runs them with `--jobs 4` and `LP_NUM_THREADS=2` to avoid unrestricted
-llvmpipe thread oversubscription.
+were run sequentially. CI runs them with `--jobs 2` and `LP_NUM_THREADS=2` to keep concurrent
+software-GPU test processes under the runner's resource limit.
 
 | Time | Graph | Shard |
 | ---: | :--- | --- |
@@ -57,9 +57,9 @@ llvmpipe thread oversubscription.
 
 ## Prioritized plan
 
-1. Wait for PR CI timings with `LP_NUM_THREADS=2` before changing shard weights again.
+1. Wait for PR CI timings with `--jobs 2` / `LP_NUM_THREADS=2` before changing shard weights again.
 2. If CI still has a >180s shard, split `04-non-slow` first.
-3. If runner shutdown continues, reduce CI to `--jobs 3` or isolate `[#map_test]` / `[#vehicle_efficiency_test]`.
+3. If runner shutdown continues, isolate `[#map_test]` / `[#vehicle_efficiency_test]`.
 4. Benchmark `--option_overrides=REALITY_BUBBLE_SIZE:2` only on map/visibility-heavy shards;
    keep failing or reality-bubble-sensitive tags on the default bubble.
 5. Avoid `REALITY_BUBBLE_SIZE:1` until a focused compatibility pass proves it does not change

--- a/build-scripts/run-linux-test-shards.sh
+++ b/build-scripts/run-linux-test-shards.sh
@@ -185,12 +185,24 @@ if command -v parallel >/dev/null 2>&1; then
     export TEST_OPTS="${test_opts[*]}"
     export USER_DIR_PREFIX="$user_dir_prefix"
     parallel --jobs "$parallel_jobs" --verbose --linebuffer --halt soon,fail=1 \
-        'filter=$(paste -sd, {}); user_dir="$USER_DIR_PREFIX"_$(basename {}); "$TEST_BIN" $TEST_OPTS --user-dir="$user_dir" "$filter"' \
+        'shard=$(basename {}); filter=$(paste -sd, {}); user_dir="$USER_DIR_PREFIX"_"$shard"; start=$(date +%s); printf "Starting shard %s\n" "$shard"; "$TEST_BIN" $TEST_OPTS --user-dir="$user_dir" "$filter"; status=$?; end=$(date +%s); printf "Finished shard %s in %ss with status %s\n" "$shard" "$(( end - start ))" "$status"; exit "$status"' \
         ::: "${shard_files[@]}"
 else
     for shard_file in "${shard_files[@]}"; do
+        shard=$(basename "$shard_file")
         filter=$(paste -sd, "$shard_file")
-        user_dir="$user_dir_prefix"_$(basename "$shard_file")
-        "$test_bin" "${test_opts[@]}" --user-dir="$user_dir" "$filter"
+        user_dir="$user_dir_prefix"_"$shard"
+        start=$(date +%s)
+        printf 'Starting shard %s\n' "$shard"
+        if "$test_bin" "${test_opts[@]}" --user-dir="$user_dir" "$filter"; then
+            status=0
+        else
+            status=$?
+        fi
+        end=$(date +%s)
+        printf 'Finished shard %s in %ss with status %s\n' "$shard" "$(( end - start ))" "$status"
+        if [ "$status" != "0" ]; then
+            exit "$status"
+        fi
     done
 fi

--- a/build-scripts/run-linux-test-shards.sh
+++ b/build-scripts/run-linux-test-shards.sh
@@ -216,7 +216,5 @@ if command -v parallel >/dev/null 2>&1; then
     parallel --jobs "$parallel_jobs" --verbose --linebuffer --halt soon,fail=1 \
         "$shard_runner" {} ::: "${shard_files[@]}"
 else
-    for shard_file in "${shard_files[@]}"; do
-        "$shard_runner" "$shard_file"
-    done
+    printf '%s\0' "${shard_files[@]}" | xargs -0 -n 1 -P "$parallel_jobs" "$shard_runner"
 fi

--- a/build-scripts/run-linux-test-shards.sh
+++ b/build-scripts/run-linux-test-shards.sh
@@ -128,9 +128,12 @@ if [ "$mode" = "file-tags" ]; then
         : > "$shard_dir/3$shard-slow"
     done
 
-    "$test_bin" "${test_opts[@]}" --user-dir="$shard_dir/discovery" --list-tags \
+    discovery_compute_accel="${CATA_TEST_COMPUTE_ACCELERATION:-cpu}"
+    CATA_TEST_COMPUTE_ACCELERATION="$discovery_compute_accel" \
+        "$test_bin" "${test_opts[@]}" --user-dir="$shard_dir/discovery" --list-tags \
         > "$shard_dir/test-tags" || true
-    "$test_bin" "${test_opts[@]}" --user-dir="$shard_dir/slow-discovery" --list-tags "[slow] ~starting_items" \
+    CATA_TEST_COMPUTE_ACCELERATION="$discovery_compute_accel" \
+        "$test_bin" "${test_opts[@]}" --user-dir="$shard_dir/slow-discovery" --list-tags "[slow] ~starting_items" \
         > "$shard_dir/slow-tags" || true
 
     slow_index=0
@@ -180,29 +183,40 @@ if [ "$dry_run" = "1" ]; then
     exit 0
 fi
 
+shard_runner="$shard_dir/run-shard.sh"
+cat > "$shard_runner" <<'EOF'
+#!/usr/bin/env bash
+set -u
+
+shard_file=$1
+shard=$(basename "$shard_file")
+filter=$(paste -sd, "$shard_file")
+user_dir="$USER_DIR_PREFIX"_"$shard"
+if [ -n "${CATA_TEST_COMPUTE_ACCELERATION:-}" ]; then
+    shard_compute_accel="$CATA_TEST_COMPUTE_ACCELERATION"
+elif [ "$shard" = "20-visibility" ]; then
+    shard_compute_accel="${CATA_TEST_VISIBILITY_COMPUTE_ACCELERATION:-gpu_software}"
+else
+    shard_compute_accel=cpu
+fi
+start=$(date +%s)
+printf 'Starting shard %s with %s compute\n' "$shard" "$shard_compute_accel"
+CATA_TEST_COMPUTE_ACCELERATION="$shard_compute_accel" "$TEST_BIN" $TEST_OPTS --user-dir="$user_dir" "$filter"
+status=$?
+end=$(date +%s)
+printf 'Finished shard %s in %ss with status %s\n' "$shard" "$(( end - start ))" "$status"
+exit "$status"
+EOF
+chmod +x "$shard_runner"
+
+export TEST_BIN="$test_bin"
+export TEST_OPTS="${test_opts[*]}"
+export USER_DIR_PREFIX="$user_dir_prefix"
 if command -v parallel >/dev/null 2>&1; then
-    export TEST_BIN="$test_bin"
-    export TEST_OPTS="${test_opts[*]}"
-    export USER_DIR_PREFIX="$user_dir_prefix"
     parallel --jobs "$parallel_jobs" --verbose --linebuffer --halt soon,fail=1 \
-        'shard=$(basename {}); filter=$(paste -sd, {}); user_dir="$USER_DIR_PREFIX"_"$shard"; start=$(date +%s); printf "Starting shard %s\n" "$shard"; "$TEST_BIN" $TEST_OPTS --user-dir="$user_dir" "$filter"; status=$?; end=$(date +%s); printf "Finished shard %s in %ss with status %s\n" "$shard" "$(( end - start ))" "$status"; exit "$status"' \
-        ::: "${shard_files[@]}"
+        "$shard_runner" {} ::: "${shard_files[@]}"
 else
     for shard_file in "${shard_files[@]}"; do
-        shard=$(basename "$shard_file")
-        filter=$(paste -sd, "$shard_file")
-        user_dir="$user_dir_prefix"_"$shard"
-        start=$(date +%s)
-        printf 'Starting shard %s\n' "$shard"
-        if "$test_bin" "${test_opts[@]}" --user-dir="$user_dir" "$filter"; then
-            status=0
-        else
-            status=$?
-        fi
-        end=$(date +%s)
-        printf 'Finished shard %s in %ss with status %s\n' "$shard" "$(( end - start ))" "$status"
-        if [ "$status" != "0" ]; then
-            exit "$status"
-        fi
+        "$shard_runner" "$shard_file"
     done
 fi

--- a/build-scripts/run-linux-test-shards.sh
+++ b/build-scripts/run-linux-test-shards.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 usage() {
     cat >&2 <<'EOF'
-Usage: build-scripts/run-linux-test-shards.sh [OPTIONS] TEST_BIN -- [TEST_OPTS...]
+Usage: build-scripts/run-linux-test-shards.sh [OPTIONS] [TEST_BIN -- [TEST_OPTS...]]
 
 Options:
   --mode MODE             auto, file-tags, tiles, or legacy (default: auto)
@@ -13,6 +13,11 @@ Options:
   --non-slow-shards N|auto
                           generated non-slow file-tag shards (default: auto, clamped jobs*2)
   --dry-run               print shard filters without running tests
+
+Defaults:
+  TEST_BIN                ./out/build/linux-full/tests/cata_test-tiles
+  TEST_OPTS               --min-duration 20 --use-colour no --rng-seed 1
+                          --error-format=github-action --gpu-backend=software
 
 Environment:
   CATA_TEST_SHARD_DIR          shard file directory
@@ -44,6 +49,7 @@ parallel_jobs=auto
 slow_shards=4
 non_slow_shards=auto
 dry_run=0
+default_test_bin=./out/build/linux-full/tests/cata_test-tiles
 test_bin=
 
 while [ $# -gt 0 ]; do
@@ -95,8 +101,10 @@ done
 test_opts=( "$@" )
 
 if [ -z "$test_bin" ]; then
-    usage
-    exit 2
+    test_bin="$default_test_bin"
+fi
+if [ "${#test_opts[@]}" -eq 0 ]; then
+    test_opts=( --min-duration 20 --use-colour no --rng-seed 1 --error-format=github-action --gpu-backend=software )
 fi
 
 if [ ! -x "$test_bin" ]; then

--- a/build-scripts/run-linux-test-shards.sh
+++ b/build-scripts/run-linux-test-shards.sh
@@ -112,7 +112,10 @@ if [ "$mode" = "file-tags" ]; then
         *) test_opts=( --filenames-as-tags "${test_opts[@]}" ) ;;
     esac
 
-    printf '%s\n' "[#vehicle_rails_test] ~[.]" > "$shard_dir/00-vehicle-rails"
+    printf '%s\n' "vehicle_rail_movement_basic" > "$shard_dir/00-vehicle-rails-basic"
+    printf '%s\n' "vehicle_rail_movement_fork" > "$shard_dir/09-vehicle-rails-fork"
+    printf '%s\n' "vehicle_rail_movement_shifting" > "$shard_dir/19-vehicle-rails-shifting"
+    printf '%s\n' "vehicle_rail_movement_derailed,vehicle_rail_movement_ramp" > "$shard_dir/29-vehicle-rails-other"
     for shard in $(seq 1 "$non_slow_shards"); do
         printf -v shard_name '%02d-non-slow' "$shard"
         : > "$shard_dir/$shard_name"

--- a/build-scripts/run-linux-test-shards.sh
+++ b/build-scripts/run-linux-test-shards.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: build-scripts/run-linux-test-shards.sh [OPTIONS] TEST_BIN -- [TEST_OPTS...]
+
+Options:
+  --mode MODE             auto, file-tags, tiles, or legacy (default: auto)
+  --jobs N                concurrent shard jobs (default: 4)
+  --slow-shards N         generated slow file-tag shards (default: 4)
+  --non-slow-shards N     generated non-slow file-tag shards (default: 6)
+  --dry-run               print shard filters without running tests
+
+Environment:
+  CATA_TEST_SHARD_DIR          shard file directory
+  CATA_TEST_USER_DIR_PREFIX    test user-dir prefix (default: test_user_dir)
+EOF
+}
+
+mode=auto
+parallel_jobs=4
+slow_shards=4
+non_slow_shards=6
+dry_run=0
+test_bin=
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mode)
+            mode="$2"
+            shift 2
+            ;;
+        --jobs)
+            parallel_jobs="$2"
+            shift 2
+            ;;
+        --slow-shards)
+            slow_shards="$2"
+            shift 2
+            ;;
+        --non-slow-shards)
+            non_slow_shards="$2"
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            printf 'Unknown option: %s\n' "$1" >&2
+            usage
+            exit 2
+            ;;
+        *)
+            test_bin="$1"
+            shift
+            if [ "${1:-}" = "--" ]; then
+                shift
+            fi
+            break
+            ;;
+    esac
+done
+
+test_opts=( "$@" )
+
+if [ -z "$test_bin" ]; then
+    usage
+    exit 2
+fi
+
+if [ ! -x "$test_bin" ]; then
+    printf 'Missing executable test binary: %s\n' "$test_bin" >&2
+    exit 2
+fi
+
+case "$mode" in
+    auto|file-tags|tiles)
+        mode=file-tags
+        ;;
+    legacy)
+        ;;
+    *)
+        printf 'Unknown shard mode: %s\n' "$mode" >&2
+        exit 2
+        ;;
+esac
+
+if [ -n "${CATA_TEST_SHARD_DIR:-}" ]; then
+    shard_dir="$CATA_TEST_SHARD_DIR"
+    rm -rf "$shard_dir"
+    mkdir -p "$shard_dir"
+else
+    shard_dir=$(mktemp -d "${RUNNER_TEMP:-/tmp}/cata-test-shards.XXXXXX")
+    trap 'rm -rf "$shard_dir"' EXIT
+fi
+user_dir_prefix="${CATA_TEST_USER_DIR_PREFIX:-test_user_dir}"
+
+if [ "$mode" = "file-tags" ]; then
+    case " ${test_opts[*]} " in
+        *' --filenames-as-tags '*) ;;
+        *) test_opts=( --filenames-as-tags "${test_opts[@]}" ) ;;
+    esac
+
+    printf '%s\n' "[#vehicle_rails_test] ~[.]" > "$shard_dir/00-vehicle-rails"
+    for shard in $(seq 1 "$non_slow_shards"); do
+        printf -v shard_name '%02d-non-slow' "$shard"
+        : > "$shard_dir/$shard_name"
+    done
+    printf '%s\n' "[#vision_test] ~[.]" "[#shadowcasting_test] ~[.]" "[#zlevel_visibility_cache_test] ~[.]" > "$shard_dir/20-visibility"
+    printf '%s\n' "[#vehicle_efficiency_test] ~[.]" > "$shard_dir/21-vehicle-efficiency"
+    printf '%s\n' "starting_items" > "$shard_dir/22-starting-items"
+
+    for shard in $(seq 1 "$slow_shards"); do
+        : > "$shard_dir/3$shard-slow"
+    done
+
+    "$test_bin" "${test_opts[@]}" --user-dir="$shard_dir/discovery" --list-tags \
+        > "$shard_dir/test-tags" || true
+    "$test_bin" "${test_opts[@]}" --user-dir="$shard_dir/slow-discovery" --list-tags "[slow] ~starting_items" \
+        > "$shard_dir/slow-tags" || true
+
+    slow_index=0
+    while IFS= read -r test_file_tag; do
+        shard=$(( slow_index % slow_shards + 1 ))
+        printf '[slow] ~starting_items %s\n' "$test_file_tag" >> "$shard_dir/3$shard-slow"
+        slow_index=$(( slow_index + 1 ))
+    done < <(
+        awk '{
+          for( i = 1; i <= NF; ++i ) {
+            if( $i ~ /^\[#.*_test\]$/ ) {
+              print $i
+            }
+          }
+        }' "$shard_dir/slow-tags" | sort -u
+    )
+    if [ "$slow_index" = "0" ]; then
+        printf '%s\n' "[slow] ~starting_items" > "$shard_dir/31-slow"
+    fi
+
+    test_index=0
+    while IFS= read -r test_file_tag; do
+        shard=$(( test_index % non_slow_shards + 1 ))
+        printf -v shard_name '%02d-non-slow' "$shard"
+        printf '~[slow] ~[.] %s\n' "$test_file_tag" >> "$shard_dir/$shard_name"
+        test_index=$(( test_index + 1 ))
+    done < <(
+        awk '{
+          for( i = 1; i <= NF; ++i ) {
+            if( $i ~ /^\[#.*_test\]$/ && $i !~ /^\[#(vehicle_(efficiency|rails)|vision|shadowcasting|zlevel_visibility_cache)_test\]$/ ) {
+              print $i
+            }
+          }
+        }' "$shard_dir/test-tags" | sort -u
+    )
+else
+    printf '%s\n' "[slow] ~starting_items" > "$shard_dir/00-slow"
+    printf '%s\n' "~[slow] ~[.],starting_items" > "$shard_dir/01-non-slow"
+fi
+
+mapfile -t shard_files < <(find "$shard_dir" -maxdepth 1 -type f -size +0c -name '[0-9]*' | sort)
+
+if [ "$dry_run" = "1" ]; then
+    for shard_file in "${shard_files[@]}"; do
+        printf '%s: %s\n' "$(basename "$shard_file")" "$(paste -sd, "$shard_file")"
+    done
+    exit 0
+fi
+
+if command -v parallel >/dev/null 2>&1; then
+    export TEST_BIN="$test_bin"
+    export TEST_OPTS="${test_opts[*]}"
+    export USER_DIR_PREFIX="$user_dir_prefix"
+    parallel --jobs "$parallel_jobs" --verbose --linebuffer --halt soon,fail=1 \
+        'filter=$(paste -sd, {}); user_dir="$USER_DIR_PREFIX"_$(basename {}); "$TEST_BIN" $TEST_OPTS --user-dir="$user_dir" "$filter"' \
+        ::: "${shard_files[@]}"
+else
+    for shard_file in "${shard_files[@]}"; do
+        filter=$(paste -sd, "$shard_file")
+        user_dir="$user_dir_prefix"_$(basename "$shard_file")
+        "$test_bin" "${test_opts[@]}" --user-dir="$user_dir" "$filter"
+    done
+fi

--- a/build-scripts/run-linux-test-shards.sh
+++ b/build-scripts/run-linux-test-shards.sh
@@ -8,9 +8,10 @@ Usage: build-scripts/run-linux-test-shards.sh [OPTIONS] TEST_BIN -- [TEST_OPTS..
 
 Options:
   --mode MODE             auto, file-tags, tiles, or legacy (default: auto)
-  --jobs N                concurrent shard jobs (default: 4)
+  --jobs N|auto           concurrent shard jobs (default: auto, detected CPU count)
   --slow-shards N         generated slow file-tag shards (default: 4)
-  --non-slow-shards N     generated non-slow file-tag shards (default: 6)
+  --non-slow-shards N|auto
+                          generated non-slow file-tag shards (default: auto, clamped jobs*2)
   --dry-run               print shard filters without running tests
 
 Environment:
@@ -19,10 +20,29 @@ Environment:
 EOF
 }
 
+detect_cpu_count() {
+    if command -v nproc >/dev/null 2>&1; then
+        nproc
+    elif getconf _NPROCESSORS_ONLN >/dev/null 2>&1; then
+        getconf _NPROCESSORS_ONLN
+    else
+        printf '%s\n' 4
+    fi
+}
+
+validate_positive_int() {
+    local name=$1
+    local value=$2
+    if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+        printf '%s must be a positive integer: %s\n' "$name" "$value" >&2
+        exit 2
+    fi
+}
+
 mode=auto
-parallel_jobs=4
+parallel_jobs=auto
 slow_shards=4
-non_slow_shards=6
+non_slow_shards=auto
 dry_run=0
 test_bin=
 
@@ -83,6 +103,21 @@ if [ ! -x "$test_bin" ]; then
     printf 'Missing executable test binary: %s\n' "$test_bin" >&2
     exit 2
 fi
+
+if [ "$parallel_jobs" = "auto" ]; then
+    parallel_jobs=$(detect_cpu_count)
+fi
+validate_positive_int "--jobs" "$parallel_jobs"
+validate_positive_int "--slow-shards" "$slow_shards"
+if [ "$non_slow_shards" = "auto" ]; then
+    non_slow_shards=$(( parallel_jobs * 2 ))
+    if [ "$non_slow_shards" -lt 6 ]; then
+        non_slow_shards=6
+    elif [ "$non_slow_shards" -gt 16 ]; then
+        non_slow_shards=16
+    fi
+fi
+validate_positive_int "--non-slow-shards" "$non_slow_shards"
 
 case "$mode" in
     auto|file-tags|tiles)

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -205,6 +205,7 @@ TEST_CASE( "mapbuffer_vehicle_lookup_uses_absolute_coordinates" )
     REQUIRE( veh != nullptr );
     REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ) ) >= 0 );
     REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "windshield" ), true ) >= 0 );
+    here.add_vehicle_to_cache( veh );
 
     const auto abs_pos = map_local_to_abs( here, local_pos );
     const auto vp = MAPBUFFER.veh_at( abs_pos );

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -49,8 +49,6 @@ static void clear_game_drag( const ter_id &terrain )
 
 static vehicle *setup_drag_test( const vproto_id &veh_id )
 {
-    clear_game_drag( ter_id( "t_pavement" ) );
-
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
     vehicle *veh_ptr = get_map().add_vehicle( veh_id, map_starting_point, -90_degrees, 0, 0 );
 
@@ -108,6 +106,7 @@ static bool test_water_drag(
         cata_printf( "    test_vehicle_water_drag( \"%s\", %f );\n",
                      veh_id.c_str(), c_water );
     }
+    get_map().destroy_vehicle( veh_ptr );
     return valid;
 
 }
@@ -152,6 +151,7 @@ static bool test_drag(
         cata_printf( "    test_vehicle_drag( \"%s\", %f, %f, %d, %d );\n",
                      veh_id.c_str(), c_air, c_rolling, safe_v, max_v );
     }
+    get_map().destroy_vehicle( veh_ptr );
     return valid;
 }
 
@@ -159,13 +159,12 @@ static void test_vehicle_drag(
     std::string type, const double expected_c_air, const double expected_c_rr,
     const double expected_c_water, const int expected_safe, const int expected_max, bool water = false )
 {
-    SECTION( type ) {
-        if( water ) {
-            test_water_drag( vproto_id( type ), expected_c_water, true );
-        }
-        test_drag( vproto_id( type ), expected_c_air, expected_c_rr,
-                   expected_safe, expected_max, true );
+    INFO( type );
+    if( water ) {
+        test_water_drag( vproto_id( type ), expected_c_water, true );
     }
+    test_drag( vproto_id( type ), expected_c_air, expected_c_rr,
+               expected_safe, expected_max, true );
 }
 
 TEST_CASE( "water drag remains positive with excess floating parts", "[vehicle] [engine]" )
@@ -267,6 +266,7 @@ std::vector<std::string> vehs_to_test_drag = {
 TEST_CASE( "vehicle_drag_calc_baseline", "[.]" )
 {
     clear_all_state();
+    clear_game_drag( ter_id( "t_pavement" ) );
     for( const std::string &veh : vehs_to_test_drag ) {
         test_drag( vproto_id( veh ) );
     }
@@ -277,6 +277,7 @@ TEST_CASE( "vehicle_drag_calc_baseline", "[.]" )
 TEST_CASE( "vehicle_drag", "[vehicle] [engine]" )
 {
     clear_all_state();
+    clear_game_drag( ter_id( "t_pavement" ) );
     test_vehicle_drag( "bicycle_test", 0.609525, 0.017205, 43.304167, 2355, 3078 );
     test_vehicle_drag( "bicycle_electric_test", 0.609525, 0.025659, 64.583333, 2754, 3268 );
     test_vehicle_drag( "motorcycle_test", 0.609525, 0.569952, 254.820312, 7296, 8687 );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -16,6 +16,7 @@
 #include "debug.h"
 #include "enums.h"
 #include "game.h"
+#include "game_constants.h"
 #include "item.h"
 #include "json.h"
 #include "map.h"
@@ -66,7 +67,7 @@ auto make_horde_vehicle_spawn_fixture(
 
     auto &here = get_map();
     auto &you = get_avatar();
-    const auto target_submap = tripoint_bub_sm( here.getmapsize() / 2, here.getmapsize() / 2, 0 );
+    const auto target_submap = tripoint_bub_sm( g_half_mapsize, g_half_mapsize, 0 );
     const auto target_submap_abs = map_local_to_abs( here, target_submap );
     const auto target_submap_origin = project_to<coords::ms>( target_submap );
     const auto target_submap_end = target_submap_origin + tripoint( SEEX - 1, SEEY - 1, 0 );


### PR DESCRIPTION
## Purpose of change (The Why)

1. tests take so long (12 minutes on ryzen 5600g)
2. linux CIs die frequently

Linux CI currently runs almost every non-slow test in one shard. After the GPU/visibility work in #9016, #9479, and #9487, that shard is the test-step critical path and can run long enough to be canceled after a cold build.

## Describe the solution (The How)

- Enable Catch filename tags for Linux tests.
- Keep `vehicle_rails`, visibility, `slow`, `vehicle_efficiency`, and `starting_items` as dedicated shards.
- Discover the remaining non-slow file tags and split them across six shards.
- Run shards with `parallel --jobs 4` so the test phase has a smaller critical path.

## Testing

| Case | Time | Result |
|---|---:|---:|
| [Before](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27534744222/job/81382375547) full Linux test step | 752.1s | baseline |
| Required target for 40% speedup | ≤451.3s | — |
| [After](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27622224732/job/81675721734) full Linux test step | 475.1s | 36.8% less / 1.58× faster |

- CI finished: `clang, curses` passed; current PR checks are green/skipped.
- `actionlint .github/workflows/matrix.yml`

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ddf8bc7](https://github.com/cataclysmbn/Cataclysm-BN/commit/ddf8bc765e34e0ebd2417110b25d9218e6df8248) (ci: add local shard runner defaults) on 2026-06-16 14:37:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27622224732/artifacts/7669136752)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27622224732/artifacts/7670139432)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27622224732/artifacts/7669378722)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27622224732/artifacts/7669254144)
<!-- END artifact comment -->