### PR TITLE
fix(UI): save after choosing sleep options

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1237,9 +1237,8 @@ static void sleep()
        and loop until we get a valid answer. */
     as_m.query();
 
-    if( as_m.ret == 1 ) {
-        g->quicksave();
-    } else if( as_m.ret == 2 || as_m.ret < 0 ) {
+    const auto save_before_sleep = as_m.ret == 1;
+    if( as_m.ret == 2 || as_m.ret < 0 ) {
         return;
     }
 
@@ -1276,6 +1275,10 @@ static void sleep()
         } else if( as_m.ret < 0 ) {
             return;
         }
+    }
+
+    if( save_before_sleep ) {
+        g->quicksave();
     }
 
     u.moves = 0;


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #9558.

Choosing "save game before sleeping" paused before the sleep duration/alarm prompt, so save time was separate from the wait to fall asleep.

## Describe the solution (The How)

- Remember the save-before-sleep choice.
- Run the quicksave after alarm/sleep duration setup, immediately before starting the sleep attempt.

## Testing

- Built `cataclysm-bn-tiles` and `cata_test-tiles` with the linux-full preset.
- Ran `[sleep]`; all assertions passed.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [aff40c3](https://github.com/cataclysmbn/Cataclysm-BN/commit/aff40c325360b04638bdbce3e613adbba0dcc14a) (fix: save after sleep setup) on 2026-06-18 10:06:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27747722488/artifacts/7720120984)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27747722488/artifacts/7719261792)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27747722488/artifacts/7718769586)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27747722488/artifacts/7718770057)
<!-- END artifact comment -->