### PR TITLE
feat(mods): bundle Transformers registry mod

### DIFF
--- a/data/mods/external.json
+++ b/data/mods/external.json
@@ -10,6 +10,11 @@
     "url": "https://github.com/NobleJake/ProjectPackRat/archive/refs/heads/main.zip"
   },
   {
+    "id": "ny_transformers",
+    "version": "2.2.0",
+    "url": "https://github.com/NobleJake/ProjectPackRat/archive/refs/heads/main.zip"
+  },
+  {
     "id": "otopack_bn_mk_2",
     "version": "2026.2.12",
     "url": "https://github.com/NarandBD/Otopack-BN-Mk-2/archive/refs/tags/sorrynotsorry.zip"


### PR DESCRIPTION
## Purpose of change (The Why)

request from @NobleJake 

Bundle Transformers from the BN mod registry in release builds.

Source: https://mods.cataclysmbn.org/mods/ny_transformers/

## Describe the solution (The How)

- Add the `ny_transformers` 2.2.0 lock to `data/mods/external.json`.

## Testing

- `deno fmt data/mods/external.json`
- `deno test --allow-read --allow-write --allow-net build-scripts/bundle-registry-mods_test.ts`
- Temp bundle with `build-scripts/bundle-registry-mods.ts --exclude-package-type soundpack`; confirmed `data/mods/transformers_beta2.2/modinfo.json` was extracted.

## Checklist

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.
- [x] This PR adds/removes a mod.
  - [x] I have added `mods` scope to the PR title.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [414488a](https://github.com/cataclysmbn/Cataclysm-BN/commit/414488a62fbdb7144a36db77a9508a6220981472) (feat(mods): bundle Transformers registry mod) on 2026-06-17 08:06:17

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27672392790/artifacts/7688670752)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27672392790/artifacts/7689399211)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27672392790/artifacts/7688674785)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27672392790/artifacts/7688789662)
<!-- END artifact comment -->