### PR TITLE
fix: fixed red fox butcher results

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -1893,7 +1893,7 @@
     "melee_cut": 2,
     "dodge": 6,
     "vision_night": 5,
-    "harvest": "mammal_tiny",
+    "harvest": "mammal_small_fur",
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "placate_triggers": [ "MEAT" ],


### PR DESCRIPTION
## Purpose of change (The Why)

Red fox harvest provides meat_scrap while gray fox provides expected amount of products. The fault lies in red fox harvest type being "mammal_tiny" instead of "mammal_small_fur".

## Describe the solution (The How)

Changed red fox harvest type from "mammal_tiny" to "mammal_small_fur"

## Describe alternatives you've considered

Cry when you starve, butcher a red fox and see a lonely meat scrap

## Testing

0. Change red fox harvest type in mammal.json 
1. Spawn red and gray foxes
2. Full butcher both
3. Compare results: both now provide the same amounts of products

## Additional context

It works uwu
Other similar cases might be worth checking

## Checklist

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7660dc9](https://github.com/cataclysmbn/Cataclysm-BN/commit/7660dc9e3193a5d3a8ccb94d9e32c01828353549) (Update mammal.json) on 2026-06-21 16:25:30

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27909245332/artifacts/7776878038)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27909245332)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27909245332/artifacts/7776890442)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27909245332/artifacts/7776944498)
<!-- END artifact comment -->