### PR TITLE
fix(mods/crt_expansion): replace obsolete enchantment value

### DIFF
--- a/data/mods/CRT_EXPANSION/items/crt_tools.json
+++ b/data/mods/CRT_EXPANSION/items/crt_tools.json
@@ -160,7 +160,7 @@
         {
           "has": "WIELD",
           "condition": "ALWAYS",
-          "values": [ { "value": "STRENGTH", "add": 10 }, { "value": "ARMOR_ELEC", "multiply": -1 } ],
+          "values": [ { "value": "STRENGTH", "add": 10 }, { "value": "ARMOR_ELECTRIC", "multiply": -1 } ],
           "mutations": [ "CRT_BERSERK_EFFECT" ],
           "hit_you_effect": [
             {


### PR DESCRIPTION
## Purpose of change (The Why)

The enchantment value was obsolete

## Describe the solution (The How)

fix it 

## Checklist

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0678db0](https://github.com/cataclysmbn/Cataclysm-BN/commit/0678db0b3d34002cf47226a5bb3b99d807d021c7) (fix obsolete enchantment value) on 2026-06-17 19:46:01

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27712967041/artifacts/7705436443)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27712967041/artifacts/7706060316)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27712967041/artifacts/7705498939)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27712967041/artifacts/7705585693)
<!-- END artifact comment -->