### PR TITLE
chore: disable force create stairs test

### DIFF
--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -726,6 +726,7 @@ TEST_CASE( "tree_terrain_supports_climbing_destination_above" )
     CHECK( here.has_floor_or_support( climb_destination ) );
 }
 
+/* Uncomment when omt pillar stair linkage from #9566 is enabled
 TEST_CASE( "omt_pillar_post_pass_links_generated_stairs" )
 {
     clear_all_state();
@@ -757,6 +758,7 @@ TEST_CASE( "omt_pillar_post_pass_links_generated_stairs" )
 
     CHECK( here.ter( missing_up_pos ) == t_stairs_up );
 }
+*/
 
 TEST_CASE( "bash_through_roof_can_destroy_multiple_times" )
 {


### PR DESCRIPTION
## Purpose of change (The Why)
#9566 left the force OMT stair link test in
It was disabled because mapgen was designed around unlinked stairs in many cases

## Describe the solution (The How)
Disable the test

## Describe alternatives you've considered
Delete the test

## Testing
Eyes and the runners will speak the truth

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [77579e0](https://github.com/cataclysmbn/Cataclysm-BN/commit/77579e01b074fe58e5af894abe61e1bedd45f9be) (disable broken test) on 2026-06-20 21:26:07

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27882390347/artifacts/7768614627)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27882390347/artifacts/7769014991)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27882390347/artifacts/7768613827)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27882390347/artifacts/7768634666)
<!-- END artifact comment -->