### PR TITLE
fix: remove basement lab spawn for basement dweller scenario

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -888,7 +888,6 @@
       "sloc_basement_bionic",
       "sloc_basement_game",
       "sloc_basement_chem",
-      "sloc_basement_hidden_lab",
       "sloc_basement_meth",
       "sloc_basement_messed",
       "sloc_basement_survival",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Basement labs are currently soft-obseleted and do not naturally spawn, thus causing errors if the player does basement dweller and picks the basement lab start.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Removes the basement lab starting location from the list.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Bugs
## Testing
Loaded in, made custom character, basement lab option no longer available.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
suggested by anime pfp T_T
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [de940e6](https://github.com/cataclysmbn/Cataclysm-BN/commit/de940e67e0182e2ccddb135c9c25725c0d94ddf9) (Update scenarios.json) on 2026-06-17 06:42:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27666493388/artifacts/7686872062)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27666493388/artifacts/7687841605)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27666493388/artifacts/7686823150)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27666493388/artifacts/7687117966)
<!-- END artifact comment -->