### PR TITLE
fix: make rope ladder climbable up and visible from ground again

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -948,7 +948,15 @@ void map::add_vehicle_to_cache( vehicle *veh )
         int part = veh->part_with_feature( vpr.part_index(), VPFLAG_LADDER, true );
         if( part != -1 ) {
             // NOTE: This cache may need to be submapfied at some point
-            cached_veh_rope[p] = std::make_pair( veh, static_cast<int>( part ) );
+            // The rope hangs DOWN from the ladder part, so register the whole column from
+            // the part down to ladder_length() below it: has_rope_at() and the climb-up /
+            // rope-rendering paths look up the tile BELOW the part, not just the top tile
+            // (issue #9590). The top tile is kept so climbing down while boarded resolves.
+            const auto len = veh->part( part ).info().ladder_length();
+            const auto min_z = std::max( p.z() - len, -OVERMAP_DEPTH );
+            for( const auto z : std::views::iota( min_z, p.z() + 1 ) ) {
+                cached_veh_rope[tripoint_bub_ms( p.xy(), z )] = std::make_pair( veh, static_cast<int>( part ) );
+            }
         }
         level_cache &ch = get_cache( p.z() );
         ch.veh_in_active_range = true;
@@ -981,7 +989,22 @@ void map::clear_vehicle_point_from_cache( vehicle *veh, const tripoint_bub_ms &p
             ch.veh_exists_at[ch.idx( pt.x(), pt.y() )] = false;
         }
         ch.veh_cached_parts.erase( it );
-        cached_veh_rope.erase( pt );
+        // The rope-ladder cache stores the whole hanging column (see add_vehicle_to_cache),
+        // so a bare erase( pt ) would leave the rope tiles below the part. When pt is one of
+        // this vehicle's rope tiles (a column top), drop every tile this vehicle owns in that
+        // column. The gate keeps the common (no rope) path at a single lookup; the scan does
+        // NOT break on gaps, so an interleaved column from another vehicle can't strand this
+        // vehicle's lower tiles, and only this vehicle's entries are removed. Index-free on
+        // purpose: part indices may be stale here (this can run mid-part_removal_cleanup).
+        if( const auto top = cached_veh_rope.find( pt );
+            top != cached_veh_rope.end() && top->second.first == veh ) {
+            for( const auto z : std::views::iota( -OVERMAP_DEPTH, pt.z() + 1 ) ) {
+                const auto col_it = cached_veh_rope.find( tripoint_bub_ms( pt.xy(), z ) );
+                if( col_it != cached_veh_rope.end() && col_it->second.first == veh ) {
+                    cached_veh_rope.erase( col_it );
+                }
+            }
+        }
     }
 
 }

