### PR TITLE
build: package no-soundpack desktop artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,15 +30,12 @@ on:
         default: |
           [
             { "name": "Windows MSVC", "platform": "windows", "artifact": "windows-tiles-x64-msvc", "os": "windows-2022", "arch": "x64", "tiles": true, "sound": true, "ext": "zip", "content-type": "application/zip" },
-            { "name": "Windows MSVC (no sound)", "platform": "windows", "artifact": "windows-tiles-no-sound-x64-msvc", "os": "windows-2022", "arch": "x64", "tiles": true, "sound": false, "ext": "zip", "content-type": "application/zip" },
             { "name": "Linux Tiles", "platform": "linux", "artifact": "linux-tiles-x64", "os": "ubuntu-latest", "tiles": true, "sound": true, "ext": "tar.gz", "content-type": "application/gzip" },
             { "name": "Linux Curses", "platform": "linux", "artifact": "linux-curses-x64", "os": "ubuntu-latest", "tiles": false, "sound": false, "ext": "tar.gz", "content-type": "application/gzip" },
             { "name": "macOS Curses", "platform": "macos", "artifact": "osx-curses-x64", "os": "macos-15-intel", "preset": "osx-curses-x64-dist", "tiles": false, "sound": false, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
             { "name": "macOS Tiles", "platform": "macos", "artifact": "osx-tiles-x64", "os": "macos-15-intel", "preset": "osx-tiles-x64-dist", "tiles": true, "sound": true, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
-            { "name": "macOS Tiles (no sound)", "platform": "macos", "artifact": "osx-tiles-no-sound-x64", "os": "macos-15-intel", "preset": "osx-tiles-no-sound-x64-dist", "tiles": true, "sound": false, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
             { "name": "macOS Curses ARM", "platform": "macos", "artifact": "osx-curses-arm", "os": "macos-15", "preset": "osx-curses-arm-dist", "tiles": false, "sound": false, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
             { "name": "macOS Tiles ARM", "platform": "macos", "artifact": "osx-tiles-arm", "os": "macos-15", "preset": "osx-tiles-arm-dist", "tiles": true, "sound": true, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
-            { "name": "macOS Tiles ARM (no sound)", "platform": "macos", "artifact": "osx-tiles-no-sound-arm", "os": "macos-15", "preset": "osx-tiles-no-sound-arm-dist", "tiles": true, "sound": false, "ext": "dmg", "content-type": "application/x-apple-diskimage" },
             { "name": "Android ARM64", "platform": "android", "artifact": "android-x64", "os": "ubuntu-latest", "android": "arm64", "tiles": true, "ext": "apk", "content-type": "application/apk" },
             { "name": "Android Bundle", "platform": "android", "artifact": "android-bundle", "os": "ubuntu-latest", "android": "bundle", "tiles": true, "ext": "aab", "content-type": "application/aab" }
           ]
@@ -172,7 +169,7 @@ jobs:
       - name: Bundle registry mods
         if: inputs.bundle-registry-mods
         continue-on-error: ${{ inputs.mode == 'ci' }}
-        run: deno run --allow-read --allow-write --allow-net build-scripts/bundle-registry-mods.ts ${{ format('{0}', matrix.sound) == 'false' && '--exclude-package-type soundpack' || '' }}
+        run: deno run --allow-read --allow-write --allow-net build-scripts/bundle-registry-mods.ts ${{ (((matrix.platform == 'windows' || matrix.platform == 'macos') && matrix.tiles == true && matrix.sound == true) || format('{0}', matrix.sound) == 'false') && '--exclude-package-type soundpack' || '' }}
 
       - name: Bundle CDDA tilesets
         if: matrix.tiles == true && inputs.bundle-tilesets
@@ -483,10 +480,6 @@ jobs:
           $localize = "False"
           $tests = "False"
           $release = "ON"
-          $sound = "False"
-          if ("${{ matrix.sound }}" -eq "true") {
-            $sound = "True"
-          }
           if ("${{ inputs.download-translations }}" -eq "true") {
             $localize = "True"
           }
@@ -508,7 +501,7 @@ jobs:
             -DCURSES=False `
             "-DLOCALIZE=$localize" `
             -DTILES=True `
-            "-DSOUND=$sound" `
+            -DSOUND=True `
             "-DTESTS=$tests" `
             "-DRELEASE=$release" `
             -DJSON_FORMAT=OFF `
@@ -544,9 +537,14 @@ jobs:
         if: runner.os == 'Windows' && inputs.package-artifacts && (!inputs.upload-artifacts || matrix.upload-artifact == true)
         run: |
           $dist = "cataclysmbn-${{ inputs.version-label }}"
+          Remove-Item -Recurse -Force $dist -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force lang/mo
           cmake --install out/build/windows-tiles-sounds-x64-msvc --prefix $dist --config Release
-
+          if ("${{ matrix.tiles }}" -eq "true" -and "${{ matrix.sound }}" -eq "true" -and "${{ inputs.bundle-registry-mods }}" -eq "true") {
+            Compress-Archive -Force -Path $dist/* -DestinationPath cbn-${{ matrix.artifact }}-no-soundpack-${{ inputs.version-label }}.zip
+            deno run --allow-read --allow-write --allow-net build-scripts/bundle-registry-mods.ts
+            cmake --install out/build/windows-tiles-sounds-x64-msvc --prefix $dist --config Release
+          }
           Compress-Archive -Force -Path $dist/* -DestinationPath cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.zip
 
       - name: Verify statically linked SDL runtime (windows msvc)
@@ -589,8 +587,17 @@ jobs:
           configurePresetAdditionalArgs: ${{ inputs.run-tests && '["-DCATA_FORMAT_TARGETS=OFF", "-DTESTS=ON"]' || '["-DCATA_FORMAT_TARGETS=OFF"]' }}
           buildPreset: ${{ matrix.preset }}
 
+      - name: Create distribution package with soundpacks (macOS)
+        if: runner.os == 'macOS' && matrix.tiles == true && matrix.sound == true && inputs.bundle-registry-mods && inputs.package-artifacts && (!inputs.upload-artifacts || matrix.upload-artifact == true)
+        run: |
+          mv CataclysmBN-*.dmg cbn-${{ matrix.artifact }}-no-soundpack-${{ inputs.version-label }}.dmg
+          deno run --allow-read --allow-write --allow-net build-scripts/bundle-registry-mods.ts
+          cmake -E copy_directory data/mods Cataclysm.app/Contents/Resources/data/mods
+          cmake -E copy_directory data/sound Cataclysm.app/Contents/Resources/data/sound
+          dmgbuild -s build-data/osx/dmgsettings.py "Cataclysm BN" cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.dmg
+
       - name: Rename distribution package (macOS)
-        if: runner.os == 'macOS' && inputs.package-artifacts && (!inputs.upload-artifacts || matrix.upload-artifact == true)
+        if: runner.os == 'macOS' && !(matrix.tiles == true && matrix.sound == true && inputs.bundle-registry-mods) && inputs.package-artifacts && (!inputs.upload-artifacts || matrix.upload-artifact == true)
         run: mv CataclysmBN-*.dmg cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.dmg
 
       - name: Verify bundled SDL runtime (macOS)
@@ -852,15 +859,17 @@ jobs:
       - name: Upload to release
         if: inputs.upload-to-release
         run: |
+          release="${{ inputs.release-tag }}"
           if [ "${{ inputs.version-label }}" = "experimental" ]; then
             SHA_SHORT=$(git rev-parse --short HEAD)
             COMMIT_SUBJECT=$(git log -1 --pretty=%s)
             TIMESTAMP=$(date -u "+%F %T")
-            gh release upload experimental --clobber cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.${{ matrix.ext }}
+            release=experimental
             gh release edit experimental --title "Experimental @ $TIMESTAMP ($SHA_SHORT)" --notes "Experimental build for commit $SHA_SHORT ($COMMIT_SUBJECT) on $TIMESTAMP"
-          else
-            gh release upload ${{ inputs.release-tag }} --clobber cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.${{ matrix.ext }}
           fi
+          extra="cbn-${{ matrix.artifact }}-no-soundpack-${{ inputs.version-label }}.${{ matrix.ext }}"
+          [ -f "$extra" ] && gh release upload "$release" --clobber "$extra"
+          gh release upload "$release" --clobber cbn-${{ matrix.artifact }}-${{ inputs.version-label }}.${{ matrix.ext }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   VCPKG_BINARY_SOURCES: "default"
-  EXPECTED_NIGHTLY_ASSET_COUNT: 14
+  EXPECTED_NIGHTLY_ASSET_COUNT: 13
 
 jobs:
   metadata:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -257,18 +257,6 @@
       }
     },
     {
-      "name": "osx-tiles-no-sound-x64-dist",
-      "inherits": ["osx-dist-base"],
-      "displayName": "macOS x64 Distribution (Tiles, No Sound, Languages)",
-      "description": "For creating portable macOS x64 distribution packages with tiles and no sound.",
-      "cacheVariables": {
-        "CMAKE_OSX_ARCHITECTURES": "x86_64",
-        "CURSES": "OFF",
-        "TILES": "ON",
-        "SOUND": "OFF"
-      }
-    },
-    {
       "name": "osx-curses-arm-dist",
       "inherits": ["osx-dist-base"],
       "displayName": "macOS ARM Distribution (Curses, Languages)",
@@ -290,18 +278,6 @@
         "CURSES": "OFF",
         "TILES": "ON",
         "SOUND": "ON"
-      }
-    },
-    {
-      "name": "osx-tiles-no-sound-arm-dist",
-      "inherits": ["osx-dist-base"],
-      "displayName": "macOS ARM Distribution (Tiles, No Sound, Languages)",
-      "description": "For creating portable macOS ARM distribution packages with tiles and no sound.",
-      "cacheVariables": {
-        "CMAKE_OSX_ARCHITECTURES": "arm64",
-        "CURSES": "OFF",
-        "TILES": "ON",
-        "SOUND": "OFF"
       }
     },
     {
@@ -463,12 +439,6 @@
       "description": "Build a macOS x64 tiles DMG."
     },
     {
-      "name": "osx-tiles-no-sound-x64-dist",
-      "configurePreset": "osx-tiles-no-sound-x64-dist",
-      "targets": ["dmgdist"],
-      "description": "Build a macOS x64 tiles DMG without sound."
-    },
-    {
       "name": "osx-curses-arm-dist",
       "configurePreset": "osx-curses-arm-dist",
       "targets": ["dmgdist"],
@@ -479,12 +449,6 @@
       "configurePreset": "osx-tiles-arm-dist",
       "targets": ["dmgdist"],
       "description": "Build a macOS ARM tiles DMG."
-    },
-    {
-      "name": "osx-tiles-no-sound-arm-dist",
-      "configurePreset": "osx-tiles-no-sound-arm-dist",
-      "targets": ["dmgdist"],
-      "description": "Build a macOS ARM tiles DMG without sound."
     },
     {
       "name": "osx-arm-dist",

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -267,17 +267,12 @@ tar -czvf cataclysmbn-linux-tiles.tar.gz cataclysmbn-linux-tiles
 
 #### Distribution Presets
 
-| Preset                        | Description                             |
-| ----------------------------- | --------------------------------------- |
-| `dist-tiles`                  | Linux: Tiles + Sound + Languages        |
-| `dist-curses`                 | Linux: Curses + Languages               |
-| `osx-tiles-x64-dist`          | macOS x64: Tiles + Sound + Languages    |
-| `osx-tiles-no-sound-x64-dist` | macOS x64: Tiles + Languages            |
-| `osx-tiles-arm-dist`          | macOS ARM: Tiles + Sound + Languages    |
-| `osx-tiles-no-sound-arm-dist` | macOS ARM: Tiles + Languages            |
-| `osx-curses-x64-dist`         | macOS x64: Curses + Languages           |
-| `osx-curses-arm-dist`         | macOS ARM: Curses + Languages           |
-| `lint`                        | Minimal build for formatting tools only |
+| Preset         | Description                             |
+| -------------- | --------------------------------------- |
+| `dist-tiles`   | Linux: Tiles + Sound + Languages        |
+| `dist-curses`  | Linux: Curses + Languages               |
+| `osx-arm-dist` | macOS ARM: Tiles + Sound + Languages    |
+| `lint`         | Minimal build for formatting tools only |
 
 #### Portable vs System Install
 


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #9563
apparently AI had minus IQ and interpreted 'no soundpack release' as 'no sound release' instead of not bundling soundpacks

## Describe the solution (The How)

- Keep the release matrix at 9 jobs.
- Keep sound enabled for desktop tiles builds.
- Package no-soundpack desktop archives before bundling registry soundpacks, then package normal archives after bundling.

## Testing

- Parsed build/release workflow YAML and asserted 9 jobs / 13 release assets.
- `actionlint .github/workflows/build.yml .github/workflows/release.yml`
- `git diff --numstat upstream/main -- .github/workflows/build.yml .github/workflows/release.yml CMakePresets.json docs/en/dev/guides/building/cmake.md` → 30 insertions.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1b23875](https://github.com/cataclysmbn/Cataclysm-BN/commit/1b2387590d6bdf28183061fe335d87592ddbe55c) (build: package no-soundpack desktop artifacts) on 2026-06-18 17:17:52

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27768230671/artifacts/7728453990)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27768230671/artifacts/7730644981)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27768230671/artifacts/7730234429)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27768230671/artifacts/7729217653)
<!-- END artifact comment -->