### PR TITLE
fix: allow self-targeted spells to resolve

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4731,6 +4731,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
             std::vector<tripoint_bub_ms> trajectory = target_handler::mode_spell( you, spell_being_cast,
                     no_fail,
                     no_mana );
+            g->refresh_player_visibility_cache_if_needed();
 
             if( !trajectory.empty() ) {
                 target = trajectory.back();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11755,6 +11755,9 @@ Attitude Character::attitude_to( const Creature &other ) const
 
 bool Character::sees( const tripoint_bub_ms &t, bool, int ) const
 {
+    if( t == bub_pos() ) {
+        return true;
+    }
     const int wanted_range = rl_dist( bub_pos(), t );
     bool can_see = is_player() ? get_map().pl_sees( t, wanted_range ) :
                    Creature::sees( t );

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -4,6 +4,7 @@
 #include "fstream_utils.h"
 #include "game.h"
 #include "magic.h"
+#include "map.h"
 #include "monster.h"
 
 #include "player_helpers.h"
@@ -102,6 +103,20 @@ TEST_CASE( "spell level", "[magic][spell][level]" )
             }
         }
     }
+}
+
+TEST_CASE( "avatar sees own tile even with dirty visibility cache",
+           "[magic][spell][target][vision]" )
+{
+    clear_all_state();
+    clear_avatar();
+
+    avatar &you = get_avatar();
+    map &here = get_map();
+    here.invalidate_map_cache( you.bub_pos().z() );
+    REQUIRE( here.visibility_caches_dirty() );
+
+    CHECK( you.sees( you.bub_pos() ) );
 }
 
 TEST_CASE( "known magic remembers the last cast spell", "[magic][spell][save]" )


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9560

Related: #9536

Targeted spells could return from the target UI with player visibility caches dirty, making the post-target `sees()` gate reject a valid target and show `Stop casting spell? Time spent will be lost.`

## Describe the solution (The How)

- Refresh player visibility after spell target UI returns before validating the selected target.
- Treat a character's own tile as visible.
- Add a regression test for self-target visibility with dirty visibility caches.

## Testing

- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "avatar sees own tile even with dirty visibility cache"`
- `./out/build/linux-full/tests/cata_test-tiles "[magic][spell]"`

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ad62a79](https://github.com/cataclysmbn/Cataclysm-BN/commit/ad62a79b03a7659b81a393c7e46149846af92d1f) (fix: keep spell targets visible after targeting) on 2026-06-18 12:07:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27755510630/artifacts/7722677966)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27755510630/artifacts/7722552600)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27755510630/artifacts/7721968710)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27755510630/artifacts/7721999410)
<!-- END artifact comment -->