--- a/tests/vehicle_ladder_test.cpp
+++ b/tests/vehicle_ladder_test.cpp
@@ -1,0 +1,64 @@
+#include "catch/catch.hpp"
+
+#include <ranges>
+
+#include "coordinates.h"
+#include "game_constants.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "state_helpers.h"
+#include "type_id.h"
+#include "units.h"
+#include "veh_type.h"
+#include "vehicle.h"
+#include "vehicle_part.h"
+
+// Regression test for issue #9590: the multi-z "3-story rope ladder" (vehicle part
+// ladder_3, flag LADDER, length 3) must be detectable along the whole rope it hangs,
+// not just at the top tile where the part actually lives. map::has_rope_at() drives both
+// climbing UP from the ground and rendering the rope below the vehicle; a refactor
+// (#9543) that re-keyed map::cached_veh_rope from 2D (x,y) to 3D (x,y,z) accidentally
+// limited the cache to the single top tile, so the ladder could only be climbed down and
+// was invisible from below.
+
+TEST_CASE( "rope_ladder_spans_full_column_in_rope_cache", "[vehicle][ladder][zlevel]" )
+{
+    clear_all_state();
+    auto &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+
+    const tripoint_bub_ms vpos( 60, 60, 0 );
+    auto *veh = here.add_vehicle( vproto_id( "none" ), vpos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
+    const auto ladder = veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "ladder_3" ), true );
+    REQUIRE( ladder >= 0 );
+
+    here.add_vehicle_to_cache( veh );
+    here.build_map_cache( vpos.z(), true );
+
+    const auto top = veh->bub_part_location( ladder );
+    const auto len = veh->part( ladder ).info().ladder_length();
+    REQUIRE( len == 3 );
+
+    SECTION( "rope is present from the part down to ladder_length below it" ) {
+        // Top tile: needed so a boarded player can climb DOWN.
+        CHECK( here.has_rope_at( top ) );
+        // Hanging rope: needed to climb UP from the ground and to render the rope.
+        for( const auto dz : std::views::iota( 1, len + 1 ) ) {
+            CHECK( here.has_rope_at( tripoint_bub_ms( top.xy(), top.z() - dz ) ) );
+        }
+        // One tile past the ladder's reach must NOT report rope.
+        CHECK_FALSE( here.has_rope_at( tripoint_bub_ms( top.xy(), top.z() - ( len + 1 ) ) ) );
+    }
+
+    SECTION( "removing the ladder clears the whole column" ) {
+        // remove_part() marks the part removed and returns shift_if_needed() (not a
+        // success flag); part_removal_cleanup() is what invokes clear_vehicle_point_from_cache.
+        veh->remove_part( ladder );
+        veh->part_removal_cleanup();
+        for( const auto dz : std::views::iota( 0, len + 1 ) ) {
+            CHECK_FALSE( here.has_rope_at( tripoint_bub_ms( top.xy(), top.z() - dz ) ) );
+        }
+    }
+}


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves #9590 

## Describe the solution (The How)

Keep the 3-D key (consistent with #9543) and make the cache cover the whole hanging column for the rope ladder.

#9543 Changed the rope cache map::cached_veh_rope from a 2-D (x,y) key to a 3-D (x,y,z) key but kept populating only the ladder part's own tile, the top of the rope.

The "3-story rope ladder" (vehicle part ladder_3, flag LADDER, length: 3) on a flying vehicle could only be climbed down, not up, and the hanging rope wasn't drawn when viewed from the ground.


## Describe alternatives you've considered

- Revert the cache key to 2-D point_bub_ms. Simplest, but undoes part of #9543 migration and reintroduces the old asymmetry between this cache and the rest of the refactor.
- Factor the column geometry into a shared helper for populate + evict. However, the evict side must stay index-free (the stored part index can be stale during part_removal_cleanup), so it can't reuse a length-based helper safely. 
- Eviction that walks down and breaks at the first gap (initial version). Replaced after review with the non-breaking, vehicle-scoped scan above, so interleaved columns (e.g. a future ladder of a different length) can't leave stale entries.

## Testing

- New Catch2 test that spawns a vehicle with a ladder_3 part, asserts the rope is present through the full column and absent past its reach, and that removing the part clears the column
- Loaded up the windows tiles version and spawned an airship, which comes with a 3-story rope ladder and climbed down the ladder, then back up the ladder. 


## Additional context

Before:

<img width="1126" height="1085" alt="{0A4156B0-9854-4484-8B4A-22E992828172}" src="https://github.com/user-attachments/assets/8143ec41-3a35-4ab1-8ec9-548fb312b47b" />


After:

<img width="680" height="856" alt="image" src="https://github.com/user-attachments/assets/0c4d6caa-b959-4fe8-b0cd-b7f207a0b5e5" />


## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [cce960e](https://github.com/cataclysmbn/Cataclysm-BN/commit/cce960e62fa6b463c30e3ea706bb67004b0d6d24) (fix: rope ladder climbable up and visible from ground (#9590)) on 2026-06-21 19:39:37

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27913616682/artifacts/7778581585)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27913616682/artifacts/7778500663)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27913616682/artifacts/7778241772)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27913616682/artifacts/7778292636)
<!-- END artifact comment -->