### PR TITLE
fix: allow targeted spells to resolve visible creatures

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -86,6 +86,7 @@
 #include "rng.h"
 #include "skill.h"
 #include "sounds.h"
+#include "spell_targeting.h"
 #include "string_formatter.h"
 #include "string_id.h"
 #include "text_snippets.h"
@@ -4735,10 +4736,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
 
             if( !trajectory.empty() ) {
                 target = trajectory.back();
-                target_is_valid = spell_being_cast.is_valid_target( *p, target );
-                if( !( spell_being_cast.is_valid_target( target_ground ) || p->sees( target ) ) ) {
-                    target_is_valid = false;
-                }
+                target_is_valid = spell_target_can_be_resolved( spell_being_cast, *p, target );
             } else {
                 target_is_valid = false;
             }

--- a/src/spell_targeting.cpp
+++ b/src/spell_targeting.cpp
@@ -1,0 +1,31 @@
+#include "spell_targeting.h"
+
+#include "character.h"
+#include "creature.h"
+#include "game.h"
+#include "magic.h"
+
+namespace
+{
+
+auto spell_target_is_visible( const spell &casting, const Character &caster,
+                              const tripoint_bub_ms &target ) -> bool
+{
+    if( casting.is_valid_target( target_ground ) || caster.sees( target ) ) {
+        return true;
+    }
+
+    const auto *const target_critter = g->critter_at<Creature>( target, true );
+    return target_critter != nullptr && ( caster.sees( *target_critter ) ||
+                                          caster.sees_with_infrared( *target_critter ) ||
+                                          caster.sees_with_specials( *target_critter ) );
+}
+
+} // namespace
+
+auto spell_target_can_be_resolved( const spell &casting, const Character &caster,
+                                   const tripoint_bub_ms &target ) -> bool
+{
+    return casting.is_valid_target( caster, target ) &&
+           spell_target_is_visible( casting, caster, target );
+}

--- a/src/spell_targeting.h
+++ b/src/spell_targeting.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "coordinates.h"
+
+class Character;
+class spell;
+
+/// Returns whether a selected spell target still satisfies casting-time target checks.
+auto spell_target_can_be_resolved( const spell &casting, const Character &caster,
+                                   const tripoint_bub_ms &target ) -> bool;

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -10,6 +10,7 @@
 #include "map.h"
 #include "monster.h"
 #include "ranged.h"
+#include "spell_targeting.h"
 
 #include "player_helpers.h"
 #include "map_helpers.h"
@@ -157,9 +158,7 @@ TEST_CASE( "hostile targeted spells accept targets selected by spell targeting",
     REQUIRE( you.sees_with_infrared( target ) );
     REQUIRE_FALSE( you.sees( target_pos ) );
 
-    const auto spell_finish_accepts_target = hostile_spell.is_valid_target( you, target_pos ) &&
-            ( hostile_spell.is_valid_target( target_ground ) || you.sees( target_pos ) );
-    CHECK( spell_finish_accepts_target );
+    CHECK( spell_target_can_be_resolved( hostile_spell, you, target_pos ) );
 }
 
 TEST_CASE( "known magic remembers the last cast spell", "[magic][spell][save]" )

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -1,11 +1,15 @@
 #include "catch/catch.hpp"
 
+#include <algorithm>
+
 #include "avatar.h"
+#include "cata_utility.h"
 #include "fstream_utils.h"
 #include "game.h"
 #include "magic.h"
 #include "map.h"
 #include "monster.h"
+#include "ranged.h"
 
 #include "player_helpers.h"
 #include "map_helpers.h"
@@ -117,6 +121,45 @@ TEST_CASE( "avatar sees own tile even with dirty visibility cache",
     REQUIRE( here.visibility_caches_dirty() );
 
     CHECK( you.sees( you.bub_pos() ) );
+}
+
+TEST_CASE( "hostile targeted spells accept targets selected by spell targeting",
+           "[magic][spell][target][vision]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    const auto cleanup_test_state = on_out_of_scope( []() { clear_all_state(); } );
+
+    clear_all_state();
+    clear_avatar();
+    clear_map();
+
+    calendar::turn = calendar::turn_zero;
+    g->reset_light_level();
+
+    avatar &you = get_avatar();
+    const auto caster_pos = tripoint_bub_ms( 60, 60, 0 );
+    const auto target_pos = caster_pos + point_rel_ms( 5, 0 );
+    you.setpos( caster_pos );
+    you.set_mutation( trait_id( "INFRARED" ) );
+    you.recalc_sight_limits();
+
+    monster &target = spawn_test_monster( "mon_zombie", target_pos );
+    map &here = get_map();
+    here.invalidate_map_cache( you.bub_pos().z() );
+    g->refresh_player_visibility_cache_if_needed();
+
+    spell hostile_spell( spell_id( "test_spell_pew" ) );
+    hostile_spell.set_level( 5 );
+    REQUIRE( hostile_spell.is_valid_target( target_hostile ) );
+    REQUIRE_FALSE( hostile_spell.is_valid_target( target_ground ) );
+    REQUIRE( std::ranges::contains( ranged::targetable_creatures( you, hostile_spell.range() ),
+                                    &target ) );
+    REQUIRE( you.sees_with_infrared( target ) );
+    REQUIRE_FALSE( you.sees( target_pos ) );
+
+    const auto spell_finish_accepts_target = hostile_spell.is_valid_target( you, target_pos ) &&
+            ( hostile_spell.is_valid_target( target_ground ) || you.sees( target_pos ) );
+    CHECK( spell_finish_accepts_target );
 }
 
 TEST_CASE( "known magic remembers the last cast spell", "[magic][spell][save]" )


### PR DESCRIPTION
## Purpose of change (The Why)

closes #9536

Related: #9564

Targeted hostile spells could select creatures visible through spell targeting, then fail the post-target casting check and reopen the Stop casting prompt.

## Describe the solution (The How)

- Share the spell target resolution check between casting and tests.
- Allow selected creature targets seen by normal, infrared, or special senses to resolve.
- Add red/green coverage for the rejected hostile target case.

## Testing

- Reproduced failure before the fix: `CHECK( spell_finish_accepts_target )` was false.
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "hostile targeted spells accept targets selected by spell targeting"`
- `./out/build/linux-full/tests/cata_test-tiles "[magic][spell]"`

## Checklist

### Mandatory

- [x] I linked any relevant issues using github keyword syntax.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4667841](https://github.com/cataclysmbn/Cataclysm-BN/commit/46678412c13a44f77ccba8c7840c8ec2831fe6f0) (fix: allow targeted spells to resolve visible creatures) on 2026-06-19 05:06:45

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27803029307/artifacts/7741023415)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27803029307/artifacts/7741726831)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27803029307/artifacts/7741112603)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27803029307/artifacts/7741105848)
<!-- END artifact comment -->