### PR TITLE
fix: harden stored food rot actualization

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1075,7 +1075,7 @@ void Character::modify_morale( item &food, int nutr )
             food_morale( MORALE_FOOD_HOT );
         }
     } else if( food.has_flag( flag_EATEN_COLD ) ) {
-        const auto temp = rot::temperature_flag_for_location( get_map(), food );
+        const auto temp = rot::temp::for_location( get_map(), food );
 
         if( temp == temperature_flag::TEMP_FREEZER ) {
             add_msg_if_player( m_good, _( "This stuff is icy!" ), food.tname() );

--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -62,7 +62,7 @@ bool run(
 
     int info_area_scroll_pos = 0;
     constexpr int info_area_scroll_step = 3;
-    temperature_flag temperature = rot::temperature_flag_for_location( get_map(), itm );
+    temperature_flag temperature = rot::temp::for_location( get_map(), itm );
     std::vector<iteminfo> item_info_vals = itm.info( temperature );
     std::vector<iteminfo> dummy_compare;
     item_info_data data( itm.tname(), itm.type_name(), item_info_vals, dummy_compare,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11044,7 +11044,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
 
             if( iItemNum > 0 && activeItem ) {
                 const item &loc = *activeItem->example;
-                temperature_flag temperature = rot::temperature_flag_for_location( m, loc );
+                temperature_flag temperature = rot::temp::for_location( m, loc );
                 std::vector<iteminfo> this_item = activeItem->example->info( temperature );
                 std::vector<iteminfo> item_info_dummy;
 
@@ -11116,7 +11116,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             const item *example_item = activeItem->example;
             // TODO: const_item_location
             const item &loc = *example_item;
-            temperature_flag temperature = rot::temperature_flag_for_location( m, loc );
+            temperature_flag temperature = rot::temp::for_location( m, loc );
             std::vector<iteminfo> this_item = example_item->info( temperature );
 
             item_info_data info_data( example_item->tname(), example_item->type_name(), this_item, dummy );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -73,6 +73,7 @@
 #include "locations.h"
 #include "magic.h"
 #include "map.h"
+#include "mapbuffer.h"
 #include "martialarts.h"
 #include "material.h"
 #include "melee.h"
@@ -801,19 +802,54 @@ void item::set_damage( int qty )
 
 auto item::prepare_for_location_removal() -> void
 {
-    if( !goes_bad() ) {
-        return;
-    }
     if( is_in_preserving_container() ) {
         mark_rot_checked_now();
         return;
     }
-    if( is_loaded() && has_position() ) {
-        const auto vehicle_loc = dynamic_cast<vehicle_item_location *>( loc );
-        const auto temperature = vehicle_loc != nullptr ? vehicle_loc->storage_temperature() :
-                                 rot::temperature_flag_for_location( get_map(), *this );
-        update_rot( bub_pos(), temperature, get_weather() );
+    const auto contents_need_location = !contents.empty() && contents.has_processing_items() &&
+                                        !( type->container && type->container->preserves );
+    if( !goes_bad() && !contents_need_location ) {
+        return;
     }
+    if( !is_loaded() || !has_position() ) {
+        return;
+    }
+
+    auto storage_temperature = temperature_flag::TEMP_NORMAL;
+    const auto vehicle_loc = dynamic_cast<vehicle_item_location *>( loc );
+    if( vehicle_loc != nullptr ) {
+        storage_temperature = vehicle_loc->storage_temperature();
+    } else if( where() == item_location_type::map ) {
+        auto &buffer = MAPBUFFER_REGISTRY.get( loc->get_dimension( this ) );
+        const auto tile = buffer.get_abs_tile( loc->abs_pos( this ), {
+            .mode = mapbuffer_lookup_mode::resident_only,
+        } );
+        if( tile ) {
+            const auto &furn = tile->get_furn_t();
+            storage_temperature = rot::temp::for_tile( {
+                .root_cellar = tile->get_ter() == t_rootcellar,
+                .fridge = furn.has_flag( TFLAG_FRIDGE ),
+                .freezer = furn.has_flag( TFLAG_FREEZER ),
+            } );
+        } else {
+            storage_temperature = rot::temp::for_location( get_map(), *this );
+        }
+    } else {
+        storage_temperature = rot::temp::for_location( get_map(), *this );
+    }
+    const auto pos = bub_pos();
+
+    if( goes_bad() ) {
+        update_rot( pos, storage_temperature, get_weather() );
+    }
+    if( !contents_need_location ) {
+        return;
+    }
+
+    const auto seals = is_in_sealing_container() || ( type->container && type->container->seals );
+    contents.remove_top_items_with( [pos, storage_temperature, seals]( detached_ptr<item> &&it ) {
+        return item::actualize_rot( std::move( it ), pos, storage_temperature, get_weather(), seals );
+    } );
 }
 
 detached_ptr<item> item::split( int qty )
@@ -879,7 +915,7 @@ bool item::attempt_split( int qty,
     const auto vehicle_loc = dynamic_cast<vehicle_item_location *>( loc );
     const auto split_temperature = !split_needs_rot_actualization ? temperature_flag::TEMP_NORMAL :
                                    vehicle_loc != nullptr ? vehicle_loc->storage_temperature() :
-                                   rot::temperature_flag_for_location( get_map(), *this );
+                                   rot::temp::for_location( get_map(), *this );
     detached_ptr<item> det = unsafe_split( qty );
     if( det && split_from_preserving_container ) {
         det->mark_rot_checked_now();
@@ -5277,7 +5313,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
             tagtext += _( " (fresh)" );
         }
         if( is_loaded() ) {
-            const auto temp = rot::temperature_flag_for_location( get_map(), *this );
+            const auto temp = rot::temp::for_location( get_map(), *this );
             if( temp == temperature_flag::TEMP_FREEZER ) {
                 tagtext += _( " (frozen)" );
             } else if( temp == temperature_flag::TEMP_FRIDGE || temp == temperature_flag::TEMP_ROOT_CELLAR ) {
@@ -6367,6 +6403,16 @@ auto item::is_in_preserving_container() const -> bool
 {
     for( const item *parent = parent_item(); parent != nullptr; parent = parent->parent_item() ) {
         if( parent->type && parent->type->container && parent->type->container->preserves ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+auto item::is_in_sealing_container() const -> bool
+{
+    for( const item *parent = parent_item(); parent != nullptr; parent = parent->parent_item() ) {
+        if( parent->type && parent->type->container && parent->type->container->seals ) {
             return true;
         }
     }
@@ -9992,7 +10038,14 @@ auto item::process_rot( detached_ptr<item> &&self,
 
     self->update_rot( options.context );
 
-    if( self->has_rotten_away() && options.carrier == nullptr && !options.seals ) {
+    auto rotted_away = false;
+    if( self->is_corpse() && !self->can_revive() ) {
+        rotted_away = self->rot > 10_days;
+    } else {
+        const auto shelf_life = self->get_shelf_life();
+        rotted_away = self->is_food() && shelf_life != 0_turns && self->rot / shelf_life > 2.0;
+    }
+    if( rotted_away && options.carrier == nullptr && !options.seals ) {
         return detached_ptr<item>();
     }
     return std::move( self );
@@ -10002,16 +10055,29 @@ auto item::actualize_rot( detached_ptr<item> &&self, const tripoint_bub_ms &pnt,
                           const temperature_flag temperature,
                           const weather_manager &weather ) -> detached_ptr<item>
 {
+    return actualize_rot( std::move( self ), pnt, temperature, weather, false );
+}
+
+auto item::actualize_rot( detached_ptr<item> &&self, const tripoint_bub_ms &pnt,
+                          const temperature_flag temperature,
+                          const weather_manager &weather, const bool seals ) -> detached_ptr<item>
+{
     return actualize_rot( std::move( self ), {
         .position = bub_to_abs( pnt ),
         .temperature = temperature,
         .weather = &weather,
         .local_temperature = g != nullptr && !g->new_game ? get_map().get_temperature( pnt ) : 0,
-    } );
+    }, seals );
 }
 
 auto item::actualize_rot( detached_ptr<item> &&self,
                           const rot_context &context ) -> detached_ptr<item>
+{
+    return actualize_rot( std::move( self ), context, false );
+}
+
+auto item::actualize_rot( detached_ptr<item> &&self,
+                          const rot_context &context, const bool seals ) -> detached_ptr<item>
 {
     // Guard against null or invalid items that can survive save/load cycles
     // during dimension transitions (e.g. zombie items from deferred arena cleanup).
@@ -10024,36 +10090,22 @@ auto item::actualize_rot( detached_ptr<item> &&self,
     }
     if( self->goes_bad() ) {
         return process_rot( std::move( self ), {
-            .seals = false,
+            .seals = seals,
             .carrier = nullptr,
             .context = context,
         } );
     } else if( self->type->container && self->type->container->preserves ) {
-        // Containers like tin cans preserves all items inside, they do not rot at all.
-        return std::move( self );
-    } else if( self->type->container && self->type->container->seals ) {
-        // Items inside rot but do not vanish as the container seals them in.
-        self->contents.remove_top_items_with( [&context]( detached_ptr<item> &&it ) {
-            if( !it || !it->type || it->type == nullitem() ) {
-                return std::move( it );
-            }
-            if( it->goes_bad() ) {
-                it = process_rot( std::move( it ), {
-                    .seals = true,
-                    .carrier = nullptr,
-                    .context = context,
-                } );
-            }
-            return std::move( it );
-        } );
-        return std::move( self );
-    } else {
-        // Check and remove rotten contents, but always keep the container.
-        self->contents.remove_top_items_with( [&context]( detached_ptr<item> &&it ) {
-            return actualize_rot( std::move( it ), context );
-        } );
+        // Containers like tin cans preserve all items inside; they do not rot at all.
         return std::move( self );
     }
+
+    const auto child_seals = seals || ( self->type->container && self->type->container->seals );
+    // Check and remove rotten contents, but always keep the container.
+    // If this item or an ancestor seals its contents, nested rotten contents rot but stay contained.
+    self->contents.remove_top_items_with( [&context, child_seals]( detached_ptr<item> &&it ) {
+        return actualize_rot( std::move( it ), context, child_seals );
+    } );
+    return std::move( self );
 }
 
 bool item_ptr_compare_by_charges( const item *left, const item *right )
@@ -10271,7 +10323,7 @@ void item::update_rot_from_location( const temperature_flag temperature )
     auto flag = temperature;
     if( is_loaded() && has_position() ) {
         pos = bub_pos();
-        flag = rot::temperature_flag_for_location( get_map(), *this );
+        flag = rot::temp::for_location( get_map(), *this );
     }
     update_rot( pos, flag, get_weather() );
 }

--- a/src/item.h
+++ b/src/item.h
@@ -2462,9 +2462,15 @@ class item : public location_visitable<item>, public game_object<item>
         static detached_ptr<item> process_internal( detached_ptr<item> &&self, player *carrier,
                 const tripoint_bub_ms &pos, bool activate,
                 bool seals, temperature_flag flag, const weather_manager &weather_generator );
+        static auto actualize_rot( detached_ptr<item> &&self, const tripoint_bub_ms &pnt,
+                                   temperature_flag temperature,
+                                   const weather_manager &weather, bool seals ) -> detached_ptr<item>;
+        static auto actualize_rot( detached_ptr<item> &&self,
+                                   const rot_context &context, bool seals ) -> detached_ptr<item>;
         static auto process_rot( detached_ptr<item> &&self,
                                  const absolute_rot_process_options &options ) -> detached_ptr<item>;
         auto is_in_preserving_container() const -> bool;
+        auto is_in_sealing_container() const -> bool;
         auto mark_rot_checked_now() -> void;
 
         /** Helper for checking reloadability. **/

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -550,7 +550,7 @@ void vehicle_item_location::attach( detached_ptr<item> &&obj )
 auto vehicle_item_location::storage_temperature() const -> temperature_flag
 {
     const auto part_index = veh->get_part_id_hack( hack_id );
-    return part_index >= 0 ? rot::temperature_flag_for_part( *veh,
+    return part_index >= 0 ? rot::temp::for_part( *veh,
             part_index ) : temperature_flag::TEMP_NORMAL;
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6700,58 +6700,42 @@ std::vector<detached_ptr<item>> map::use_charges( const tripoint_bub_ms &origin,
         const std::optional<vpart_reference> autoclavepart = vp.part_with_feature( "AUTOCLAVE", true );
         const std::optional<vpart_reference> cargo = vp.part_with_feature( "CARGO", true );
 
-        if( crafterpart ) {
-            for( itype_id id : crafterpart->info().craftertools() ) {
-                if( type == id ) {
-                    detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-                    tmp->charges = crafterpart->vehicle().drain( itype_battery, quantity );
-                    quantity -= tmp->charges;
-                    ret.push_back( std::move( tmp ) );
+        auto drain_vehicle_pseudo_item = [&ret, &quantity, &type]( vehicle & veh,
+        const itype_id & drain_type ) -> bool {
+            const auto drained = veh.drain( drain_type, quantity );
+            quantity -= drained;
+            if( drained <= 0 )
+            {
+                return quantity == 0;
+            }
+            auto tmp = item::spawn( type, calendar::turn );
+            tmp->charges = drained;
+            ret.push_back( std::move( tmp ) );
+            return quantity == 0;
+        };
 
-                    if( quantity == 0 ) {
-                        return ret;
-                    }
+        if( crafterpart ) {
+            for( const auto &id : crafterpart->info().craftertools() ) {
+                if( type == id && drain_vehicle_pseudo_item( crafterpart->vehicle(), itype_battery ) ) {
+                    return ret;
                 }
             }
         }
         if( faupart ) { // we have a faucet, now to see what to drain
-            itype_id ftype = itype_id::NULL_ID();
-
-            ftype = type;
-
-            // TODO: add a sane birthday arg
-            //TODO!: check if we actually need the return  here
-            detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = faupart->vehicle().drain( ftype, quantity );
             // TODO: Handle water poison when crafting starts respecting it
-            quantity -= tmp->charges;
-            // Don't return a 0-charge phantom for types the tanks can't provide:
-            // it would replace the real component during crafting (#9440)
-            if( tmp->charges > 0 ) {
-                ret.push_back( std::move( tmp ) );
-            }
-
-            if( quantity == 0 ) {
+            if( drain_vehicle_pseudo_item( faupart->vehicle(), type ) ) {
                 return ret;
             }
         }
 
         if( autoclavepart ) { // we have an autoclave, now to see what to drain
-            itype_id ftype = itype_id::NULL_ID();
+            auto ftype = itype_id::NULL_ID();
 
             if( type == itype_autoclave ) {
                 ftype = itype_battery;
             }
 
-            // TODO: add a sane birthday arg
-            detached_ptr<item> tmp = item::spawn( type, calendar::start_of_cataclysm );
-            tmp->charges = autoclavepart->vehicle().drain( ftype, quantity );
-            quantity -= tmp->charges;
-            if( tmp->charges > 0 ) {
-                ret.push_back( std::move( tmp ) );
-            }
-
-            if( quantity == 0 ) {
+            if( drain_vehicle_pseudo_item( autoclavepart->vehicle(), ftype ) ) {
                 return ret;
             }
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -102,6 +102,7 @@
 #include "projectile.h"
 #include "profile.h"
 #include "rng.h"
+#include "rot.h"
 #include "safe_reference.h"
 #include "scent_map.h"
 #include "sounds.h"
@@ -6304,21 +6305,6 @@ void map::process_items()
     TracyPlot( "Total Rottable Active Items", total_rottable_active_items );
 }
 
-static temperature_flag temperature_flag_at_point( const map &m, const tripoint_bub_ms &p )
-{
-    if( m.ter( p ) == t_rootcellar ) {
-        return temperature_flag::TEMP_ROOT_CELLAR;
-    }
-    if( m.has_flag_furn( TFLAG_FRIDGE, p ) ) {
-        return temperature_flag::TEMP_FRIDGE;
-    }
-    if( m.has_flag_furn( TFLAG_FREEZER, p ) ) {
-        return temperature_flag::TEMP_FREEZER;
-    }
-
-    return temperature_flag::TEMP_NORMAL;
-}
-
 auto map::process_items_in_submap( submap &current_submap, const tripoint_bub_sm &gridp,
                                    std::vector<item *> &active_items ) -> void
 {
@@ -6340,7 +6326,7 @@ auto map::process_items_in_submap( submap &current_submap, const tripoint_bub_sm
             }
 
             const auto map_location = active_item_ref->bub_pos();
-            temperature_flag flag = temperature_flag_at_point( *this, tripoint_bub_ms( map_location ) );
+            const auto flag = rot::temp::for_location( *this, *active_item_ref );
             process_map_items( active_item_ref, map_location, flag );
         }
     }
@@ -6403,21 +6389,10 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
         }
         const item &target = *active_item_ref;
         // Find the cargo part and coordinates corresponding to the current active item.
-        const vehicle_part &pt = it->part();
         const auto item_loc = it->pos();
-        auto items = cur_veh.get_items( static_cast<int>( it->part_index() ) );
-        temperature_flag flag = temperature_flag::TEMP_NORMAL;
+        auto flag = temperature_flag::TEMP_NORMAL;
         if( target.is_food() || target.is_food_container() || target.is_corpse() ) {
-            const vpart_info &pti = pt.info();
-            if( engine_heater_is_on ) {
-                flag = temperature_flag::TEMP_HEATER;
-            }
-
-            if( pt.enabled && pti.has_flag( VPFLAG_FRIDGE ) ) {
-                flag = temperature_flag::TEMP_FRIDGE;
-            } else if( pt.enabled && pti.has_flag( VPFLAG_FREEZER ) ) {
-                flag = temperature_flag::TEMP_FREEZER;
-            }
+            flag = rot::temp::for_part( cur_veh, it->part_index(), engine_heater_is_on );
         }
         if( !process_map_items( active_item_ref, item_loc, flag ) ) {
             // If the item was NOT destroyed, we can skip the remainder,

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -53,6 +53,7 @@
 #include "popup.h"
 #include "profile.h"
 #include "rng.h"
+#include "rot.h"
 #include "skill.h"
 #include "string_formatter.h"
 #include "submap.h"
@@ -173,18 +174,12 @@ auto trap_at_tile( const submap &sm, const point_sm_ms &local ) -> const trap &
 
 auto temperature_flag_at_tile( const submap &sm, const point_sm_ms &local ) -> temperature_flag
 {
-    if( sm.get_ter( local ) == t_rootcellar ) {
-        return temperature_flag::TEMP_ROOT_CELLAR;
-    }
     const auto &furn = sm.get_furn( local ).obj();
-    if( furn.has_flag( TFLAG_FRIDGE ) ) {
-        return temperature_flag::TEMP_FRIDGE;
-    }
-    if( furn.has_flag( TFLAG_FREEZER ) ) {
-        return temperature_flag::TEMP_FREEZER;
-    }
-
-    return temperature_flag::TEMP_NORMAL;
+    return rot::temp::for_tile( {
+        .root_cellar = sm.get_ter( local ) == t_rootcellar,
+        .fridge = furn.has_flag( TFLAG_FRIDGE ),
+        .freezer = furn.has_flag( TFLAG_FREEZER ),
+    } );
 }
 
 auto add_item_to_actualized_tile( const actualize_tile_options &options,

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -760,7 +760,7 @@ auto pick_up_from_items( const std::vector<item_stack::iterator> &here, const in
 
             if( selected >= 0 && selected <= static_cast<int>( stacked_here.size() ) - 1 ) {
                 item *loc = *stacked_here[matches[selected]].front();
-                temperature_flag temperature = rot::temperature_flag_for_location( get_map(), *loc );
+                temperature_flag temperature = rot::temp::for_location( get_map(), *loc );
 
                 std::vector<iteminfo> this_item = selected_item.info( temperature );
 

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -7,10 +7,25 @@
 #include "veh_type.h"
 #include "vpart_position.h"
 
-namespace rot
+namespace rot::temp
 {
 
-auto temperature_flag_for_location( const map &m, const item &loc ) -> temperature_flag
+auto for_tile( const tile_flags &flags ) -> temperature_flag
+{
+    if( flags.root_cellar ) {
+        return temperature_flag::TEMP_ROOT_CELLAR;
+    }
+    if( flags.freezer ) {
+        return temperature_flag::TEMP_FREEZER;
+    }
+    if( flags.fridge ) {
+        return temperature_flag::TEMP_FRIDGE;
+    }
+
+    return temperature_flag::TEMP_NORMAL;
+}
+
+auto for_location( const map &m, const item &loc ) -> temperature_flag
 {
     if( !loc.has_position() ) {
         return temperature_flag::TEMP_NORMAL;
@@ -22,17 +37,12 @@ auto temperature_flag_for_location( const map &m, const item &loc ) -> temperatu
         case item_location_type::monster:
             return temperature_flag::TEMP_NORMAL;
         case item_location_type::map: {
-            auto pos = loc.bub_pos();
-            if( m.has_flag_furn( TFLAG_FREEZER, pos ) ) {
-                return temperature_flag::TEMP_FREEZER;
-            }
-            if( m.has_flag_furn( TFLAG_FRIDGE, pos ) ) {
-                return temperature_flag::TEMP_FRIDGE;
-            }
-            if( m.ter( pos ) == t_rootcellar ) {
-                return temperature_flag::TEMP_ROOT_CELLAR;
-            }
-            return temperature_flag::TEMP_NORMAL;
+            const auto pos = loc.bub_pos();
+            return for_tile( {
+                .root_cellar = m.ter( pos ) == t_rootcellar,
+                .fridge = m.has_flag_furn( TFLAG_FRIDGE, pos ),
+                .freezer = m.has_flag_furn( TFLAG_FREEZER, pos ),
+            } );
         }
         case item_location_type::vehicle: {
             auto pos = loc.bub_pos();
@@ -45,14 +55,14 @@ auto temperature_flag_for_location( const map &m, const item &loc ) -> temperatu
             if( cargo_index < 0 ) {
                 return temperature_flag::TEMP_NORMAL;
             }
-            return temperature_flag_for_part( veh->vehicle(), cargo_index );
+            return for_part( veh->vehicle(), cargo_index );
         }
         case item_location_type::container: {
             const auto parent = loc.parent_item();
             if( parent == nullptr ) {
                 return temperature_flag::TEMP_NORMAL;
             }
-            return temperature_flag_for_location( m, *parent );
+            return for_location( m, *parent );
         }
         default:
             debugmsg( "Invalid item location %d", static_cast<int>( loc.where() ) );
@@ -60,22 +70,24 @@ auto temperature_flag_for_location( const map &m, const item &loc ) -> temperatu
     }
 }
 
-auto temperature_flag_for_part( const vehicle &veh, size_t part_index ) -> temperature_flag
+auto for_part( const vehicle &veh, const size_t part_index,
+               const bool engine_heater_is_on ) -> temperature_flag
 {
-    const vehicle_part &part = veh.cpart( part_index );
-    const vpart_info &info = part.info();
-    if( !part.enabled ) {
-        return temperature_flag::TEMP_NORMAL;
-    }
-
-    if( info.has_flag( VPFLAG_FREEZER ) ) {
+    const auto &part = veh.cpart( part_index );
+    const auto &info = part.info();
+    if( part.enabled && info.has_flag( VPFLAG_FREEZER ) ) {
         return temperature_flag::TEMP_FREEZER;
     }
 
-    if( info.has_flag( VPFLAG_FRIDGE ) ) {
+    if( part.enabled && info.has_flag( VPFLAG_FRIDGE ) ) {
         return temperature_flag::TEMP_FRIDGE;
     }
+
+    if( engine_heater_is_on ) {
+        return temperature_flag::TEMP_HEATER;
+    }
+
     return temperature_flag::TEMP_NORMAL;
 }
 
-} // namespace rot
+} // namespace rot::temp

--- a/src/rot.h
+++ b/src/rot.h
@@ -1,16 +1,29 @@
 #pragma once
 
+#include <cstddef>
+
 enum class temperature_flag : int;
 
 class map;
 class item;
+class vehicle;
 
-namespace rot
+namespace rot::temp
 {
 
+struct tile_flags {
+    bool root_cellar = false;
+    bool fridge = false;
+    bool freezer = false;
+};
+
+/** Resolve the rot temperature modifier for map terrain/furniture storage. */
+auto for_tile( const tile_flags &flags ) -> temperature_flag;
+
 // TODO: Move to item_location method?
-auto temperature_flag_for_location( const map &m, const item &loc ) -> temperature_flag;
+auto for_location( const map &m, const item &loc ) -> temperature_flag;
+auto for_part( const vehicle &veh, size_t part,
+               bool engine_heater_is_on = false ) -> temperature_flag;
 
-} // namespace rot
-
+} // namespace rot::temp
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1907,8 +1907,3 @@ class vehicle
         // Persisted across saves so cross-dimension processing survives reload.
         dimension_id dimension_id_;
 };
-
-namespace rot
-{
-temperature_flag temperature_flag_for_part( const vehicle &veh, size_t part );
-} // namespace rot

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -1090,327 +1090,247 @@ TEST_CASE( "tool selection ui", "[crafting][ui]" )
     }
 }
 
+namespace
+{
+
+struct vehicle_craft_fixture_options {
+    vpart_id work_part;
+    bool install_battery = false;
+    bool install_freezer = false;
+};
+
+struct vehicle_craft_fixture {
+    avatar *you = nullptr;
+    map *here = nullptr;
+    vehicle *veh = nullptr;
+    int work_part = -1;
+    int freezer_part = -1;
+    tripoint_bub_ms vehicle_pos = tripoint_bub_ms::zero();
+    tripoint_bub_ms stand_pos = tripoint_bub_ms::zero();
+};
+
+auto old_world_craft_turn() -> time_point
+{
+    return calendar::start_of_cataclysm + 19_days + 12_hours;
+}
+
+auto setup_vehicle_rot_test_at( const time_point turn ) -> void
+{
+    clear_all_state();
+    calendar::turn = turn;
+    get_weather().temperature = 18_c;
+    get_weather().clear_temp_cache();
+    clear_avatar();
+}
+
+auto install_part_on_frame( vehicle &veh, const tripoint_mnt_veh &mount,
+                            const vpart_id &part ) -> int
+{
+    REQUIRE( veh.install_part( mount, vpart_id( "frame_vertical" ), true ) >= 0 );
+    const auto part_index = veh.install_part( mount, part, true );
+    REQUIRE( part_index >= 0 );
+    return part_index;
+}
+
+auto make_vehicle_craft_fixture( const vehicle_craft_fixture_options &opts ) ->
+vehicle_craft_fixture
+{
+    auto &you = get_avatar();
+    auto &here = get_map();
+    const auto vehicle_pos = tripoint_bub_ms( 60, 60, 0 );
+    auto *veh = here.add_vehicle( vproto_id( "none" ), vehicle_pos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+
+    const auto work_part = install_part_on_frame( *veh, tripoint_mnt_veh::zero(), opts.work_part );
+    auto freezer_part = -1;
+    if( opts.install_battery ) {
+        static_cast<void>( install_part_on_frame( *veh, tripoint_mnt_veh( 1, 0, 0 ),
+                           vpart_id( "storage_battery" ) ) );
+        veh->charge_battery( 5000 );
+    }
+    if( opts.install_freezer ) {
+        freezer_part = install_part_on_frame( *veh, tripoint_mnt_veh( -1, 0, 0 ),
+                                              vpart_id( "minifreezer" ) );
+        veh->part( freezer_part ).enabled = true;
+    }
+
+    here.add_vehicle_to_cache( veh );
+    here.build_map_cache( vehicle_pos.z(), true );
+    REQUIRE( here.veh_at( vehicle_pos ) );
+
+    const auto stand_pos = vehicle_pos + tripoint( 0, 1, 0 );
+    you.setpos( stand_pos );
+    REQUIRE_FALSE( here.veh_at( stand_pos ) );
+
+    return vehicle_craft_fixture{
+        .you = &you,
+        .here = &here,
+        .veh = veh,
+        .work_part = work_part,
+        .freezer_part = freezer_part,
+        .vehicle_pos = vehicle_pos,
+        .stand_pos = stand_pos,
+    };
+}
+
+auto add_fresh_meat_to_part( vehicle_craft_fixture &fixture, const int part ) -> void
+{
+    auto meat = item::spawn( "meat" );
+    REQUIRE( meat->goes_bad() );
+    INFO( "spawned meat bday_turn=" << to_turn<int>( meat->birthday() )
+          << " now=" << to_turn<int>( calendar::turn ) );
+    REQUIRE_FALSE( fixture.veh->add_item( part, std::move( meat ) ) );
+}
+
+auto add_fresh_meat_to_work_part( vehicle_craft_fixture &fixture ) -> void
+{
+    add_fresh_meat_to_part( fixture, fixture.work_part );
+}
+
+auto add_inventory_cooking_tools( avatar &you ) -> void
+{
+    you.i_add( item::spawn( "hotplate", calendar::turn, 20 ) );
+    you.i_add( item::spawn( "pot", calendar::turn ) );
+}
+
+auto keep_meat_frozen_then_move_to_work_part( vehicle_craft_fixture &fixture ) -> void
+{
+    REQUIRE( fixture.freezer_part >= 0 );
+    calendar::turn += 19_days;
+
+    auto frozen_items = fixture.veh->get_items( fixture.freezer_part );
+    REQUIRE( frozen_items.size() == 1 );
+    auto &frozen = frozen_items.only_item();
+    INFO( "POST-FREEZE meat bday_turn=" << to_turn<int>( frozen.birthday() )
+          << " relative_rot=" << frozen.get_relative_rot()
+          << " rot_turns=" << to_turns<int>( frozen.get_rot() )
+          << " now=" << to_turn<int>( calendar::turn ) );
+    REQUIRE( frozen.get_rot() == 0_turns );
+    REQUIRE( frozen.attempt_detach( [&fixture]( detached_ptr<item> &&it ) {
+        return fixture.veh->add_item( fixture.work_part, std::move( it ) );
+    } ) );
+
+    REQUIRE( fixture.veh->get_items( fixture.freezer_part ).empty() );
+    REQUIRE( fixture.veh->get_items( fixture.work_part ).size() == 1 );
+}
+
+auto find_cooked_meat_result( const vehicle_craft_fixture &fixture ) -> item *
+{
+    auto *result = static_cast<item *>( nullptr );
+    fixture.you->visit_items( [&result]( item * it ) {
+        if( it->typeId() == itype_id( "meat_cooked" ) ) {
+            result = it;
+            return VisitResponse::ABORT;
+        }
+        return VisitResponse::NEXT;
+    } );
+
+    for( const auto &p : { fixture.vehicle_pos, fixture.stand_pos } ) {
+        if( result != nullptr ) {
+            break;
+        }
+        for( auto *it : fixture.here->i_at( p ) ) {
+            if( it->typeId() == itype_id( "meat_cooked" ) ) {
+                result = it;
+                break;
+            }
+        }
+    }
+    if( result == nullptr ) {
+        for( auto *it : fixture.veh->get_items( fixture.work_part ) ) {
+            if( it->typeId() == itype_id( "meat_cooked" ) ) {
+                result = it;
+                break;
+            }
+        }
+    }
+    return result;
+}
+
+auto craft_cooked_meat_at_vehicle( const vehicle_craft_fixture &fixture ) -> item *
+{
+    auto &you = *fixture.you;
+    const auto rid = recipe_id( "meat_cooked" );
+    const auto &rec = rid.obj();
+    you.set_skill_level( rec.skill_used, std::max( rec.difficulty, 2 ) );
+    you.learn_recipe( &rec );
+    set_time( calendar::turn );
+
+    you.invalidate_crafting_inventory();
+    REQUIRE( you.crafting_inventory().has_components( itype_id( "meat" ), 1 ) );
+
+    you.make_craft( rid, 1, fixture.vehicle_pos );
+    REQUIRE( you.activity );
+    auto guard = 0;
+    while( you.activity && you.activity->id() == activity_id( "ACT_CRAFT" ) ) {
+        you.moves = 100;
+        you.activity->do_turn( you );
+        guard += 1;
+        REQUIRE( guard <= 100000 );
+    }
+
+    auto *result = find_cooked_meat_result( fixture );
+    REQUIRE( result != nullptr );
+    return result;
+}
+
+auto check_cooked_meat_is_fresh( item &result ) -> void
+{
+    INFO( "result relative_rot = " << result.get_relative_rot() );
+    INFO( "result rot turns = " << to_turns<int>( result.get_rot() ) );
+    CHECK_FALSE( result.rotten() );
+    CHECK( result.get_relative_rot() < 0.5 );
+}
+
+} // namespace
+
 // REPRO for issue #9254: cooking in a vehicle kitchen with a fresh vehicle-stored
 // component should NOT produce a rotten result.
 TEST_CASE( "vehicle kitchen craft preserves fresh component rot", "[crafting][rot]" )
 {
-    clear_all_state();
-    // Day 19, midday for crafting light.
-    calendar::turn = calendar::start_of_cataclysm + 19_days + 12_hours;
-    get_weather().temperature = 18_c;
-    get_weather().clear_temp_cache();
-
-    avatar &you = get_avatar();
-    clear_avatar();
-
-    auto &here = get_map();
-    const tripoint_bub_ms vpos( 60, 60, 0 );
-    auto *veh = here.add_vehicle( vproto_id( "none" ), vpos, 0_degrees, 0, 0 );
-    REQUIRE( veh != nullptr );
-    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
-    const int kitchen = veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "kitchen_unit" ), true );
-    REQUIRE( kitchen >= 0 );
-    // Give the kitchen battery power for the hotplate (on an adjacent mount).
-    REQUIRE( veh->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "frame_vertical" ),
-                                true ) >= 0 );
-    const int batt = veh->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "storage_battery" ),
-                                        true );
-    REQUIRE( batt >= 0 );
-    veh->charge_battery( 5000 );
-    here.add_vehicle_to_cache( veh );
-    here.build_map_cache( vpos.z(), true );
-    REQUIRE( here.veh_at( vpos ) );
-
-    // Fresh meat (bday = now = day 19) into the kitchen cargo.
-    auto meat = item::spawn( "meat" );
-    REQUIRE( meat->goes_bad() );
-    INFO( "spawned meat bday_turn=" << to_turn<int>( meat->birthday() )
-          << " now=" << to_turn<int>( calendar::turn ) );
-    REQUIRE_FALSE( veh->add_item( kitchen, std::move( meat ) ) );
-
-    // Stand adjacent to the kitchen (kitchen is an OBSTACLE), like the real repro.
-    const tripoint_bub_ms stand = vpos + tripoint( 0, 1, 0 );
-    you.setpos( stand );
-    REQUIRE_FALSE( here.veh_at( stand ) );
-    REQUIRE( here.veh_at( vpos ) );
-
-    const recipe_id rid( "meat_cooked" );
-    const recipe &rec = rid.obj();
-    you.set_skill_level( rec.skill_used, std::max( rec.difficulty, 2 ) );
-    you.learn_recipe( &rec );
-    set_time( calendar::turn ); // refresh light at current (day 19 midday)
-
-    you.invalidate_crafting_inventory();
-    REQUIRE( you.crafting_inventory().has_components( itype_id( "meat" ), 1 ) );
-
-    you.make_craft( rid, 1, vpos );
-    REQUIRE( you.activity );
-    int guard = 0;
-    while( you.activity && you.activity->id() == activity_id( "ACT_CRAFT" ) ) {
-        you.moves = 100;
-        you.activity->do_turn( you );
-        if( ++guard > 100000 ) {
-            break;
-        }
-    }
-
-    // Find the cooked meat result (inventory, ground, or vehicle).
-    item *result = nullptr;
-    you.visit_items( [&]( item * it ) {
-        if( it->typeId() == itype_id( "meat_cooked" ) ) {
-            result = it;
-            return VisitResponse::ABORT;
-        }
-        return VisitResponse::NEXT;
+    setup_vehicle_rot_test_at( old_world_craft_turn() );
+    auto fixture = make_vehicle_craft_fixture( {
+        .work_part = vpart_id( "kitchen_unit" ),
+        .install_battery = true,
     } );
-    for( const tripoint_bub_ms &p : { vpos, stand } ) {
-        if( result ) {
-            break;
-        }
-        for( item *&it : here.i_at( p ) ) {
-            if( it->typeId() == itype_id( "meat_cooked" ) ) {
-                result = it;
-            }
-        }
-    }
-    if( !result ) {
-        for( item *&it : veh->get_items( kitchen ) ) {
-            if( it->typeId() == itype_id( "meat_cooked" ) ) {
-                result = it;
-            }
-        }
-    }
-    REQUIRE( result != nullptr );
-    INFO( "result relative_rot = " << result->get_relative_rot() );
-    INFO( "result rot turns = " << to_turns<int>( result->get_rot() ) );
-    CHECK_FALSE( result->rotten() );
-    CHECK( result->get_relative_rot() < 0.5 );
+    add_fresh_meat_to_work_part( fixture );
+
+    auto &result = *craft_cooked_meat_at_vehicle( fixture );
+
+    check_cooked_meat_is_fresh( result );
 }
 
-// AUTOCLAVE variant of the BN9254 test above: map::use_charges' AUTOCLAVE branch has the
-// same phantom-injection hole as the FAUCET branch (for non-autoclave requests ftype stays
-// NULL_ID, drain returns 0, and the 0-charge phantom was pushed unconditionally). The
-// autoclave part is CARGO+AUTOCLAVE on one tile, so the phantom always precedes the real
-// component. Cooking tools come from the avatar's inventory so the autoclave is the only
-// vehicle feature in play; the vehicle deliberately has no battery.
+// AUTOCLAVE variant of the BN9254 test above: the autoclave part is
+// CARGO+AUTOCLAVE on one tile, so any phantom from map::use_charges precedes the
+// real component. Cooking tools come from inventory so the vehicle has no battery.
 TEST_CASE( "vehicle autoclave craft preserves fresh component rot", "[crafting][rot]" )
 {
-    clear_all_state();
-    // Day 19, midday for crafting light.
-    calendar::turn = calendar::start_of_cataclysm + 19_days + 12_hours;
-    get_weather().temperature = 18_c;
-    get_weather().clear_temp_cache();
-
-    avatar &you = get_avatar();
-    clear_avatar();
-
-    auto &here = get_map();
-    const tripoint_bub_ms vpos( 60, 60, 0 );
-    auto *veh = here.add_vehicle( vproto_id( "none" ), vpos, 0_degrees, 0, 0 );
-    REQUIRE( veh != nullptr );
-    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
-    const int clave = veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "autoclave" ), true );
-    REQUIRE( clave >= 0 );
-    here.add_vehicle_to_cache( veh );
-    here.build_map_cache( vpos.z(), true );
-    REQUIRE( here.veh_at( vpos ) );
-
-    // Fresh meat (bday = now = day 19) into the autoclave's cargo space.
-    auto meat = item::spawn( "meat" );
-    REQUIRE( meat->goes_bad() );
-    INFO( "spawned meat bday_turn=" << to_turn<int>( meat->birthday() )
-          << " now=" << to_turn<int>( calendar::turn ) );
-    REQUIRE_FALSE( veh->add_item( clave, std::move( meat ) ) );
-
-    // Stand adjacent (the autoclave is an OBSTACLE); cooking tools live in inventory.
-    const tripoint_bub_ms stand = vpos + tripoint( 0, 1, 0 );
-    you.setpos( stand );
-    REQUIRE_FALSE( here.veh_at( stand ) );
-    you.i_add( item::spawn( "hotplate", calendar::turn, 20 ) );
-    you.i_add( item::spawn( "pot", calendar::turn ) );
-
-    const recipe_id rid( "meat_cooked" );
-    const recipe &rec = rid.obj();
-    you.set_skill_level( rec.skill_used, std::max( rec.difficulty, 2 ) );
-    you.learn_recipe( &rec );
-    set_time( calendar::turn ); // refresh light at current (day 19 midday)
-
-    you.invalidate_crafting_inventory();
-    REQUIRE( you.crafting_inventory().has_components( itype_id( "meat" ), 1 ) );
-
-    you.make_craft( rid, 1, vpos );
-    REQUIRE( you.activity );
-    int guard = 0;
-    while( you.activity && you.activity->id() == activity_id( "ACT_CRAFT" ) ) {
-        you.moves = 100;
-        you.activity->do_turn( you );
-        if( ++guard > 100000 ) {
-            break;
-        }
-    }
-
-    // Find the cooked meat result (inventory, ground, or vehicle).
-    item *result = nullptr;
-    you.visit_items( [&]( item * it ) {
-        if( it->typeId() == itype_id( "meat_cooked" ) ) {
-            result = it;
-            return VisitResponse::ABORT;
-        }
-        return VisitResponse::NEXT;
+    setup_vehicle_rot_test_at( old_world_craft_turn() );
+    auto fixture = make_vehicle_craft_fixture( {
+        .work_part = vpart_id( "autoclave" ),
     } );
-    for( const tripoint_bub_ms &p : { vpos, stand } ) {
-        if( result ) {
-            break;
-        }
-        for( item *&it : here.i_at( p ) ) {
-            if( it->typeId() == itype_id( "meat_cooked" ) ) {
-                result = it;
-            }
-        }
-    }
-    if( !result ) {
-        for( item *&it : veh->get_items( clave ) ) {
-            if( it->typeId() == itype_id( "meat_cooked" ) ) {
-                result = it;
-            }
-        }
-    }
-    REQUIRE( result != nullptr );
-    INFO( "result relative_rot = " << result->get_relative_rot() );
-    INFO( "result rot turns = " << to_turns<int>( result->get_rot() ) );
-    CHECK_FALSE( result->rotten() );
-    CHECK( result->get_relative_rot() < 0.5 );
+    add_fresh_meat_to_work_part( fixture );
+    add_inventory_cooking_tools( *fixture.you );
+
+    auto &result = *craft_cooked_meat_at_vehicle( fixture );
+
+    check_cooked_meat_is_fresh( result );
 }
 
-// REPRO for issue #9440: cooking with a FROZEN ingredient (kept fresh for 19 days in a
-// powered vehicle freezer) in a vehicle kitchen should NOT produce a rotten result.
-// Frozen variant of the BN9254 test above: the FAUCET phantom-component mechanism
-// predicts the same poisoned result regardless of the real component's frozen state,
-// because the consumed front item is a counterfeit spawned at start_of_cataclysm.
-// NOTE: BN has no per-item FROZEN tag; "frozen" is positional (rot.cpp
-// temperature_flag_for_part -> TEMP_FREEZER while stored in an enabled freezer part).
-// The item is frozen for 19 days in a minifreezer, then moved into the kitchen cargo
-// on the craft turn (same-tile-as-faucet, deterministic consume order; no rot accrues
-// in the same turn).
+// REPRO for issue #9440: cooking with a frozen ingredient kept fresh for 19 days
+// in a powered vehicle freezer near a kitchen should NOT produce a rotten result.
 TEST_CASE( "vehicle kitchen craft preserves frozen component rot", "[crafting][rot]" )
 {
-    clear_all_state();
-    // Spawn at day 0 + 12h; freeze 19 days; craft at day 19, midday (same craft time
-    // as the BN9254 test).
-    calendar::turn = calendar::start_of_cataclysm + 12_hours;
-    get_weather().temperature = 18_c;
-    get_weather().clear_temp_cache();
-
-    avatar &you = get_avatar();
-    clear_avatar();
-
-    auto &here = get_map();
-    const tripoint_bub_ms vpos( 60, 60, 0 );
-    auto *veh = here.add_vehicle( vproto_id( "none" ), vpos, 0_degrees, 0, 0 );
-    REQUIRE( veh != nullptr );
-    REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ), true ) >= 0 );
-    const int kitchen = veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "kitchen_unit" ), true );
-    REQUIRE( kitchen >= 0 );
-    // Battery power for the hotplate.
-    REQUIRE( veh->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "frame_vertical" ),
-                                true ) >= 0 );
-    const int batt = veh->install_part( tripoint_mnt_veh( 1, 0, 0 ), vpart_id( "storage_battery" ),
-                                        true );
-    REQUIRE( batt >= 0 );
-    // Working freezer on a third mount.
-    REQUIRE( veh->install_part( tripoint_mnt_veh( -1, 0, 0 ), vpart_id( "frame_vertical" ),
-                                true ) >= 0 );
-    const int freezer = veh->install_part( tripoint_mnt_veh( -1, 0, 0 ), vpart_id( "minifreezer" ),
-                                           true );
-    REQUIRE( freezer >= 0 );
-    veh->part( freezer ).enabled = true;
-    veh->charge_battery( 5000 );
-    here.add_vehicle_to_cache( veh );
-    here.build_map_cache( vpos.z(), true );
-    REQUIRE( here.veh_at( vpos ) );
-
-    // Fresh meat (bday = day 0 + 12h) into the powered freezer.
-    auto meat = item::spawn( "meat" );
-    REQUIRE( meat->goes_bad() );
-    INFO( "spawned meat bday_turn=" << to_turn<int>( meat->birthday() )
-          << " now=" << to_turn<int>( calendar::turn ) );
-    REQUIRE_FALSE( veh->add_item( freezer, std::move( meat ) ) );
-
-    // 19 days pass; the freezer keeps the meat at zero rot.
-    calendar::turn += 19_days;
-    {
-        auto frozen_items = veh->get_items( freezer );
-        REQUIRE( frozen_items.size() == 1 );
-        item &frozen = frozen_items.only_item();
-        // get_relative_rot() actualizes rot using the freezer's TEMP_FREEZER flag.
-        INFO( "POST-FREEZE meat bday_turn=" << to_turn<int>( frozen.birthday() )
-              << " relative_rot=" << frozen.get_relative_rot()
-              << " rot_turns=" << to_turns<int>( frozen.get_rot() )
-              << " now=" << to_turn<int>( calendar::turn ) );
-        REQUIRE( frozen.get_rot() == 0_turns );
-        // Move the still-frozen-fresh meat into the kitchen cargo on the craft turn.
-        frozen.attempt_detach( [&]( detached_ptr<item> &&it ) {
-            return veh->add_item( kitchen, std::move( it ) );
-        } );
-    }
-    REQUIRE( veh->get_items( freezer ).empty() );
-    REQUIRE( veh->get_items( kitchen ).size() == 1 );
-
-    // Stand adjacent to the kitchen (kitchen is an OBSTACLE), like the real repro.
-    const tripoint_bub_ms stand = vpos + tripoint( 0, 1, 0 );
-    you.setpos( stand );
-    REQUIRE_FALSE( here.veh_at( stand ) );
-    REQUIRE( here.veh_at( vpos ) );
-
-    const recipe_id rid( "meat_cooked" );
-    const recipe &rec = rid.obj();
-    you.set_skill_level( rec.skill_used, std::max( rec.difficulty, 2 ) );
-    you.learn_recipe( &rec );
-    set_time( calendar::turn ); // refresh light at current (day 19 midday)
-
-    you.invalidate_crafting_inventory();
-    REQUIRE( you.crafting_inventory().has_components( itype_id( "meat" ), 1 ) );
-
-    you.make_craft( rid, 1, vpos );
-    REQUIRE( you.activity );
-    int guard = 0;
-    while( you.activity && you.activity->id() == activity_id( "ACT_CRAFT" ) ) {
-        you.moves = 100;
-        you.activity->do_turn( you );
-        if( ++guard > 100000 ) {
-            break;
-        }
-    }
-
-    // Find the cooked meat result (inventory, ground, or vehicle).
-    item *result = nullptr;
-    you.visit_items( [&]( item * it ) {
-        if( it->typeId() == itype_id( "meat_cooked" ) ) {
-            result = it;
-            return VisitResponse::ABORT;
-        }
-        return VisitResponse::NEXT;
+    setup_vehicle_rot_test_at( calendar::start_of_cataclysm + 12_hours );
+    auto fixture = make_vehicle_craft_fixture( {
+        .work_part = vpart_id( "kitchen_unit" ),
+        .install_battery = true,
+        .install_freezer = true,
     } );
-    for( const tripoint_bub_ms &p : { vpos, stand } ) {
-        if( result ) {
-            break;
-        }
-        for( item *&it : here.i_at( p ) ) {
-            if( it->typeId() == itype_id( "meat_cooked" ) ) {
-                result = it;
-            }
-        }
-    }
-    if( !result ) {
-        for( item *&it : veh->get_items( kitchen ) ) {
-            if( it->typeId() == itype_id( "meat_cooked" ) ) {
-                result = it;
-            }
-        }
-    }
-    REQUIRE( result != nullptr );
-    INFO( "result relative_rot = " << result->get_relative_rot() );
-    INFO( "result rot turns = " << to_turns<int>( result->get_rot() ) );
-    CHECK_FALSE( result->rotten() );
-    CHECK( result->get_relative_rot() < 0.5 );
+    add_fresh_meat_to_part( fixture, fixture.freezer_part );
+    keep_meat_frozen_then_move_to_work_part( fixture );
+
+    auto &result = *craft_cooked_meat_at_vehicle( fixture );
+
+    check_cooked_meat_is_fresh( result );
 }

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -9,6 +9,7 @@
 #include "crafting.h"
 #include "enums.h"
 #include "item.h"
+#include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "game.h" // Just for get_convection_temperature(), TODO: Remove
@@ -76,6 +77,54 @@ static auto add_food_to_vehicle_part( vehicle &veh, const int part_index,
 static auto add_sashimi_to_vehicle_part( vehicle &veh, const int part_index ) -> void
 {
     add_food_to_vehicle_part( veh, part_index, itype_id( "sashimi" ) );
+}
+
+static auto make_backpack_with_sashimi() -> detached_ptr<item>
+{
+    auto backpack = item::spawn( "backpack" );
+    backpack->put_in( item::spawn( "rock" ) );
+    backpack->put_in( item::spawn( "sashimi" ) );
+    REQUIRE( backpack->is_food_container() );
+    return backpack;
+}
+
+static auto add_backpack_with_sashimi_to_vehicle_part( vehicle &veh, const int part_index ) -> void
+{
+    REQUIRE_FALSE( veh.add_item( part_index, make_backpack_with_sashimi() ) );
+}
+
+static auto nested_sashimi_in( item &container ) -> item *; // *NOPAD*
+
+static auto make_plastic_bag_with_sashimi() -> detached_ptr<item>
+{
+    auto bag = item::spawn( "bag_plastic" );
+    REQUIRE( bag->is_container() );
+    bag->put_in( item::spawn( "sashimi" ) );
+    return bag;
+}
+
+static auto make_sealed_carton_with_rotten_nested_sashimi() -> detached_ptr<item>
+{
+    auto carton = item::spawn( "carton_unsealed" );
+    REQUIRE( carton->is_container() );
+    REQUIRE( carton->type->container->seals );
+    REQUIRE_FALSE( carton->type->container->preserves );
+    carton->put_in( make_plastic_bag_with_sashimi() );
+    item *sashimi = nested_sashimi_in( *carton );
+    sashimi->set_relative_rot( 3.0 );
+    REQUIRE( sashimi->has_rotten_away() );
+    return carton;
+}
+
+static auto nested_sashimi_in( item &container ) -> item * // *NOPAD*
+{
+    namespace ranges = std::ranges;
+    using namespace std::views;
+    const auto nested_food = container.contents.all_items_ptr()
+    | filter( []( const item * it ) { return it->typeId() == itype_id( "sashimi" ); } )
+    | ranges::to<std::vector>();
+    REQUIRE( nested_food.size() == 1 );
+    return nested_food.front();
 }
 
 TEST_CASE( "Food lookup finds nested food after non-food contents", "[item][food]" )
@@ -170,6 +219,12 @@ static auto add_food_to_map( const tripoint_bub_ms &pos, const itype_id &food_ty
 static auto add_sashimi_to_map( const tripoint_bub_ms &pos ) -> void
 {
     add_food_to_map( pos, itype_id( "sashimi" ) );
+}
+
+static auto add_backpack_with_sashimi_to_map( const tripoint_bub_ms &pos ) -> void
+{
+    get_map().add_item( pos, make_backpack_with_sashimi() );
+    REQUIRE( get_map().i_at( pos ).size() == 1 );
 }
 
 TEST_CASE( "Rate of rotting" )
@@ -431,39 +486,50 @@ TEST_CASE( "Items don't rot away on map load if in a freezer" )
     m.load( test_location.xy(), false );
 
     const tripoint_bub_ms freezer_pnt = {13, 13, 0};
-    const tripoint_bub_ms sealed_pnt = {14, 13, 0};
-    const tripoint_bub_ms normal_pnt = {15, 13, 0};
+    const tripoint_bub_ms powered_freezer_pnt = {14, 13, 0};
+    const tripoint_bub_ms sealed_pnt = {15, 13, 0};
+    const tripoint_bub_ms normal_pnt = {16, 13, 0};
     m.furn_set( freezer_pnt, f_atomic_freezer );
+    m.furn_set( powered_freezer_pnt, f_test_minifreezer_on );
     m.furn_set( sealed_pnt, furn_str_id::NULL_ID() );
     m.furn_set( normal_pnt, furn_str_id::NULL_ID() );
     m.ter_set( freezer_pnt, t_grass );
+    m.ter_set( powered_freezer_pnt, t_grass );
     m.ter_set( sealed_pnt, t_grass );
     m.ter_set( normal_pnt, t_grass );
-
+    REQUIRE( m.has_flag_furn( TFLAG_FREEZER, freezer_pnt ) );
+    REQUIRE( m.has_flag_furn( TFLAG_FREEZER, powered_freezer_pnt ) );
 
     detached_ptr<item> normal_item_d = item::spawn( "meat_cooked" );
     item &normal_item = *normal_item_d;
     detached_ptr<item> freeze_item_d = item::spawn( "offal_canned" );
     item &freeze_item = *freeze_item_d;
+    auto powered_freeze_item_d = item::spawn( "meat_cooked" );
+    item &powered_freeze_item = *powered_freeze_item_d;
     detached_ptr<item> sealed_item_d = item::in_its_container( item::spawn( "offal_canned" ) );
     item &sealed_item = *sealed_item_d;
 
     set_map_temperature( weather, 18_c );
 
     m.i_clear( freezer_pnt );
+    m.i_clear( powered_freezer_pnt );
     m.i_clear( sealed_pnt );
     m.i_clear( normal_pnt );
 
     m.add_item( freezer_pnt, std::move( freeze_item_d ) );
+    m.add_item( powered_freezer_pnt, std::move( powered_freeze_item_d ) );
     m.add_item( sealed_pnt, std::move( sealed_item_d ) );
     m.add_item( normal_pnt, std::move( normal_item_d ) );
 
     REQUIRE( normal_item.get_rot() == 0_turns );
     REQUIRE( sealed_item.get_rot() == 0_turns );
     REQUIRE( freeze_item.get_rot() == 0_turns );
+    REQUIRE( powered_freeze_item.get_rot() == 0_turns );
 
     auto freezer_stack = m.i_at( freezer_pnt );
     REQUIRE( freezer_stack.size() == 1 );
+    auto powered_freezer_stack = m.i_at( powered_freezer_pnt );
+    REQUIRE( powered_freezer_stack.size() == 1 );
     auto sealed_stack = m.i_at( sealed_pnt );
     REQUIRE( sealed_stack.size() == 1 );
     auto normal_stack = m.i_at( normal_pnt );
@@ -476,8 +542,14 @@ TEST_CASE( "Items don't rot away on map load if in a freezer" )
     calendar::turn += 365_days;
     m.load( test_location.xy(), false );
 
+    CHECK( m.has_flag_furn( TFLAG_FREEZER, freezer_pnt ) );
+    CHECK( m.has_flag_furn( TFLAG_FREEZER, powered_freezer_pnt ) );
     auto freezer_stack_after = m.i_at( freezer_pnt );
     REQUIRE( freezer_stack_after.size() == 1 );
+    auto powered_freezer_stack_after = m.i_at( powered_freezer_pnt );
+    REQUIRE( powered_freezer_stack_after.size() == 1 );
+    CHECK( powered_freezer_stack_after.only_item().get_rot() == 0_turns );
+    CHECK( !powered_freezer_stack_after.only_item().rotten() );
     auto sealed_stack_after = m.i_at( sealed_pnt );
     REQUIRE( sealed_stack_after.size() == 1 );
     auto normal_stack_after = m.i_at( normal_pnt );
@@ -503,6 +575,22 @@ TEST_CASE( "Vehicle storage temperature controls food rot" )
 
         CHECK( !carried->rotten() );
         CHECK( carried->get_rot() == 0_turns );
+    }
+
+    SECTION( "powered freezers preserve nested food when removed after missed processing" ) {
+        auto fixture = make_storage( vpart_id( "minifreezer" ), true );
+        add_backpack_with_sashimi_to_vehicle_part( *fixture.veh, fixture.part_index );
+
+        auto freezer_items = fixture.veh->get_items( fixture.part_index );
+        REQUIRE( freezer_items.size() == 1 );
+
+        calendar::turn += 21_days;
+        auto *carried = move_to_inventory_with_attempt_detach( freezer_items.only_item() );
+        REQUIRE( carried != nullptr );
+        auto *food = nested_sashimi_in( *carried );
+
+        CHECK( food->get_rot() == 0_turns );
+        CHECK( !food->rotten() );
     }
 
     SECTION( "powered fridges catch up partial rot when removed after missed processing" ) {
@@ -696,11 +784,28 @@ TEST_CASE( "Contained item keeps parent location while temporarily detached" )
     container->contents.remove_top_items_with( [&]( detached_ptr<item> &&it ) {
         checked = true;
         CHECK( it->parent_item() == &*container );
-        CHECK( rot::temperature_flag_for_location( get_map(), *it ) == temperature_flag::TEMP_NORMAL );
+        CHECK( rot::temp::for_location( get_map(), *it ) == temperature_flag::TEMP_NORMAL );
         return std::move( it );
     } );
 
     CHECK( checked );
+}
+
+TEST_CASE( "Sealed containers keep rotten nested contents on location removal", "[item][rot]" )
+{
+    prepare_map_storage_test();
+    const auto pos = tripoint_bub_ms( 60, 60, 0 );
+    get_map().set_temperature( pos, 100 );
+    get_map().add_item( pos, make_sealed_carton_with_rotten_nested_sashimi() );
+
+    auto items = get_map().i_at( pos );
+    REQUIRE( items.size() == 1 );
+    auto *carried = move_to_inventory_with_attempt_detach( items.only_item() );
+    REQUIRE( carried != nullptr );
+    auto *food = nested_sashimi_in( *carried );
+
+    CHECK( food->rotten() );
+    CHECK( food->has_rotten_away() );
 }
 
 TEST_CASE( "Map powered fridge and freezer furniture controls food rot" )
@@ -751,6 +856,25 @@ TEST_CASE( "Map powered fridge and freezer furniture controls food rot" )
         REQUIRE( carried != nullptr );
         CHECK( carried->get_rot() == 0_turns );
         CHECK( !carried->rotten() );
+    }
+
+    SECTION( "powered freezer furniture keeps nested food fresh after missed processing" ) {
+        prepare_map_storage_test();
+        const auto pos = tripoint_bub_ms( 60, 60, 0 );
+        get_map().set_temperature( pos, 100 );
+        get_map().furn_set( pos, f_test_minifreezer_on );
+        add_backpack_with_sashimi_to_map( pos );
+
+        calendar::turn += 21_days;
+
+        auto items = get_map().i_at( pos );
+        REQUIRE( items.size() == 1 );
+        auto *carried = move_to_inventory_with_attempt_detach( items.only_item() );
+        REQUIRE( carried != nullptr );
+        auto *food = nested_sashimi_in( *carried );
+
+        CHECK( food->get_rot() == 0_turns );
+        CHECK( !food->rotten() );
     }
 
     SECTION( "powered freezer furniture keeps whole food fresh when consumed for crafting" ) {


### PR DESCRIPTION
## Purpose of change (The Why)

- closes #9631
- closes #9600
- Follow-up to #9448 / #9440.

Powered appliance freezers could leave food frozen-but-rotten after the map unloaded because removal/catch-up paths re-read rot through the active map instead of the stored tile. The branch also keeps the #9448 vehicle kitchen/autoclave pseudo-drain cleanup so synthetic consumed components cannot be empty or born at `calendar::start_of_cataclysm`.

Related: #9322, #9381, #9389.

## Describe the solution (The How)

- Put storage temperature helpers under `rot::temp::*`.
- Resolve map-item removal temperature from the resident mapbuffer tile before detaching.
- Avoid a mutating rotten-away re-read after `process_rot` already applied the requested context.
- Preserve sealed-ancestor behavior for nested rotten contents.
- Centralize vehicle pseudo-drains and return no item for 0 drained charges.

## Describe alternatives you've considered

A full tank liquid rot provenance model is broader and left as follow-up.

## Testing

<img width="2686" height="1550" alt="image" src="https://github.com/user-attachments/assets/abfd2d9b-25e8-4fed-b5fa-0aa7be62db58" />

used same testing method as #9600, meat on ground rotted, confirmed meat on freezer was fresh

- Built `cataclysm-bn-tiles` and `cata_test-tiles`.
- `Items don't rot away on map load if in a freezer`: powered minifreezer furniture survives unload/reload catch-up.
- `Map powered fridge and freezer furniture controls food rot`: passed.
- `Vehicle storage temperature controls food rot`: passed.
- `[crafting][rot]`: passed, 3 cases / 2748 assertions.
- `[rot]`: passed, 4 cases / 2759 assertions.

## Additional context

Draft PR for review of the #9448 cleanup direction.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked relevant issues/PRs.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 xhigh on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [fc9bd6b](https://github.com/cataclysmbn/Cataclysm-BN/commit/fc9bd6b32c25935783b8a9b0390a9ea2f088451d) (fix: centralize rot storage actualization) on 2026-06-24 17:09:49

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28110982299/artifacts/7856153465)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28110982299/artifacts/7856844750)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28110982299/artifacts/7856682252)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28110982299/artifacts/7856106112)
<!-- END artifact comment -->