### PR TITLE
ci: make registry mod bundling not fail CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,7 @@ jobs:
 
       - name: Bundle registry mods
         if: inputs.bundle-registry-mods
+        continue-on-error: ${{ inputs.mode == 'ci' }}
         run: deno run --allow-read --allow-write --allow-net build-scripts/bundle-registry-mods.ts ${{ format('{0}', matrix.sound) == 'false' && '--exclude-package-type soundpack' || '' }}
 
       - name: Bundle CDDA tilesets


### PR DESCRIPTION
## Purpose of change (The Why)

PR #9559 Windows MSVC artifact build failed when `mods.cataclysmbn.org` reset the registry mod fetch.

https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27741687279/job/82071465674

## Describe the solution (The How)

- Let registry mod bundling continue on error only in `ci` mode.
- Keep release-mode registry bundling strict.

## Testing

- `deno fmt --check .github/workflows/build.yml`

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [581f314](https://github.com/cataclysmbn/Cataclysm-BN/commit/581f31415bc54e794330808c982caf46a5836ddd) (ci: let registry mod bundling fail in CI) on 2026-06-18 14:40:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27747585388/artifacts/7719646090)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27747585388/artifacts/7719340273)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27747585388/artifacts/7718778247)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27747585388/artifacts/7718827844)
<!-- END artifact comment -->