### PR TITLE
fix: fix auto-drive not working

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1202,6 +1202,9 @@ autodrive_result vehicle::do_autodrive( Character &driver )
         stop_autodriving( false );
         return autodrive_result::abort;
     }
+    if( driver.is_avatar() ) {
+        g->refresh_player_visibility_cache_if_needed();
+    }
     const tripoint_abs_ms veh_pos = abs_ms_location();
     const tripoint_abs_omt veh_omt = project_to<coords::omt>( veh_pos );
     std::vector<tripoint_abs_omt> &omt_path = driver.omt_path;

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "avatar.h"
+#include "calendar.h"
 #include "cata_utility.h"
 #include "coordinates.h"
 #include "creature_tracker.h"
@@ -362,6 +363,35 @@ TEST_CASE( "vehicle speed control free in cruise mode", "[vehicle][speed]" )
     veh_ptr->pldrive( you, tripoint_rel_veh{ 0, 1, 0 } );
 
     CHECK( you.get_moves() == 25 );
+}
+
+TEST_CASE( "can autodrive", "[vehicle][autodrive]" )
+{
+    clear_all_state();
+    set_time( calendar::turn_zero + 12_hours );
+
+    auto &here = get_map();
+    auto &you = get_avatar();
+    const auto origin = tripoint_bub_ms( 60, 60, 0 );
+    you.setpos( origin );
+    you.set_moves( 1000 );
+
+    auto *veh_ptr = here.add_vehicle( vproto_id( "car" ), origin, 0_degrees, 100, 0, true, false,
+                                      true );
+    REQUIRE( veh_ptr != nullptr );
+    here.board_vehicle( origin, &you );
+    veh_ptr->start_engines( true, true );
+    veh_ptr->engine_on = true;
+    REQUIRE( veh_ptr->player_in_control( you ) );
+
+    const auto current_omt = project_to<coords::omt>( veh_ptr->abs_ms_location() );
+    you.omt_path = { current_omt + tripoint_rel_omt( 1, 0, 0 ) };
+    veh_ptr->is_autodriving = true;
+
+    here.invalidate_visibility_caches();
+    REQUIRE( here.visibility_caches_dirty() );
+
+    CHECK( veh_ptr->do_autodrive( you ) == autodrive_result::ok );
 }
 
 TEST_CASE( "horde_spawns_skip_owned_vehicle_tiles", "[horde][vehicle][monster]" )

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <sstream>
 #include <string>
@@ -374,6 +375,7 @@ TEST_CASE( "can autodrive", "[vehicle][autodrive]" )
     auto &you = get_avatar();
     const auto origin = tripoint_bub_ms( 60, 60, 0 );
     you.setpos( origin );
+    you.clear_map_memory();
     you.set_moves( 1000 );
 
     auto *veh_ptr = here.add_vehicle( vproto_id( "car" ), origin, 0_degrees, 100, 0, true, false,
@@ -385,6 +387,15 @@ TEST_CASE( "can autodrive", "[vehicle][autodrive]" )
     REQUIRE( veh_ptr->player_in_control( you ) );
 
     const auto current_omt = project_to<coords::omt>( veh_ptr->abs_ms_location() );
+    const auto memory_origin = project_to<coords::ms>( current_omt );
+    // Keep path planning deterministic; the regression check is the dirty live visibility cache.
+    using namespace std::views;
+    constexpr auto omt_size = coords::map_squares_per( coords::omt );
+    for( const auto x : iota( 0, omt_size * 2 ) ) {
+        for( const auto y : iota( 0, omt_size ) ) {
+            you.memorize_tile( memory_origin + tripoint_rel_ms( x, y, 0 ), "t_grass", 0, 0 );
+        }
+    }
     you.omt_path = { current_omt + tripoint_rel_omt( 1, 0, 0 ) };
     veh_ptr->is_autodriving = true;
 


### PR DESCRIPTION
## Purpose of change (The Why)

close #9523

Auto-drive could cancel in clear visibility because the SDL visibility cache is dirty before activity processing.

## Describe the solution (The How)

- Refresh the avatar visibility cache on demand before auto-drive checks sight.
- Add `can autodrive` regression coverage for a dirty visibility cache.
- Keep the refresh scoped to active avatar auto-driving and behind the existing dirty-cache guard; this does not restore the broader per-turn refresh removed by #9519.

## Testing

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/5c213aa0-b04e-41fa-ba74-3c228af0b327" />

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [72120ac](https://github.com/cataclysmbn/Cataclysm-BN/commit/72120acb5cd94e1b5f8d958a6a3dfe5084dd44dd) (test: stabilize autodrive coverage) on 2026-06-17 13:49:00

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27689711807/artifacts/7696887617)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27689711807/artifacts/7696687511)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27689711807/artifacts/7695875778)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27689711807/artifacts/7695966183)
<!-- END artifact comment -->