### PR TITLE
ci: use git for PR changed-file detection

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -131,11 +131,19 @@ jobs:
         if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           sparse-checkout: |
             docs
             scripts/docs_translation_warning.ts
+            scripts/git_changed_files.ts
             deno.jsonc
             deno.lock
+
+      - name: Fetch pull request head for docs warning
+        if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
+        run: |
+          git fetch --no-tags --filter=blob:none origin \
+            +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/pull/${{ github.event.pull_request.number }}/head
 
       - name: Setup Deno for docs warning
         if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
@@ -145,8 +153,11 @@ jobs:
       - name: Update docs translation PR body
         if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: deno task docs:translation-warning ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          deno task docs:translation-warning ${{ github.event.pull_request.number }} \
+            --base ${{ github.event.pull_request.base.sha }} \
+            --head refs/remotes/pull/${{ github.event.pull_request.number }}/head
 
       - name: Comment and close pull request
         if: >-

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -42,6 +42,7 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
 
       - name: install dependencies
         run: |
@@ -118,7 +119,7 @@ jobs:
       #     clang-tidy --version
 
       - name: gather affected files
-        run: deno task affected-files ${{ github.event.pull_request.number }} --output "$AFFECTED_FILES"
+        run: deno task affected-files --base ${{ github.event.pull_request.base.sha }} --head HEAD --output "$AFFECTED_FILES"
 
       - name: run clang-tidy
         run: bash ./build-scripts/run-clang-tidy-plugin.sh

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -21,8 +21,8 @@
       "description": "update available semantic commit types",
       "command": "deno run -R=data/mods -W=.github/semantic.yml scripts/semantic.ts",
     },
-    "docs:translation-warning": "deno run --allow-read=docs --allow-env=GITHUB_TOKEN,GITHUB_REPOSITORY --allow-net=api.github.com scripts/docs_translation_warning.ts",
-    "affected-files": "deno run -RWEN --allow-run scripts/affected_files.ts",
+    "docs:translation-warning": "deno run --allow-read=docs --allow-run=git,gh --allow-env=GH_TOKEN,GITHUB_TOKEN scripts/docs_translation_warning.ts",
+    "affected-files": "deno run --allow-read --allow-write --allow-run=git scripts/affected_files.ts",
   },
   "test": { "include": ["scripts", ".agents"] },
   "lint": {
@@ -45,7 +45,6 @@
     "$zod/": "https://deno.land/x/zod@v3.22.4/",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",
     "@deno-library/compress": "jsr:@deno-library/compress@^0.5.6",
-    "@octokit/rest": "npm:@octokit/rest@21.0.2",
     "@cliffy/flags": "jsr:@cliffy/flags@^1.0.0-rc.7",
     "@scarf/json-map": "jsr:@scarf/json-map@^0.0.4",
     "@std/assert": "jsr:@std/assert@^1.0.15",

--- a/deno.lock
+++ b/deno.lock
@@ -56,7 +56,6 @@
     "jsr:@valibot/valibot@^1.1.0": "1.1.0",
     "jsr:@zip-js/zip-js@2.7.53": "2.7.53",
     "jsr:@zip-js/zip-js@^2.8.26": "2.8.26",
-    "npm:@octokit/rest@21.0.2": "21.0.2",
     "npm:dprint@*": "0.47.5",
     "npm:json-order@*": "1.1.3",
     "npm:markdown-table@3.0.4": "3.0.4",
@@ -440,102 +439,6 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@octokit/auth-token@5.1.2": {
-      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="
-    },
-    "@octokit/core@6.1.6": {
-      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
-      "dependencies": [
-        "@octokit/auth-token",
-        "@octokit/graphql",
-        "@octokit/request",
-        "@octokit/request-error",
-        "@octokit/types@14.1.0",
-        "before-after-hook",
-        "universal-user-agent"
-      ]
-    },
-    "@octokit/endpoint@10.1.4": {
-      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
-      "dependencies": [
-        "@octokit/types@14.1.0",
-        "universal-user-agent"
-      ]
-    },
-    "@octokit/graphql@8.2.2": {
-      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
-      "dependencies": [
-        "@octokit/request",
-        "@octokit/types@14.1.0",
-        "universal-user-agent"
-      ]
-    },
-    "@octokit/openapi-types@24.2.0": {
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="
-    },
-    "@octokit/openapi-types@25.1.0": {
-      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
-    },
-    "@octokit/plugin-paginate-rest@11.6.0_@octokit+core@6.1.6": {
-      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
-      "dependencies": [
-        "@octokit/core",
-        "@octokit/types@13.10.0"
-      ]
-    },
-    "@octokit/plugin-request-log@5.3.1_@octokit+core@6.1.6": {
-      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
-      "dependencies": [
-        "@octokit/core"
-      ]
-    },
-    "@octokit/plugin-rest-endpoint-methods@13.5.0_@octokit+core@6.1.6": {
-      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
-      "dependencies": [
-        "@octokit/core",
-        "@octokit/types@13.10.0"
-      ]
-    },
-    "@octokit/request-error@6.1.8": {
-      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
-      "dependencies": [
-        "@octokit/types@14.1.0"
-      ]
-    },
-    "@octokit/request@9.2.4": {
-      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
-      "dependencies": [
-        "@octokit/endpoint",
-        "@octokit/request-error",
-        "@octokit/types@14.1.0",
-        "fast-content-type-parse",
-        "universal-user-agent"
-      ]
-    },
-    "@octokit/rest@21.0.2": {
-      "integrity": "sha512-+CiLisCoyWmYicH25y1cDfCrv41kRSvTq6pPWtRroRJzhsCZWZyCqGyI8foJT5LmScADSwRAnr/xo+eewL04wQ==",
-      "dependencies": [
-        "@octokit/core",
-        "@octokit/plugin-paginate-rest",
-        "@octokit/plugin-request-log",
-        "@octokit/plugin-rest-endpoint-methods"
-      ]
-    },
-    "@octokit/types@13.10.0": {
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
-      "dependencies": [
-        "@octokit/openapi-types@24.2.0"
-      ]
-    },
-    "@octokit/types@14.1.0": {
-      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
-      "dependencies": [
-        "@octokit/openapi-types@25.1.0"
-      ]
-    },
-    "before-after-hook@3.0.2": {
-      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
-    },
     "color-convert@2.0.1": {
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": [
@@ -576,9 +479,6 @@
       ],
       "scripts": true,
       "bin": true
