### PR TITLE
feat(UI): Add throw info to item panel

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3962,6 +3962,76 @@ void item::damage_statblock_info( std::vector<iteminfo> &info, damage_instance a
     info.emplace_back( "BASE", sep, "", iteminfo::no_newline );
 }
 
+void item::throw_info( std::vector < iteminfo > &info, const iteminfo_query *parts, int /*batch*/,
+                       bool /*debug*/ ) const
+{
+    avatar &you = get_avatar();
+    int throw_range = you.throw_range( *this );
+
+    if( throw_range == 0 ) {
+        return;
+    }
+
+    insert_separation_line( info );
+
+    int dmg_bash = base_damage_thrown().type_damage( DT_BASH );
+    int dmg_cut = base_damage_thrown().type_damage( DT_CUT );
+    int dmg_stab = base_damage_thrown().type_damage( DT_STAB );
+
+    projectile proj = ranged::throw_damage_projectile( *this, you.get_skill_level( skill_throw ),
+                      you.get_str() );
+
+    int proj_dmg_bash = proj.impact.type_damage( DT_BASH );
+    int proj_dmg_cut = proj.impact.type_damage( DT_CUT );
+    int proj_dmg_stab = proj.impact.type_damage( DT_STAB );
+
+    if( dmg_bash || dmg_cut || dmg_stab ) {
+        std::string sep;
+        info.emplace_back( "BASE", _( "<bold>Base throw damage</bold>: " ), "", iteminfo::no_newline );
+        if( dmg_bash ) {
+            info.emplace_back( "BASE", _( "Bash: " ), "", iteminfo::no_newline, dmg_bash );
+            sep = " ";
+        }
+        if( dmg_cut ) {
+            info.emplace_back( "BASE", sep + _( "Cut: " ), "", iteminfo::no_newline, dmg_cut );
+            sep = " ";
+        }
+        if( dmg_stab ) {
+            info.emplace_back( "BASE", sep + _( "Pierce: " ), "", iteminfo::no_newline, dmg_stab );
+        }
+        info.emplace_back( "BASE", "\n", "", iteminfo::no_newline );
+    }
+
+    if( proj_dmg_bash || proj_dmg_cut || proj_dmg_stab ) {
+        std::string sep;
+        info.emplace_back( "BASE", _( "<bold>Throw damage</bold>: " ), "", iteminfo::no_newline );
+        if( proj_dmg_bash ) {
+            info.emplace_back( "BASE", _( "Bash: " ), "", iteminfo::no_newline, proj_dmg_bash );
+            sep = " ";
+        }
+        if( proj_dmg_cut ) {
+            info.emplace_back( "BASE", sep + _( "Cut: " ), "", iteminfo::no_newline, proj_dmg_cut );
+            sep = " ";
+        }
+        if( proj_dmg_stab ) {
+            info.emplace_back( "BASE", sep + _( "Pierce: " ), "", iteminfo::no_newline, proj_dmg_stab );
+        }
+        info.emplace_back( "BASE", "\n", "", iteminfo::no_newline );
+    }
+
+    info.emplace_back( "BASE", _( "Throw range: " ), "<num>", iteminfo::no_flags, throw_range );
+
+    int throw_cost = ranged::throw_cost( you, *this );
+    info.emplace_back( "BASE", _( "Moves per throw: " ), "<num>", iteminfo::lower_is_better,
+                       throw_cost );
+
+    int stamina_cost = ranged::throw_stamina_cost( you, *this );
+    info.emplace_back( "BASE", _( "Stamina cost: " ), "<num>", iteminfo::lower_is_better,
+                       stamina_cost );
+
+    insert_separation_line( info );
+}
+
 void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                           bool debug ) const
 {
@@ -4446,6 +4516,7 @@ std::vector<iteminfo> item::info( const iteminfo_query &parts_ref, int batch,
     container_info( info, parts, batch, debug );
     contents_info( info, parts, batch, debug );
     combat_info( info, parts, batch, debug );
+    throw_info( info, parts, batch, debug );
 
     magazine_info( info, parts, batch, debug );
     ammo_info( info, parts, batch, debug );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3965,8 +3965,8 @@ void item::damage_statblock_info( std::vector<iteminfo> &info, damage_instance a
 void item::throw_info( std::vector < iteminfo > &info, const iteminfo_query *parts, int /*batch*/,
                        bool /*debug*/ ) const
 {
-    avatar &you = get_avatar();
-    int throw_range = you.throw_range( *this );
+    const avatar &you = get_avatar();
+    const int throw_range = you.throw_range( *this );
 
     if( throw_range == 0 ) {
         return;
@@ -3974,16 +3974,17 @@ void item::throw_info( std::vector < iteminfo > &info, const iteminfo_query *par
 
     insert_separation_line( info );
 
-    int dmg_bash = base_damage_thrown().type_damage( DT_BASH );
-    int dmg_cut = base_damage_thrown().type_damage( DT_CUT );
-    int dmg_stab = base_damage_thrown().type_damage( DT_STAB );
+    const int dmg_bash = base_damage_thrown().type_damage( DT_BASH );
+    const int dmg_cut = base_damage_thrown().type_damage( DT_CUT );
+    const int dmg_stab = base_damage_thrown().type_damage( DT_STAB );
 
-    projectile proj = ranged::throw_damage_projectile( *this, you.get_skill_level( skill_throw ),
-                      you.get_str() );
+    const projectile proj =
+        ranged::throw_damage_projectile( *this, you.get_skill_level( skill_throw ),
+                                         you.get_str() );
 
-    int proj_dmg_bash = proj.impact.type_damage( DT_BASH );
-    int proj_dmg_cut = proj.impact.type_damage( DT_CUT );
-    int proj_dmg_stab = proj.impact.type_damage( DT_STAB );
+    const int proj_dmg_bash = proj.impact.type_damage( DT_BASH );
+    const int proj_dmg_cut = proj.impact.type_damage( DT_CUT );
+    const int proj_dmg_stab = proj.impact.type_damage( DT_STAB );
 
     if( dmg_bash || dmg_cut || dmg_stab ) {
         std::string sep;
@@ -4021,11 +4022,11 @@ void item::throw_info( std::vector < iteminfo > &info, const iteminfo_query *par
 
     info.emplace_back( "BASE", _( "Throw range: " ), "<num>", iteminfo::no_flags, throw_range );
 
-    int throw_cost = ranged::throw_cost( you, *this );
+    const int throw_cost = ranged::throw_cost( you, *this );
     info.emplace_back( "BASE", _( "Moves per throw: " ), "<num>", iteminfo::lower_is_better,
                        throw_cost );
 
-    int stamina_cost = ranged::throw_stamina_cost( you, *this );
+    const int stamina_cost = ranged::throw_stamina_cost( you, *this );
     info.emplace_back( "BASE", _( "Stamina cost: " ), "<num>", iteminfo::lower_is_better,
                        stamina_cost );
 

--- a/src/item.h
+++ b/src/item.h
@@ -581,6 +581,8 @@ class item : public location_visitable<item>, public game_object<item>
                           bool debug ) const;
         void combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                           bool debug ) const;
+        void throw_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
+                         bool debug ) const;
         void damage_statblock_info( std::vector<iteminfo> &info, damage_instance attack,
                                     bool line_by_line ) const;
         void contents_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1710,8 +1710,6 @@ int throwing_dispersion( const Character &c, const item &to_throw, Creature *cri
     return std::max( 0, dispersion );
 }
 
-namespace
-{
 auto throw_damage_projectile( const item &it, const int skill, const int str ) -> projectile
 {
     const units::mass weight = it.weight();
@@ -1732,11 +1730,21 @@ auto throw_damage_projectile( const item &it, const int skill, const int str ) -
 
     return proj;
 }
-} // namespace
 
 auto throw_damage( const item &it, const int skill, const int str ) -> int
 {
     return throw_damage_projectile( it, skill, str ).impact.total_damage();
+}
+
+auto throw_stamina_cost( const Character &thrower, const item &item ) -> int
+{
+    // Previously calculated as 2_gram * std::max( 1, str_cur )
+    // using 16_gram normalizes it to 8 str. Same effort expenditure
+    // for being able to throw farther.
+    const int weight_cost = item.weight() / ( 16_gram );
+    const int encumbrance_cost = roll_remainder(
+                                     ( thrower.encumb( body_part_arm_l ) + thrower.encumb( body_part_arm_r ) ) * 2.0f );
+    return weight_cost + encumbrance_cost - thrower.get_skill_level( skill_throw ) + 50;
 }
 
 dealt_projectile_attack throw_item( Character &who, const tripoint_bub_ms &target,
@@ -1752,14 +1760,6 @@ dealt_projectile_attack throw_item( Character &who, const tripoint_bub_ms &targe
     const units::volume volume = thrown.volume();
     const units::mass weight = thrown.weight();
 
-    // Previously calculated as 2_gram * std::max( 1, str_cur )
-    // using 16_gram normalizes it to 8 str. Same effort expenditure
-    // for being able to throw farther.
-    const int weight_cost = weight / ( 16_gram );
-    const int encumbrance_cost = roll_remainder( ( who.encumb( body_part_arm_l ) + who.encumb(
-                                     body_part_arm_r ) ) * 2.0f );
-    const int stamina_cost = ( weight_cost + encumbrance_cost - throwing_skill + 50 ) * -1;
-
     bool throw_assist = false;
     int throw_assist_str = 0;
     if( who.is_mounted() ) {
@@ -1771,6 +1771,7 @@ dealt_projectile_attack throw_item( Character &who, const tripoint_bub_ms &targe
         }
     }
     if( !throw_assist ) {
+        const int stamina_cost = throw_stamina_cost( who, thrown ) * -1;
         who.mod_stamina( stamina_cost );
     }
 

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -189,6 +189,12 @@ int fire_gun( Character &who, const tripoint_bub_ms &target, int shots = 1 );
 int fire_gun( Character &who, const tripoint_bub_ms &target, int shots, item &gun,
               item *ammo, const std::optional<tripoint_bub_ms> &shot_origin = std::nullopt );
 
+/** Generates a projectile for throwing the item, used to show actual damage.*/
+auto throw_damage_projectile( const item &it, const int skill, const int str ) -> projectile;
+
+/** Expected stamina cost for throwing a given item. */
+auto throw_stamina_cost( const Character &thrower, const item &item ) -> int;
+
 /** Expected thrown damage with a given item, given the thrower's effective strength and skill. */
 auto throw_damage( const item &it, const int skill, const int str ) -> int;
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Information about throwing stats isn't shown anywhere and I'd like to see it.

## Describe the solution (The How)

I added the info to the item panel, below the info about melee damage.

## Describe alternatives you've considered

Broadly speaking there's 4 categories of items:

- Items that can be thrown and deal damage (most items)
- Items that can be thrown but deal no damage (e.g. feathers)
- Items that can't be thrown (because they're too heavy for you) but would deal damage (e.g. engines)
- Actually, there's probably only 3, because any item that's too heavy to throw would deal damage

In any case, I opted to not show this info only on category 3, because there might be reasons why you'd want to throw something that doesn't deal damage (lights, noisemakers). I could have shown this info on category 3 as well, but I feel like that'll just be confusing and clutter the window (do you really need to know that an engine would deal 200 damage if you could throw it, even though you can't?)

I also wanted to refactor the code some more (I mean, look at that `throw_damage_projectile`), but since someone else is working on throws, I tried to keep changes to a minimum.

## Testing

Spawned different items and checked that info is shown accurately.

## Additional context

Combat knife:
<img width="294" height="105" src="https://github.com/user-attachments/assets/b6d8c4cc-b041-42e5-bf19-a1e868521767" />

Flashlight:
<img width="199" height="94" src="https://github.com/user-attachments/assets/1f3829cd-fd70-457a-acff-2002bd8e47f1" />


Feather:
<img width="172" height="75" src="https://github.com/user-attachments/assets/28bec69f-1837-4b39-9481-1a0a6de0d1da" />

Rock:
<img width="237" height="114" src="https://github.com/user-attachments/assets/82c2cc83-50f6-4283-844c-7fed5063b55a" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a2b6da9](https://github.com/cataclysmbn/Cataclysm-BN/commit/a2b6da9726325a84c8ab2dbb4dbd6faffd54aa53) (Add some consts) on 2026-06-20 23:49:34

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27885898653/artifacts/7769790251)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27885898653)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27885898653/artifacts/7769818959)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27885898653/artifacts/7769714067)
<!-- END artifact comment -->