### PR TITLE
feat(balance): move krakens to a dedicated location

### DIFF
--- a/data/json/mapgen/lake_buildings/kraken_lair.json
+++ b/data/json/mapgen/lake_buildings/kraken_lair.json
@@ -32,9 +32,7 @@
         "                        ",
         "                        "
       ],
-      "terrain": {
-        "~": "t_water_dp"
-      },
+      "terrain": { "~": "t_water_dp" },
       "furniture": {
         " ": [ [ "f_null", 18 ], "f_wreckage", "f_rubble_landfill" ],
         "?": [ [ "f_null", 2 ], "f_wreckage", "f_rubble_landfill" ],

--- a/data/json/mapgen/lake_buildings/kraken_lair.json
+++ b/data/json/mapgen/lake_buildings/kraken_lair.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "kraken_lair",
+    "weight": 75,
+    "object": {
+      "fill_ter": "t_water_dp",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "      ???      ???      ",
+        "     ?%%%?    ?%%%?     ",
+        "     ?%??      ??%?     ",
+        "     ?%?        ?%?     ",
+        "    ?%%?        ?%%?    ",
+        "    ?%?          ?%?    ",
+        "    ?%?          ?%?    ",
+        "   ?%%?    ~~    ?%%?   ",
+        "   ?%?    ~~~~    ?%?   ",
+        "   ?%?    ~~~~    ?%?   ",
+        "   ?%%?    ~~    ?%%?   ",
+        "    ?%?          ?%?    ",
+        "    ?%?          ?%?    ",
+        "    ?%%?        ?%%?    ",
+        "     ?%?        ?%?     ",
+        "     ?%??      ??%?     ",
+        "     ?%%%?    ?%%%?     ",
+        "      ???      ???      ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": {
+        "~": "t_water_dp"
+      },
+      "furniture": {
+        " ": [ [ "f_null", 18 ], "f_wreckage", "f_rubble_landfill" ],
+        "?": [ [ "f_null", 2 ], "f_wreckage", "f_rubble_landfill" ],
+        "%": [ "f_wreckage", "f_rubble_landfill" ]
+      },
+      "items": {
+        "?": { "item": "lake_bed", "chance": 25 },
+        "%": [ { "item": "lake_bed", "chance": 25, "repeat": 2 }, { "item": "rare", "chance": 5 } ]
+      },
+      "place_monster": [ { "monster": "mon_kraken_boss", "x": 12, "y": 12 } ]
+    }
+  }
+]

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -2209,7 +2209,6 @@
         "pack_size": [ 1, 3 ]
       },
       { "monster": "mon_fish_blinky", "freq": 5, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
-      { "monster": "mon_kraken_boss", "freq": 1, "cost_multiplier": 3 },
       { "monster": "mon_dragonfly_naiad", "freq": 50, "cost_multiplier": 2, "pack_size": [ 1, 3 ] }
     ]
   },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -6613,9 +6613,7 @@
   {
     "type": "overmap_special",
     "id": "Kraken Lair",
-    "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "kraken_lair_north" }
-    ],
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "kraken_lair_north" } ],
     "locations": [ "lake_surface" ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "LAKE" ]

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -6609,5 +6609,15 @@
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 8 ],
     "flags": [ "CLASSIC", "MAN_MADE" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "Kraken Lair",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "kraken_lair_north" }
+    ],
+    "locations": [ "lake_surface" ],
+    "occurrences": [ 0, 2 ],
+    "flags": [ "CLASSIC", "LAKE" ]
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waterbody.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waterbody.json
@@ -102,5 +102,15 @@
     "copy-from": "cargo_ship_a",
     "name": "sunken ship",
     "color": "brown"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "kraken_lair",
+    "name": "kraken nest",
+    "sym": "K",
+    "color": "red",
+    "looks_like": "shipwreck_river_1",
+    "see_cost": 5,
+    "flags": [ "RISK_HIGH" ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fixes the issue of krakens just randomly showing up in waterways unannounced and kicking your ass.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Adds a new overmap special to lakes littered with wreckage, with some potential for rare items buried under the floating rubble, that spawns the kraken.
2. Accordingly, removed krakens from `GROUP_RIVER`.

## Describe alternatives you've considered

Giant Enemy Crab

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

<img width="981" height="909" alt="image" src="https://github.com/user-attachments/assets/f9aac7ae-31cc-4100-b493-69d228bfd742" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Plan to later on maybe add dedicated wreck versions of some boats that spawn torn in half to spawn here, but for now just adds the lair itself so it stops being a menace.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4bb7608](https://github.com/cataclysmbn/Cataclysm-BN/commit/4bb76082da6ebf6a8f806c277a7a941aec278664) (I forgor) on 2026-06-17 05:39:00

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27665236908/artifacts/7686482564)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27665236908/artifacts/7686917330)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27665236908/artifacts/7686005718)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27665236908/artifacts/7686052554)
<!-- END artifact comment -->