### PR TITLE
fix: let ear protection block screecher daze

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -329,6 +329,23 @@ static std::unique_ptr<npc> make_fake_npc( monster *z, int str, int dex, int int
     return tmp;
 }
 
+namespace
+{
+constexpr auto shriek_stun_hearing_protection_threshold = 40;
+
+auto has_shriek_stun_hearing_protection( const Creature &target ) -> bool
+{
+    if( target.is_immune_effect( effect_deaf ) ) {
+        return true;
+    }
+
+    const auto *const character = target.as_character();
+    return character != nullptr && character->get_char_hearing_protection() +
+           character->get_char_hearing_protection( true ) >= shriek_stun_hearing_protection_threshold;
+}
+
+} // namespace
+
 bool mattack::none( monster * )
 {
     return true;
@@ -545,7 +562,7 @@ bool mattack::shriek_stun( monster *z )
         if( target == nullptr ) {
             continue;
         }
-        if( one_in( dist / 2 ) && !( target->is_immune_effect( effect_deaf ) ) ) {
+        if( one_in( dist / 2 ) && !has_shriek_stun_hearing_protection( *target ) ) {
             target->add_effect( effect_dazed, rng( 1_minutes, 2_minutes ), bodypart_str_id::NULL_ID(),
                                 rng( 1, ( 15 - dist ) / 3 ) );
         }

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -1,0 +1,60 @@
+#include "catch/catch.hpp"
+
+#include "avatar.h"
+#include "calendar.h"
+#include "coordinates.h"
+#include "game.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "monattack.h"
+#include "monster.h"
+#include "state_helpers.h"
+#include "type_id.h"
+
+namespace
+{
+const auto effect_dazed = efftype_id( "dazed" );
+const auto effect_shrieking = efftype_id( "shrieking" );
+
+struct shriek_stun_setup {
+    monster &screecher;
+    avatar &target;
+};
+
+auto setup_shriek_stun_test() -> shriek_stun_setup
+{
+    clear_all_state();
+
+    auto &target = get_avatar();
+    const auto screecher_pos = tripoint_bub_ms( 60, 60, 0 );
+    const auto target_pos = tripoint_bub_ms( 62, 60, 0 );
+    target.setpos( map_local_to_abs( get_map(), target_pos ) );
+
+    auto &screecher = spawn_test_monster( "mon_zombie_screecher", screecher_pos );
+    screecher.set_dest( target.bub_pos() );
+    screecher.add_effect( effect_shrieking, 1_minutes );
+
+    return { .screecher = screecher, .target = target };
+}
+
+} // namespace
+
+TEST_CASE( "hearing protection blocks screecher daze", "[monster][sound]" )
+{
+    auto setup = setup_shriek_stun_test();
+    REQUIRE( !setup.target.wear_item( item::spawn( "ear_plugs" ), false ) );
+
+    REQUIRE( mattack::shriek_stun( &setup.screecher ) );
+
+    CHECK_FALSE( setup.target.has_effect( effect_dazed ) );
+}
+
+TEST_CASE( "screecher dazes unprotected targets", "[monster][sound]" )
+{
+    auto setup = setup_shriek_stun_test();
+
+    REQUIRE( mattack::shriek_stun( &setup.screecher ) );
+
+    CHECK( setup.target.has_effect( effect_dazed ) );
+}

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -42,8 +42,11 @@ auto setup_shriek_stun_test() -> shriek_stun_setup
 
 TEST_CASE( "hearing protection blocks screecher daze", "[monster][sound]" )
 {
+    const auto protected_item = GENERATE( "ear_plugs", "army_powered_earmuffs_on" );
+    CAPTURE( protected_item );
+
     auto setup = setup_shriek_stun_test();
-    REQUIRE( !setup.target.wear_item( item::spawn( "ear_plugs" ), false ) );
+    REQUIRE( !setup.target.wear_item( item::spawn( protected_item ), false ) );
 
     REQUIRE( mattack::shriek_stun( &setup.screecher ) );
 


### PR DESCRIPTION
## Purpose of change (The Why)

close #9572

#8205 moved ear protection to `hearing_protection`, but screecher daze still only checked deaf immunity.

## Describe the solution (The How)

- Let `SHRIEK_STUN` treat 40+ basic/advanced hearing protection as protection from daze.
- Add coverage for ear plugs, active tactical headset, and unprotected targets.

## Describe alternatives you've considered

Restoring `DEAF`/`PARTIAL_DEAF` item flags would reintroduce the old protection model.

## Testing

- Red: `./out/build/linux-full/tests/cata_test-tiles "hearing protection blocks screecher daze"` failed before the fix.
- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[monster][sound]"`

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9d37c08](https://github.com/cataclysmbn/Cataclysm-BN/commit/9d37c0835cc9c187e140e7f3c77b0c6be385df46) (fix: honor hearing protection against shrieks) on 2026-06-19 08:27:18

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27811379311/artifacts/7744025025)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27811379311/artifacts/7745086743)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27811379311/artifacts/7744279461)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27811379311/artifacts/7744108517)
<!-- END artifact comment -->