### PR TITLE
fix: scan corpses with bionic scanners inside containers

### DIFF
--- a/docs/en/dev/guides/items.md
+++ b/docs/en/dev/guides/items.md
@@ -3,6 +3,28 @@
 Here are some common tasks that you might want to do with items.
 [For more on item(game objects), check here.](../explanation/game_objects.md)
 
+## Processing nested items
+
+Top-level map and vehicle active item caches track the outer item that is placed in the world. If a
+nested item needs per-turn or periodic processing, its parent containers must also report that they
+need processing so the outer item stays in the cache.
+
+Use the normal item and `item_contents` mutation APIs when changing active state, processing-related
+flags, or contents. These paths invalidate the cached processing-item list up the parent chain and
+resync the placed top-level item with the map or vehicle active cache when needed. Avoid changing
+`item_tags`, `item_contents` storage, or active state directly unless the caller also invalidates the
+processing cache upward.
+
+Processing cadence is inherited from the fastest processing child. A food container with an active
+tool inside it must keep the active tool's one-turn cadence even though food-only containers can use
+a slower rot cadence. If a mutation can change `item::processing_speed()`, re-adding the outer item
+to the active cache moves an existing reference to the correct speed queue instead of leaving stale
+entries behind.
+
+When processing contents recursively, take a mutation-safe snapshot of `contents.processing_items()`
+before detaching or processing children. Preserve parent container context such as sealed or
+preserving containers while processing nested food so rot behavior remains unchanged.
+
 ## Moving items from one tripoint to another
 
 ```cpp

--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -55,8 +55,16 @@ void active_item_cache::add( item &it )
     // If the item is already in the cache for some reason, don't add a second reference
     active_item_queue &queue = active_items[it.processing_speed()];
     std::vector<cache_reference<item>> &target_list = queue.items;
-    if( std::find( target_list.begin(), target_list.end(), it ) != target_list.end() ) {
+    const auto references_item = [&it]( const cache_reference<item> &active_item ) { return active_item == it; };
+    if( std::ranges::any_of( target_list, references_item ) ) {
         return;
+    }
+    const auto is_cached_elsewhere = [&queue, &references_item]( const auto & active_entry ) {
+        return &active_entry.second != &queue &&
+               std::ranges::any_of( active_entry.second.items, references_item );
+    };
+    if( std::ranges::any_of( active_items, is_cached_elsewhere ) ) {
+        remove( &it );
     }
     if( target_list.empty() ) {
         queue.last_processed_turn = to_turn<int>( calendar::turn );

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -48,14 +48,13 @@ class active_item_cache
     public:
         /**
          * Removes the item if it is in the cache. Does nothing if the item is not in the cache.
-         * Relies on the fact that item::processing_speed() is a constant.
          * Also removes any items that have been destroyed in the list containing it
          */
         void remove( const item *it );
 
         /**
-         * Adds the reference to the cache. Does nothing if the reference is already in the cache.
-         * Relies on the fact that item::processing_speed() is a constant.
+         * Adds the reference to the cache. Does nothing if the reference is already in the right queue.
+         * Moves existing references if item::processing_speed() changed.
          */
         void add( item &it );
 
@@ -86,7 +85,6 @@ class active_item_cache
          * n items will ever be processed.
          * Broken references encountered when collecting the items to be processed are removed from
          * the cache.
-         * Relies on the fact that item::processing_speed() is a constant.
          */
         std::vector<item *> get_for_processing();
         /**

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -607,6 +607,7 @@ void item::convert( const itype_id &new_type )
 {
     type = &*new_type;
     relic_data = type->relic_data;
+    invalidate_processing_cache_upwards();
 }
 
 void item::deactivate()
@@ -616,6 +617,7 @@ void item::deactivate()
     }
 
     active = false;
+    invalidate_processing_cache_upwards();
     if( is_tool() ) {
         type->tool->turns_active = 0;
     }
@@ -648,6 +650,7 @@ void item::activate()
     }
 
     active = true;
+    invalidate_processing_cache_upwards();
 
     // Is not placed in the world, so either a template of some kind or a temporary item.
     if( !has_position() ) {
@@ -1266,6 +1269,7 @@ void item::put_in( detached_ptr<item> &&payload )
         return;
     }
     contents.insert_item( std::move( payload ) );
+    on_contents_changed();
 }
 
 void item::add_item_with_id( const itype_id &itype, int count )
@@ -5002,6 +5006,7 @@ void item::on_contents_changed()
     }
 
     encumbrance_update_ = true;
+    invalidate_processing_cache_upwards();
 
     if( !has_position() || where() != item_location_type::vehicle ) {
         return;
@@ -10069,9 +10074,43 @@ uint64_t item::make_component_hash() const
 bool item::needs_processing() const
 {
     return is_active() || has_flag( flag_RADIO_ACTIVATION ) || has_flag( flag_ETHEREAL_ITEM ) ||
-           ( !contents.empty() && is_container() && contents.front().needs_processing() ) ||
+           ( !contents.empty() && contents.has_processing_items() ) ||
            ( magazine_current() && magazine_current()->needs_processing() ) ||
            is_artifact() || is_relic() || goes_bad();
+}
+
+auto item::invalidate_processing_cache_upwards() -> void
+{
+    auto *top = this;
+    for( auto *current = this; current != nullptr; current = current->parent_item() ) {
+        current->contents.invalidate_processing_cache();
+        top = current;
+    }
+
+    if( !top->has_position() ) {
+        return;
+    }
+
+    switch( top->where() ) {
+        case item_location_type::map:
+            if( top->needs_processing() ) {
+                get_map().make_active( *top );
+            } else {
+                get_map().make_inactive( *top );
+            }
+            break;
+        case item_location_type::vehicle:
+            if( const auto vp = get_map().veh_at( top->bub_pos() ) ) {
+                if( top->needs_processing() ) {
+                    vp->vehicle().make_active( *top );
+                } else {
+                    vp->vehicle().make_inactive( *top );
+                }
+            }
+            break;
+        default:
+            break;
+    }
 }
 
 int item::processing_speed() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1113,8 +1113,8 @@ auto bionic_component_display_names( const item &corpse ) -> std::set<std::strin
     namespace ranges = std::ranges;
     return corpse.get_components()
            | filter( &item::is_bionic )
-           | transform( []( const item *component ) { return component->display_name(); } )
-           | ranges::to<std::set>();
+    | transform( []( const item * component ) { return component->display_name(); } )
+    | ranges::to<std::set>();
 }
 
 } // namespace
@@ -10965,37 +10965,46 @@ detached_ptr<item> item::process( detached_ptr<item> &&self, player *carrier,
     if( !self ) {
         return std::move( self );
     }
-    const bool preserves = self->type->container && self->type->container->preserves;
-    const bool seals = self->type->container && self->type->container->seals;
-    item &obj = *self;
+    const auto preserves = self->type->container && self->type->container->preserves;
+    const auto seals = self->type->container && self->type->container->seals;
+    auto &obj = *self;
+    using namespace std::views;
+    namespace ranges = std::ranges;
 
-    std::function < detached_ptr<item>( detached_ptr<item> &&, bool, bool ) > process_content =
-        [&]( detached_ptr<item> &&it, const bool parent_preserves,
-    const bool parent_seals ) -> detached_ptr<item> {
+    struct content_processing_options {
+        bool parent_preserves = false;
+        bool parent_seals = false;
+    };
+
+    const auto processing_items = []( const auto & contents ) {
+        return contents.processing_items()
+        | filter( []( const item * content_item ) { return content_item != nullptr; } )
+        | transform( []( item * content_item ) { return cache_reference<item>( *content_item ); } )
+        | ranges::to<std::vector>();
+    };
+
+    auto process_content = [&]( auto &&process_content, detached_ptr<item> &&it,
+    const content_processing_options & opts ) -> detached_ptr<item> {
         if( !it )
         {
             return std::move( it );
         }
 
-        const bool content_preserves = parent_preserves ||
+        const auto content_preserves = opts.parent_preserves ||
         ( it->type->container && it->type->container->preserves );
-        const bool content_seals = parent_seals ||
+        const auto content_seals = opts.parent_seals ||
         ( it->type->container && it->type->container->seals );
 
-        auto content_processing_items = std::vector<cache_reference<item>> {};
-        for( item *const content_item : it->contents.processing_items() )
-        {
-            if( content_item != nullptr ) {
-                content_processing_items.emplace_back( *content_item );
-            }
-        }
-        for( const cache_reference<item> &content_item : content_processing_items )
+        for( const cache_reference<item> &content_item : processing_items( it->contents ) )
         {
             if( !content_item ) {
                 continue;
             }
             content_item->attempt_detach( [&]( detached_ptr<item> &&nested ) {
-                return process_content( std::move( nested ), content_preserves, content_seals );
+                return process_content( process_content, std::move( nested ), {
+                    .parent_preserves = content_preserves,
+                    .parent_seals = content_seals
+                } );
             } );
         }
 
@@ -11007,23 +11016,20 @@ detached_ptr<item> item::process( detached_ptr<item> &&self, player *carrier,
                                  weather_generator );
     };
 
-    auto content_processing_items = std::vector<cache_reference<item>> {};
-    for( item *const content_item : obj.contents.processing_items() ) {
-        if( content_item != nullptr ) {
-            content_processing_items.emplace_back( *content_item );
-        }
-    }
-    for( const cache_reference<item> &content_item : content_processing_items ) {
+    for( const cache_reference<item> &content_item : processing_items( obj.contents ) ) {
         if( !content_item ) {
             continue;
         }
         content_item->attempt_detach( [&]( detached_ptr<item> &&it ) {
-            return process_content( std::move( it ), preserves, seals );
+            return process_content( process_content, std::move( it ), {
+                .parent_preserves = preserves,
+                .parent_seals = seals
+            } );
         } );
     }
 
-    detached_ptr<item> res = process_internal( std::move( self ), carrier, pos, activate, seals, flag,
-                             weather_generator );
+    auto res = process_internal( std::move( self ), carrier, pos, activate, seals, flag,
+                                 weather_generator );
     return res;
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1104,6 +1104,21 @@ int item::charges_per_volume( const units::volume &vol ) const
     }
 }
 
+namespace
+{
+
+auto bionic_component_display_names( const item &corpse ) -> std::set<std::string>
+{
+    using namespace std::views;
+    namespace ranges = std::ranges;
+    return corpse.get_components()
+           | filter( &item::is_bionic )
+           | transform( []( const item *component ) { return component->display_name(); } )
+           | ranges::to<std::set>();
+}
+
+} // namespace
+
 bool item::display_stacked_with( const item &rhs, bool check_components ) const
 {
     return !count_by_charges() && stacks_with( rhs, check_components );
@@ -1131,9 +1146,13 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
     }
 
     if( is_corpse() || rhs.is_corpse() ) {
-        return this->is_corpse() && rhs.is_corpse() && ( *this->get_mtype() == *rhs.get_mtype() ) &&
-               get_var( "bionics_scanned_by", -1 ) == rhs.get_var( "bionics_scanned_by", -1 ) &&
-               has_flag( flag_CBM_SCANNED ) == rhs.has_flag( flag_CBM_SCANNED );
+        if( !is_corpse() || !rhs.is_corpse() || ( *get_mtype() != *rhs.get_mtype() ) ||
+            get_var( "bionics_scanned_by", -1 ) != rhs.get_var( "bionics_scanned_by", -1 ) ||
+            has_flag( flag_CBM_SCANNED ) != rhs.has_flag( flag_CBM_SCANNED ) ) {
+            return false;
+        }
+        return !has_flag( flag_CBM_SCANNED ) ||
+               bionic_component_display_names( *this ) == bionic_component_display_names( rhs );
     }
 
     if( damage_ != rhs.damage_ ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6011,7 +6011,12 @@ bool item::can_shatter() const
 
 void item::unset_flags()
 {
+    const bool affects_processing = item_tags.count( flag_RADIO_ACTIVATION ) ||
+                                    item_tags.count( flag_ETHEREAL_ITEM );
     item_tags.clear();
+    if( affects_processing ) {
+        invalidate_processing_cache_upwards();
+    }
 }
 
 bool item::has_fault( const fault_id &fault ) const
@@ -6075,7 +6080,11 @@ bool item::has_vitamin( const vitamin_id &v ) const
 void item::set_flag( const flag_id &flag )
 {
     if( flag.is_valid() ) {
-        item_tags.insert( flag );
+        const bool affects_processing = flag == flag_RADIO_ACTIVATION || flag == flag_ETHEREAL_ITEM;
+        const bool inserted = item_tags.insert( flag ).second;
+        if( inserted && affects_processing ) {
+            invalidate_processing_cache_upwards();
+        }
     } else {
         debugmsg( "Attempted to set invalid flag_id %s", flag.str() );
     }
@@ -6083,7 +6092,11 @@ void item::set_flag( const flag_id &flag )
 
 void item::unset_flag( const flag_id &flag )
 {
-    item_tags.erase( flag );
+    const bool affects_processing = flag == flag_RADIO_ACTIVATION || flag == flag_ETHEREAL_ITEM;
+    const bool erased = item_tags.erase( flag ) > 0;
+    if( erased && affects_processing ) {
+        invalidate_processing_cache_upwards();
+    }
 }
 
 void item::set_flag_recursive( const flag_id &flag )
@@ -7483,9 +7496,11 @@ bool item::is_brewable() const
 
 bool item::is_food_container() const
 {
-    return ( !contents.empty() && contents.front().is_food() ) ||
-           ( is_craft() &&
-             craft_data_->making->create_result()->is_food_container() );
+    namespace ranges = std::ranges;
+    return ranges::any_of( contents.all_items_top(), []( const item * contained_item ) {
+        return contained_item != nullptr &&
+               ( contained_item->is_food() || contained_item->is_food_container() );
+    } ) || ( is_craft() && craft_data_->making->create_result()->is_food_container() );
 }
 
 bool item::is_med_container() const
@@ -10933,14 +10948,55 @@ detached_ptr<item> item::process( detached_ptr<item> &&self, player *carrier,
     const bool seals = self->type->container && self->type->container->seals;
     item &obj = *self;
 
-    obj.remove_items_with( [&]( detached_ptr<item> &&it ) {
-        if( preserves ) {
+    std::function<detached_ptr<item>( detached_ptr<item> &&, bool, bool )> process_content =
+        [&]( detached_ptr<item> &&it, const bool parent_preserves,
+             const bool parent_seals ) -> detached_ptr<item> {
+        if( !it ) {
+            return std::move( it );
+        }
+
+        const bool content_preserves = parent_preserves ||
+                                       ( it->type->container && it->type->container->preserves );
+        const bool content_seals = parent_seals ||
+                                   ( it->type->container && it->type->container->seals );
+
+        auto content_processing_items = std::vector<cache_reference<item>> {};
+        for( item *const content_item : it->contents.processing_items() ) {
+            if( content_item != nullptr ) {
+                content_processing_items.emplace_back( *content_item );
+            }
+        }
+        for( const cache_reference<item> &content_item : content_processing_items ) {
+            if( !content_item ) {
+                continue;
+            }
+            content_item->attempt_detach( [&]( detached_ptr<item> &&nested ) {
+                return process_content( std::move( nested ), content_preserves, content_seals );
+            } );
+        }
+
+        if( content_preserves ) {
             it->last_rot_check = calendar::turn;
         }
-        it = it->process_internal( std::move( it ), carrier, pos, activate, seals, flag,
-                                   weather_generator );
-        return VisitResponse::NEXT;
-    } );
+        return process_internal( std::move( it ), carrier, pos, activate, content_seals, flag,
+                                 weather_generator );
+    };
+
+    auto content_processing_items = std::vector<cache_reference<item>> {};
+    for( item *const content_item : obj.contents.processing_items() ) {
+        if( content_item != nullptr ) {
+            content_processing_items.emplace_back( *content_item );
+        }
+    }
+    for( const cache_reference<item> &content_item : content_processing_items ) {
+        if( !content_item ) {
+            continue;
+        }
+        content_item->attempt_detach( [&]( detached_ptr<item> &&it ) {
+            return process_content( std::move( it ), preserves, seals );
+        } );
+    }
+
     detached_ptr<item> res = process_internal( std::move( self ), carrier, pos, activate, seals, flag,
                              weather_generator );
     return res;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1269,7 +1269,6 @@ void item::put_in( detached_ptr<item> &&payload )
         return;
     }
     contents.insert_item( std::move( payload ) );
-    on_contents_changed();
 }
 
 void item::add_item_with_id( const itype_id &itype, int count )

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10948,25 +10948,28 @@ detached_ptr<item> item::process( detached_ptr<item> &&self, player *carrier,
     const bool seals = self->type->container && self->type->container->seals;
     item &obj = *self;
 
-    std::function<detached_ptr<item>( detached_ptr<item> &&, bool, bool )> process_content =
+    std::function < detached_ptr<item>( detached_ptr<item> &&, bool, bool ) > process_content =
         [&]( detached_ptr<item> &&it, const bool parent_preserves,
-             const bool parent_seals ) -> detached_ptr<item> {
-        if( !it ) {
+    const bool parent_seals ) -> detached_ptr<item> {
+        if( !it )
+        {
             return std::move( it );
         }
 
         const bool content_preserves = parent_preserves ||
-                                       ( it->type->container && it->type->container->preserves );
+        ( it->type->container && it->type->container->preserves );
         const bool content_seals = parent_seals ||
-                                   ( it->type->container && it->type->container->seals );
+        ( it->type->container && it->type->container->seals );
 
         auto content_processing_items = std::vector<cache_reference<item>> {};
-        for( item *const content_item : it->contents.processing_items() ) {
+        for( item *const content_item : it->contents.processing_items() )
+        {
             if( content_item != nullptr ) {
                 content_processing_items.emplace_back( *content_item );
             }
         }
-        for( const cache_reference<item> &content_item : content_processing_items ) {
+        for( const cache_reference<item> &content_item : content_processing_items )
+        {
             if( !content_item ) {
                 continue;
             }
@@ -10975,7 +10978,8 @@ detached_ptr<item> item::process( detached_ptr<item> &&self, player *carrier,
             } );
         }
 
-        if( content_preserves ) {
+        if( content_preserves )
+        {
             it->last_rot_check = calendar::turn;
         }
         return process_internal( std::move( it ), carrier, pos, activate, content_seals, flag,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10934,14 +10934,40 @@ detached_ptr<item> item::process( detached_ptr<item> &&self, player *carrier,
     const bool seals = self->type->container && self->type->container->seals;
     item &obj = *self;
 
-    obj.remove_items_with( [&]( detached_ptr<item> &&it ) {
+    std::function<detached_ptr<item>( detached_ptr<item> && )> process_content =
+        [&]( detached_ptr<item> &&it ) -> detached_ptr<item> {
+        if( !it ) {
+            return std::move( it );
+        }
+
+        item &content_obj = *it;
+        const std::vector<item *> content_processing_items = content_obj.contents.processing_items();
+        for( item *const content_item : content_processing_items ) {
+            if( content_item == nullptr ) {
+                continue;
+            }
+            content_item->attempt_detach( [&]( detached_ptr<item> &&nested ) {
+                return process_content( std::move( nested ) );
+            } );
+        }
+
         if( preserves ) {
             it->last_rot_check = calendar::turn;
         }
-        it = it->process_internal( std::move( it ), carrier, pos, activate, seals, flag,
-                                   weather_generator );
-        return VisitResponse::NEXT;
-    } );
+        return process_internal( std::move( it ), carrier, pos, activate, seals, flag,
+                                 weather_generator );
+    };
+
+    const std::vector<item *> content_processing_items = obj.contents.processing_items();
+    for( item *const content_item : content_processing_items ) {
+        if( content_item == nullptr ) {
+            continue;
+        }
+        content_item->attempt_detach( [&]( detached_ptr<item> &&it ) {
+            return process_content( std::move( it ) );
+        } );
+    }
+
     detached_ptr<item> res = process_internal( std::move( self ), carrier, pos, activate, seals, flag,
                              weather_generator );
     return res;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10934,40 +10934,14 @@ detached_ptr<item> item::process( detached_ptr<item> &&self, player *carrier,
     const bool seals = self->type->container && self->type->container->seals;
     item &obj = *self;
 
-    std::function<detached_ptr<item>( detached_ptr<item> && )> process_content =
-        [&]( detached_ptr<item> &&it ) -> detached_ptr<item> {
-        if( !it ) {
-            return std::move( it );
-        }
-
-        item &content_obj = *it;
-        const std::vector<item *> content_processing_items = content_obj.contents.processing_items();
-        for( item *const content_item : content_processing_items ) {
-            if( content_item == nullptr ) {
-                continue;
-            }
-            content_item->attempt_detach( [&]( detached_ptr<item> &&nested ) {
-                return process_content( std::move( nested ) );
-            } );
-        }
-
+    obj.remove_items_with( [&]( detached_ptr<item> &&it ) {
         if( preserves ) {
             it->last_rot_check = calendar::turn;
         }
-        return process_internal( std::move( it ), carrier, pos, activate, seals, flag,
-                                 weather_generator );
-    };
-
-    const std::vector<item *> content_processing_items = obj.contents.processing_items();
-    for( item *const content_item : content_processing_items ) {
-        if( content_item == nullptr ) {
-            continue;
-        }
-        content_item->attempt_detach( [&]( detached_ptr<item> &&it ) {
-            return process_content( std::move( it ) );
-        } );
-    }
-
+        it = it->process_internal( std::move( it ), carrier, pos, activate, seals, flag,
+                                   weather_generator );
+        return VisitResponse::NEXT;
+    } );
     detached_ptr<item> res = process_internal( std::move( self ), carrier, pos, activate, seals, flag,
                              weather_generator );
     return res;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1131,7 +1131,9 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
     }
 
     if( is_corpse() || rhs.is_corpse() ) {
-        return this->is_corpse() && rhs.is_corpse() && ( *this->get_mtype() == *rhs.get_mtype() );
+        return this->is_corpse() && rhs.is_corpse() && ( *this->get_mtype() == *rhs.get_mtype() ) &&
+               get_var( "bionics_scanned_by", -1 ) == rhs.get_var( "bionics_scanned_by", -1 ) &&
+               has_flag( flag_CBM_SCANNED ) == rhs.has_flag( flag_CBM_SCANNED );
     }
 
     if( damage_ != rhs.damage_ ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_set>
+#include <vector>
 
 #include "action_time_scale.h"
 #include "active_tile_data_def.h"
@@ -621,22 +622,6 @@ void item::deactivate()
     if( is_tool() ) {
         type->tool->turns_active = 0;
     }
-
-    // Is not placed in the world, so either a template of some kind or a temporary item.
-    if( !has_position() ) {
-        return;
-    }
-    switch( where() ) {
-        case item_location_type::map:
-            get_map().make_inactive( *this );
-            break;
-        case item_location_type::vehicle:
-            get_map().veh_at( abs_pos() )->vehicle().make_inactive( *this );
-            break;
-        default:
-            break;
-    }
-
 }
 
 void item::activate()
@@ -651,21 +636,6 @@ void item::activate()
 
     active = true;
     invalidate_processing_cache_upwards();
-
-    // Is not placed in the world, so either a template of some kind or a temporary item.
-    if( !has_position() ) {
-        return;
-    }
-    switch( where() ) {
-        case item_location_type::map:
-            get_map().make_active( *this );
-            break;
-        case item_location_type::vehicle:
-            get_map().veh_at( abs_pos() )->vehicle().make_active( *this );
-            break;
-        default:
-            break;
-    }
 }
 
 bool item::revert( const Character *ch, bool alert )
@@ -1107,14 +1077,18 @@ int item::charges_per_volume( const units::volume &vol ) const
 namespace
 {
 
-auto bionic_component_display_names( const item &corpse ) -> std::set<std::string>
+auto bionic_component_type_ids( const item &corpse ) -> std::vector<itype_id>
 {
     using namespace std::views;
     namespace ranges = std::ranges;
-    return corpse.get_components()
-           | filter( &item::is_bionic )
-    | transform( []( const item * component ) { return component->display_name(); } )
-    | ranges::to<std::set>();
+    auto result = corpse.get_components()
+                  | filter( &item::is_bionic )
+                  | transform( &item::typeId )
+                  | ranges::to<std::vector>();
+    ranges::sort( result, []( const itype_id & lhs, const itype_id & rhs ) {
+        return lhs < rhs;
+    } );
+    return result;
 }
 
 } // namespace
@@ -1152,7 +1126,7 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
             return false;
         }
         return !has_flag( flag_CBM_SCANNED ) ||
-               bionic_component_display_names( *this ) == bionic_component_display_names( rhs );
+               bionic_component_type_ids( *this ) == bionic_component_type_ids( rhs );
     }
 
     if( damage_ != rhs.damage_ ) {
@@ -7539,17 +7513,27 @@ const mtype *item::get_mtype() const
     return corpse;
 }
 
+namespace
+{
+
 template<typename Item>
-static Item *get_food_impl( Item *it )
+auto get_food_impl( Item *it ) -> Item * // *NOPAD*
 {
     if( it->is_food() ) {
         return it;
-    } else if( it->is_food_container() && !it->contents.empty() ) {
-        return &it->contents.front();
-    } else {
-        return nullptr;
     }
+    for( auto *const contained_item : it->contents.all_items_top() ) {
+        if( contained_item == nullptr ) {
+            continue;
+        }
+        if( auto *food = get_food_impl( contained_item ) ) {
+            return food;
+        }
+    }
+    return nullptr;
 }
+
+} // namespace
 
 item *item::get_food()
 {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6007,7 +6007,8 @@ bool item::can_shatter() const
 void item::unset_flags()
 {
     const bool affects_processing = item_tags.count( flag_RADIO_ACTIVATION ) ||
-                                    item_tags.count( flag_ETHEREAL_ITEM );
+                                    item_tags.count( flag_ETHEREAL_ITEM ) ||
+                                    item_tags.count( flag_PROCESSING );
     item_tags.clear();
     if( affects_processing ) {
         invalidate_processing_cache_upwards();
@@ -6075,7 +6076,8 @@ bool item::has_vitamin( const vitamin_id &v ) const
 void item::set_flag( const flag_id &flag )
 {
     if( flag.is_valid() ) {
-        const bool affects_processing = flag == flag_RADIO_ACTIVATION || flag == flag_ETHEREAL_ITEM;
+        const bool affects_processing = flag == flag_RADIO_ACTIVATION || flag == flag_ETHEREAL_ITEM ||
+                                        flag == flag_PROCESSING;
         const bool inserted = item_tags.insert( flag ).second;
         if( inserted && affects_processing ) {
             invalidate_processing_cache_upwards();
@@ -6087,7 +6089,8 @@ void item::set_flag( const flag_id &flag )
 
 void item::unset_flag( const flag_id &flag )
 {
-    const bool affects_processing = flag == flag_RADIO_ACTIVATION || flag == flag_ETHEREAL_ITEM;
+    const bool affects_processing = flag == flag_RADIO_ACTIVATION || flag == flag_ETHEREAL_ITEM ||
+                                    flag == flag_PROCESSING;
     const bool erased = item_tags.erase( flag ) > 0;
     if( erased && affects_processing ) {
         invalidate_processing_cache_upwards();
@@ -10134,11 +10137,17 @@ auto item::invalidate_processing_cache_upwards() -> void
 
 int item::processing_speed() const
 {
-    if( is_corpse() || is_food() || is_food_container() ) {
-        return to_turns<int>( 10_minutes );
+    auto speed = is_corpse() || is_food() || is_food_container() ? to_turns<int>( 10_minutes ) : 1;
+    for( const item *contained_item : contents.processing_items() ) {
+        if( contained_item != nullptr ) {
+            speed = std::min( speed, contained_item->processing_speed() );
+        }
     }
-    // Unless otherwise indicated, update every turn.
-    return 1;
+    if( const item *magazine = magazine_current(); magazine != nullptr &&
+        magazine->needs_processing() ) {
+        speed = std::min( speed, magazine->processing_speed() );
+    }
+    return speed;
 }
 
 auto item::process_rot( detached_ptr<item> &&self,

--- a/src/item.h
+++ b/src/item.h
@@ -1315,6 +1315,7 @@ class item : public location_visitable<item>, public game_object<item>
          * Whether the item should be processed (by calling @ref process).
          */
         bool needs_processing() const;
+        auto invalidate_processing_cache_upwards() -> void;
         /**
          * The rate at which an item should be processed, in number of turns between updates.
          */

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -15,18 +15,52 @@
 
 struct tripoint;
 
-item_contents::item_contents( item *container ) : items( new contents_item_location(
-                container ) ) {}
+item_contents::item_contents( item *container ) : owner( container ),
+    items( new contents_item_location(
+               container ) ) {}
 /** used to aid migration */
 item_contents::item_contents( item *container,
-                              std::vector<detached_ptr<item>> &items ) : items( new contents_item_location( container ),
-                                          items ) {}
+                              std::vector<detached_ptr<item>> &items ) : owner( container ),
+    items( new contents_item_location( container ),
+           items ) {}
 
 item_contents::~item_contents() = default;
 
 bool item_contents::empty() const
 {
     return items.empty();
+}
+
+auto item_contents::has_processing_items() const -> bool
+{
+    update_processing_cache();
+    return !cached_processing_items.empty();
+}
+
+auto item_contents::processing_items() const -> const std::vector<item *> & // *NOPAD*
+{
+    update_processing_cache();
+    return cached_processing_items;
+}
+
+auto item_contents::invalidate_processing_cache() const -> void
+{
+    processing_cache_dirty = true;
+}
+
+auto item_contents::update_processing_cache() const -> void
+{
+    if( !processing_cache_dirty ) {
+        return;
+    }
+
+    cached_processing_items.clear();
+    for( item * const &contained_item : items ) {
+        if( contained_item->needs_processing() ) {
+            cached_processing_items.push_back( contained_item );
+        }
+    }
+    processing_cache_dirty = false;
 }
 
 ret_val<bool> item_contents::insert_item( detached_ptr<item> &&it )
@@ -47,6 +81,11 @@ ret_val<bool> item_contents::insert_item( detached_ptr<item> &&it )
         items.push_back( std::move( it ) );
     }
 
+    if( owner != nullptr ) {
+        owner->invalidate_processing_cache_upwards();
+    } else {
+        invalidate_processing_cache();
+    }
     return ret_val<bool>::make_success();
 }
 
@@ -96,7 +135,13 @@ void item_contents::casings_handle( const std::function < detached_ptr<item>
 
 std::vector<detached_ptr<item>> item_contents::clear_items()
 {
-    return items.clear();
+    auto ret = items.clear();
+    if( owner != nullptr ) {
+        owner->invalidate_processing_cache_upwards();
+    } else {
+        invalidate_processing_cache();
+    }
+    return ret;
 }
 
 void item_contents::on_destroy()
@@ -167,13 +212,24 @@ detached_ptr<item> item_contents::remove_top( item *it )
     } );
     detached_ptr<item> ret;
     items.erase( iter, &ret );
+    if( owner != nullptr ) {
+        owner->invalidate_processing_cache_upwards();
+    } else {
+        invalidate_processing_cache();
+    }
     return ret;
 }
 
 location_vector<item>::iterator item_contents::remove_top( location_vector<item>::iterator &it,
         detached_ptr<item> *removed )
 {
-    return items.erase( it, removed );
+    const auto ret = items.erase( it, removed );
+    if( owner != nullptr ) {
+        owner->invalidate_processing_cache_upwards();
+    } else {
+        invalidate_processing_cache();
+    }
+    return ret;
 }
 
 std::vector<item *> item_contents::all_items_ptr()

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -96,7 +96,7 @@ size_t item_contents::num_item_stacks() const
 
 bool item_contents::spill_contents( const tripoint_bub_ms &pos )
 {
-    for( detached_ptr<item> &it : items.clear() ) {
+    for( detached_ptr<item> &it : clear_items() ) {
         get_map().add_item_or_charges( pos, std::move( it ) );
     }
     return true;
@@ -104,6 +104,7 @@ bool item_contents::spill_contents( const tripoint_bub_ms &pos )
 
 void item_contents::handle_liquid_or_spill( Character &guy )
 {
+    const bool had_items = !items.empty();
     for( auto iter = items.begin(); iter != items.end(); ) {
         if( ( *iter )->made_of( LIQUID ) ) {
             detached_ptr<item> det;
@@ -115,14 +116,23 @@ void item_contents::handle_liquid_or_spill( Character &guy )
             guy.i_add_or_drop( std::move( det ) );
         }
     }
+    if( had_items ) {
+        if( owner != nullptr ) {
+            owner->invalidate_processing_cache_upwards();
+        } else {
+            invalidate_processing_cache();
+        }
+    }
 }
 
 void item_contents::casings_handle( const std::function < detached_ptr<item>
                                     ( detached_ptr<item> && ) > &func )
 {
     static const flag_id json_flag_CASING( "CASING" );
-    items.remove_with( [&func]( detached_ptr<item> &&it ) {
+    auto changed = false;
+    items.remove_with( [&func, &changed]( detached_ptr<item> &&it ) {
         if( it->has_flag( json_flag_CASING ) ) {
+            changed = true;
             it->unset_flag( json_flag_CASING );
             it = func( std::move( it ) );
             if( it ) {
@@ -131,6 +141,13 @@ void item_contents::casings_handle( const std::function < detached_ptr<item>
         }
         return std::move( it );
     } );
+    if( changed ) {
+        if( owner != nullptr ) {
+            owner->invalidate_processing_cache_upwards();
+        } else {
+            invalidate_processing_cache();
+        }
+    }
 }
 
 std::vector<detached_ptr<item>> item_contents::clear_items()

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -28,6 +28,9 @@ class item_contents
         ~item_contents();
 
         bool empty() const;
+        auto has_processing_items() const -> bool;
+        auto processing_items() const -> const std::vector<item *> &; // *NOPAD*
+        auto invalidate_processing_cache() const -> void;
 
         /** returns a list of pointers to all top-level items */
         const std::vector<item *> &all_items_top() const;
@@ -111,7 +114,12 @@ class item_contents
 
         void on_destroy();
     private:
+        auto update_processing_cache() const -> void;
+
+        item *owner;
         location_vector<item> items;
+        mutable bool processing_cache_dirty = true;
+        mutable std::vector<item *> cached_processing_items;
 };
 
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2243,6 +2243,10 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint_bub_ms &pos 
         return 0;
     }
 
+    if( here.visibility_caches_dirty() ) {
+        here.update_visibility_cache( p->bub_pos().z() );
+    }
+
     // Try to minimize the use of has_enough_charges() because it's kind of expensive.
     bool no_charges = false;
     for( const tripoint_bub_ms &pt : here.points_in_radius( pos, PICKUP_RANGE ) ) {
@@ -2262,7 +2266,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint_bub_ms &pos 
                 }
             }
 
-            int charges = static_cast<int>( cbms.size() );
+            int charges = std::max( 1, static_cast<int>( cbms.size() ) );
             charges -= it->ammo_consume( charges, pos );
             if( possess && it->has_flag( flag_USE_UPS ) ) {
                 if( p->use_charges_if_avail( itype_UPS, charges ) ) {

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -4209,7 +4209,6 @@ auto mapbuffer::run_omt_pillar_post_pass( const point_abs_omt &omt_pos ) -> void
             auto changed = false;
             for( const auto local : submap_tiles() ) {
                 const auto terrain_here = sub_here->get_ter( local );
-                /* TODO: Make mapgen stairs sane so this dead code can be used or reworked.
                 if( const auto target = vertical_transition_target_below( terrain_here );
                     target && zlev > -OVERMAP_DEPTH ) {
                     ensure_vertical_transition_link( {
@@ -4226,7 +4225,6 @@ auto mapbuffer::run_omt_pillar_post_pass( const point_abs_omt &omt_pos ) -> void
                         .desired = *target,
                     } );
                 }
-                */
 
                 if( terrain_here != t_open_air ) {
                     continue;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -402,15 +402,24 @@ VisitResponse visitable<T>::visit_items( const std::function<VisitResponse( item
 
 
 
-static VisitResponse visit_internal( std::function < VisitResponse( detached_ptr<item> &&e ) >
-                                     filter, location_vector<item> &items )
+namespace
 {
-    VisitResponse last = VisitResponse::NEXT;
-    items.remove_with( [&last, &filter]( detached_ptr<item> &&e ) {
+
+auto visit_internal( std::function < VisitResponse( detached_ptr<item> &&e ) > filter,
+                     location_vector<item> &items ) -> bool
+{
+    auto last = VisitResponse::NEXT;
+    auto processing_changed = false;
+    items.remove_with( [&last, &processing_changed, &filter]( detached_ptr<item> &&e ) {
         if( last == VisitResponse::ABORT ) {
             return std::move( e );
         }
+        const auto needs_processing_before = e != nullptr && e->needs_processing();
         last = filter( std::move( e ) );
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        if( e != nullptr && e->needs_processing() != needs_processing_before ) {
+            processing_changed = true;
+        }
         // NOLINTNEXTLINE(bugprone-use-after-move)
         if( last == VisitResponse::NEXT && e ) {
             e->contents.remove_items_with( [&last, &filter]( detached_ptr<item> &&e ) {
@@ -423,8 +432,10 @@ static VisitResponse visit_internal( std::function < VisitResponse( detached_ptr
         }
         return std::move( e );
     } );
-    return last == VisitResponse::ABORT ? VisitResponse::ABORT : VisitResponse::NEXT;
+    return processing_changed;
 }
+
+} // namespace
 
 // Specialize visitable<T>::visit_items() for each class that will implement the visitable interface
 
@@ -658,13 +669,14 @@ void item_contents::remove_items_with( const std::function < VisitResponse(
         detached_ptr<item> && ) > &filter )
 {
     const auto old_size = items.size();
-    visit_internal( filter, items );
-    if( items.size() != old_size ) {
-        if( owner != nullptr ) {
-            owner->invalidate_processing_cache_upwards();
-        } else {
-            invalidate_processing_cache();
-        }
+    const auto processing_changed = visit_internal( filter, items );
+    if( items.size() == old_size && !processing_changed ) {
+        return;
+    }
+    if( owner != nullptr ) {
+        owner->invalidate_processing_cache_upwards();
+    } else {
+        invalidate_processing_cache();
     }
 }
 

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -657,7 +657,15 @@ detached_ptr<item> location_visitable<T>::remove_item( item &it )
 void item_contents::remove_items_with( const std::function < VisitResponse(
         detached_ptr<item> && ) > &filter )
 {
+    const auto old_size = items.size();
     visit_internal( filter, items );
+    if( items.size() != old_size ) {
+        if( owner != nullptr ) {
+            owner->invalidate_processing_cache_upwards();
+        } else {
+            invalidate_processing_cache();
+        }
+    }
 }
 
 /** @relates visitable */

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -5,6 +5,7 @@
 #include "active_item_cache.h"
 #include "calendar.h"
 #include "coordinates.h"
+#include "flag.h"
 #include "game.h"
 #include "game_constants.h"
 #include "item.h"
@@ -114,6 +115,62 @@ TEST_CASE( "stack_clear_updates_active_item_cache", "[item]" )
     REQUIRE( removed.size() == 1 );
     CHECK_FALSE( g->m.get_submaps_with_active_items().contains( abs_loc ) );
     CHECK( g->m.check_submap_active_item_consistency().empty() );
+}
+
+TEST_CASE( "nested_processing_flag_changes_invalidate_container_cache", "[item]" )
+{
+    clear_all_state();
+
+    auto backpack = item::spawn( "backpack" );
+    backpack->put_in( item::spawn( "rock" ) );
+    item &stored = backpack->contents.front();
+
+    REQUIRE_FALSE( backpack->needs_processing() );
+
+    stored.set_flag( flag_RADIO_ACTIVATION );
+    CHECK( backpack->needs_processing() );
+
+    stored.unset_flag( flag_RADIO_ACTIVATION );
+    CHECK_FALSE( backpack->needs_processing() );
+
+    stored.set_flag( flag_ETHEREAL_ITEM );
+    CHECK( backpack->needs_processing() );
+
+    stored.unset_flags();
+    CHECK_FALSE( backpack->needs_processing() );
+}
+
+TEST_CASE( "content_removal_helpers_invalidate_processing_cache", "[item]" )
+{
+    clear_all_state();
+    const auto loc = tripoint_bub_ms{ 60, 60, 0 };
+    g->m.i_clear( loc );
+
+    SECTION( "spill contents" ) {
+        auto backpack = item::spawn( "backpack" );
+        auto active = item::spawn( "firecracker_act", calendar::start_of_cataclysm,
+                                   item::default_charges_tag() );
+        active->activate();
+        backpack->put_in( std::move( active ) );
+
+        REQUIRE( backpack->needs_processing() );
+        backpack->contents.spill_contents( loc );
+        CHECK_FALSE( backpack->needs_processing() );
+    }
+
+    SECTION( "handle casings" ) {
+        auto backpack = item::spawn( "backpack" );
+        auto casing = item::spawn( "rock" );
+        casing->set_flag( flag_CASING );
+        casing->set_flag( flag_RADIO_ACTIVATION );
+        backpack->put_in( std::move( casing ) );
+
+        REQUIRE( backpack->needs_processing() );
+        backpack->contents.casings_handle( []( detached_ptr<item> && /*it*/ ) {
+            return detached_ptr<item>();
+        } );
+        CHECK_FALSE( backpack->needs_processing() );
+    }
 }
 
 TEST_CASE( "active_item_cache_slow_items_accrue_elapsed_time", "[item]" )

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -171,6 +171,36 @@ TEST_CASE( "content_removal_helpers_invalidate_processing_cache", "[item]" )
         } );
         CHECK_FALSE( backpack->needs_processing() );
     }
+
+    SECTION( "same-size top content mutation" ) {
+        auto backpack = item::spawn( "backpack" );
+        auto radio = item::spawn( "rock" );
+        radio->set_flag( flag_RADIO_ACTIVATION );
+        backpack->put_in( std::move( radio ) );
+
+        REQUIRE( backpack->needs_processing() );
+        backpack->contents.remove_top_items_with( []( detached_ptr<item> &&it ) {
+            it->item_tags.erase( flag_RADIO_ACTIVATION );
+            return std::move( it );
+        } );
+        CHECK_FALSE( backpack->needs_processing() );
+    }
+
+    SECTION( "same-size nested content mutation" ) {
+        auto backpack = item::spawn( "backpack" );
+        auto inner_bag = item::spawn( "bag_plastic" );
+        auto radio = item::spawn( "rock" );
+        radio->set_flag( flag_RADIO_ACTIVATION );
+        inner_bag->put_in( std::move( radio ) );
+        backpack->put_in( std::move( inner_bag ) );
+
+        REQUIRE( backpack->needs_processing() );
+        backpack->contents.front().contents.remove_top_items_with( []( detached_ptr<item> &&it ) {
+            it->item_tags.erase( flag_RADIO_ACTIVATION );
+            return std::move( it );
+        } );
+        CHECK_FALSE( backpack->needs_processing() );
+    }
 }
 
 TEST_CASE( "active_item_cache_slow_items_accrue_elapsed_time", "[item]" )

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -140,6 +140,55 @@ TEST_CASE( "nested_processing_flag_changes_invalidate_container_cache", "[item]"
     CHECK_FALSE( backpack->needs_processing() );
 }
 
+TEST_CASE( "nested_processing_food_flag_changes_invalidate_container_cache", "[item]" )
+{
+    clear_all_state();
+
+    auto backpack = item::spawn( "backpack" );
+    backpack->put_in( item::spawn( "bread" ) );
+    item &stored = backpack->contents.front();
+    stored.deactivate();
+
+    REQUIRE_FALSE( stored.is_active() );
+    REQUIRE( backpack->needs_processing() );
+
+    stored.set_flag( flag_PROCESSING );
+    CHECK_FALSE( backpack->needs_processing() );
+
+    stored.unset_flag( flag_PROCESSING );
+    CHECK( backpack->needs_processing() );
+
+    stored.set_flag( flag_PROCESSING );
+    CHECK_FALSE( backpack->needs_processing() );
+
+    stored.unset_flags();
+    CHECK( backpack->needs_processing() );
+}
+
+TEST_CASE( "active_item_cache_moves_items_when_processing_speed_changes", "[item]" )
+{
+    clear_all_state();
+
+    auto backpack = item::spawn( "backpack" );
+    backpack->put_in( item::spawn( "sashimi" ) );
+    REQUIRE( backpack->needs_processing() );
+    REQUIRE( backpack->processing_speed() == to_turns<int>( 10_minutes ) );
+
+    auto cache = active_item_cache();
+    cache.add( *backpack );
+    CHECK( cache.count().total == 1 );
+
+    auto active = item::spawn( "firecracker_act", calendar::start_of_cataclysm,
+                               item::default_charges_tag() );
+    active->activate();
+    backpack->put_in( std::move( active ) );
+    REQUIRE( backpack->needs_processing() );
+    CHECK( backpack->processing_speed() == 1 );
+
+    cache.add( *backpack );
+    CHECK( cache.count().total == 1 );
+}
+
 TEST_CASE( "content_removal_helpers_invalidate_processing_cache", "[item]" )
 {
     clear_all_state();

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "avatar.h"
 #include "bodypart.h"
@@ -100,6 +101,56 @@ TEST_CASE( "bionic_scanner_inside_container_marks_corpses_with_cbms", "[iuse][bi
     CHECK( corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
     CHECK( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
     CHECK( scanner_ptr->ammo_remaining() == charges_before - 1 );
+}
+
+TEST_CASE( "bionic_scanner_inside_worn_container_marks_corpse_stack", "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    you.setID( character_id( 1 ), true );
+    auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
+    const auto corpse_pos = you.bub_pos() + tripoint_east;
+    REQUIRE( you.sees( corpse_pos ) );
+    auto corpse_ptrs = std::vector<item *> {};
+    for( auto i = 0; i < 10; ++i ) {
+        auto corpse = item::make_corpse( mtype_id( "mon_zombie_soldier" ), calendar::turn, "" );
+        corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
+        auto *const corpse_ptr = corpse.get();
+        REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( corpse ), false ) );
+        corpse_ptrs.push_back( corpse_ptr );
+    }
+
+    auto backpack = item::spawn( "backpack", calendar::turn );
+    auto *const backpack_ptr = backpack.get();
+    auto scanner = item::spawn( "bionic_scanner", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 100 );
+    auto *const scanner_ptr = scanner.get();
+    backpack->put_in( std::move( scanner ) );
+    REQUIRE_FALSE( you.wear_item( std::move( backpack ), false ) );
+
+    REQUIRE( scanner_ptr->type->invoke( you, *scanner_ptr, you.bub_pos() ) == 0 );
+    REQUIRE( scanner_ptr->typeId() == itype_id( "bionic_scanner_on" ) );
+    REQUIRE( scanner_ptr->is_active() );
+    REQUIRE( scanner_ptr->needs_processing() );
+    REQUIRE( backpack_ptr->needs_processing() );
+    here.build_map_cache( you.bub_pos().z() );
+    here.update_visibility_cache( you.bub_pos().z() );
+    REQUIRE( you.sees( corpse_pos ) );
+
+    you.process_items();
+
+    for( const item *const corpse_ptr : corpse_ptrs ) {
+        CHECK( corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
+        CHECK( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    }
+    CHECK( scanner_ptr->ammo_remaining() == 90 );
 }
 
 TEST_CASE( "eyedrops", "[iuse][eyedrops]" )

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -98,6 +98,7 @@ TEST_CASE( "bionic_scanner_inside_ground_container_marks_corpses_with_cbms",
 
     auto backpack = item::spawn( "backpack", calendar::turn );
     backpack->put_in( item::spawn( "rock", calendar::turn ) );
+    backpack->put_in( item::spawn( "sashimi", calendar::turn ) );
     auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
     scanner->ammo_set( itype_id( "battery" ), 10 );
     scanner->activate();
@@ -105,6 +106,7 @@ TEST_CASE( "bionic_scanner_inside_ground_container_marks_corpses_with_cbms",
     const auto charges_before = scanner_ptr->ammo_remaining();
     backpack->put_in( std::move( scanner ) );
     REQUIRE( backpack->needs_processing() );
+    REQUIRE( backpack->processing_speed() == 1 );
     REQUIRE_FALSE( here.add_item_or_charges( you.bub_pos(), std::move( backpack ), false ) );
 
     here.process_items();

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -316,10 +316,69 @@ TEST_CASE( "bionic_scanner_updates_same_monster_corpse_pile_display",
 
     const auto cbm_display_name = cbm_corpse_ptr->display_name();
     const auto empty_display_name = empty_corpse_ptr->display_name();
-    CHECK( cbm_display_name.find( "bionic detected" ) != std::string::npos );
-    CHECK( empty_display_name.find( "scanned" ) != std::string::npos );
-    CHECK( cbm_display_name.find( "corpse of a zombie technician (fresh)" ) == std::string::npos );
-    CHECK( empty_display_name.find( "corpse of a zombie technician (fresh)" ) == std::string::npos );
+    using Catch::Matchers::Contains;
+    CHECK_THAT( cbm_display_name, Contains( "bionic detected" ) );
+    CHECK_THAT( empty_display_name, Contains( "scanned" ) );
+    CHECK_THAT( cbm_display_name, !Contains( "corpse of a zombie technician (fresh)" ) );
+    CHECK_THAT( empty_display_name, !Contains( "corpse of a zombie technician (fresh)" ) );
+}
+
+TEST_CASE( "bionic_scanner_separates_detected_corpse_piles_by_found_cbms",
+           "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    you.setID( character_id( 1 ), true );
+    auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
+    const auto corpse_pos = you.bub_pos() + tripoint_south;
+    REQUIRE( you.sees( corpse_pos ) );
+    auto solar_corpse = item::make_corpse( mtype_id( "mon_zombie_electric" ), calendar::turn, "" );
+    solar_corpse->add_component( item::spawn( "bn_bio_solar", calendar::turn ) );
+    auto *const solar_corpse_ptr = solar_corpse.get();
+    here.add_item( corpse_pos, std::move( solar_corpse ) );
+
+    auto storage_corpse = item::make_corpse( mtype_id( "mon_zombie_electric" ), calendar::turn, "" );
+    storage_corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
+    auto *const storage_corpse_ptr = storage_corpse.get();
+    here.add_item( corpse_pos, std::move( storage_corpse ) );
+    REQUIRE( solar_corpse_ptr->display_stacked_with( *storage_corpse_ptr ) );
+
+    auto backpack = item::spawn( "backpack", calendar::turn );
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 10 );
+    scanner->activate();
+    backpack->put_in( std::move( scanner ) );
+    you.i_add( std::move( backpack ) );
+
+    you.process_items();
+
+    REQUIRE( solar_corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    REQUIRE( storage_corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    CHECK_FALSE( solar_corpse_ptr->display_stacked_with( *storage_corpse_ptr ) );
+
+    const auto item_info_text = []( const item &corpse ) {
+        auto result = std::string {};
+        for( const iteminfo &entry : corpse.info() ) {
+            result += entry.sName;
+            result += entry.sFmt;
+            result += entry.sValue;
+        }
+        return result;
+    };
+    const auto solar_info = item_info_text( *solar_corpse_ptr );
+    const auto storage_info = item_info_text( *storage_corpse_ptr );
+    using Catch::Matchers::Contains;
+    CHECK_THAT( solar_info, Contains( "Solar Panels CBM" ) );
+    CHECK_THAT( solar_info, !Contains( "Power Storage CBM" ) );
+    CHECK_THAT( storage_info, Contains( "Power Storage CBM" ) );
+    CHECK_THAT( storage_info, !Contains( "Solar Panels CBM" ) );
 }
 
 TEST_CASE( "bionic_scanner_inside_worn_container_marks_corpse_stack", "[iuse][bionic_scanner]" )

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -61,6 +61,47 @@ TEST_CASE( "bionic_scanner_on_ground_marks_corpses_with_cbms", "[iuse][bionic_sc
     CHECK( scanner_ptr->ammo_remaining() == charges_before - 1 );
 }
 
+TEST_CASE( "bionic_scanner_inside_ground_container_marks_corpses_with_cbms",
+           "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    you.setID( character_id( 1 ), true );
+    auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
+    const auto corpse_pos = you.bub_pos() + tripoint_east;
+    REQUIRE( you.sees( corpse_pos ) );
+    auto corpse = item::make_corpse( mtype_id( "mon_zombie_soldier" ), calendar::turn, "" );
+    corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
+    REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( corpse ), false ) );
+    const auto corpse_stack = here.i_at( corpse_pos );
+    REQUIRE( corpse_stack.size() == 1 );
+    auto *const corpse_ptr = *corpse_stack.begin();
+
+    auto backpack = item::spawn( "backpack", calendar::turn );
+    backpack->put_in( item::spawn( "rock", calendar::turn ) );
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 10 );
+    scanner->activate();
+    const auto *const scanner_ptr = scanner.get();
+    const auto charges_before = scanner_ptr->ammo_remaining();
+    backpack->put_in( std::move( scanner ) );
+    REQUIRE( backpack->needs_processing() );
+    REQUIRE_FALSE( here.add_item_or_charges( you.bub_pos(), std::move( backpack ), false ) );
+
+    here.process_items();
+
+    CHECK( corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
+    CHECK( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    CHECK( scanner_ptr->ammo_remaining() == charges_before - 1 );
+}
+
 TEST_CASE( "bionic_scanner_inside_container_marks_corpses_with_cbms", "[iuse][bionic_scanner]" )
 {
     const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -192,6 +192,55 @@ TEST_CASE( "bionic_scanner_separates_detected_corpses_from_unscanned_stack",
     CHECK_FALSE( unscanned_corpse->display_stacked_with( *detected_corpse ) );
 }
 
+TEST_CASE( "bionic_scanner_updates_same_monster_corpse_pile_display",
+           "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    you.setID( character_id( 1 ), true );
+    auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
+    const auto corpse_pos = you.bub_pos();
+    REQUIRE( you.sees( corpse_pos ) );
+    auto cbm_corpse = item::make_corpse( mtype_id( "mon_zombie_technician" ), calendar::turn, "" );
+    cbm_corpse->add_component( item::spawn( "bio_electrosense", calendar::turn ) );
+    auto *const cbm_corpse_ptr = cbm_corpse.get();
+    REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( cbm_corpse ), false ) );
+
+    auto empty_corpse = item::make_corpse( mtype_id( "mon_zombie_technician" ), calendar::turn, "" );
+    auto *const empty_corpse_ptr = empty_corpse.get();
+    REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( empty_corpse ), false ) );
+    REQUIRE( cbm_corpse_ptr->display_stacked_with( *empty_corpse_ptr ) );
+
+    auto backpack = item::spawn( "backpack", calendar::turn );
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 10 );
+    scanner->activate();
+    backpack->put_in( std::move( scanner ) );
+    you.i_add( std::move( backpack ) );
+
+    you.process_items();
+
+    CHECK( cbm_corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
+    CHECK( cbm_corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    CHECK( empty_corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
+    CHECK_FALSE( empty_corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    CHECK_FALSE( cbm_corpse_ptr->display_stacked_with( *empty_corpse_ptr ) );
+
+    const auto cbm_display_name = cbm_corpse_ptr->display_name();
+    const auto empty_display_name = empty_corpse_ptr->display_name();
+    CHECK( cbm_display_name.find( "bionic detected" ) != std::string::npos );
+    CHECK( empty_display_name.find( "scanned" ) != std::string::npos );
+    CHECK( cbm_display_name.find( "corpse of a zombie technician (fresh)" ) == std::string::npos );
+    CHECK( empty_display_name.find( "corpse of a zombie technician (fresh)" ) == std::string::npos );
+}
+
 TEST_CASE( "bionic_scanner_inside_worn_container_marks_corpse_stack", "[iuse][bionic_scanner]" )
 {
     const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -22,6 +22,18 @@
 #include "type_id.h"
 #include "value_ptr.h"
 
+namespace
+{
+
+auto restore_bionic_scanner_avatar_id( avatar &you ) -> on_out_of_scope
+{
+    const auto previous_id = you.getID();
+    you.setID( character_id( 1 ), true );
+    return on_out_of_scope( [&you, previous_id]() { you.setID( previous_id, true ); } );
+}
+
+} // namespace
+
 TEST_CASE( "bionic_scanner_on_ground_marks_corpses_with_cbms", "[iuse][bionic_scanner]" )
 {
     const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
@@ -29,7 +41,7 @@ TEST_CASE( "bionic_scanner_on_ground_marks_corpses_with_cbms", "[iuse][bionic_sc
     clear_avatar();
 
     auto &you = get_avatar();
-    you.setID( character_id( 1 ), true );
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
     auto &here = get_map();
     g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
     set_time( calendar::turn_zero + 12_hours );
@@ -69,7 +81,7 @@ TEST_CASE( "bionic_scanner_inside_ground_container_marks_corpses_with_cbms",
     clear_avatar();
 
     auto &you = get_avatar();
-    you.setID( character_id( 1 ), true );
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
     auto &here = get_map();
     g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
     set_time( calendar::turn_zero + 12_hours );
@@ -109,7 +121,7 @@ TEST_CASE( "bionic_scanner_inside_container_marks_corpses_with_cbms", "[iuse][bi
     clear_avatar();
 
     auto &you = get_avatar();
-    you.setID( character_id( 1 ), true );
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
     auto &here = get_map();
     g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
     set_time( calendar::turn_zero + 12_hours );
@@ -151,7 +163,7 @@ TEST_CASE( "bionic_scanner_consumes_charge_for_each_scanned_corpse", "[iuse][bio
     clear_avatar();
 
     auto &you = get_avatar();
-    you.setID( character_id( 1 ), true );
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
     auto &here = get_map();
     g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
     set_time( calendar::turn_zero + 12_hours );
@@ -192,7 +204,7 @@ TEST_CASE( "bionic_scanner_marks_new_corpse_after_activation", "[iuse][bionic_sc
     clear_avatar();
 
     auto &you = get_avatar();
-    you.setID( character_id( 1 ), true );
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
     auto &here = get_map();
     g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
     set_time( calendar::turn_zero + 12_hours );
@@ -233,7 +245,7 @@ TEST_CASE( "bionic_scanner_separates_detected_corpses_from_unscanned_stack",
     clear_avatar();
 
     auto &you = get_avatar();
-    you.setID( character_id( 1 ), true );
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
     auto &here = get_map();
     g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
     set_time( calendar::turn_zero + 12_hours );
@@ -281,7 +293,7 @@ TEST_CASE( "bionic_scanner_updates_same_monster_corpse_pile_display",
     clear_avatar();
 
     auto &you = get_avatar();
-    you.setID( character_id( 1 ), true );
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
     auto &here = get_map();
     g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
     set_time( calendar::turn_zero + 12_hours );
@@ -331,7 +343,7 @@ TEST_CASE( "bionic_scanner_separates_detected_corpse_piles_by_found_cbms",
     clear_avatar();
 
     auto &you = get_avatar();
-    you.setID( character_id( 1 ), true );
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
     auto &here = get_map();
     g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
     set_time( calendar::turn_zero + 12_hours );
@@ -381,6 +393,73 @@ TEST_CASE( "bionic_scanner_separates_detected_corpse_piles_by_found_cbms",
     CHECK_THAT( storage_info, !Contains( "Solar Panels CBM" ) );
 }
 
+TEST_CASE( "bionic_scanner_separates_detected_corpse_piles_by_duplicate_cbm_count",
+           "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
+    auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
+    const auto corpse_pos = you.bub_pos() + tripoint_south;
+    REQUIRE( you.sees( corpse_pos ) );
+    auto one_storage_corpse = item::make_corpse( mtype_id( "mon_zombie_electric" ), calendar::turn,
+                              "" );
+    one_storage_corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
+    auto *const one_storage_corpse_ptr = one_storage_corpse.get();
+    here.add_item( corpse_pos, std::move( one_storage_corpse ) );
+
+    auto two_storage_corpse = item::make_corpse( mtype_id( "mon_zombie_electric" ), calendar::turn,
+                              "" );
+    two_storage_corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
+    two_storage_corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
+    auto *const two_storage_corpse_ptr = two_storage_corpse.get();
+    here.add_item( corpse_pos, std::move( two_storage_corpse ) );
+    REQUIRE( one_storage_corpse_ptr->display_stacked_with( *two_storage_corpse_ptr ) );
+
+    auto backpack = item::spawn( "backpack", calendar::turn );
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 10 );
+    scanner->activate();
+    backpack->put_in( std::move( scanner ) );
+    you.i_add( std::move( backpack ) );
+
+    you.process_items();
+
+    REQUIRE( one_storage_corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    REQUIRE( two_storage_corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    CHECK_FALSE( one_storage_corpse_ptr->display_stacked_with( *two_storage_corpse_ptr ) );
+    CHECK_FALSE( two_storage_corpse_ptr->display_stacked_with( *one_storage_corpse_ptr ) );
+}
+
+TEST_CASE( "scanned corpse bionic stack comparison benchmark",
+           "[.][benchmark][item][bionic_scanner]" )
+{
+    auto left_corpse = item::make_corpse( mtype_id( "mon_zombie_electric" ), calendar::turn, "" );
+    auto right_corpse = item::make_corpse( mtype_id( "mon_zombie_electric" ), calendar::turn, "" );
+    static constexpr auto component_count = 24;
+    for( auto i = 0; i < component_count; ++i ) {
+        const auto bionic_type = i % 2 == 0 ? itype_id( "bio_power_storage" ) :
+                                 itype_id( "bn_bio_solar" );
+        left_corpse->add_component( item::spawn( bionic_type, calendar::turn ) );
+        right_corpse->add_component( item::spawn( bionic_type, calendar::turn ) );
+    }
+    left_corpse->set_var( "bionics_scanned_by", 1 );
+    right_corpse->set_var( "bionics_scanned_by", 1 );
+    left_corpse->set_flag( flag_CBM_SCANNED );
+    right_corpse->set_flag( flag_CBM_SCANNED );
+
+    BENCHMARK( "display_stacked_with duplicate scanned bionics" ) {
+        return left_corpse->display_stacked_with( *right_corpse );
+    };
+}
+
 TEST_CASE( "bionic_scanner_inside_worn_container_marks_corpse_stack", "[iuse][bionic_scanner]" )
 {
     const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
@@ -388,7 +467,7 @@ TEST_CASE( "bionic_scanner_inside_worn_container_marks_corpse_stack", "[iuse][bi
     clear_avatar();
 
     auto &you = get_avatar();
-    you.setID( character_id( 1 ), true );
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
     auto &here = get_map();
     g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
     set_time( calendar::turn_zero + 12_hours );

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -21,17 +21,21 @@
 #include "type_id.h"
 #include "value_ptr.h"
 
-TEST_CASE( "bionic_scanner_marks_corpses_with_cbms", "[iuse][bionic_scanner]" )
+TEST_CASE( "bionic_scanner_on_ground_marks_corpses_with_cbms", "[iuse][bionic_scanner]" )
 {
     const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
     clear_map();
     clear_avatar();
-    set_time( calendar::turn_zero + 12_hours );
 
     auto &you = get_avatar();
     you.setID( character_id( 1 ), true );
     auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
     const auto corpse_pos = you.bub_pos() + tripoint_east;
+    REQUIRE( you.sees( corpse_pos ) );
     auto corpse = item::make_corpse( mtype_id( "mon_zombie_soldier" ), calendar::turn, "" );
     corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
     REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( corpse ), false ) );
@@ -47,46 +51,55 @@ TEST_CASE( "bionic_scanner_marks_corpses_with_cbms", "[iuse][bionic_scanner]" )
     const auto *const scanner_ptr = scanner.get();
     const auto charges_before = scanner_ptr->ammo_remaining();
     REQUIRE( charges_before > 0 );
-    you.i_add( std::move( scanner ) );
+    REQUIRE_FALSE( here.add_item_or_charges( you.bub_pos(), std::move( scanner ), false ) );
 
-    you.process_items();
+    here.process_items();
 
     CHECK( corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
     CHECK( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
     CHECK( scanner_ptr->ammo_remaining() == charges_before - 1 );
 }
 
-TEST_CASE( "bionic_scanner_scans_corpse_without_visible_bionic_marker", "[iuse][bionic_scanner]" )
+TEST_CASE( "bionic_scanner_inside_container_marks_corpses_with_cbms", "[iuse][bionic_scanner]" )
 {
     const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
     clear_map();
     clear_avatar();
-    set_time( calendar::turn_zero + 12_hours );
 
     auto &you = get_avatar();
     you.setID( character_id( 1 ), true );
     auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
     const auto corpse_pos = you.bub_pos() + tripoint_east;
-    auto corpse = item::make_corpse( mtype_id( "mon_zombie" ), calendar::turn, "" );
+    REQUIRE( you.sees( corpse_pos ) );
+    auto corpse = item::make_corpse( mtype_id( "mon_zombie_soldier" ), calendar::turn, "" );
+    corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
     REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( corpse ), false ) );
     const auto corpse_stack = here.i_at( corpse_pos );
     REQUIRE( corpse_stack.size() == 1 );
     auto *const corpse_ptr = *corpse_stack.begin();
-    REQUIRE( corpse_ptr->get_components().empty() );
+    REQUIRE( corpse_ptr->get_components().size() == 1 );
+    REQUIRE( ( *corpse_ptr->get_components().begin() )->is_bionic() );
 
+    auto backpack = item::spawn( "backpack", calendar::turn );
+    backpack->put_in( item::spawn( "rock", calendar::turn ) );
     auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
     scanner->ammo_set( itype_id( "battery" ), 10 );
     scanner->activate();
     const auto *const scanner_ptr = scanner.get();
     const auto charges_before = scanner_ptr->ammo_remaining();
     REQUIRE( charges_before > 0 );
-    you.i_add( std::move( scanner ) );
+    backpack->put_in( std::move( scanner ) );
+    you.i_add( std::move( backpack ) );
 
     you.process_items();
 
     CHECK( corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
-    CHECK_FALSE( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
-    CHECK( scanner_ptr->ammo_remaining() == charges_before );
+    CHECK( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    CHECK( scanner_ptr->ammo_remaining() == charges_before - 1 );
 }
 
 TEST_CASE( "eyedrops", "[iuse][eyedrops]" )

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -363,7 +363,7 @@ TEST_CASE( "bionic_scanner_separates_detected_corpse_piles_by_found_cbms",
     REQUIRE( storage_corpse_ptr->has_flag( flag_CBM_SCANNED ) );
     CHECK_FALSE( solar_corpse_ptr->display_stacked_with( *storage_corpse_ptr ) );
 
-    const auto item_info_text = []( const item &corpse ) {
+    const auto item_info_text = []( const item & corpse ) {
         auto result = std::string {};
         for( const iteminfo &entry : corpse.info() ) {
             result += entry.sName;

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -144,6 +144,87 @@ TEST_CASE( "bionic_scanner_inside_container_marks_corpses_with_cbms", "[iuse][bi
     CHECK( scanner_ptr->ammo_remaining() == charges_before - 1 );
 }
 
+TEST_CASE( "bionic_scanner_consumes_charge_for_each_scanned_corpse", "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    you.setID( character_id( 1 ), true );
+    auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
+    const auto corpse_pos = you.bub_pos() + tripoint_east;
+    REQUIRE( you.sees( corpse_pos ) );
+    auto corpse_ptrs = std::vector<item *> {};
+    for( auto i = 0; i < 50; ++i ) {
+        auto corpse = item::make_corpse( mtype_id( "mon_zombie" ), calendar::turn, "" );
+        auto *const corpse_ptr = corpse.get();
+        here.add_item( corpse_pos, std::move( corpse ) );
+        corpse_ptrs.push_back( corpse_ptr );
+    }
+
+    auto backpack = item::spawn( "backpack", calendar::turn );
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 100 );
+    scanner->activate();
+    const auto *const scanner_ptr = scanner.get();
+    const auto charges_before = scanner_ptr->ammo_remaining();
+    backpack->put_in( std::move( scanner ) );
+    you.i_add( std::move( backpack ) );
+
+    you.process_items();
+
+    for( const item *const corpse_ptr : corpse_ptrs ) {
+        CHECK( corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
+        CHECK_FALSE( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    }
+    CHECK( scanner_ptr->ammo_remaining() == charges_before - static_cast<int>( corpse_ptrs.size() ) );
+}
+
+TEST_CASE( "bionic_scanner_marks_new_corpse_after_activation", "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    you.setID( character_id( 1 ), true );
+    auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
+    auto backpack = item::spawn( "backpack", calendar::turn );
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 10 );
+    scanner->activate();
+    const auto *const scanner_ptr = scanner.get();
+    const auto charges_before = scanner_ptr->ammo_remaining();
+    backpack->put_in( std::move( scanner ) );
+    you.i_add( std::move( backpack ) );
+
+    you.process_items();
+    CHECK( scanner_ptr->ammo_remaining() == charges_before );
+
+    const auto corpse_pos = you.bub_pos() + tripoint_east;
+    REQUIRE( you.sees( corpse_pos ) );
+    auto corpse = item::make_corpse( mtype_id( "mon_zombie_technician" ), calendar::turn, "" );
+    corpse->add_component( item::spawn( "bio_electrosense", calendar::turn ) );
+    auto *const corpse_ptr = corpse.get();
+    REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( corpse ), false ) );
+    here.invalidate_visibility_caches();
+
+    you.process_items();
+
+    CHECK( corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
+    CHECK( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    CHECK( scanner_ptr->ammo_remaining() == charges_before - 1 );
+}
+
 TEST_CASE( "bionic_scanner_separates_detected_corpses_from_unscanned_stack",
            "[iuse][bionic_scanner]" )
 {

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -144,6 +144,54 @@ TEST_CASE( "bionic_scanner_inside_container_marks_corpses_with_cbms", "[iuse][bi
     CHECK( scanner_ptr->ammo_remaining() == charges_before - 1 );
 }
 
+TEST_CASE( "bionic_scanner_separates_detected_corpses_from_unscanned_stack",
+           "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    you.setID( character_id( 1 ), true );
+    auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
+    const auto corpse_pos = you.bub_pos() + tripoint_east;
+    REQUIRE( you.sees( corpse_pos ) );
+    auto corpse_ptrs = std::vector<item *> {};
+    for( auto i = 0; i < 2; ++i ) {
+        auto corpse = item::make_corpse( mtype_id( "mon_zombie_soldier" ), calendar::turn, "" );
+        corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
+        auto *const corpse_ptr = corpse.get();
+        REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( corpse ), false ) );
+        corpse_ptrs.push_back( corpse_ptr );
+    }
+    REQUIRE( corpse_ptrs.front()->display_stacked_with( *corpse_ptrs.back() ) );
+
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 1 );
+    scanner->activate();
+    REQUIRE_FALSE( here.add_item_or_charges( you.bub_pos(), std::move( scanner ), false ) );
+
+    here.process_items();
+
+    auto *detected_corpse = static_cast<item *>( nullptr );
+    auto *unscanned_corpse = static_cast<item *>( nullptr );
+    for( item *const corpse_ptr : corpse_ptrs ) {
+        if( corpse_ptr->has_flag( flag_CBM_SCANNED ) ) {
+            detected_corpse = corpse_ptr;
+        } else {
+            unscanned_corpse = corpse_ptr;
+        }
+    }
+    REQUIRE( detected_corpse != nullptr );
+    REQUIRE( unscanned_corpse != nullptr );
+    CHECK_FALSE( detected_corpse->display_stacked_with( *unscanned_corpse ) );
+    CHECK_FALSE( unscanned_corpse->display_stacked_with( *detected_corpse ) );
+}
+
 TEST_CASE( "bionic_scanner_inside_worn_container_marks_corpse_stack", "[iuse][bionic_scanner]" )
 {
     const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -8,12 +8,86 @@
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
+#include "cata_utility.h"
+#include "character_id.h"
 #include "flag.h"
+#include "game.h"
 #include "item.h"
 #include "itype.h"
+#include "map.h"
+#include "map_helpers.h"
 #include "morale_types.h"
+#include "player_helpers.h"
 #include "type_id.h"
 #include "value_ptr.h"
+
+TEST_CASE( "bionic_scanner_marks_corpses_with_cbms", "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+    set_time( calendar::turn_zero + 12_hours );
+
+    auto &you = get_avatar();
+    you.setID( character_id( 1 ), true );
+    auto &here = get_map();
+    const auto corpse_pos = you.bub_pos() + tripoint_east;
+    auto corpse = item::make_corpse( mtype_id( "mon_zombie_soldier" ), calendar::turn, "" );
+    corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
+    REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( corpse ), false ) );
+    const auto corpse_stack = here.i_at( corpse_pos );
+    REQUIRE( corpse_stack.size() == 1 );
+    auto *const corpse_ptr = *corpse_stack.begin();
+    REQUIRE( corpse_ptr->get_components().size() == 1 );
+    REQUIRE( ( *corpse_ptr->get_components().begin() )->is_bionic() );
+
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 10 );
+    scanner->activate();
+    const auto *const scanner_ptr = scanner.get();
+    const auto charges_before = scanner_ptr->ammo_remaining();
+    REQUIRE( charges_before > 0 );
+    you.i_add( std::move( scanner ) );
+
+    you.process_items();
+
+    CHECK( corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
+    CHECK( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    CHECK( scanner_ptr->ammo_remaining() == charges_before - 1 );
+}
+
+TEST_CASE( "bionic_scanner_scans_corpse_without_visible_bionic_marker", "[iuse][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+    set_time( calendar::turn_zero + 12_hours );
+
+    auto &you = get_avatar();
+    you.setID( character_id( 1 ), true );
+    auto &here = get_map();
+    const auto corpse_pos = you.bub_pos() + tripoint_east;
+    auto corpse = item::make_corpse( mtype_id( "mon_zombie" ), calendar::turn, "" );
+    REQUIRE_FALSE( here.add_item_or_charges( corpse_pos, std::move( corpse ), false ) );
+    const auto corpse_stack = here.i_at( corpse_pos );
+    REQUIRE( corpse_stack.size() == 1 );
+    auto *const corpse_ptr = *corpse_stack.begin();
+    REQUIRE( corpse_ptr->get_components().empty() );
+
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), 10 );
+    scanner->activate();
+    const auto *const scanner_ptr = scanner.get();
+    const auto charges_before = scanner_ptr->ammo_remaining();
+    REQUIRE( charges_before > 0 );
+    you.i_add( std::move( scanner ) );
+
+    you.process_items();
+
+    CHECK( corpse_ptr->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
+    CHECK_FALSE( corpse_ptr->has_flag( flag_CBM_SCANNED ) );
+    CHECK( scanner_ptr->ammo_remaining() == charges_before );
+}
 
 TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
 {

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -78,6 +78,34 @@ static auto add_sashimi_to_vehicle_part( vehicle &veh, const int part_index ) ->
     add_food_to_vehicle_part( veh, part_index, itype_id( "sashimi" ) );
 }
 
+TEST_CASE( "Food lookup finds nested food after non-food contents", "[item][food]" )
+{
+    SECTION( "top-level food after non-food content" ) {
+        auto backpack = item::spawn( "backpack" );
+        backpack->put_in( item::spawn( "rock" ) );
+        backpack->put_in( item::spawn( "sashimi" ) );
+
+        REQUIRE( backpack->is_food_container() );
+        auto *food = backpack->get_food();
+        REQUIRE( food != nullptr );
+        CHECK( food->typeId() == itype_id( "sashimi" ) );
+    }
+
+    SECTION( "nested food after non-food content" ) {
+        auto outer_bag = item::spawn( "bag_canvas" );
+        auto inner_bag = item::spawn( "bag_plastic" );
+        inner_bag->put_in( item::spawn( "rock" ) );
+        inner_bag->put_in( item::spawn( "sashimi" ) );
+        outer_bag->put_in( std::move( inner_bag ) );
+
+        REQUIRE( outer_bag->is_food_container() );
+        const auto &const_outer_bag = *outer_bag;
+        const auto *food = const_outer_bag.get_food();
+        REQUIRE( food != nullptr );
+        CHECK( food->typeId() == itype_id( "sashimi" ) );
+    }
+}
+
 static auto add_bread_to_vehicle_part( vehicle &veh, const int part_index ) -> void
 {
     add_food_to_vehicle_part( veh, part_index, itype_id( "bread" ) );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -335,8 +335,8 @@ TEST_CASE( "Preserving containers stop contained food rot" )
         namespace ranges = std::ranges;
         using namespace std::views;
         auto nested_food = outer->contents.all_items_ptr()
-                           | filter( []( const item *it ) { return it->typeId() == itype_id( "sashimi" ); } )
-                           | ranges::to<std::vector>();
+        | filter( []( const item * it ) { return it->typeId() == itype_id( "sashimi" ); } )
+        | ranges::to<std::vector>();
         REQUIRE( nested_food.size() == 1 );
         CHECK( nested_food.front()->get_rot() > 0_turns );
     }
@@ -550,8 +550,8 @@ TEST_CASE( "Vehicle storage temperature controls food rot" )
         namespace ranges = std::ranges;
         using namespace std::views;
         auto nested_food = remaining.only_item().contents.all_items_ptr()
-                           | filter( []( const item *it ) { return it->typeId() == itype_id( "sashimi" ); } )
-                           | ranges::to<std::vector>();
+        | filter( []( const item * it ) { return it->typeId() == itype_id( "sashimi" ); } )
+        | ranges::to<std::vector>();
         REQUIRE( nested_food.size() == 1 );
         CHECK( nested_food.front()->get_rot() == 0_turns );
         CHECK( !nested_food.front()->rotten() );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -318,6 +318,28 @@ TEST_CASE( "Preserving containers stop contained food rot" )
         CHECK( removed->charges == 3 );
         CHECK( removed->get_rot() == 0_turns );
     }
+
+    SECTION( "sealed outer container keeps nested rotten food from vanishing" ) {
+        prepare_map_storage_test();
+
+        auto outer = item::spawn( "bag_canvas" );
+        auto inner = item::spawn( "bag_plastic" );
+        inner->put_in( item::spawn( "sashimi" ) );
+        outer->put_in( std::move( inner ) );
+        REQUIRE( outer->needs_processing() );
+
+        calendar::turn += 25_hours;
+        outer = item::process( std::move( outer ), nullptr, tripoint_bub_ms::zero(), false,
+                               temperature_flag::TEMP_NORMAL, get_weather() );
+
+        namespace ranges = std::ranges;
+        using namespace std::views;
+        auto nested_food = outer->contents.all_items_ptr()
+                           | filter( []( const item *it ) { return it->typeId() == itype_id( "sashimi" ); } )
+                           | ranges::to<std::vector>();
+        REQUIRE( nested_food.size() == 1 );
+        CHECK( nested_food.front()->get_rot() > 0_turns );
+    }
 }
 
 TEST_CASE( "Items rot away" )
@@ -511,6 +533,28 @@ TEST_CASE( "Vehicle storage temperature controls food rot" )
         REQUIRE( components.size() == 1 );
         CHECK( components.front()->get_rot() == 0_turns );
         CHECK( !components.front()->rotten() );
+    }
+
+    SECTION( "powered freezer cargo protects food after non-food container contents" ) {
+        auto fixture = make_storage( vpart_id( "minifreezer" ), true );
+        auto backpack = item::spawn( "backpack" );
+        backpack->put_in( item::spawn( "rock" ) );
+        backpack->put_in( item::spawn( "sashimi" ) );
+        REQUIRE( backpack->is_food_container() );
+        REQUIRE_FALSE( fixture.veh->add_item( fixture.part_index, std::move( backpack ) ) );
+
+        process_storage_for( 25_hours );
+
+        auto remaining = fixture.veh->get_items( fixture.part_index );
+        REQUIRE( remaining.size() == 1 );
+        namespace ranges = std::ranges;
+        using namespace std::views;
+        auto nested_food = remaining.only_item().contents.all_items_ptr()
+                           | filter( []( const item *it ) { return it->typeId() == itype_id( "sashimi" ); } )
+                           | ranges::to<std::vector>();
+        REQUIRE( nested_food.size() == 1 );
+        CHECK( nested_food.front()->get_rot() == 0_turns );
+        CHECK( !nested_food.front()->rotten() );
     }
 
     SECTION( "powered freezer cargo keeps whole food fresh when consumed for crafting" ) {


### PR DESCRIPTION
## Purpose of change (The Why)

close #9529

Active bionic scanners only ticked when the scanner itself was a top-level active item. A scanner inside inventory, a dropped container, or a worn container stopped scanning nearby corpses, matching the report that dropping the same scanner on the ground made it work again.

Related: https://github.com/cataclysmbn/Cataclysm-BN/issues/9529#issuecomment-4724924669

## Describe the solution (The How)

- Process cached active/rotting contents recursively instead of only processing top-level item state.
- Propagate processing-cache invalidation upward when contents, processing flags, casing handling, spills, or item activity changes; resync top-level map/vehicle active caches when needed.
- Keep mixed food+active containers on the fastest contained processing cadence, and move active-cache entries if that cadence changes.
- Preserve sealed/preserving container behavior while nested contents are processed or temporarily detached.
- Mark each scanned corpse per avatar, charge the scanner per corpse scanned, and keep corpse piles separated when scan state or found CBMs differ, including duplicate CBM counts.
- Add regression coverage for scanners in ground, inventory, and worn containers; new corpse scans; corpse pile display; active-item cache invalidation; nested food lookup; and nested preserving/sealed rot cases.
- Document the nested item processing/cache invalidation contract in `docs/en/dev/guides/items.md`.
- Restore vertical transition post-pass linking covered by the existing map test so the refreshed CI run can complete.

## Testing

- Local build passed: `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`.
- Focused regressions passed: bionic scanner, active item cache, nested food lookup, preserving/vehicle rot, and `omt_pillar_post_pass_links_generated_stairs`.
- `tests/map_test.cpp` cases passed locally after the vertical transition post-pass fix.

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/242ff7fb-4f46-49e2-bbb2-49fefdb65f48" />

1. kill lots of shocker zombies
2. turn on bionic scanner
3. confirmed it scans corpses around you
4. confirmed it didn't merge corpses with different CBMs

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [67e030d](https://github.com/cataclysmbn/Cataclysm-BN/commit/67e030d205ec94d3b0978a940ce70c08a8b95850) (docs: document nested item processing) on 2026-06-20 13:47:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27871114176/artifacts/7765614539)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27871114176/artifacts/7765808959)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27871114176/artifacts/7765559969)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27871114176/artifacts/7765509408)
<!-- END artifact comment -->