### PR TITLE
fix(UI): keep consume cursor on matching item type

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -185,6 +185,8 @@ static item *inv_internal( player &u, const inventory_selector_preset &preset,
     bool init_selection = false;
     std::string init_filter;
     bool has_init_filter = false;
+    auto init_type = itype_id::NULL_ID();
+    bool has_init_type = false;
 
     const std::vector<activity_id> consuming {
         ACT_EAT_MENU,
@@ -200,6 +202,11 @@ static item *inv_internal( player &u, const inventory_selector_preset &preset,
     if( u.has_activity( consuming ) && !u.activity->str_values.empty() ) {
         init_filter = u.activity->str_values[0];
         has_init_filter = true;
+    }
+    if( u.has_activity( consuming ) && u.activity->str_values.size() >= 2 &&
+        !u.activity->str_values[1].empty() ) {
+        init_type = itype_id( u.activity->str_values[1] );
+        has_init_type = true;
     }
 
     do {
@@ -217,7 +224,13 @@ static item *inv_internal( player &u, const inventory_selector_preset &preset,
             has_init_filter = false;
         }
         // Set position after filter to keep cursor at the right position
-        if( init_selection ) {
+        auto restored_type_selection = false;
+        if( has_init_type ) {
+            restored_type_selection = inv_s.select_item_type( init_type );
+            init_selection = init_selection && !restored_type_selection;
+            has_init_type = false;
+        }
+        if( init_selection && !restored_type_selection ) {
             inv_s.select_position( init_pair );
             init_selection = false;
         }
@@ -244,6 +257,8 @@ static item *inv_internal( player &u, const inventory_selector_preset &preset,
             u.activity->values.push_back( init_pair.second );
             u.activity->str_values.clear();
             u.activity->str_values.emplace_back( inv_s.get_filter() );
+            u.activity->str_values.emplace_back( location != nullptr ? location->typeId().str() :
+                                                 std::string() );
         }
 
         return location;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -46,6 +46,7 @@
 #include <map>
 #include <numeric>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <string>
 #include <type_traits>
@@ -1389,6 +1390,28 @@ bool inventory_selector::select( const item *loc )
     }
 
     return res;
+}
+
+auto inventory_selector::select_item_type( const itype_id &type ) -> bool
+{
+    namespace ranges = std::ranges;
+
+    prepare_layout();
+    for( const auto index : std::views::iota( size_t{}, columns.size() ) ) {
+        auto *column = columns[index];
+        if( !column->visible() || !column->activatable() ) {
+            continue;
+        }
+        const auto entries = column->get_entries( []( const auto & entry ) { return entry.is_selectable(); } );
+        const auto iter = ranges::find_if( entries, [&type]( const auto * entry ) {
+            return entry->any_item()->typeId() == type;
+        } );
+        if( iter != entries.end() && column->select( ( *iter )->any_item() ) ) {
+            set_active_column( index );
+            return true;
+        }
+    }
+    return false;
 }
 
 inventory_entry *inventory_selector::find_entry_by_invlet( int invlet ) const

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -22,6 +22,7 @@
 #include "pimpl.h"
 #include "units.h"
 #include "pickup_token.h"
+#include "type_id.h"
 
 class Character;
 class player;
@@ -582,6 +583,7 @@ class inventory_selector
          * @return true on success.
          */
         bool select( const item *loc );
+        auto select_item_type( const itype_id &type ) -> bool;
 
         const inventory_entry &get_selected() {
             return get_active_column().get_selected();

--- a/tests/inventory_ui_test.cpp
+++ b/tests/inventory_ui_test.cpp
@@ -1,0 +1,23 @@
+#include "catch/catch.hpp"
+
+#include "avatar.h"
+#include "inventory_ui.h"
+#include "item.h"
+#include "player_helpers.h"
+
+TEST_CASE( "inventory selector restores consume selection by item type",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto bandages = item::spawn( "bandages" );
+    auto heroin = item::spawn( "heroin" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, heroin.get() );
+    selector.add_item( selector.own_inv_column, bandages.get() );
+
+    REQUIRE( selector.select_item_type( bandages->typeId() ) );
+    CHECK( selector.get_selected().any_item()->typeId() == bandages->typeId() );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

close #9580

Consuming an item could reopen the consume menu on the same row after the list changed, moving the cursor to a different consumable.

## Describe the solution (The How)

- Store the selected item type with the consume menu's saved filter/row state.
- Restore a matching type before falling back to the saved row.
- Add regression coverage for item-type reselection.

## Testing

- Red test: `cmake --build --preset linux-full --target cata_test-tiles` failed before the selector could restore by item type.
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "inventory selector restores consume selection by item type"`

## Additional context

Related upstream behavior: https://github.com/CleverRaven/Cataclysm-DDA/pull/29148

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [814791f](https://github.com/cataclysmbn/Cataclysm-BN/commit/814791ff623808f95ad76bec4e86c64aa6ea6a83) (fix(UI): keep consume cursor on matching item type) on 2026-06-23 11:54:01

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28021854867/artifacts/7819260344)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28021854867/artifacts/7819968222)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28021854867/artifacts/7819308910)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28021854867/artifacts/7819384796)
<!-- END artifact comment -->