### PR TITLE
fix: allow examining charcoal purifier

### DIFF
--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -84,6 +84,18 @@
     "use_action": [ "ARTIFACT_ANALYZER" ]
   },
   {
+    "id": "char_purifier_fake",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "makeshift water purifier" },
+    "description": "Pseudo item for charcoal purifier furniture.",
+    "material": [ "wood", "cotton" ],
+    "sub": "water_purifier",
+    "ammo": "charcoal",
+    "max_charges": 500,
+    "flags": [ "ALLOWS_REMOTE_USE", "TRADER_AVOID" ]
+  },
+  {
     "id": "fake_goggles",
     "copy-from": "fake_item",
     "type": "TOOL",


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #9573.

PR #7849 added charcoal purifier furniture that referenced `char_purifier_fake`, but the pseudo tool definition was missing. Examining the furniture raised `Missing item definition: char_purifier_fake`.

## Describe the solution (The How)

- Add the missing `char_purifier_fake` pseudo tool.
- Give it charcoal ammo data so `reload_furniture` can restock the purifier.

## Testing

- `cmake --build --preset linux-full --target style-json-parallel`
- `./build-scripts/lint-json.sh`
- `SDL_VIDEODRIVER=dummy out/build/linux-full/src/cataclysm-bn-tiles --userdir /tmp/pi-cbn-json-9573 --configdir /tmp/pi-cbn-json-9573/config/ --jsonverify`
- `SDL_VIDEODRIVER=dummy out/build/linux-full/src/cataclysm-bn-tiles --userdir /tmp/pi-cbn-check-9573 --configdir /tmp/pi-cbn-check-9573/config/ --check-mods bn`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [755edbd](https://github.com/cataclysmbn/Cataclysm-BN/commit/755edbd00ee26b2410953b6e73d8930a69d5f1e8) (fix: allow examining charcoal purifier) on 2026-06-19 05:41:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27804777057/artifacts/7741941443)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27804777057/artifacts/7742510715)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27804777057/artifacts/7741915160)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27804777057/artifacts/7741848805)
<!-- END artifact comment -->