-    },
-    "fast-content-type-parse@2.0.1": {
-      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
     },
     "is-arrayish@0.3.2": {
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
@@ -643,9 +543,6 @@
     },
     "type-fest@4.27.0": {
       "integrity": "sha512-3IMSWgP7C5KSQqmo1wjhKrwsvXAtF33jO3QY+Uy++ia7hqvgSK6iXbbg5PbDBc1P2ZbNEDgejOrN4YooXvhwCw=="
-    },
-    "universal-user-agent@7.0.3": {
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
     }
   },
   "redirects": {
@@ -909,7 +806,6 @@
       "jsr:@std/yaml@^1.0.10",
       "jsr:@valibot/valibot@^1.1.0",
       "jsr:@zip-js/zip-js@^2.8.26",
-      "npm:@octokit/rest@21.0.2",
       "npm:markdown-table@3.0.4"
     ]
   }

--- a/scripts/affected_files.ts
+++ b/scripts/affected_files.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-read --allow-write
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run=git --allow-env
 
 /**
  * @module
@@ -6,28 +6,19 @@
  * gets list of all affected files
  */
 
-import { walk, type WalkEntry, type WalkOptions } from "jsr:@std/fs"
 import { MuxAsyncIterator } from "jsr:@std/async"
 import { partition } from "jsr:@std/collections"
-import { Octokit, type RestEndpointMethodTypes } from "@octokit/rest"
+import { walk, type WalkEntry, type WalkOptions } from "jsr:@std/fs"
 import { Command } from "@cliffy/command"
+import { changedFilesFromGit, type PullFileStatus } from "./git_changed_files.ts"
 
 const paths = ["src", "tests"]
 
