### PR TITLE
fix: max magic sounds at sound limit

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1130,7 +1130,7 @@ void spell::make_sound( const tripoint_bub_ms & /*target*/, Creature &caster, in
 {
     sound_event se;
     se.origin = caster.bub_pos();
-    se.volume = loudness;
+    se.volume = std::max( 190, loudness );
     se.category = type->sound_type;
     se.description = type->sound_description.translated();
     se.movement_noise = ( type->sound_type == sounds::sound_t::movement );


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #9594

## Describe the solution (The How)
Max magic sound at max sound

## Describe alternatives you've considered
Make magic sound scaling much less

## Testing
Casted spell spell no make greater then worldsplode sound

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e06dfc8](https://github.com/cataclysmbn/Cataclysm-BN/commit/e06dfc8d797549ae6bc38d5ad7ab97414e76aa2e) (fix: max magic sounds at sound limit) on 2026-06-21 18:59:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27912237098/artifacts/7778198679)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27912237098/artifacts/7778328718)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27912237098/artifacts/7778073804)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27912237098/artifacts/7778091627)
<!-- END artifact comment -->