### PR TITLE
test: fix throw and iteminfo tests

### DIFF
--- a/data/mods/TEST_DATA/terrain.json
+++ b/data/mods/TEST_DATA/terrain.json
@@ -44,6 +44,19 @@
   },
   {
     "type": "terrain",
+    "id": "t_test_indestructible_wall",
+    "name": "indestructible test wall",
+    "description": "A test-only wall that blocks movement and cannot be bashed down.",
+    "looks_like": "t_wall",
+    "symbol": "LINE_OXOX",
+    "color": "blue",
+    "move_cost": 0,
+    "coverage": 100,
+    "roof": "t_flat_roof",
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL" ]
+  },
+  {
+    "type": "terrain",
     "id": "t_fragile_floor",
     "copy-from": "t_floor",
     "name": "fragile floor",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3963,6 +3963,10 @@ void item::damage_statblock_info( std::vector<iteminfo> &info, damage_instance a
 void item::throw_info( std::vector < iteminfo > &info, const iteminfo_query *parts, int /*batch*/,
                        bool /*debug*/ ) const
 {
+    if( !parts->test( iteminfo_parts::BASE_THROW ) ) {
+        return;
+    }
+
     const avatar &you = get_avatar();
     const int throw_range = you.throw_range( *this );
 

--- a/src/iteminfo_query.h
+++ b/src/iteminfo_query.h
@@ -17,6 +17,7 @@ enum class iteminfo_parts : size_t {
     BASE_DAMAGE,
     BASE_TOHIT,
     BASE_MOVES,
+    BASE_THROW,
     BASE_REQUIREMENTS,
     BASE_MATERIAL,
     BASE_CONTENTS,

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -180,6 +180,21 @@ TEST_CASE( "item rigidity", "[item][iteminfo][rigidity]" )
     }
 }
 
+TEST_CASE( "throwing ratings and costs", "[item][iteminfo][throwing]" )
+{
+    clear_all_state();
+    const auto q = q_vec( { iteminfo_parts::BASE_THROW } );
+
+    test_info_equals(
+        "test_rock", q,
+        "--\n"
+        "<color_c_white>Base throw damage</color>: Bash: <color_c_yellow>7</color>\n"
+        "<color_c_white>Throw damage</color>: Bash: <color_c_yellow>9</color>\n"
+        "Throw range: <color_c_yellow>13</color>\n"
+        "Moves per throw: <color_c_yellow>70</color>\n"
+        "Stamina cost: <color_c_yellow>91</color>\n" );
+}
+
 TEST_CASE( "weapon attack ratings and moves", "[item][iteminfo][weapon]" )
 {
     clear_all_state();

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -191,6 +191,8 @@ TEST_CASE( "flung creatures take damage when they slam into a wall", "[throwing]
     clear_all_state();
     clear_map();
 
+    g->u.setpos( tripoint_bub_ms{ 10, 10, 0 } );
+
     auto &here = g->m;
     const auto source = tripoint_bub_ms{ 40, 30, 0 };
     const auto target = tripoint_bub_ms{ 41, 30, 0 };
@@ -200,8 +202,9 @@ TEST_CASE( "flung creatures take damage when they slam into a wall", "[throwing]
     here.ter_set( source, ter_id( "t_floor" ) );
     here.ter_set( target, ter_id( "t_floor" ) );
     here.ter_set( landing, ter_id( "t_floor" ) );
-    here.ter_set( wall, ter_id( "t_wall" ) );
-    g->u.setpos( tripoint_bub_ms{ 10, 10, 0 } );
+    here.ter_set( wall, ter_id( "t_test_indestructible_wall" ) );
+    REQUIRE( here.impassable( wall ) );
+    REQUIRE_FALSE( here.is_bashable( wall ) );
 
     auto &zombie = spawn_test_monster( "mon_zombie", target );
     const auto hp_before = zombie.get_hp();
@@ -218,13 +221,15 @@ TEST_CASE( "flung creatures stop at the reality bubble edge", "[throwing][bubble
     clear_map();
 
     auto &here = get_map();
-    const auto bubble_edge_x = SEEX * here.getmapsize() - 1;
-    const auto bubble_mid_y = SEEY * here.getmapsize() / 2;
+    const auto bubble_mapsize = 2 * g_reality_bubble_size + 3;
+    const auto bubble_edge_x = SEEX * bubble_mapsize - 1;
+    const auto bubble_mid_y = SEEY * bubble_mapsize / 2;
     const auto start = tripoint_bub_ms{ bubble_edge_x - 1, bubble_mid_y, 0 };
     const auto edge = tripoint_bub_ms{ bubble_edge_x, bubble_mid_y, 0 };
 
     here.ter_set( start, ter_id( "t_floor" ) );
     here.ter_set( edge, ter_id( "t_floor" ) );
+    REQUIRE( is_in_reality_bubble_bounds( edge ) );
 
     auto &zombie = spawn_test_monster( "mon_zombie", start );
 


### PR DESCRIPTION
## Purpose of change (The Why)

Recent PR test jobs fail from regressions in #9108 and #9597:
- throw info appears in unrelated iteminfo queries.
- throwing tests assume a bashable wall is immovable and use loaded map size instead of reality bubble bounds.

## Describe the solution (The How)

- Gate throw item info behind `BASE_THROW`.
- Add regression coverage for throw info queries.
- Use a TEST_DATA indestructible wall and reality-bubble-sized edge fixture in throwing tests.

## Testing

- `cmake --build --preset linux-full --target style-json-parallel`
- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "[throwing][impact],[throwing][bubble],[iteminfo]" --rng-seed 1782048451`
- `build-scripts/run-linux-test-shards.ts --mode file-tags --jobs 4 --non-slow-shards 8 ./out/build/linux-full/tests/cata_test-tiles -- --min-duration 20 --use-colour no --rng-seed 1782048451 --error-format=github-action --gpu-backend=software`
- `./build-scripts/lint-json.sh`

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [46f887a](https://github.com/cataclysmbn/Cataclysm-BN/commit/46f887aa0a54b24196dc1cdb9f661d951e766fa6) (fix: restore throw and iteminfo tests) on 2026-06-21 16:08:25

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27908369588/artifacts/7776747863)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27908369588/artifacts/7777001450)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27908369588/artifacts/7776739649)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27908369588/artifacts/7776770760)
<!-- END artifact comment -->