### PR TITLE
fix: re-add instruction booklet to basic first aid kit

### DIFF
--- a/data/json/itemgroups/misc.json
+++ b/data/json/itemgroups/misc.json
@@ -258,7 +258,8 @@
       { "item": "medical_tape", "charges": 20 },
       { "item": "disinfectant", "charges": 10, "container-item": "bottle_plastic_small" },
       { "item": "bandages", "charges": 6 },
-      { "item": "medical_gauze", "charges": 6 }
+      { "item": "medical_gauze", "charges": 6 },
+      { "item": "booklet_firstaid" }
     ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

I said in https://github.com/cataclysmbn/Cataclysm-BN/pull/9207 I could either remove the booklet from basic first aid kits and that lets me bump the volume down to 750 ml OR I could keep the booklets and make them 1 liter, somehow I fucked up and did neither of those things.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Re-added booklet to `pocket_first_aid_kit`.

## Describe alternatives you've considered

Lowering basic first aid kit from 1 liter to 750 ml.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

<img width="944" height="179" alt="image" src="https://github.com/user-attachments/assets/a478460c-67b5-41a8-9312-0fb0f619276b" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f0e8abf](https://github.com/cataclysmbn/Cataclysm-BN/commit/f0e8abff0e3977280db04678d4e1398fe6c183b9) (fix: re-add instruction booklet to basic first aid kit) on 2026-06-17 23:08:36

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27723756599/artifacts/7709584937)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27723756599/artifacts/7710042256)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27723756599/artifacts/7709608758)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27723756599/artifacts/7709683538)
<!-- END artifact comment -->