### PR TITLE
build: make emmylua checks not fail nightly linux tiles builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,6 +402,7 @@ jobs:
 
       - name: Run EmmyLua check
         if: runner.os == 'Linux' && matrix.artifact == 'linux-tiles-x64'
+        continue-on-error: true
         run: emmylua_check .
 
       - name: Generate documentation artifacts


### PR DESCRIPTION
## Purpose of change (The Why)
Linux tiles nightly has not appeared for the last three days because of it

## Describe the solution (The How)
Make it continue on failure

## Describe alternatives you've considered
Let scarf do this?

## Testing
I dunno how to test this. Copied the format of #9561

## Additional context
Why are we checking things on nightly release anyways?
And also why aren't PRs failing if we are checking things there?

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [73e81b1](https://github.com/cataclysmbn/Cataclysm-BN/commit/73e81b1af3af8ccb3158bf3b698f9349810465dc) (fix: make emmylua checks not fail builds) on 2026-06-20 00:19:49

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27852810599/artifacts/7759859953)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27852810599/artifacts/7760081825)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27852810599/artifacts/7759864110)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27852810599/artifacts/7759903860)
<!-- END artifact comment -->