### PR TITLE
fix(lua): link lab stairs between z-levels

### DIFF
--- a/data/json/lua/mapgen/lab.lua
+++ b/data/json/lua/mapgen/lab.lua
@@ -119,41 +119,77 @@ shuffle = function(set)
 end
 
 ---@param map MapgenConstructor
+---@param pt PointOmtMs
+local function is_valid_stair_point(map, pt)
+  return map:get_ter_at(pt) == t_thconc_floor and map:get_furn_at(pt) == f_null and map:get_trap_at(pt) == tr_null
+end
+
+---@param map MapgenConstructor
 ---@param stair_id TerIntId
-local function insert_stairs_single(map, stair_id)
+---@param pt PointOmtMs
+local function place_stair(map, stair_id, pt)
+  map:set_ter_at(pt, stair_id)
+  map:set_furn_at(pt, f_null)
+  map:remove_trap_at(pt)
+  map:clear_items_at(pt)
+end
+
+---@param map MapgenConstructor
+---@return PointOmtMs[]
+local function valid_stair_points(map)
   ---@type PointOmtMs[]
   local valid_points = {}
   for i = 0, 23 do
     for j = 0, 23 do
       local pt = PointOmtMs.new(i, j)
-      if map:get_ter_at(pt) == t_thconc_floor and map:get_furn_at(pt) == f_null and map:get_trap_at(pt) == tr_null then
-        table.insert(valid_points, PointOmtMs.new(i, j))
+      if is_valid_stair_point(map, pt) then
+        table.insert(valid_points, pt)
       end
     end
   end