-type ListFileResponse = RestEndpointMethodTypes["pulls"]["listFiles"]["response"]["data"][number]
-
-const ACMRT: Set<ListFileResponse["status"]> = new Set(
-  ["added", "copied", "modified", "renamed", "changed"],
-)
-const octokit = new Octokit({ auth: Deno.env.get("GITHUB_TOKEN") })
-const getDiffs = async (pr: number) => {
-  const res = await octokit.paginate(
-    octokit.rest.pulls.listFiles,
-    { owner: "cataclysmbn", repo: "Cataclysm-BN", pull_number: pr },
-  )
+const ACMRT: Set<PullFileStatus> = new Set(["added", "copied", "modified", "renamed", "changed"])
+const getDiffs = async (base: string, head: string) => {
   const pathsFilter = new RegExp(`^(?:${paths.join("|")})/.*\\.(?:cpp|h|hpp)$`)
 
-  return res
+  return (await changedFilesFromGit({ base, head }))
     .filter((x) => ACMRT.has(x.status))
     .map((x) => x.filename)
     .filter((x) => pathsFilter.test(x))
@@ -71,12 +62,14 @@ const getAllDependencies = async (xs: WalkEntry[]): Promise<Deps> => {
 
 const main = new Command()
   .description("gets list of all affected files for use in clang-tidy.")
-  .arguments("<pr:number>")
+  .arguments("[pr:number]")
+  .option("--base <rev:string>", "Base git revision", { default: "origin/main" })
+  .option("--head <rev:string>", "Head git revision", { default: "HEAD" })
   .option("-o, --output <file>", "Output file to save template to")
-  .action(async ({ output }, pr) => {
+  .action(async ({ base, head, output }) => {
     const [deps, [headers, src]] = await Promise.all([
       getAllSourceFiles().then(getAllDependencies),
-      getDiffs(pr).then((xs) => partition(xs, (x) => x.endsWith(".h"))),
+      getDiffs(base, head).then((xs) => partition(xs, (x) => x.endsWith(".h"))),
     ])
     // console.log(deps)
     console.log({ src, headers })

--- a/scripts/docs_translation_warning.ts
+++ b/scripts/docs_translation_warning.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-read=docs --allow-env=GITHUB_TOKEN,GITHUB_REPOSITORY --allow-net=api.github.com
+#!/usr/bin/env -S deno run --allow-read=docs --allow-run=git,gh --allow-env=GH_TOKEN,GITHUB_TOKEN
 
 /**
  * @module
@@ -6,9 +6,10 @@
  * Updates PR bodies when localized docs changed without every tracked language variant.
  */
 
+import { Command } from "@cliffy/command"
 import { walk } from "@std/fs"
-import { Octokit, type RestEndpointMethodTypes } from "@octokit/rest"
 import { markdownTable } from "markdown-table"
+import { changedFilesFromGit, type PullFile } from "./git_changed_files.ts"
 
 const beginMarker = "<!-- BEGIN docs comment -->"
 const endMarker = "<!-- END docs comment -->"
@@ -16,10 +17,7 @@ const markerPattern = new RegExp(`\n*${beginMarker}[\\s\\S]*?${endMarker}\\s*`, 
 const changedStatuses = new Set(["added", "modified", "removed", "renamed", "changed"])
 const trackedLanguages = ["en", "ja", "ko"]
 
-type PullFile = Pick<
-  RestEndpointMethodTypes["pulls"]["listFiles"]["response"]["data"][number],
-  "filename" | "previous_filename" | "status"
->
+export type { PullFile }
 type DocPath = { lang: string; path: string }
 export type TranslationWarning = {
   path: string
@@ -27,6 +25,9 @@ export type TranslationWarning = {
   stale: string[]
   missing: string[]
 }
+
+const decoder = new TextDecoder()
+const encoder = new TextEncoder()
 
 const docPaths = (paths: (string | undefined)[]): DocPath[] =>
   paths.flatMap((file) => {
@@ -86,26 +87,70 @@ const withTranslationBlock = (body: string, block: string | undefined): string =
   return block === undefined ? cleanBody : [cleanBody, block].filter(Boolean).join("\n\n")
 }
 
-if (import.meta.main) {
-  const token = Deno.env.get("GITHUB_TOKEN")
-  const [owner, repo] = Deno.env.get("GITHUB_REPOSITORY")?.split("/") ?? []
-  const pr = Number(Deno.args[0])
-  if (!token) throw new Error("GITHUB_TOKEN is required")
-  if (!owner || !repo) throw new Error("GITHUB_REPOSITORY must be owner/repo")
-  if (!Number.isInteger(pr)) throw new Error("PR number is required")
+const run = async (
+  command: string,
+  args: string[],
+  input?: string,
+  env?: Record<string, string>,
+): Promise<string> => {
+  const process = new Deno.Command(command, {
+    args,
+    clearEnv: env !== undefined,
+    env,
+    stdin: input === undefined ? "null" : "piped",
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn()
+  if (input !== undefined) {
+    const writer = process.stdin.getWriter()
+    await writer.write(encoder.encode(input))
+    await writer.close()
+  }
+  const { success, stdout, stderr } = await process.output()
+  if (!success) {
+    const message = decoder.decode(stderr).trim()
+    throw new Error(`${command} ${args.join(" ")} failed${message ? `: ${message}` : ""}`)
+  }
+  return decoder.decode(stdout)
+}
 
-  const octokit = new Octokit({ auth: token })
-  const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
-    owner,
-    repo,
-    pull_number: pr,
-    per_page: 100,
-  })
-  const block = renderTranslationBlock(
-    findTranslationWarnings(files, trackedLanguages, await existingDocPaths()),
+const ghEnv = (): Record<string, string> | undefined => {
+  const token = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN")
+  return token === undefined ? undefined : { GH_TOKEN: token }
+}
+
+const readPrBody = async (pr: number): Promise<string> =>
+  (await run(
+    "gh",
+    ["pr", "view", String(pr), "--json", "body", "--jq", ".body"],
+    undefined,
+    ghEnv(),
+  ))
+    .trimEnd()
+
+const updatePrBody = async (pr: number, body: string): Promise<void> => {
+  await run("gh", ["pr", "edit", String(pr), "--body-file", "-"], body, ghEnv())
+}
+
+const main = new Command()
+  .description(
+    "updates PR bodies when localized docs changed without every tracked language variant.",
   )
-  const { data } = await octokit.rest.pulls.get({ owner, repo, pull_number: pr })
-  const oldBody = data.body ?? ""
-  const body = withTranslationBlock(oldBody, block)
-  if (body !== oldBody) await octokit.rest.pulls.update({ owner, repo, pull_number: pr, body })
+  .arguments("<pr:number>")
+  .option("--base <rev:string>", "Base git revision", { default: "origin/main" })
+  .option("--head <rev:string>", "Head git revision", { default: "HEAD" })
+  .action(async ({ base, head }, pr) => {
+    const files = await changedFilesFromGit({ base, head })
+    if (files.flatMap(changedDocPaths).length === 0) return
+
+    const block = renderTranslationBlock(
+      findTranslationWarnings(files, trackedLanguages, await existingDocPaths()),
+    )
+    const oldBody = await readPrBody(pr)
+    const body = withTranslationBlock(oldBody, block)
+    if (body !== oldBody) await updatePrBody(pr, body)
+  })
+
+if (import.meta.main) {
+  await main.parse(Deno.args)
 }

--- a/scripts/git_changed_files.ts
+++ b/scripts/git_changed_files.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env -S deno run --allow-run=git
+
+/**
+ * @module
+ *
+ * Lists pull request file changes using the local git checkout.
+ */
+
+export type PullFileStatus = "added" | "copied" | "modified" | "removed" | "renamed" | "changed"
+
+export type PullFile = {
+  filename: string
+  previous_filename?: string
+  status: PullFileStatus
+}
+
+export type ChangedFilesOptions = {
+  base?: string
+  head?: string
+}
+
+const decoder = new TextDecoder()
+
+const runGit = async (args: string[]): Promise<string> => {
+  const command = new Deno.Command("git", {
+    args,
+    clearEnv: true,
+    stdout: "piped",
+    stderr: "piped",
+  })
+  const { success, stdout, stderr } = await command.output()
+  if (!success) {
+    const message = decoder.decode(stderr).trim()
+    throw new Error(`git ${args.join(" ")} failed${message ? `: ${message}` : ""}`)
+  }
+  return decoder.decode(stdout)
+}
+
+const parseGitStatus = (status: string): PullFileStatus => {
+  switch (status[0]) {
+    case "A":
+      return "added"
+    case "C":
+      return "copied"
+    case "D":
+      return "removed"
+    case "M":
+      return "modified"
+    case "R":
+      return "renamed"
+    default:
+      return "changed"
+  }
+}
+
+export const parseGitNameStatus = (output: string): PullFile[] =>
+  output.trim().split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [status, firstPath, secondPath] = line.split("\t")
+      if ((status.startsWith("R") || status.startsWith("C")) && secondPath !== undefined) {
+        return {
+          filename: secondPath,
+          previous_filename: firstPath,
+          status: parseGitStatus(status),
+        }
+      }
+      return { filename: firstPath, status: parseGitStatus(status) }
+    })
+
+export const changedFilesFromGit = async (
+  { base = "origin/main", head = "HEAD" }: ChangedFilesOptions = {},
+): Promise<PullFile[]> => {
+  const output = await runGit([
+    "diff",
+    "--name-status",
+    "--find-renames",
+    "--find-copies",
+    `${base}...${head}`,
+  ])
+  return parseGitNameStatus(output)
+}

--- a/scripts/git_changed_files_test.ts
+++ b/scripts/git_changed_files_test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "@std/assert"
+import { parseGitNameStatus } from "./git_changed_files.ts"
+
+Deno.test("parseGitNameStatus() maps native git status output to PR file shape", () => {
+  assertEquals(
+    parseGitNameStatus([
+      "A\tdocs/en/new.md",
+      "M\tsrc/foo.cpp",
+      "D\tdocs/ko/old.md",
+      "R100\tdocs/en/before.md\tdocs/en/after.md",
+      "C075\tsrc/original.cpp\tsrc/copied.cpp",
+      "T\tdata/file.json",
+    ].join("\n")),
+    [
+      { filename: "docs/en/new.md", status: "added" },
+      { filename: "src/foo.cpp", status: "modified" },
+      { filename: "docs/ko/old.md", status: "removed" },
+      { filename: "docs/en/after.md", previous_filename: "docs/en/before.md", status: "renamed" },
+      { filename: "src/copied.cpp", previous_filename: "src/original.cpp", status: "copied" },
+      { filename: "data/file.json", status: "changed" },
+    ],
+  )
+})


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #9535: the docs translation warning step can fail non-doc PRs while asking GitHub for PR files/body.

## Describe the solution (The How)

- Replace Octokit PR file listing with `git diff --name-status --find-renames --find-copies`.
- Share the git changed-file parser between clang-tidy and docs warning scripts.
- Fetch PR refs in actions so scripts can diff local commits.
- Skip PR body reads/edits when no docs changed.
- Remove `@octokit/rest`.

## Testing

- `deno fmt scripts/git_changed_files.ts scripts/git_changed_files_test.ts scripts/affected_files.ts scripts/docs_translation_warning.ts scripts/docs_translation_warning_test.ts deno.jsonc .github/workflows/clang-tidy.yml .github/workflows/autofix.yml`
- `deno check --lock deno.lock scripts/affected_files.ts scripts/docs_translation_warning.ts scripts/git_changed_files.ts`
- `deno test scripts/git_changed_files_test.ts scripts/docs_translation_warning_test.ts`
- `deno lint scripts/affected_files.ts scripts/docs_translation_warning.ts scripts/git_changed_files.ts scripts/git_changed_files_test.ts scripts/docs_translation_warning_test.ts`
- `deno task affected-files --base upstream/main --head HEAD --output /tmp/affected-files.txt`
- `deno task docs:translation-warning 9535 --base upstream/main --head HEAD`
- `actionlint .github/workflows/autofix.yml .github/workflows/clang-tidy.yml`

## Checklist

### Mandatory

- [x] No tracked issue; follow-up to #9535 CI failure.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [18dd190](https://github.com/cataclysmbn/Cataclysm-BN/commit/18dd1909e4f60725e8838b2b10d3c2a118805473) (ci: use git for PR changed files) on 2026-06-17 14:21:15

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27691467642/artifacts/7697700024)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27691467642/artifacts/7697500561)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27691467642/artifacts/7696634098)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27691467642/artifacts/7696759902)
<!-- END artifact comment -->