### PR TITLE
fix: failing to find action id no longer aborts the game

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -224,7 +224,7 @@ std::string io::enum_to_string<action_id>( action_id data )
             break;
     }
     debugmsg( "Invalid action_id" );
-    abort();
+    return "null";
 }
 
 class inventory;


### PR DESCRIPTION
## Purpose of change (The Why)
When testing #9108 I got an abort on compile due to the lua docs gen being run on compile
And that calling the game, because it added a new action id
Caused by: #9372

## Describe the solution (The How)
Delete the abort and make it return NULL instead

## Describe alternatives you've considered
Delete the entire function
Move docs gen to a script and not when I'm compiling thank you
Especially as it blocks me getting my build artifact

## Testing
Abort deleted
Game loads

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [16edd6b](https://github.com/cataclysmbn/Cataclysm-BN/commit/16edd6b6cd2d66f49b4750f7d225c767729d1642) (fix: failing to find action id no longer aborts the game) on 2026-06-15 21:53:20

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27572162245/artifacts/7649622675)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27572162245)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27572162245/artifacts/7649835674)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27572162245/artifacts/7650035608)
<!-- END artifact comment -->