### PR TITLE
ci: diff clang-tidy against fetched PR merge

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -119,7 +119,10 @@ jobs:
       #     clang-tidy --version
 
       - name: gather affected files
-        run: deno task affected-files --base ${{ github.event.pull_request.base.sha }} --head HEAD --output "$AFFECTED_FILES"
+        run: |
+          ref=refs/remotes/pull/${{ github.event.pull_request.number }}/merge
+          git fetch --no-tags --filter=blob:none --depth=2 origin "+refs/pull/${{ github.event.pull_request.number }}/merge:$ref"
+          deno task affected-files --base "$ref^1" --head "$ref" --output "$AFFECTED_FILES"
 
       - name: run clang-tidy
         run: bash ./build-scripts/run-clang-tidy-plugin.sh


### PR DESCRIPTION
## Purpose of change (The Why)

Follow-up to #9544 and #9545. Clang-tidy can fail changed-file detection when the PR event base SHA is not connected in the shallow checkout.

Related failure: #9567 `Clang-tidy (tiles) / build`

## Describe the solution (The How)

- Fetch the PR merge ref in the clang-tidy job.
- Diff `merge^1...merge` so the base and head are both present in shallow history.

## Testing

- `deno check --lock deno.lock scripts/affected_files.ts scripts/git_changed_files.ts`
- `deno test scripts/git_changed_files_test.ts`
- `deno lint scripts/affected_files.ts scripts/git_changed_files.ts scripts/git_changed_files_test.ts`
- `actionlint .github/workflows/clang-tidy.yml`
- Reproduced the old `Invalid symmetric difference expression` on a shallow PR merge checkout; confirmed `deno task affected-files --base "$ref^1" --head "$ref"` writes affected files.

## Checklist

### Mandatory

- [x] No tracked issue; follow-up to #9544/#9545 and #9567 CI failure.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This is a PR that modifies build process or code organization.
  - [x] CI-only workflow fix; no user-facing build documentation change needed.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e46f919](https://github.com/cataclysmbn/Cataclysm-BN/commit/e46f91914c7549f642eeee7f4c5db7ee0345c2ab) (ci: diff clang-tidy against fetched PR merge) on 2026-06-20 01:50:25

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27854555611/artifacts/7760814286)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27854555611/artifacts/7760952626)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27854555611/artifacts/7760522731)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27854555611/artifacts/7760511660)
<!-- END artifact comment -->