### PR TITLE
fix(lua): revert error-throwing ipairs to pairs in change_hairstyle

### DIFF
--- a/data/mods/change_hairstyle/main.lua
+++ b/data/mods/change_hairstyle/main.lua
@@ -14,7 +14,7 @@ mod.change_hairstyle_function = function(params)
   local function get_hair_trait_type(mut_raw)
     if not mut_raw then return nil end
 
-    for _, t in ipairs(mut_raw:mutation_types()) do
+    for _, t in pairs(mut_raw:mutation_types()) do
       if t == "hair_style" then return "hair_style" end
       if t == "hair_color" then return "hair_color" end
     end


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Using default mod "Change Hairstyle" (`change_hairstyle`): Attempting to change the player's hairstyle or hair color with an `electric hair trimmer` or  `makeshift haircut kit` results in the following error:

```=== Lua backtrace report ===
stack traceback:
(continued from above) ERROR: Failed to run iuse_function k='CHANGE_HAIRSTYLE_ACTION': Script runtime error: stack index -1, expected string, received number
stack traceback:
	[C]: in ?
	[C]: in for iterator 'for iterator'
	data/mods/change_hairstyle/main.lua:17: in local 'get_hair_trait_type'
	data/mods/change_hairstyle/main.lua:43: in function <data/mods/change_hairstyle/main.lua:11>
	(...tail calls...)
```

## Describe the solution (The How)

Change (back) the `ipairs` call at the offending line to a `pairs` call in the `get_hair_trait_type` call, this had become an `ipairs` call somehow in #9525. Verify that changing hairstyle and hair color works OK afterwards.

## Describe alternatives you've considered

Figure out how `ipairs` *should* work in this context, if it even is appropriate here.

## Testing

Spawn a `makeshift haircut kit` and an `electric hair trimmer`, use each to change hairstyle and/or hair color successfully.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x n/a] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7b805fd](https://github.com/cataclysmbn/Cataclysm-BN/commit/7b805fd0789bedea3b0b1adfa73f57239b96d274) (fix(lua): revert error-throwing ipairs to pairs in change_hairstyle) on 2026-06-20 19:00:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27878812537/artifacts/7767789149)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27878812537/artifacts/7767992185)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27878812537/artifacts/7767527251)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27878812537/artifacts/7767535542)
<!-- END artifact comment -->