### PR TITLE
chore(mods): bundle overhaul tileset

### DIFF
--- a/data/mods/external.json
+++ b/data/mods/external.json
@@ -15,6 +15,16 @@
     "url": "https://github.com/NobleJake/ProjectPackRat/archive/refs/heads/main.zip"
   },
   {
+    "id": "overhaul",
+    "version": "0.0.2",
+    "url": "https://github.com/scarf005/Overhaul/archive/refs/tags/v0.0.2.zip"
+  },
+  {
+    "id": "overhaul_additions",
+    "version": "0.0.2",
+    "url": "https://github.com/scarf005/Overhaul/archive/refs/tags/v0.0.2.zip"
+  },
+  {
     "id": "otopack_bn_mk_2",
     "version": "2026.2.12",
     "url": "https://github.com/NarandBD/Otopack-BN-Mk-2/archive/refs/tags/sorrynotsorry.zip"


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="528" height="588" alt="image" src="https://github.com/user-attachments/assets/8287c90b-fb3e-484d-bd3a-99fbf005ea7f" />

i always wanted to mainline anime tileset

## Describe the solution (The How)

added https://github.com/scarf005/Overhaul to external mods

## Testing

```
$ deno run --allow-read --allow-net build-scripts/bundle-registry-mods.ts --dry-run
cbn_sky_island: Sky Island (mod)
jake_s_squirrel_mod: 프로젝트: 다람쥐 (mod)
ny_transformers: Transformers (mod)
overhaul_tileset: Overhaul Tileset (mod)
otopack_bn_mk_2: Otopack BN Mk 2 (soundpack)
```

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [94d06b1](https://github.com/cataclysmbn/Cataclysm-BN/commit/94d06b1b25ed8c5eb490e8cda58ac6ce7e14f6e2) (chore(mods): add overhaul tileset) on 2026-06-21 14:02:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27900842020/artifacts/7775756546)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27900842020)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27900842020/artifacts/7774360066)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27900842020/artifacts/7774785828)
<!-- END artifact comment -->