### PR TITLE
ci: avoid full fetch for PR file detection

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -131,7 +131,7 @@ jobs:
         if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           sparse-checkout: |
             docs
             scripts/docs_translation_warning.ts
@@ -139,11 +139,11 @@ jobs:
             deno.jsonc
             deno.lock
 
-      - name: Fetch pull request head for docs warning
+      - name: Fetch pull request merge for docs warning
         if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
         run: |
-          git fetch --no-tags --filter=blob:none origin \
-            +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/pull/${{ github.event.pull_request.number }}/head
+          git fetch --no-tags --filter=blob:none --depth=2 origin \
+            +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup Deno for docs warning
         if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
@@ -157,7 +157,7 @@ jobs:
         run: |
           deno task docs:translation-warning ${{ github.event.pull_request.number }} \
             --base ${{ github.event.pull_request.base.sha }} \
-            --head refs/remotes/pull/${{ github.event.pull_request.number }}/head
+            --head refs/remotes/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Comment and close pull request
         if: >-

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with: { fetch-depth: 2 }
 
       - name: install dependencies
         run: |

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -21,8 +21,8 @@
       "description": "update available semantic commit types",
       "command": "deno run -R=data/mods -W=.github/semantic.yml scripts/semantic.ts",
     },
-    "docs:translation-warning": "deno run --allow-read=docs --allow-run=git,gh --allow-env=GH_TOKEN,GITHUB_TOKEN scripts/docs_translation_warning.ts",
-    "affected-files": "deno run --allow-read --allow-write --allow-run=git scripts/affected_files.ts",
+    "docs:translation-warning": "deno run --allow-read --allow-run=git,gh --allow-env=GH_TOKEN,GITHUB_TOKEN,PATH scripts/docs_translation_warning.ts",
+    "affected-files": "deno run --allow-read --allow-write --allow-run=git --allow-env=PATH scripts/affected_files.ts",
   },
   "test": { "include": ["scripts", ".agents"] },
   "lint": {
@@ -44,6 +44,7 @@
     "$outdent/": "https://deno.land/x/outdent@v0.8.0/",
     "$zod/": "https://deno.land/x/zod@v3.22.4/",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",
+    "@david/dax": "jsr:@david/dax",
     "@deno-library/compress": "jsr:@deno-library/compress@^0.5.6",
     "@cliffy/flags": "jsr:@cliffy/flags@^1.0.0-rc.7",
     "@scarf/json-map": "jsr:@scarf/json-map@^0.0.4",

--- a/deno.lock
+++ b/deno.lock
@@ -794,6 +794,7 @@
     "dependencies": [
       "jsr:@cliffy/command@^1.0.0-rc.7",
       "jsr:@cliffy/flags@^1.0.0-rc.7",
+      "jsr:@david/dax@*",
       "jsr:@deno-library/compress@~0.5.6",
       "jsr:@scarf/json-map@^0.0.4",
       "jsr:@std/assert@^1.0.15",

--- a/scripts/dax.ts
+++ b/scripts/dax.ts
@@ -1,0 +1,22 @@
+/**
+ * @module
+ *
+ * Shared Dax instance for scripts that need restricted subprocess permissions.
+ */
+
+import { build$ } from "@david/dax"
+
+const pathEnv = (): Record<string, string> => {
+  try {
+    return { PATH: Deno.env.get("PATH") ?? "" }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotCapable) return {}
+    throw error
+  }
+}
+
+const $ = build$({
+  commandBuilder: (builder) => builder.clearEnv().env(pathEnv()),
+})
+
+export default $

--- a/scripts/docs_translation_warning.ts
+++ b/scripts/docs_translation_warning.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-read=docs --allow-run=git,gh --allow-env=GH_TOKEN,GITHUB_TOKEN
+#!/usr/bin/env -S deno run --allow-read --allow-run=git,gh --allow-env=GH_TOKEN,GITHUB_TOKEN,PATH
 
 /**
  * @module
@@ -7,6 +7,7 @@
  */
 
 import { Command } from "@cliffy/command"
+import $ from "./dax.ts"
 import { walk } from "@std/fs"
 import { markdownTable } from "markdown-table"
 import { changedFilesFromGit, type PullFile } from "./git_changed_files.ts"
@@ -25,9 +26,6 @@ export type TranslationWarning = {
   stale: string[]
   missing: string[]
 }
-
-const decoder = new TextDecoder()
-const encoder = new TextEncoder()
 
 const docPaths = (paths: (string | undefined)[]): DocPath[] =>
   paths.flatMap((file) => {
@@ -87,49 +85,16 @@ const withTranslationBlock = (body: string, block: string | undefined): string =
   return block === undefined ? cleanBody : [cleanBody, block].filter(Boolean).join("\n\n")
 }
 
-const run = async (
-  command: string,
-  args: string[],
-  input?: string,
-  env?: Record<string, string>,
-): Promise<string> => {
-  const process = new Deno.Command(command, {
-    args,
-    clearEnv: env !== undefined,
-    env,
-    stdin: input === undefined ? "null" : "piped",
-    stdout: "piped",
-    stderr: "piped",
-  }).spawn()
-  if (input !== undefined) {
-    const writer = process.stdin.getWriter()
-    await writer.write(encoder.encode(input))
-    await writer.close()
-  }
-  const { success, stdout, stderr } = await process.output()
-  if (!success) {
-    const message = decoder.decode(stderr).trim()
-    throw new Error(`${command} ${args.join(" ")} failed${message ? `: ${message}` : ""}`)
-  }
-  return decoder.decode(stdout)
-}
-
-const ghEnv = (): Record<string, string> | undefined => {
+const ghEnv = (): Record<string, string> => {
   const token = Deno.env.get("GH_TOKEN") ?? Deno.env.get("GITHUB_TOKEN")
-  return token === undefined ? undefined : { GH_TOKEN: token }
+  return token === undefined ? {} : { GH_TOKEN: token }
 }
 
 const readPrBody = async (pr: number): Promise<string> =>
-  (await run(
-    "gh",
-    ["pr", "view", String(pr), "--json", "body", "--jq", ".body"],
-    undefined,
-    ghEnv(),
-  ))
-    .trimEnd()
+  (await $`gh pr view ${pr} --json body --jq .body`.env(ghEnv()).text()).trimEnd()
 
 const updatePrBody = async (pr: number, body: string): Promise<void> => {
-  await run("gh", ["pr", "edit", String(pr), "--body-file", "-"], body, ghEnv())
+  await $`gh pr edit ${pr} --body-file -`.env(ghEnv()).stdinText(body)
 }
 
 const main = new Command()

--- a/scripts/git_changed_files.ts
+++ b/scripts/git_changed_files.ts
@@ -1,10 +1,12 @@
-#!/usr/bin/env -S deno run --allow-run=git
+#!/usr/bin/env -S deno run --allow-read --allow-run=git --allow-env=PATH
 
 /**
  * @module
  *
  * Lists pull request file changes using the local git checkout.
  */
+
+import $ from "./dax.ts"
 
 export type PullFileStatus = "added" | "copied" | "modified" | "removed" | "renamed" | "changed"
 
@@ -19,39 +21,16 @@ export type ChangedFilesOptions = {
   head?: string
 }
 
-const decoder = new TextDecoder()
+const gitStatusMap = {
+  A: "added",
+  C: "copied",
+  D: "removed",
+  M: "modified",
+  R: "renamed",
+} as const satisfies Record<string, PullFileStatus>
 
-const runGit = async (args: string[]): Promise<string> => {
-  const command = new Deno.Command("git", {
-    args,
-    clearEnv: true,
-    stdout: "piped",
-    stderr: "piped",
-  })
-  const { success, stdout, stderr } = await command.output()
-  if (!success) {
-    const message = decoder.decode(stderr).trim()
-    throw new Error(`git ${args.join(" ")} failed${message ? `: ${message}` : ""}`)
-  }
-  return decoder.decode(stdout)
-}
-
-const parseGitStatus = (status: string): PullFileStatus => {
-  switch (status[0]) {
-    case "A":
-      return "added"
-    case "C":
-      return "copied"
-    case "D":
-      return "removed"
-    case "M":
-      return "modified"
-    case "R":
-      return "renamed"
-    default:
-      return "changed"
-  }
-}
+const parseGitStatus = (status: string): PullFileStatus =>
+  gitStatusMap[status[0] as keyof typeof gitStatusMap] ?? "changed"
 
 export const parseGitNameStatus = (output: string): PullFile[] =>
   output.trim().split("\n")
@@ -71,12 +50,7 @@ export const parseGitNameStatus = (output: string): PullFile[] =>
 export const changedFilesFromGit = async (
   { base = "origin/main", head = "HEAD" }: ChangedFilesOptions = {},
 ): Promise<PullFile[]> => {
-  const output = await runGit([
-    "diff",
-    "--name-status",
-    "--find-renames",
-    "--find-copies",
-    `${base}...${head}`,
-  ])
+  const output = await $`git diff --name-status --find-renames --find-copies ${`${base}...${head}`}`
+    .text()
   return parseGitNameStatus(output)
 }


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #9544: avoid full-history fetches and keep the PR-file scripts on Dax/native git.

## Describe the solution (The How)

- Use PR merge refs with shallow fetch depth for changed-file detection.
- Replace verbose subprocess wrappers in PR-file helpers with Dax `CommandBuilder`.

## Testing

- `deno fmt deno.jsonc scripts/docs_translation_warning.ts scripts/git_changed_files.ts`
- `deno check --lock deno.lock scripts/affected_files.ts scripts/docs_translation_warning.ts scripts/git_changed_files.ts`
- `deno test scripts/git_changed_files_test.ts scripts/docs_translation_warning_test.ts`
- `deno lint scripts/affected_files.ts scripts/docs_translation_warning.ts scripts/git_changed_files.ts scripts/git_changed_files_test.ts scripts/docs_translation_warning_test.ts`
- `deno task affected-files --base upstream/main --head HEAD --output /tmp/affected-files-followup.txt`
- `deno task docs:translation-warning 9544 --base upstream/main --head HEAD`
- `actionlint .github/workflows/autofix.yml .github/workflows/clang-tidy.yml`

## Checklist

### Mandatory

- [x] No tracked issue; follow-up to #9544.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d9aa4d4](https://github.com/cataclysmbn/Cataclysm-BN/commit/d9aa4d4348df8a96e7b872c5fe8a2144e43475fc) (ci: use Dax for PR file helpers) on 2026-06-17 16:39:20

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27700950614/artifacts/7701683904)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27700950614/artifacts/7701338785)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27700950614/artifacts/7700702107)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27700950614/artifacts/7700778933)
<!-- END artifact comment -->