+  return valid_points
+end
+
+---@param map MapgenConstructor
+---@param stair_id TerIntId
+local function insert_stairs_single(map, stair_id)
+  local valid_points = valid_stair_points(map)
   if #valid_points == 0 then return end
   local final_point = valid_points[gapi.rng(1, #valid_points)]
   if final_point == nil then return end
-  map:set_ter_at(final_point, stair_id)
+  place_stair(map, stair_id, final_point)
 end
 
-insert_stairs = function(map, up_id, down_id, from_above)
-  ---@type PointOmtMs[]
-  local valid_points = {}
-  for i = 0, 23 do
-    for j = 0, 23 do
-      local pt = PointOmtMs.new(i, j)
-      if map:get_ter_at(pt) == t_thconc_floor and map:get_furn_at(pt) == f_null and map:get_trap_at(pt) == tr_null then
-        table.insert(valid_points, PointOmtMs.new(i, j))
-      end
+---@param data MapgenData
+---@param map MapgenConstructor
+---@param up_id TerIntId
+---@param down_id TerIntId
+---@param from_above boolean
+insert_stairs = function(data, map, up_id, down_id, from_above)
+  local existing_point = nil
+  if( from_above ) then
+    existing_point = data:join_point("above", "lab_to_lab")
+    if existing_point then
+      place_stair(map, up_id, existing_point)
+      return
+    end
+  else
+    existing_point = data:join_point("below", "lab_to_lab")
+    if existing_point then
+      place_stair(map, down_id, existing_point)
+      return
     end
   end
+
+  local valid_points = valid_stair_points(map)
   if #valid_points > 0 then
-    local final_point = valid_points[gapi.rng(1, #valid_points)]
+    local candidate = valid_points[gapi.rng(1, #valid_points)]
     if( from_above ) then
-      map:set_ter_at(final_point, up_id)
+      local final_point = data:get_or_set_above_join_point("lab_to_lab", candidate) or candidate
+      place_stair(map, up_id, final_point)
     else
-      map:set_ter_at(final_point, down_id)
+      local final_point = data:get_or_set_below_join_point("lab_to_lab", candidate) or candidate
+      place_stair(map, down_id, final_point)
     end
   else
     if( from_above ) then
@@ -293,9 +329,9 @@ draw_normal_room = function(data, map)
   -- Build forth the walls
   draw_walls(data, map, walls)
   if map.is_ot_match( "stairs", data:above(), ot_match_contains ) then
-    insert_stairs(map, t_stairs_up, t_stairs_down, true)
+    insert_stairs(data, map, t_stairs_up, t_stairs_down, true)
   elseif map.is_ot_match( "stairs", data:id(), ot_match_contains ) then
-    insert_stairs(map, t_stairs_up, t_stairs_down, false)
+    insert_stairs(data, map, t_stairs_up, t_stairs_down, false)
   end
   draw_lights(data, map)
 end

--- a/src/catalua_bindings_mapgen.cpp
+++ b/src/catalua_bindings_mapgen.cpp
@@ -12,6 +12,59 @@
 #include "popup.h"
 #include "string_input_popup.h"
 
+namespace
+{
+
+auto lua_cube_direction( const std::string &direction ) -> cube_direction
+{
+    if( direction == "north" ) {
+        return cube_direction::north;
+    } else if( direction == "east" ) {
+        return cube_direction::east;
+    } else if( direction == "south" ) {
+        return cube_direction::south;
+    } else if( direction == "west" ) {
+        return cube_direction::west;
+    } else if( direction == "above" ) {
+        return cube_direction::above;
+    } else if( direction == "below" ) {
+        return cube_direction::below;
+    }
+    return cube_direction::last;
+}
+
+auto mapgen_join_point( const mapgendata &dat, const std::string &direction,
+                        const std::string &join_id ) -> sol::optional<point_omt_ms>
+{
+    const auto point = dat.join_point( lua_cube_direction( direction ), join_id );
+    if( !point ) {
+        return sol::nullopt;
+    }
+    return *point;
+}
+
+auto mapgen_get_or_set_above_join_point( const mapgendata &dat, const std::string &join_id,
+        const point_omt_ms &candidate ) -> sol::optional<point_omt_ms>
+{
+    const auto point = dat.get_or_set_join_point( cube_direction::above, join_id, candidate );
+    if( !point ) {
+        return sol::nullopt;
+    }
+    return *point;
+}
+
+auto mapgen_get_or_set_below_join_point( const mapgendata &dat, const std::string &join_id,
+        const point_omt_ms &candidate ) -> sol::optional<point_omt_ms>
+{
+    const auto point = dat.get_or_set_join_point( cube_direction::below, join_id, candidate );
+    if( !point ) {
+        return sol::nullopt;
+    }
+    return *point;
+}
+
+} // namespace
+
 void cata::detail::reg_mapgendata( sol::state &lua )
 {
     sol::usertype<mapgendata> ut = luna::new_usertype<mapgendata>( lua, luna::no_bases,
@@ -43,6 +96,24 @@ void cata::detail::reg_mapgendata( sol::state &lua )
     luna::set_fx( ut, "get_nesw", []( mapgendata & dat, int i ) { return dat.t_nesw[i]; } );
     DOC( "Gets the z-level that it is generated at." );
     luna::set_fx( ut, "zlevel", []( mapgendata & dat ) { return dat.zlevel(); } );
+    DOC( "Returns the OMT-local anchor point for a matched overmap join, or nil if none exists." );
+    DOC_PARAMS(
+        "direction: string - one of north/east/south/west/above/below",
+        "join_id: string - mutable overmap join id",
+        "returns: PointOmtMs?" );
+    luna::set_fx( ut, "join_point", &mapgen_join_point );
+    DOC( "Returns the existing OMT-local anchor point for a matched above overmap join, or initializes it from candidate." );
+    DOC_PARAMS(
+        "join_id: string - mutable overmap join id",
+        "candidate: PointOmtMs - point to store if the join has no anchor yet",
+        "returns: PointOmtMs?" );
+    luna::set_fx( ut, "get_or_set_above_join_point", &mapgen_get_or_set_above_join_point );
+    DOC( "Returns the existing OMT-local anchor point for a matched below overmap join, or initializes it from candidate." );
+    DOC_PARAMS(
+        "join_id: string - mutable overmap join id",
+        "candidate: PointOmtMs - point to store if the join has no anchor yet",
+        "returns: PointOmtMs?" );
+    luna::set_fx( ut, "get_or_set_below_join_point", &mapgen_get_or_set_below_join_point );
     DOC( "Sets the direction of the mapgen." );
     luna::set_fx( ut, "set_dir", []( mapgendata & dat, int i, int j ) { return dat.set_dir( i, j ); } );
     DOC( "Gets rotation" );

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -4209,7 +4209,6 @@ auto mapbuffer::run_omt_pillar_post_pass( const point_abs_omt &omt_pos ) -> void
             auto changed = false;
             for( const auto local : submap_tiles() ) {
                 const auto terrain_here = sub_here->get_ter( local );
-                /* TODO: Make mapgen stairs sane so this dead code can be used or reworked.
                 if( const auto target = vertical_transition_target_below( terrain_here );
                     target && zlev > -OVERMAP_DEPTH ) {
                     ensure_vertical_transition_link( {
@@ -4226,7 +4225,6 @@ auto mapbuffer::run_omt_pillar_post_pass( const point_abs_omt &omt_pos ) -> void
                         .desired = *target,
                     } );
                 }
-                */
 
                 if( terrain_here != t_open_air ) {
                     continue;

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -4,6 +4,7 @@
 
 #include "all_enum_values.h"
 #include "debug.h"
+#include "game_constants.h"
 #include "int_id.h"
 #include "mapgen_constructor.h"
 #include "mapdata.h"
@@ -15,6 +16,46 @@
 #include "regional_settings.h"
 
 static const regional_settings dummy_regional_settings;
+
+namespace
+{
+
+auto is_inside_omt_tile_bounds( const point_omt_ms &p ) -> bool
+{
+    return p.x() >= 0 && p.x() < SEEX * 2 && p.y() >= 0 && p.y() < SEEY * 2;
+}
+
+auto actual_cube_direction( const mapgendata &dat, const cube_direction dir ) -> cube_direction
+{
+    const auto ignore_rotation = dat.terrain_type()->has_flag(
+                                     oter_flags::ignore_rotation_for_adjacency );
+    const auto rotation = ignore_rotation ? 0 : dat.terrain_type()->get_rotation();
+    return dir + rotation;
+}
+
+auto opposite_cube_direction( const cube_direction dir ) -> cube_direction
+{
+    switch( dir ) {
+        case cube_direction::north:
+            return cube_direction::south;
+        case cube_direction::east:
+            return cube_direction::west;
+        case cube_direction::south:
+            return cube_direction::north;
+        case cube_direction::west:
+            return cube_direction::east;
+        case cube_direction::above:
+            return cube_direction::below;
+        case cube_direction::below:
+            return cube_direction::above;
+        case cube_direction::last:
+            break;
+    }
+    debugmsg( "Invalid cube_direction" );
+    return cube_direction::last;
+}
+
+} // namespace
 
 void mapgen_arguments::merge( const mapgen_arguments &other )
 {
@@ -222,6 +263,41 @@ bool mapgendata::has_join( const cube_direction dir, const std::string &join_id 
 {
     auto it = joins.find( dir );
     return it != joins.end() && it->second == join_id;
+}
+
+auto mapgendata::join_point( const cube_direction dir,
+                             const std::string &join_id ) const -> std::optional<point_omt_ms>
+{
+    if( !has_join( dir, join_id ) ) {
+        return std::nullopt;
+    }
+    const auto point = omapbuf_.join_point_at( { pos, actual_cube_direction( *this, dir ) } );
+    if( point && is_inside_omt_tile_bounds( *point ) ) {
+        return point;
+    }
+    return std::nullopt;
+}
+
+auto mapgendata::get_or_set_join_point( const cube_direction dir, const std::string &join_id,
+                                        const point_omt_ms &candidate ) const -> std::optional<point_omt_ms>
+{
+    if( !has_join( dir, join_id ) || !is_inside_omt_tile_bounds( candidate ) ) {
+        return std::nullopt;
+    }
+    if( const auto point = join_point( dir, join_id ) ) {
+        return point;
+    }
+    const auto actual_dir = actual_cube_direction( *this, dir );
+    omapbuf_.set_join_point( { pos, actual_dir }, candidate );
+    const auto opposite_pos = pos + displace( actual_dir );
+    const auto opposite_dir = opposite_cube_direction( actual_dir );
+    if( opposite_dir != cube_direction::last ) {
+        const auto *opposite_join = omapbuf_.join_used_at( { opposite_pos, opposite_dir } );
+        if( opposite_join != nullptr && *opposite_join == join_id ) {
+            omapbuf_.set_join_point( { opposite_pos, opposite_dir }, candidate );
+        }
+    }
+    return candidate;
 }
 
 const oter_id &mapgendata::neighbor_at( direction dir ) const

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <unordered_map>
 
 #include "calendar.h"
@@ -187,6 +188,10 @@ class mapgendata
         bool is_groundcover( const ter_id &iid ) const;
 
         bool has_join( const cube_direction, const std::string &join_id ) const;
+        auto join_point( cube_direction dir,
+                         const std::string &join_id ) const -> std::optional<point_omt_ms>;
+        auto get_or_set_join_point( cube_direction dir, const std::string &join_id,
+                                    const point_omt_ms &candidate ) const -> std::optional<point_omt_ms>;
 
         template<typename Result>
         Result get_arg( const std::string &name ) const {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3023,6 +3023,20 @@ std::string *overmap::join_used_at( const om_pos_dir &p )
     return &it->second;
 }
 
+auto overmap::join_point_at( const om_pos_dir &p ) const -> std::optional<point_omt_ms>
+{
+    const auto it = join_points.find( p );
+    if( it == join_points.end() ) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+auto overmap::set_join_point( const om_pos_dir &p, const point_omt_ms &point ) -> void
+{
+    join_points[p] = point;
+}
+
 std::optional<mapgen_arguments> *overmap::mapgen_args( const tripoint_om_omt &p )
 {
     auto it = mapgen_args_index.find( p );
@@ -5875,6 +5889,10 @@ std::vector<tripoint_om_omt> overmap::place_special(
                 linked = build_connection( *elem.connection, stub, rp.z() );
             }
         }
+    }
+
+    for( const auto &join : result.joins_used ) {
+        joins_used.insert( join );
     }
 
     // Link grid and mapgens

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -315,6 +315,8 @@ class overmap
         void ter_set( const tripoint_om_omt &p, const oter_id &id );
         const oter_id &ter( const tripoint_om_omt &p ) const;
         std::string *join_used_at( const om_pos_dir & );
+        auto join_point_at( const om_pos_dir & ) const -> std::optional<point_omt_ms>;
+        auto set_join_point( const om_pos_dir &, const point_omt_ms & ) -> void;
         std::optional<mapgen_arguments> *mapgen_args( const tripoint_om_omt & );
 
         /** Slot returned by get_mapgen_args_slot for lock-free fast-path access. */
@@ -477,6 +479,8 @@ class overmap
         // Records the joins that were chosen during placement of a mutable
         // special, so that it can be queried later by mapgen
         std::unordered_map<om_pos_dir, std::string> joins_used;
+        // Records OMT-local tile anchors for joins that need matching mapgen surfaces.
+        std::unordered_map<om_pos_dir, point_omt_ms> join_points;
         // Records mapgen parameters required at the overmap special level
         // These are lazily evaluated; empty optional means that they have yet
         // to be evaluated.

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -875,6 +875,20 @@ std::string *overmapbuffer::join_used_at( const std::pair<tripoint_abs_omt, cube
     return om_loc.om->join_used_at( { om_loc.local, p.second } );
 }
 
+auto overmapbuffer::join_point_at( const std::pair<tripoint_abs_omt, cube_direction> &p ) ->
+std::optional<point_omt_ms>
+{
+    const overmap_with_local_coords om_loc = get_om_global( p.first );
+    return om_loc.om->join_point_at( { om_loc.local, p.second } );
+}
+
+auto overmapbuffer::set_join_point( const std::pair<tripoint_abs_omt, cube_direction> &p,
+                                    const point_omt_ms &point ) -> void
+{
+    const overmap_with_local_coords om_loc = get_om_global( p.first );
+    om_loc.om->set_join_point( { om_loc.local, p.second }, point );
+}
+
 std::optional<mapgen_arguments> *overmapbuffer::mapgen_args( const tripoint_abs_omt &p )
 {
     const overmap_with_local_coords om_loc = get_om_global( p );

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -220,6 +220,10 @@ class overmapbuffer
         const oter_id &ter_existing( const tripoint_abs_omt &p );
         void ter_set( const tripoint_abs_omt &p, const oter_id &id );
         std::string *join_used_at( const std::pair<tripoint_abs_omt, cube_direction> & );
+        auto join_point_at( const std::pair<tripoint_abs_omt, cube_direction> & ) ->
+        std::optional<point_omt_ms>;
+        auto set_join_point( const std::pair<tripoint_abs_omt, cube_direction> &,
+                             const point_omt_ms & ) -> void;
         std::optional<mapgen_arguments> *mapgen_args( const tripoint_abs_omt & );
         /**
          * Thread-safe lazy initializer for overmap_special mapgen arguments.

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -786,6 +786,12 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
             for( const std::pair<om_pos_dir, std::string> &p : flat_index ) {
                 joins_used.insert( p );
             }
+        } else if( name == "join_points" ) {
+            std::vector<std::pair<om_pos_dir, point_omt_ms>> flat_index;
+            jsin.read( flat_index, true );
+            for( const std::pair<om_pos_dir, point_omt_ms> &p : flat_index ) {
+                join_points.insert( p );
+            }
         } else if( name == "mapgen_arg_storage" ) {
             jsin.read( mapgen_arg_storage, true );
         } else if( name == "mapgen_arg_index" ) {
@@ -1264,6 +1270,9 @@ void overmap::serialize( std::ostream &fout ) const
     std::vector<std::pair<om_pos_dir, std::string>> flattened_joins_used(
                 joins_used.begin(), joins_used.end() );
     json.member( "joins_used", flattened_joins_used );
+    std::vector<std::pair<om_pos_dir, point_omt_ms>> flattened_join_points(
+                join_points.begin(), join_points.end() );
+    json.member( "join_points", flattened_join_points );
     json.member( "mapgen_arg_storage", mapgen_arg_storage );
     fout << '\n';
     json.member( "mapgen_arg_index" );

--- a/tests/mapgen_function_test.cpp
+++ b/tests/mapgen_function_test.cpp
@@ -1,7 +1,142 @@
 #include "catch/catch.hpp"
 
+#include <algorithm>
+#include <array>
+#include <string>
+#include <vector>
+
+#include "calendar.h"
+#include "catalua_impl.h"
+#include "coordinates.h"
+#include "init.h"
+#include "mapbuffer_registry.h"
 #include "mapgen.h"
+#include "mapgen_constructor.h"
+#include "mapgendata.h"
+#include "overmap.h"
+#include "overmap_special.h"
+#include "overmapbuffer.h"
+#include "overmapbuffer_registry.h"
+#include "state_helpers.h"
 #include "type_id.h"
+
+namespace
+{
+
+struct linked_lab_positions {
+    tripoint_abs_omt upper;
+    tripoint_abs_omt lower;
+};
+
+auto insert_lab_stairs( mapgendata &dat, const bool from_above ) -> void
+{
+    auto &lua = DynamicDataLoader::get_instance().lua->lua;
+    auto require = sol::protected_function( lua["require"] );
+    auto require_result = require( "lua/mapgen/lab" );
+    check_func_result( require_result );
+    auto insert_stairs = sol::protected_function( lua.globals()["insert_stairs"] );
+    auto insert_result = insert_stairs( &dat, &dat.m, ter_id( "t_stairs_up" ),
+                                        ter_id( "t_stairs_down" ), from_above );
+    check_func_result( insert_result );
+}
+
+auto lab_points_with_terrain_flag( const tripoint_abs_omt &pos, const bool from_above,
+                                   const std::string &flag ) -> std::vector<point_omt_ms>
+{
+    auto &buffer = MAPBUFFER_REGISTRY.get( mapbuffer_registry::primary_dimension_id() );
+    auto tm = mapgen_constructor( buffer );
+    tm.reset_scratch_omt( pos, ter_id( "t_thconc_floor" ), furn_id( "f_null" ), trap_id( "tr_null" ) );
+    auto &omb = get_overmapbuffer( buffer.get_dimension_id() );
+    auto dat = mapgendata( pos, tm, 0.0f, calendar::turn, nullptr, omb );
+    insert_lab_stairs( dat, from_above );
+
+    auto result = std::vector<point_omt_ms> {};
+    for( const auto p : tm.points_on_zlevel() ) {
+        if( tm.has_flag_ter( flag, p ) ) {
+            result.push_back( p );
+        }
+    }
+    return result;
+}
+
+auto has_sewer_neighbor( overmapbuffer &omb, const tripoint_abs_omt &pos ) -> bool
+{
+    static constexpr auto directions = std::array<tripoint, 4> {
+        tripoint_north, tripoint_east, tripoint_south, tripoint_west
+    };
+    return std::ranges::any_of( directions, [&]( const tripoint & direction ) {
+        return is_ot_match( "sewer", omb.ter( pos + direction ), ot_match_type::type );
+    } );
+}
+
+auto first_lab_stair_pair( overmapbuffer &omb,
+                           const std::vector<tripoint_abs_omt> &placed ) -> linked_lab_positions
+{
+    for( const auto &pos : placed ) {
+        if( !is_ot_match( "stairs", omb.ter( pos ), ot_match_type::contains ) ) {
+            continue;
+        }
+        const auto lower = pos + tripoint_below;
+        if( std::ranges::find( placed, lower ) == placed.end() ) {
+            continue;
+        }
+        if( is_ot_match( "lab", omb.ter( lower ), ot_match_type::contains ) &&
+            !has_sewer_neighbor( omb, pos ) && !has_sewer_neighbor( omb, lower ) ) {
+            return { .upper = pos, .lower = lower };
+        }
+    }
+    FAIL( "placed lab special did not contain a vertical stair pair" );
+    return {};
+}
+
+auto prepare_lab_stair_pair() -> linked_lab_positions
+{
+    clear_all_state();
+    auto &omb = get_overmapbuffer( mapbuffer_registry::primary_dimension_id() );
+    static auto next_origin = int{ 500000 };
+    const auto origin = tripoint_abs_omt( next_origin, next_origin, -2 );
+    next_origin += 20;
+    const auto placed = omb.place_special( *overmap_special_id( "lab_basement" ), origin,
+                                           om_direction::type::north, false, true );
+    REQUIRE( placed.has_value() );
+    return first_lab_stair_pair( omb, *placed );
+}
+
+auto check_lab_stair_pair_links( const bool generate_upper_first ) -> void
+{
+    const auto positions = prepare_lab_stair_pair();
+    auto &omb = get_overmapbuffer( mapbuffer_registry::primary_dimension_id() );
+    INFO( "upper " << positions.upper.to_string() << " " << omb.ter( positions.upper ).id().str() );
+    INFO( "lower " << positions.lower.to_string() << " " << omb.ter( positions.lower ).id().str() );
+    auto upper_down = std::vector<point_omt_ms> {};
+    auto lower_up = std::vector<point_omt_ms> {};
+    if( generate_upper_first ) {
+        upper_down = lab_points_with_terrain_flag( positions.upper, false, "GOES_DOWN" );
+        lower_up = lab_points_with_terrain_flag( positions.lower, true, "GOES_UP" );
+    } else {
+        lower_up = lab_points_with_terrain_flag( positions.lower, true, "GOES_UP" );
+        upper_down = lab_points_with_terrain_flag( positions.upper, false, "GOES_DOWN" );
+    }
+
+    INFO( "upper down count " << upper_down.size() );
+    INFO( "lower up count " << lower_up.size() );
+    REQUIRE( upper_down.size() == 1 );
+    REQUIRE( lower_up.size() == 1 );
+    CHECK( upper_down.front() == lower_up.front() );
+}
+
+} // namespace
+
+TEST_CASE( "lua_lab_mapgen_links_stairs_from_vertical_join_anchor", "[mapgen][lua][lab]" )
+{
+    SECTION( "upper generated first" ) {
+        check_lab_stair_pair_links( true );
+    }
+
+    SECTION( "lower generated first" ) {
+        check_lab_stair_pair_links( false );
+    }
+}
 
 TEST_CASE( "connects_to", "[mapgen][connects]" )
 {


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #9569.

Lab stairs generated on adjacent z-levels could pick unrelated coordinates after #9543, leaving disconnected up/down stairs.

## Describe the solution (The How)

- Persist `point_omt_ms` anchors on mutable overmap joins.
- Expose join anchors through `MapgenData` Lua APIs.
- Make lab stair placement share the `lab_to_lab` anchor for linked up/down stairs.
- Enable the OMT pillar post-pass stair linker for generated one-sided stairs.
- Remove the rejected `MapgenConstructor` z-offset lookup approach.

## Testing

- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "lua_lab_mapgen_links_stairs_from_vertical_join_anchor,omt_pillar_post_pass_links_generated_stairs"`
- `./out/build/linux-full/tests/cata_test-tiles "[mapgen]"`
- `./out/build/linux-full/tests/cata_test-tiles "firing_from_a_vehicle_applies_recoil_to_the_vehicle,vehicle gun recoil scaling factor can disable vehicle thrust,brake hold toggles parked braking drag,single birdshot can move a swivel chair one tile on office floor at 10x recoil,vehicle gun recoil can launch a shopping cart with a mounted M2 Browning near 6 km/h,perpendicular gun recoil keeps full sideways push on rigid-wheel vehicles"`
- `SDL_VIDEODRIVER=dummy ./out/build/linux-full/src/cataclysm-bn-tiles --jsonverify`
- `SDL_VIDEODRIVER=dummy ./out/build/linux-full/src/cataclysm-bn-tiles --check-mods`
- `git diff --check`

## Additional context

Related: #9543, #9566

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [x] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [66963ae](https://github.com/cataclysmbn/Cataclysm-BN/commit/66963aecd746cb9b75424ec723c47216f210a8e4) (fix: enable stair post-pass links) on 2026-06-20 05:02:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27858567656/artifacts/7761987726)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27858567656/artifacts/7762228459)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27858567656/artifacts/7762125641)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27858567656/artifacts/7761905849)
<!-- END artifact comment -->