### PR TITLE
fix(lua): reject duplicate binding registrations

### DIFF
--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -18,6 +18,10 @@
   },
   "diagnostics": {
     "enable": true,
-    "globals": [ "test_data", "catadoc", "doc_gen_func", "get_requirement" ]
+    "globals": [ "test_data", "catadoc", "doc_gen_func", "get_requirement" ],
+    "severity": {
+      "param-type-mismatch": "error",
+      "undefined-field": "error"
+    }
   }
 }

--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -18,7 +18,7 @@
   },
   "diagnostics": {
     "enable": true,
-    "globals": [ "test_data", "catadoc", "doc_gen_func", "get_requirement" ],
+    "globals": [ "test_data", "catadoc", "doc_gen_func" ],
     "severity": {
       "param-type-mismatch": "error",
       "undefined-field": "error"

--- a/data/json/lua/iuse/item_var_viewer.lua
+++ b/data/json/lua/iuse/item_var_viewer.lua
@@ -80,10 +80,14 @@ local function is_item_choice(selected) return selected.type == "item" or select
 ---@return nil
 local function set_subject_var(selected, key, value)
   if is_item_choice(selected) then
-    selected.subject:set_var_str(key, value)
+    local subject = selected.subject
+    ---@cast subject Item
+    subject:set_var_str(key, value)
     return
   end
-  selected.subject:set_value(key, value)
+  local subject = selected.subject
+  ---@cast subject Creature
+  subject:set_value(key, value)
 end
 
 ---@param selected ItemVarViewerChoice
@@ -91,10 +95,14 @@ end
 ---@return nil
 local function remove_subject_var(selected, key)
   if is_item_choice(selected) then
-    selected.subject:erase_var(key)
+    local subject = selected.subject
+    ---@cast subject Item
+    subject:erase_var(key)
     return
   end
-  selected.subject:remove_value(key)
+  local subject = selected.subject
+  ---@cast subject Creature
+  subject:remove_value(key)
 end
 
 ---@param title string
@@ -205,7 +213,7 @@ local function manage_vars(selected)
   end
 end
 
----@type fun(who: Character, item: Item, pos: Tripoint): integer
+---@type fun(params: ItemUseParams): integer
 viewer.menu = function(params)
   local who = params.user
   local item = params.item
@@ -263,7 +271,7 @@ viewer.menu = function(params)
   push_choice(player_label, player_choice)
 
   local map = gapi.get_map()
-  ---@type Tripoint[]
+  ---@type TripointBubMs[]
   local points = map:points_in_radius(pos, 5)
   ---@type table<string, boolean>
   local seen_monsters = {}

--- a/data/json/lua/iuse/sonar.lua
+++ b/data/json/lua/iuse/sonar.lua
@@ -37,6 +37,8 @@ sonar.register = function(mod)
     if pos == nil then return 0 end
     local abs_ms = gapi.bub_to_abs(pos)
     local center_omt = abs_ms:to_omt()
+    if center_omt == nil then return 0 end
+    ---@cast center_omt TripointAbsOmt
     local radius = 7
     local depth_steps = 5
     local any_revealed = false

--- a/data/json/lua/iuse/voltmeter.lua
+++ b/data/json/lua/iuse/voltmeter.lua
@@ -126,11 +126,13 @@ voltmeter.modify_grid_connections = function(who, item, pos)
 
   if connection_present[idx] then
     -- Remove connection
+    ---@diagnostic disable-next-line: param-type-mismatch
     gapi.get_overmap_buffer():remove_grid_connection(pos_abs_omt, destination_pos_abs_omt)
     gapi.add_msg(MsgType.good, locale.gettext("Grid connection removed."))
   else
     -- Add connection
     local lhs_locations = gapi.get_overmap_buffer():electric_grid_at(pos_abs_omt)
+    ---@diagnostic disable-next-line: param-type-mismatch
     local rhs_locations = gapi.get_overmap_buffer():electric_grid_at(destination_pos_abs_omt)
 
     -- Check if same grid
@@ -222,6 +224,7 @@ voltmeter.modify_grid_connections = function(who, item, pos)
       end
       who:invalidate_crafting_inventory()
 
+      ---@diagnostic disable-next-line: param-type-mismatch
       local success = gapi.get_overmap_buffer():add_grid_connection(pos_abs_omt, destination_pos_abs_omt)
       if success then
         gapi.add_msg(MsgType.good, locale.gettext("Grid connection established."))

--- a/data/json/lua/iuse/voltmeter.lua
+++ b/data/json/lua/iuse/voltmeter.lua
@@ -126,13 +126,11 @@ voltmeter.modify_grid_connections = function(who, item, pos)
 
   if connection_present[idx] then
     -- Remove connection
-    ---@diagnostic disable-next-line: param-type-mismatch
     gapi.get_overmap_buffer():remove_grid_connection(pos_abs_omt, destination_pos_abs_omt)
     gapi.add_msg(MsgType.good, locale.gettext("Grid connection removed."))
   else
     -- Add connection
     local lhs_locations = gapi.get_overmap_buffer():electric_grid_at(pos_abs_omt)
-    ---@diagnostic disable-next-line: param-type-mismatch
     local rhs_locations = gapi.get_overmap_buffer():electric_grid_at(destination_pos_abs_omt)
 
     -- Check if same grid
@@ -181,7 +179,7 @@ voltmeter.modify_grid_connections = function(who, item, pos)
     end
 
     -- Get the requirement and multiply by cost
-    local requirement_base = get_requirement("add_grid_connection")
+    local requirement_base = requirements.get("add_grid_connection")
     if not requirement_base then
       gapi.add_msg(MsgType.warning, locale.gettext("Error: requirement not found."))
       return 0
@@ -224,7 +222,6 @@ voltmeter.modify_grid_connections = function(who, item, pos)
       end
       who:invalidate_crafting_inventory()
 
-      ---@diagnostic disable-next-line: param-type-mismatch
       local success = gapi.get_overmap_buffer():add_grid_connection(pos_abs_omt, destination_pos_abs_omt)
       if success then
         gapi.add_msg(MsgType.good, locale.gettext("Grid connection established."))

--- a/data/json/lua/mapgen/slimepit.lua
+++ b/data/json/lua/mapgen/slimepit.lua
@@ -4,6 +4,7 @@ slimepit.draw = function(data, map)
   local ot_match_prefix = 2
   local ter = data:id()
   local z = data:zlevel()
+  ---@cast z integer
   if z == 0 then
     data:fill_groundcover()
   else

--- a/data/json/lua/nuclear_tear.lua
+++ b/data/json/lua/nuclear_tear.lua
@@ -14,7 +14,7 @@ M.on_explosion = function(params)
 
   local m = gapi.get_map()
 
-  ---@type Tripoint[]
+  ---@type TripointBubMs[]
   local points_to_expand = {}
   for _, check_pos in ipairs(m:points_in_radius(pos, radius // 2, radius // 2)) do
     local field_at_pos = m:has_field_at(check_pos, fd_fatigue_id)

--- a/data/json/lua/plumbing.lua
+++ b/data/json/lua/plumbing.lua
@@ -165,6 +165,7 @@ end
 local get_fixture_resources = function(opts)
   local pos_abs_ms = opts.map:bub_to_abs(opts.pos)
   local pos_abs_omt = pos_abs_ms:to_omt()
+  ---@cast pos_abs_omt TripointAbsOmt
   local source = resource_source.grid
   local clean_charges = overmapbuffer.fluid_grid_liquid_charges_at(pos_abs_omt, item_water_clean)
   local dirty_charges = overmapbuffer.fluid_grid_liquid_charges_at(pos_abs_omt, item_water)
@@ -239,6 +240,7 @@ local consume_body_cleanser_candidate = function(opts)
   local label = opts.candidate.item:display_name(1)
   if opts.candidate.source == "inventory" then
     if opts.candidate.item.charges > 1 then
+      ---@diagnostic disable-next-line: param-type-mismatch
       opts.user:use_charges(opts.candidate.item:get_type(), 1, function(_) return true end)
     else
       opts.user:remove_item(opts.candidate.item)
@@ -280,6 +282,7 @@ end
 local refresh_morale = function(opts)
   local current = opts.user:get_morale(opts.morale_type)
   local delta = current < opts.bonus and opts.bonus - current or 0
+  ---@diagnostic disable-next-line: param-type-mismatch
   opts.user:add_morale(opts.morale_type, delta, opts.bonus, opts.duration, opts.decay_start, true, nil)
 end
 
@@ -577,6 +580,7 @@ local examine = function(params, mode)
     is_cold_weather = map:get_temperature_c(params.pos) < warm_temperature_threshold_c,
     bloody_tile_count = count_bloody_tiles({ map = map, center = params.pos }),
   }
+  ---@diagnostic disable-next-line: param-type-mismatch
   examine_context({ context = context })
 end
 

--- a/data/json/lua/plumbing.lua
+++ b/data/json/lua/plumbing.lua
@@ -90,6 +90,7 @@ local blood_field_ids = {
   FieldTypeId.new("fd_gibs_invertebrate"):int_id(),
 }
 
+---@type table<string, PlumbingModeData>
 local wash_mode_data = {
   shower = {
     duration_minutes = 15,
@@ -240,8 +241,7 @@ local consume_body_cleanser_candidate = function(opts)
   local label = opts.candidate.item:display_name(1)
   if opts.candidate.source == "inventory" then
     if opts.candidate.item.charges > 1 then
-      ---@diagnostic disable-next-line: param-type-mismatch
-      opts.user:use_charges(opts.candidate.item:get_type(), 1, function(_) return true end)
+      opts.user:use_charges(opts.candidate.item:get_type(), 1)
     else
       opts.user:remove_item(opts.candidate.item)
     end
@@ -282,7 +282,6 @@ end
 local refresh_morale = function(opts)
   local current = opts.user:get_morale(opts.morale_type)
   local delta = current < opts.bonus and opts.bonus - current or 0
-  ---@diagnostic disable-next-line: param-type-mismatch
   opts.user:add_morale(opts.morale_type, delta, opts.bonus, opts.duration, opts.decay_start, true, nil)
 end
 
@@ -580,7 +579,6 @@ local examine = function(params, mode)
     is_cold_weather = map:get_temperature_c(params.pos) < warm_temperature_threshold_c,
     bloody_tile_count = count_bloody_tiles({ map = map, center = params.pos }),
   }
-  ---@diagnostic disable-next-line: param-type-mismatch
   examine_context({ context = context })
 end
 

--- a/data/json/lua/robofac.lua
+++ b/data/json/lua/robofac.lua
@@ -17,7 +17,7 @@ local nearby_hub01_scan_radius_omt = 4
 ---@field om_terrain string?
 
 ---@class RobofacNpcParams
----@field npc NPC?
+---@field npc Npc?
 
 ---@class RobofacMonsterParams
 ---@field monster Monster?
@@ -44,19 +44,26 @@ local has_hub01_clearance = function(ch) return ch ~= nil and ch:get_value(hub01
 ---@return boolean
 local is_in_hub01 = function(ch)
   if ch == nil then return false end
-  return overmapbuffer.check_ot("robofachq", OtMatchType.PREFIX, ch:global_square_location():to_omt())
+  local omt_pos = ch:global_square_location():to_omt()
+  if omt_pos == nil then return false end
+  ---@cast omt_pos TripointAbsOmt
+  return overmapbuffer.check_ot("robofachq", OtMatchType.PREFIX, omt_pos)
 end
 
 ---@return TripointAbsOmt?
 local hub01_scan_center = function()
   ---@type Avatar?
   local player = gapi.get_avatar()
+  ---@cast player Character?
+  if player == nil then return nil end
   if not has_hub01_clearance(player) then return nil end
   if not is_in_hub01(player) then return nil end
-  return player:global_square_location():to_omt()
+  local center = player:global_square_location():to_omt()
+  ---@cast center TripointAbsOmt?
+  return center
 end
 
----@return NPC[]
+---@return Npc[]
 local nearby_hub01_npcs = function()
   local center = hub01_scan_center()
   if center == nil then return {} end
@@ -94,6 +101,7 @@ M.authorize_hub01_security = function(params)
   if not npc then return true end
 
   local player = gapi.get_avatar()
+  ---@cast player Character?
   if not has_hub01_clearance(player) then return true end
   if npc:get_faction_id():str() ~= robofac_faction:str() then return true end
   if npc:get_first_topic() ~= "TALK_HUB_SECURITY" then return true end
@@ -105,7 +113,7 @@ M.authorize_hub01_security = function(params)
   return true
 end
 
----@param npcs NPC[]?
+---@param npcs Npc[]?
 ---@return boolean?
 M.authorize_active_hub01_security = function(npcs)
   for _, npc in ipairs(npcs or nearby_hub01_npcs()) do
@@ -123,6 +131,7 @@ M.authorize_hub01_turret = function(params)
   if monster_type ~= hub01_turret and monster_type ~= legacy_light_turret then return true end
 
   local player = gapi.get_avatar()
+  ---@cast player Character?
   if not has_hub01_clearance(player) then return true end
 
   if monster_type == legacy_light_turret then
@@ -148,6 +157,7 @@ end
 ---@return boolean?
 M.authorize_active_hub01 = function()
   local player = gapi.get_avatar()
+  ---@cast player Character?
   if not has_hub01_clearance(player) then return true end
   if not is_in_hub01(player) then return true end
 

--- a/data/json/lua/traits/lua_traits.lua
+++ b/data/json/lua/traits/lua_traits.lua
@@ -103,7 +103,6 @@ local function apply_penalty(who, morale_id, penalty)
     return
   end
 
-  ---@diagnostic disable-next-line: param-type-mismatch
   who:add_morale(
     morale_id,
     -magnitude,
@@ -111,7 +110,6 @@ local function apply_penalty(who, morale_id, penalty)
     TimeDuration.from_minutes(20),
     TimeDuration.from_minutes(20),
     true,
-    ---@diagnostic disable-next-line: param-type-mismatch
     nil
   )
 end

--- a/data/json/lua/traits/lua_traits.lua
+++ b/data/json/lua/traits/lua_traits.lua
@@ -55,7 +55,7 @@ local function random_entry(list)
 end
 
 ---@param map Map
----@param pt Tripoint
+---@param pt TripointBubMs
 ---@return boolean
 local function is_passable(map, pt)
   local ter = map:get_ter_at(pt):obj()
@@ -77,7 +77,7 @@ local function is_wielding_mop(who)
 end
 
 ---@param here Map
----@param center Tripoint
+---@param center TripointBubMs
 local function auto_mop_surrounding(here, center)
   local mopped_tiles = 0
   for _, pt in ipairs(here:points_in_radius(center, 1)) do
@@ -103,6 +103,7 @@ local function apply_penalty(who, morale_id, penalty)
     return
   end
 
+  ---@diagnostic disable-next-line: param-type-mismatch
   who:add_morale(
     morale_id,
     -magnitude,
@@ -110,6 +111,7 @@ local function apply_penalty(who, morale_id, penalty)
     TimeDuration.from_minutes(20),
     TimeDuration.from_minutes(20),
     true,
+    ---@diagnostic disable-next-line: param-type-mismatch
     nil
   )
 end
@@ -126,7 +128,7 @@ local function drain_focus(who, amount, minimum)
 end
 
 ---@param here Map
----@param pt Tripoint
+---@param pt TripointBubMs
 ---@return boolean
 local function is_loot_on_floor(here, pt)
   local furn = here:get_furn_at(pt):obj()
@@ -137,7 +139,7 @@ local function is_loot_on_floor(here, pt)
 end
 
 ---@param here Map
----@param center Tripoint
+---@param center TripointBubMs
 ---@return integer
 local function count_loose_items(here, center)
   local you = gapi.get_avatar()

--- a/data/mods/Civilians/main.lua
+++ b/data/mods/Civilians/main.lua
@@ -123,7 +123,9 @@ local function process_civilian_corpse_pulping(monster, all_creatures, map)
   end
 
   local m_pos = monster:get_pos_ms()
+  ---@type Item?
   local found_corpse = nil
+  ---@type TripointBubMs?
   local corpse_pos = nil
 
   -- 2. Scan surroundings for unpulped corpses (radius 8 tiles)
@@ -148,10 +150,11 @@ local function process_civilian_corpse_pulping(monster, all_creatures, map)
     if found_corpse then break end
   end
 
-  if not found_corpse then return end
+  if not found_corpse or corpse_pos == nil then return end
+  ---@cast corpse_pos TripointBubMs
 
   -- 3. Determine distance and execute action
-  local dist = coords.rl_dist(m_pos, corpse_pos)
+  local dist = coords.rl_dist(m_pos, corpse_pos) or math.maxinteger
   if dist <= 1 then
     -- Close enough, execute pulping action
     found_corpse:set_damage(found_corpse:get_max_damage())

--- a/data/mods/Civilians/preload.lua
+++ b/data/mods/Civilians/preload.lua
@@ -1,6 +1,7 @@
 local mod = game.mod_runtime[game.current_mod]
 
 -- Register mapgen postprocess hook (responsible for randomly spawning civilians)
+---@diagnostic disable-next-line: param-type-mismatch
 table.insert(game.hooks.on_mapgen_postprocess, function(params)
   if mod.on_mapgen_postprocess then return mod.on_mapgen_postprocess(params) end
 end)

--- a/data/mods/Civilians/preload.lua
+++ b/data/mods/Civilians/preload.lua
@@ -1,8 +1,7 @@
 local mod = game.mod_runtime[game.current_mod]
 
 -- Register mapgen postprocess hook (responsible for randomly spawning civilians)
----@diagnostic disable-next-line: param-type-mismatch
-table.insert(game.hooks.on_mapgen_postprocess, function(params)
+game.add_hook("on_mapgen_postprocess", function(params)
   if mod.on_mapgen_postprocess then return mod.on_mapgen_postprocess(params) end
 end)
 

--- a/data/mods/change_hairstyle/main.lua
+++ b/data/mods/change_hairstyle/main.lua
@@ -14,14 +14,9 @@ mod.change_hairstyle_function = function(params)
   local function get_hair_trait_type(mut_raw)
     if not mut_raw then return nil end
 
-    local success, types = pcall(function() return mut_raw:mutation_types() end)
-    if success and types then
-      ---@diagnostic disable-next-line: param-type-mismatch
-      for k, v in pairs(types) do
-        local t = (type(v) == "string") and v or k
-        if t == "hair_style" then return "hair_style" end
-        if t == "hair_color" then return "hair_color" end
-      end
+    for _, t in ipairs(mut_raw:mutation_types()) do
+      if t == "hair_style" then return "hair_style" end
+      if t == "hair_color" then return "hair_color" end
     end
 
     local id_str = mut_raw.id:str()

--- a/data/mods/change_hairstyle/main.lua
+++ b/data/mods/change_hairstyle/main.lua
@@ -16,6 +16,7 @@ mod.change_hairstyle_function = function(params)
 
     local success, types = pcall(function() return mut_raw:mutation_types() end)
     if success and types then
+      ---@diagnostic disable-next-line: param-type-mismatch
       for k, v in pairs(types) do
         local t = (type(v) == "string") and v or k
         if t == "hair_style" then return "hair_style" end

--- a/data/mods/lua_ai_attitude_debug/ai_behaviors.lua
+++ b/data/mods/lua_ai_attitude_debug/ai_behaviors.lua
@@ -170,15 +170,15 @@ local function run_fetch_mode(runtime_ctx, ctx)
 
   if fetch_pos.x == ctx.pos.x and fetch_pos.y == ctx.pos.y and fetch_pos.z == ctx.pos.z then
     local stack = ctx.here:get_items_at(fetch_pos)
+    ---@type Item?
     local picked = nil
-    for _, item in ipairs(stack) do
+    for _, item in ipairs(stack:items()) do
       if item:get_type():str() == item_id then
         picked = item
         break
       end
     end
     if picked ~= nil then
-      ---@diagnostic disable-next-line: param-type-mismatch
       local taken = ctx.here:detach_item_at(fetch_pos, picked)
       if taken ~= nil then
         ctx.mon:add_detached_item(taken)

--- a/data/mods/lua_ai_attitude_debug/ai_behaviors.lua
+++ b/data/mods/lua_ai_attitude_debug/ai_behaviors.lua
@@ -178,6 +178,7 @@ local function run_fetch_mode(runtime_ctx, ctx)
       end
     end
     if picked ~= nil then
+      ---@diagnostic disable-next-line: param-type-mismatch
       local taken = ctx.here:detach_item_at(fetch_pos, picked)
       if taken ~= nil then
         ctx.mon:add_detached_item(taken)
@@ -276,6 +277,7 @@ end
 ---@param safe_step fun(mon: Monster, dest: TripointBubMs): boolean
 ---@return boolean
 local function run_calm_dance_turn(mon, serialize_tripoint_abs_ms, deserialize_tripoint_abs_ms, safe_step)
+  ---@type [integer, integer][]
   local dance_points = {
     { 1, 0 },
     { 1, 1 },
@@ -316,6 +318,7 @@ local function run_calm_dance_turn(mon, serialize_tripoint_abs_ms, deserialize_t
   end
 
   local offset = dance_points[idx]
+  if offset == nil then return false end
   local dest = TripointBubMs.new(anchor_local.x + offset[1], anchor_local.y + offset[2], anchor_local.z)
 
   if not safe_step(mon, dest) then

--- a/data/mods/lua_ai_attitude_debug/lib/utils.lua
+++ b/data/mods/lua_ai_attitude_debug/lib/utils.lua
@@ -20,7 +20,7 @@ end
 ---@return TripointBubMs|nil
 function utils.deserialize_tripoint_bub_ms(str)
   local x, y, z = utils.parse_tripoint_components(str)
-  if x ~= nil then return TripointBubMs.new(x, y, z) end
+  if x ~= nil and y ~= nil and z ~= nil then return TripointBubMs.new(x, y, z) end
   return nil
 end
 
@@ -28,7 +28,7 @@ end
 ---@return TripointAbsMs|nil
 function utils.deserialize_tripoint_abs_ms(str)
   local x, y, z = utils.parse_tripoint_components(str)
-  if x ~= nil then return TripointAbsMs.new(x, y, z) end
+  if x ~= nil and y ~= nil and z ~= nil then return TripointAbsMs.new(x, y, z) end
   return nil
 end
 

--- a/data/mods/resurrection_mod/main.lua
+++ b/data/mods/resurrection_mod/main.lua
@@ -61,13 +61,14 @@ mod.on_character_death_hook = function()
   local anchor_pos = mod.pick_teleport_destination(who)
   if anchor_pos ~= nil then
     local player_abs = who:abs_pos()
-    local distance = math.abs(player_abs:rl_dist(anchor_pos))
-    ---@cast distance integer
+    local distance = math.abs(player_abs:rl_dist(anchor_pos) or 0)
     who:drop_inv(math.ceil(distance / 50))
     gapi.add_msg("Respawning Player at " .. tostring(anchor_pos))
 
     -- Convert abs_ms to abs_omt
     local omt_pos = anchor_pos:to_omt()
+    if omt_pos == nil then return end
+    ---@cast omt_pos TripointAbsOmt
     gapi.place_player_overmap_at(omt_pos)
 
     -- Convert abs_ms to local_ms

--- a/data/mods/smart_house_remotes/main.lua
+++ b/data/mods/smart_house_remotes/main.lua
@@ -38,10 +38,14 @@ mod.remote_wireless_range_z = 2
 mod.get_remote_base_omt = function(item) return item:get_var_tri(mod.var_base, TripointAbsOmt.new(0, 0, 0)) end
 
 -- Get abs ms of remote's base
----@type fun(item: Item): Tripoint
+---@type fun(item: Item): TripointAbsMs
 mod.get_remote_base_abs_ms = function(item)
   local p_omt = mod.get_remote_base_omt(item)
-  return p_omt:to_ms() + PointRelMs.new(const.OMT_MS_SIZE // 2, const.OMT_MS_SIZE // 2)
+  local p_ms = p_omt:to_ms()
+  ---@cast p_ms TripointAbsMs
+  local center_ms = p_ms + PointRelMs.new(const.OMT_MS_SIZE // 2, const.OMT_MS_SIZE // 2)
+  ---@cast center_ms TripointAbsMs
+  return center_ms
 end
 
 -- Set remote's base abs omt
@@ -301,6 +305,7 @@ mod.iuse_function = function(params)
   local item = params.item
   local pos = params.pos
   local user_pos = gapi.bub_to_abs(pos)
+  ---@cast user_pos TripointAbsMs
 
   -- Uncomment this so on activation the remote reconfigures itself to work in user's omt
   --[[
@@ -312,14 +317,13 @@ mod.iuse_function = function(params)
     ]]
 
   local base_pos = mod.get_remote_base_abs_ms(item)
-  ---@cast base_pos Tripoint
 
   -- Check distance to wireless base the remote is bound to.
   -- The base does not physically exist in game world, but we imagine
   -- it's tucked away into a hoouse wall or something.
   if
     math.abs(user_pos.z - base_pos.z) > mod.remote_wireless_range_z
-    or user_pos:rl_dist(base_pos) > mod.remote_wireless_range
+    or (user_pos:rl_dist(base_pos) or math.maxinteger) > mod.remote_wireless_range
   then
     mod.show_no_signal_error()
     return 0

--- a/data/mods/teleportation_mod/main.lua
+++ b/data/mods/teleportation_mod/main.lua
@@ -160,6 +160,7 @@ mod.iuse_function_anchor = function(params)
   --print(player_abs_pos)
 
   local player_omt = player_abs_pos:to_omt()
+  ---@cast player_omt TripointAbsOmt
 
   local no_furn = gapi.get_map():get_furn_at(player_map_pos)
   local b = tostring(no_furn)
@@ -209,6 +210,7 @@ mod.iuse_function_station = function(params)
   --print(player_map_pos)
 
   local player_omt = player_abs_pos:to_omt()
+  ---@cast player_omt TripointAbsOmt
   --print(player_omt)
 
   local no_furn = gapi.get_map():get_furn_at(player_map_pos)
@@ -276,6 +278,7 @@ end
 mod.charge_stations_from_grid = function(pos)
   local abs_pos = gapi.bub_to_abs(pos)
   local abs_omt = abs_pos:to_omt()
+  ---@cast abs_omt TripointAbsOmt
   local grid = gapi.get_distribution_grid_tracker():grid_at(abs_pos)
   local power_available = grid:get_resource(true)
   local chosen_station_list = {}
@@ -334,6 +337,7 @@ end
 mod.pick_teleporter = function(who, eidx, pos)
   local abs_pos = gapi.bub_to_abs(pos)
   local abs_omt = abs_pos:to_omt()
+  ---@cast abs_omt TripointAbsOmt
   local anchor = mod.anchor_list[eidx]
   if not anchor then return 0 end
   local distance = abs_omt:rl_dist(anchor)
@@ -381,6 +385,7 @@ mod.pick_teleport_destination = function(who, pos)
   local ui_teleport = UiList.new()
   local abs_pos = gapi.bub_to_abs(pos)
   local abs_omt = abs_pos:to_omt()
+  ---@cast abs_omt TripointAbsOmt
   ui_teleport:title(locale.gettext("Select teleportation target"))
 
   for i in pairs(mod.anchor_list) do
@@ -406,6 +411,7 @@ end
 mod.get_anchor_distance = function(pos, i)
   local abs_pos = gapi.bub_to_abs(pos)
   local abs_omt = abs_pos:to_omt()
+  ---@cast abs_omt TripointAbsOmt
   local anchor = mod.anchor_list[i]
   if not anchor then return 0 end
   local distance = abs_omt:rl_dist(anchor)
@@ -596,6 +602,7 @@ end
 mod.remove_placed_furniture = function(pos)
   local abs_pos = gapi.bub_to_abs(pos)
   local abs_omt = abs_pos:to_omt()
+  ---@cast abs_omt TripointAbsOmt
   local ui_remove_furn = UiList.new()
   ui_remove_furn:title(locale.gettext("Remove station or anchor?"))
   ui_remove_furn:add(1, locale.gettext("Station"))

--- a/data/raw/generate_types.lua
+++ b/data/raw/generate_types.lua
@@ -369,6 +369,8 @@ doc_gen_func.impl = function()
 ---@field bionic_functions table<string, BionicFunctionTable>
 ---@field mutation_functions table<string, table<string, function>>
 ---@field horde_behaviours table<string, function>
+---@field monster_ai_functions table<string, function>
+---@field monster_attitude_functions table<string, function>
 ---@field mapgen_functions table<string, MapgenFunction>
 ---@field examine_functions table<string, fun(params: { user: Character, pos: TripointBubMs })>
 ---@field activity_functions table<string, LuaActivityFinishFunction>
@@ -586,7 +588,7 @@ on_npc_loaded = {}
     ret = ret .. "--================---- " .. section_name .. " ----================\n\n"
 
     for _, item in ipairs(section_sorted) do
-      local name = item.k -- Class or Library name
+      local name = tostring(item.k) -- Class or Library name
       local data = item.v or {}
       local comment = data.type_comment or data.lib_comment or ""
       local bases = data["#bases"] or {}
@@ -709,7 +711,14 @@ on_npc_loaded = {}
     full_ret = full_ret .. "}\n\n"
   end
 
-  -- No second pass needed anymore
+  full_ret = full_ret:gsub("%-%-%-@class (Point%u[%w]*)\n", function(name)
+    if name == "PointCoord" then return "---@class " .. name .. "\n" end
+    return "---@class " .. name .. " : PointCoord\n"
+  end)
+  full_ret = full_ret:gsub("%-%-%-@class (Tripoint%u[%w]*)\n", function(name)
+    if name == "TripointCoord" then return "---@class " .. name .. "\n" end
+    return "---@class " .. name .. " : TripointCoord\n"
+  end)
 
   return full_ret
 end

--- a/data/raw/generate_types.lua
+++ b/data/raw/generate_types.lua
@@ -222,6 +222,15 @@ local fmt_function_field = function(member, class_name)
   return ret .. "\n"
 end
 
+---@param annotations string
+---@param class_name string
+---@param annotation string
+---@return string
+local add_class_annotation = function(annotations, class_name, annotation)
+  local pattern = "(---@class " .. class_name .. " : [^\n]+\n)"
+  return (annotations:gsub(pattern, "%1" .. annotation .. "\n"))
+end
+
 --[[
     Formats ---@overload annotations and function stub for constructors ('new' function).
   ]]
@@ -719,6 +728,7 @@ on_npc_loaded = {}
     if name == "TripointCoord" then return "---@class " .. name .. "\n" end
     return "---@class " .. name .. " : TripointCoord\n"
   end)
+  full_ret = add_class_annotation(full_ret, "TripointAbsOmt", "---@operator add(TripointRelOmt): TripointAbsOmt")
 
   return full_ret
 end

--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -231,9 +231,11 @@ void cata::detail::reg_creature( sol::state &lua )
 
         SET_FX_N_T( setpos, "set_pos_ms", void( const tripoint_bub_ms & ) );
 
-        SET_FX_N_T( setpos, "set_pos", void( const tripoint_bub_ms & ) );
-
-        SET_FX_N_T( setpos, "set_pos", void( const tripoint_abs_ms & ) );
+        luna::set_fx( ut, "set_pos",
+                      sol::overload(
+        []( Creature & cr, const tripoint_bub_ms & p ) -> void { cr.setpos( p ); },
+        []( Creature & cr, const tripoint_abs_ms & p ) -> void { cr.setpos( p ); }
+                      ) );
 
         luna::set_fx( ut, "has_effect", []( const Creature & cr, const efftype_id & eff,
         sol::optional<const bodypart_str_id &> bpid ) -> bool {
@@ -823,10 +825,6 @@ void cata::detail::reg_character( sol::state &lua )
 
         SET_FX_T( mutate_category, void( const mutation_category_id & ) );
 
-        SET_FX_T( mutate_towards, bool( std::vector<trait_id>, int ) );
-
-        SET_FX_T( mutate_towards, bool( const trait_id & ) );
-
         luna::set_fx( ut, "mutate_towards", sol::overload(
                           sol::resolve<bool( std::vector<trait_id>, int )>( &UT_CLASS::mutate_towards ),
                           sol::resolve<bool( const trait_id & )>( &UT_CLASS::mutate_towards )
@@ -1238,7 +1236,6 @@ void cata::detail::reg_character( sol::state &lua )
         SET_FX( knows_trap );
 
         DOC( "Character learns that the given trap is on the given tripoint. If the trap is null, the character learns that there is no trap there." );
-        SET_FX( add_known_trap );
         luna::set_fx( ut, "add_known_trap", []( UT_CLASS & c, const tripoint_bub_ms & p, const trap_id & tr )
         {
             c.add_known_trap( p, tr.obj() );

--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -1215,9 +1215,12 @@ void cata::detail::reg_character( sol::state &lua )
         SET_FX_T( is_wearing_helmet, bool() const );
 
         SET_FX_T( get_morale_level, int() const );
-        SET_FX_T( add_morale,
-                  void( const morale_type &, int, int, const time_duration &, const time_duration &,
-                        bool, const itype * ) );
+        luna::set_fx( ut, "add_morale", []( UT_CLASS & c, const morale_type & type, int bonus,
+                                            int max_bonus, const time_duration & duration,
+                                            const time_duration & decay_start, bool capped,
+        sol::optional<const itype *> item_type ) -> void {
+            c.add_morale( type, bonus, max_bonus, duration, decay_start, capped, item_type.value_or( nullptr ) );
+        } );
         SET_FX_T( has_morale, bool( const morale_type & ) const );
         SET_FX_T( get_morale, int( const morale_type & ) const );
         SET_FX_T( rem_morale, void( const morale_type & ) );
@@ -1270,7 +1273,14 @@ void cata::detail::reg_character( sol::state &lua )
             c.drench( saturation, drenched_parts, ignore_waterproof );
         } );
 
-        SET_FX( use_charges );
+        luna::set_fx( ut, "use_charges", sol::overload(
+        []( UT_CLASS & c, const itype_id & what, int qty ) -> std::vector<detached_ptr<item>> {
+            return c.use_charges( what, qty );
+        },
+        []( UT_CLASS & c, const itype_id & what, int qty,
+        const sol::function & filter ) -> std::vector<detached_ptr<item>> {
+            return c.use_charges( what, qty, [&filter]( const item & it ) { return filter( it ); } );
+        } ) );
         SET_FX( use_charges_if_avail );
 
         DOC( "Returns the crafting inventory for this character (includes nearby items)" );

--- a/src/catalua_bindings_game.cpp
+++ b/src/catalua_bindings_game.cpp
@@ -62,10 +62,16 @@ void cata::detail::reg_game_api( sol::state &lua )
 
     luna::set_fx( lib, "get_avatar", &get_avatar );
     luna::set_fx( lib, "get_map", &get_map );
-    luna::set_fx( lib, "bub_to_abs", []( const tripoint_bub_ms & p ) -> tripoint_abs_ms { return bub_to_abs( p ); } );
-    luna::set_fx( lib, "bub_to_abs", []( const tripoint_bub_sm & p ) -> tripoint_abs_sm { return bub_to_abs( p ); } );
-    luna::set_fx( lib, "abs_to_bub", []( const tripoint_abs_ms & p ) -> tripoint_bub_ms { return abs_to_bub( p ); } );
-    luna::set_fx( lib, "abs_to_bub", []( const tripoint_abs_sm & p ) -> tripoint_bub_sm { return abs_to_bub( p ); } );
+    luna::set_fx( lib, "bub_to_abs",
+                  sol::overload(
+                      []( const tripoint_bub_ms & p ) -> tripoint_abs_ms { return bub_to_abs( p ); },
+                      []( const tripoint_bub_sm & p ) -> tripoint_abs_sm { return bub_to_abs( p ); }
+                  ) );
+    luna::set_fx( lib, "abs_to_bub",
+                  sol::overload(
+                      []( const tripoint_abs_ms & p ) -> tripoint_bub_ms { return abs_to_bub( p ); },
+                      []( const tripoint_abs_sm & p ) -> tripoint_bub_sm { return abs_to_bub( p ); }
+                  ) );
     luna::set_fx( lib, "get_distribution_grid_tracker",
                   []() -> distribution_grid_tracker & { return get_distribution_grid_tracker(); } );
     luna::set_fx( lib, "light_ambient_lit", []() -> float { return LIGHT_AMBIENT_LIT; } );

--- a/src/catalua_bindings_item.cpp
+++ b/src/catalua_bindings_item.cpp
@@ -459,15 +459,11 @@ void reg_item( sol::state &lua )
         DOC( "Gets the faction id that owns this item" );
         SET_FX( get_owner );
 
-        DOC( "Sets the ownership of this item to a faction" );
-        luna::set_fx( ut, "set_owner",
-                      sol::resolve<void( const faction_id & )>
-                      ( &item::set_owner ) );
-
-        DOC( "Sets the ownership of this item to a character" );
-        luna::set_fx( ut, "set_owner",
-                      sol::resolve<void( const Character & )>
-                      ( &item::set_owner ) );
+        DOC( "Sets the ownership of this item to a faction or character" );
+        luna::set_fx( ut, "set_owner", sol::overload(
+                          sol::resolve<void( const faction_id & )>( &item::set_owner ),
+                          sol::resolve<void( const Character & )>( &item::set_owner )
+                      ) );
 
         SET_FX( get_owner_name );
 

--- a/src/catalua_bindings_requirement.cpp
+++ b/src/catalua_bindings_requirement.cpp
@@ -65,10 +65,11 @@ void cata::detail::reg_requirement( sol::state &lua )
     }
 #undef UT_CLASS
 
-    // Global function to look up requirement by ID
+    DOC( "Requirement definitions and lookup helpers." );
+    luna::userlib lib = luna::begin_lib( lua, "requirements" );
+
     DOC( "Look up requirement_data by ID string. Returns nil if not found." );
-    lua.set_function( "get_requirement", []( const std::string & id_str ) ->
-    std::optional<requirement_data> {
+    luna::set_fx( lib, "get", []( const std::string & id_str ) -> std::optional<requirement_data> {
         requirement_id id( id_str );
         if( id.is_valid() )
         {
@@ -76,4 +77,6 @@ void cata::detail::reg_requirement( sol::state &lua )
         }
         return std::nullopt;
     } );
+
+    luna::finalize_lib( lib );
 }

--- a/src/catalua_luna.h
+++ b/src/catalua_luna.h
@@ -4,6 +4,8 @@
 #include <functional>
 #include <map>
 #include <set>
+#include <stdexcept>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
@@ -68,6 +70,7 @@ constexpr std::string_view KEY_DOCTABLE = "catadoc";
 constexpr std::string_view KEY_BASES = "#bases";
 constexpr std::string_view KEY_CONSTRUCT = "#construct";
 constexpr std::string_view KEY_MEMBER = "#member";
+constexpr std::string_view KEY_MEMBER_NAMES = "#member_names";
 constexpr std::string_view KEY_MEMBER_TYPE = "type";
 constexpr std::string_view KEY_MEMBER_COMMENT = "comment";
 constexpr std::string_view KEY_MEMBER_VARIABLE_TYPE = "vartype";
@@ -119,6 +122,45 @@ inline void add_comment( sol::table &dt, std::string_view key )
 }
 
 
+
+template<typename Key>
+auto member_key_name( const Key &key ) -> std::string
+{
+    if constexpr( std::is_same_v<std::remove_cv_t<Key>, sol::meta_function> ) {
+        return sol::to_string( key );
+    } else if constexpr( std::is_constructible_v<std::string_view, const Key &> ) {
+        return std::string( std::string_view( key ) );
+    }
+    return "<non-string>";
+}
+
+inline auto member_key_name( const sol::object &key ) -> std::string
+{
+    if( key.is<std::string>() ) {
+        return key.as<std::string>();
+    }
+    if( key.is<sol::meta_function>() ) {
+        return sol::to_string( key.as<sol::meta_function>() );
+    }
+    return "<non-string>";
+}
+
+template<typename Key>
+auto require_unique_member( sol::table &owner_dt, const Key &key ) -> void
+{
+    const auto key_name = member_key_name( key );
+    sol::state_view lua( owner_dt.lua_state() );
+    sol::table member_names = owner_dt[KEY_MEMBER_NAMES].get_or( sol::table() );
+    if( !member_names.valid() ) {
+        member_names = lua.create_table();
+        owner_dt[KEY_MEMBER_NAMES] = member_names;
+    }
+    if( member_names[key_name].get_or( false ) ) {
+        throw std::runtime_error( string_format(
+                                      "Duplicate Lua binding registration for member '%s'", key_name ) );
+    }
+    member_names[key_name] = true;
+}
 
 template<typename Val>
 struct doc_typename;
@@ -589,14 +631,16 @@ void set_fx(
     Func value
 )
 {
+    sol::state_view lua( ut.lua_state() );
+    sol::table type_dt = detail::get_type_doctable<Class>( lua );
+    detail::require_unique_member( type_dt, key );
+
     // Due to a bug in sol2, on GCC build protected function call may call wrong lambda
     // https://github.com/ThePhD/sol2/issues/1444
     // This happens if we register with table.set( key, func ), but for
     // some reason table[key] = func makes it work fine.
     ut[ key ] = std::forward<Func>( value );
 
-    sol::state_view lua( ut.lua_state() );
-    sol::table type_dt = detail::get_type_doctable<Class>( lua );
     sol::table member_dt = detail::make_type_member_doctable( type_dt, key );
     detail::doc_member_fx<Class>( member_dt, sol::types<Func>() );
 }
@@ -608,10 +652,11 @@ void set(
     Value &&value
 )
 {
-    ut[ key ] = std::forward<Value>( value );
-
     sol::state_view lua( ut.lua_state() );
     sol::table type_dt = detail::get_type_doctable<Class>( lua );
+    detail::require_unique_member( type_dt, key );
+    ut[ key ] = std::forward<Value>( value );
+
     sol::table member_dt = detail::make_type_member_doctable( type_dt, key );
     detail::doc_member<Class>( member_dt, sol::types<Value>() );
 }
@@ -626,6 +671,9 @@ void set_prop(
 {
     using std_function_type = decltype( std::function{std::forward<Getter>( get )} );
     using Value = std_function_type::result_type;
+    sol::state_view lua( ut.lua_state() );
+    sol::table type_dt = detail::get_type_doctable<Class>( lua );
+    detail::require_unique_member( type_dt, key );
     ut[ key ] = sol::property( std::forward<Getter>( get ), std::forward<Setter>( set ) );
     detail::doc_member_fake<Value, Class>( ut, key );
 }
@@ -640,6 +688,9 @@ void set_prop(
 {
     using std_function_type = decltype( std::function{std::forward<Getter>( get )} );
     using Value = std_function_type::result_type;
+    sol::state_view lua( ut.lua_state() );
+    sol::table type_dt = detail::get_type_doctable<Class>( lua );
+    detail::require_unique_member( type_dt, key );
     ut[ key ] = sol::property( std::forward<Getter>( get ) );
     detail::doc_member_fake<Value, Class>( ut, key );
 }
@@ -753,13 +804,14 @@ void set_fx(
     Func value
 )
 {
+    detail::require_unique_member( lib.dt, key );
+
     // Due to a bug in sol2, on GCC build protected function call may call wrong lambda
     // https://github.com/ThePhD/sol2/issues/1444
     // This happens if we register with table.set( key, func ), but for
     // some reason table[key] = func makes it work fine.
     lib.t[ key ] = std::forward<Func>( value );
 
-    sol::state_view lua( lib.t.lua_state() );
     sol::table member_dt = detail::make_type_member_doctable( lib.dt, key );
     detail::doc_free_fx( member_dt, sol::types<Func>() );
 }
@@ -771,9 +823,9 @@ void set(
     Value &&value
 )
 {
+    detail::require_unique_member( lib.dt, key );
     lib.t[ key ] = value;
 
-    sol::state_view lua( lib.t.lua_state() );
     sol::table member_dt = detail::make_type_member_doctable( lib.dt, key );
     detail::doc_free( member_dt, value );
 }

--- a/src/catalua_luna.h
+++ b/src/catalua_luna.h
@@ -157,7 +157,8 @@ auto require_unique_member( sol::table &owner_dt, const Key &key ) -> void
     }
     if( member_names[key_name].get_or( false ) ) {
         throw std::runtime_error( string_format(
-                                      "Duplicate Lua binding registration for member '%s'", key_name ) );
+                                      "Duplicate Lua binding registration for member '%s'; use a single sol::overload(...) registration for overloads",
+                                      key_name ) );
     }
     member_names[key_name] = true;
 }

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -486,6 +486,30 @@ TEST_CASE( "lua_typed_coords_projection", "[lua]" )
     CHECK( test_data.get<std::string>( "raw_delta_arithmetic" ) == "TripointAbsSm(364,2,-1)" );
 }
 
+TEST_CASE( "voltmeter_lua_uses_typed_coordinates", "[lua][voltmeter]" )
+{
+    auto lua = make_lua_state();
+    auto test_data = lua.create_table();
+    lua.globals()["test_data"] = test_data;
+
+    run_lua_test_script( lua, "voltmeter_test.lua" );
+
+    CHECK( test_data.get<bool>( "charge_ok" ) );
+    CHECK( test_data.get<std::string>( "charge_info_type" ) == "string" );
+    CHECK( test_data.get<bool>( "connections_ok" ) );
+    CHECK( test_data.get<std::string>( "connections_info_type" ) == "string" );
+}
+
+TEST_CASE( "luna_rejects_duplicate_member_registration", "[lua]" )
+{
+    auto lua = make_lua_state();
+    auto lib = luna::begin_lib( lua, "duplicate_member_test" );
+    luna::set_fx( lib, "same_name", []() -> int { return 1; } );
+    CHECK_THROWS_WITH( luna::set_fx( lib, "same_name", []() -> int { return 2; } ),
+                       Catch::Contains( "Duplicate Lua binding registration" ) );
+    luna::finalize_lib( lib );
+}
+
 TEST_CASE( "lua_coord_cpp_helpers", "[lua]" )
 {
     auto lua = make_lua_state();

--- a/tests/lua/voltmeter_test.lua
+++ b/tests/lua/voltmeter_test.lua
@@ -1,0 +1,13 @@
+package.path = package.path .. ";data/json/?.lua"
+package.loaded["lua.iuse.voltmeter"] = nil
+
+local voltmeter = require("lua/iuse/voltmeter")
+local pos = TripointBubMs.new(60, 60, 0)
+
+local charge_ok, charge_info = pcall(function() return voltmeter.get_grid_charge_info(nil, nil, pos) end)
+local connections_ok, connections_info = pcall(function() return voltmeter.get_grid_connections_info(nil, nil, pos) end)
+
+test_data["charge_ok"] = charge_ok
+test_data["charge_info_type"] = type(charge_info)
+test_data["connections_ok"] = connections_ok
+test_data["connections_info_type"] = type(connections_info)


### PR DESCRIPTION
## Purpose of change (The Why)

close #9524
close #9497

Follow-up to #9414: duplicate Lua registrations hid the `TripointBubMs` overload used by voltmeter/sonar.

## Describe the solution (The How)

- Reject duplicate Luna member registrations.
- Register same-name Lua overloads with `sol::overload`.
- Add a voltmeter Lua regression test.
- Promote `param-type-mismatch` and `undefined-field` to EmmyLua errors and fix current hits.

## Testing

- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[lua]"`
- `emmylua_check .`
- `./out/build/linux-full/src/cataclysm-bn-tiles --dont-debugmsg --check-mods`

## Checklist

### Mandatory

- [x] I linked any relevant issues using github keyword syntax.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.
- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added `lua` scope to the PR title.
  - [x] I have added type annotations to functions so that it's safe and easy to maintain.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [01049d7](https://github.com/cataclysmbn/Cataclysm-BN/commit/01049d7238ab26daa73981023ceee0570cfbd199) (fix(lua): resolve typecheck suppressions at source) on 2026-06-16 15:56:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27626397740/artifacts/7671133010)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27626397740)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27626397740/artifacts/7671448646)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27626397740/artifacts/7671226456)
<!-- END artifact comment -->