### PR TITLE
ci: make docs translation not fail ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -139,14 +139,9 @@ jobs:
             deno.jsonc
             deno.lock
 
-      - name: Fetch pull request merge for docs warning
-        if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
-        run: |
-          git fetch --no-tags --filter=blob:none --depth=2 origin \
-            +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
-
       - name: Setup Deno for docs warning
         if: always() && github.event.pull_request.head.ref != github.event.repository.default_branch
+        continue-on-error: true
         uses: denoland/setup-deno@v2
         with: { cache: true }
 
@@ -155,9 +150,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          deno task docs:translation-warning ${{ github.event.pull_request.number }} \
-            --base ${{ github.event.pull_request.base.sha }} \
-            --head refs/remotes/pull/${{ github.event.pull_request.number }}/merge
+          ref=refs/remotes/pull/${{ github.event.pull_request.number }}/merge
+          git fetch --no-tags --filter=blob:none --depth=2 origin "+refs/pull/${{ github.event.pull_request.number }}/merge:$ref" || exit 0
+          deno task docs:translation-warning ${{ github.event.pull_request.number }} --base "$ref^1" --head "$ref" || true
 
       - name: Comment and close pull request
         if: >-


### PR DESCRIPTION
## Purpose of change

Docs translation warning is advisory, but the autofix lint job failed on #8521 because shallow `base...merge` diff could not find a merge base.

Related: #9451, #9544, #9545, #8521

## Describe the solution

- Fetch the PR merge ref inside the warning update step and skip if GitHub has no merge ref.
- Compare against `refs/pull/N/merge^1` instead of the event base SHA.
- Keep docs warning update best-effort so it cannot fail CI.

## Testing

- Reproduced the #8521 shallow `no merge base` failure with the old command.
- Verified `merge^1...merge` lists #8521 changed files under the same shallow fetch.
- Checked open PR merge refs: 90 diff OK, 2 conflicting draft PRs skipped, 0 diff failures, 0 `no merge base` failures.
- Ran YAML parse and `git diff --check`.

## Checklist

### Mandatory

- [x] No issue to close.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4db9d60](https://github.com/cataclysmbn/Cataclysm-BN/commit/4db9d60f52e73c2bf926e9ed19ab75b8d7bfb9c5) (ci: make docs translation warning best effort) on 2026-06-18 04:30:11

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27733337068/artifacts/7713689137)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27733337068/artifacts/7714183389)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27733337068/artifacts/7713648413)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27733337068/artifacts/7713533401)
<!-- END artifact comment -->