### PR TITLE
fix: make aisles use matching repair materials

### DIFF
--- a/data/json/vehicleparts/aisle.json
+++ b/data/json/vehicleparts/aisle.json
@@ -41,7 +41,11 @@
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "qualities": [ { "id": "SAW_M", "level": 1 } ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_repair_carbon", 3 ] ] }
+      "repair": {
+        "skills": [ [ "mechanics", 2 ] ],
+        "time": "60 m",
+        "using": [ [ "welding_standard", 5 ], [ "vehicle_repair_small_metal", 3 ] ]
+      }
     },
     "flags": [ "AISLE", "BOARDABLE" ],
     "breaks_into": "ig_vp_sheet_metal",
@@ -85,11 +89,7 @@
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "qualities": [ { "id": "SAW_M", "level": 1 } ] },
-      "repair": {
-        "skills": [ [ "mechanics", 2 ] ],
-        "time": "60 m",
-        "using": [ [ "welding_standard", 5 ], [ "vehicle_repair_small_metal", 3 ] ]
-      }
+      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_repair_carbon", 3 ] ] }
     },
     "flags": [ "AISLE", "BOARDABLE" ],
     "breaks_into": "ig_vp_carbon",


### PR DESCRIPTION
Fixes metal aisle repair requiring carbon fiber; regression from #8201, reported: https://m.dcinside.com/board/rlike/519903
Swaps vertical metal/carbon aisle repair requirements to match their item and breakage materials.
Testing: ./build-scripts/lint-json.sh

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [09a1c58](https://github.com/cataclysmbn/Cataclysm-BN/commit/09a1c585616242ba5f09d00ec9e85e43c3386569) (fix: correct aisle repair materials) on 2026-06-22 03:57:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27926445584/artifacts/7782382165)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27926445584/artifacts/7782711801)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27926445584/artifacts/7782853873)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27926445584/artifacts/7782364653)
<!-- END artifact comment -->