### PR TITLE
fix: enchantment skill and construction speed fixes

### DIFF
--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -266,6 +266,7 @@
       "THROW",
       "MELEE",
       "BASHING",
+      "CUTTING",
       "DODGE",
       "STABBING",
       "UNARMED"
@@ -301,6 +302,7 @@
       "THROW",
       "MELEE",
       "BASHING",
+      "CUTTING",
       "DODGE",
       "STABBING",
       "UNARMED"

--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -53,7 +53,8 @@
   },
   {
     "id": "CONSTRUCTION_SPEED",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "suffixes": [ "CON", "VEH" ]
   },
   {
     "id": "METABOLISM",

--- a/docs/en/mod/json/reference/enchantments.md
+++ b/docs/en/mod/json/reference/enchantments.md
@@ -485,6 +485,7 @@ In addition there are the following children of this enchantment
 - `SKILL_LEVEL_THROW`
 - `SKILL_LEVEL_MELEE`
 - `SKILL_LEVEL_BASHING`
+- `SKILL_LEVEL_CUTTING`
 - `SKILL_LEVEL_DODGE`
 - `SKILL_LEVEL_STABBING`
 - `SKILL_LEVEL_UNARMED`
@@ -519,6 +520,7 @@ In addition there are the following children of this enchantment
 - `SKILL_EXP_THROW`
 - `SKILL_EXP_MELEE`
 - `SKILL_EXP_BASHING`
+- `SKILL_EXP_CUTTING`
 - `SKILL_EXP_DODGE`
 - `SKILL_EXP_STABBING`
 - `SKILL_EXP_UNARMED`

--- a/docs/en/mod/json/reference/enchantments.md
+++ b/docs/en/mod/json/reference/enchantments.md
@@ -253,8 +253,15 @@ Calculated after all other multipliers
 
 ##### CONSTRUCTION_SPEED
 
-Construction speed. `base_value` is a multiplier of construction speed.
+Construction speed. `base_value` is a multiplier of construction speed for vehicles and furniture/terrain.
 Calculated after all other multipliers
+
+It has two children:
+
+- `CONSTRUCTION_SPEED_CON`
+- `CONSTRUCTION_SPEED_VEH`
+
+That would only work for furniture/terrain or vehicles respectively
 
 ##### METABOLISM
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -963,7 +963,7 @@ int Character::clairvoyance() const
 
     int ench = bonus_from_enchantments( 0.0, enchantment_value_id( "CLAIRVOYANCE" ) );
     if( ench > 0 ) {
-        max = ench;
+        max = std::max( ench, max );
     }
     return max;
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4074,23 +4074,40 @@ SkillLevel &Character::get_skill_level_object( const skill_id &ident )
 
 int Character::get_skill_level( const skill_id &ident ) const
 {
+    return get_skill_level( ident, false );
+}
+
+int Character::get_skill_level( const skill_id &ident, const bool no_enchant ) const
+{
     int skill_level = _skills->get_skill_level( ident );
+    if( no_enchant ) {
+        return skill_level;
+    }
     auto ench_id = enchantment_value_id( "SKILL_LEVEL_" + to_upper_case( ident.str() ) );
     if( ench_id.is_valid() ) {
         skill_level += bonus_from_enchantments( skill_level, ench_id );
     }
-    return skill_level;
+    return std::max( 0, skill_level );
 }
 
 int Character::get_skill_level( const skill_id &ident, const item &context ) const
 {
+    return get_skill_level( ident, context, false );
+}
+
+int Character::get_skill_level( const skill_id &ident, const item &context,
+                                const bool no_enchant ) const
+{
     int skill_level = _skills->get_skill_level( ident, context );
+    if( no_enchant ) {
+        return skill_level;
+    }
     const auto id = context.is_null() ? ident : context.contextualize_skill( ident );
     auto ench_id = enchantment_value_id( "SKILL_LEVEL_" + to_upper_case( id.str() ) );
     if( ench_id.is_valid() ) {
         skill_level += bonus_from_enchantments( skill_level, ench_id );
     }
-    return skill_level;
+    return std::max( 0, skill_level );
 }
 
 void Character::set_skill_level( const skill_id &ident, const int level )

--- a/src/character.h
+++ b/src/character.h
@@ -1589,8 +1589,12 @@ class Character : public Creature, public location_visitable<Character>
         std::vector<overlay_entry> get_overlay_ids() const;
 
         // --------------- Skill Stuff ---------------
+        // These are calling the following with no_enchant = false -> for catalua bindings
         int get_skill_level( const skill_id &ident ) const;
         int get_skill_level( const skill_id &ident, const item &context ) const;
+
+        int get_skill_level( const skill_id &ident, const bool no_enchant ) const;
+        int get_skill_level( const skill_id &ident, const item &context, const bool no_enchant ) const;
 
         const SkillLevelMap &get_all_skills() const;
         SkillLevel &get_skill_level_object( const skill_id &ident );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -788,7 +788,7 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                     const auto tools_mult =
                         crafting_tools_speed_multiplier( g->u, current_con->requirements.obj() );
                     const auto mutation_mult = g->u.mutation_value( "construction_speed_modifier" );
-                    const auto ench_mult = g->u.bonus_from_enchantments( 1.0,
+                    const auto ench_mult = 1.0 + g->u.bonus_from_enchantments( 1.0,
                                            enchantment_value_id( "CONSTRUCTION_SPEED_CON" ) );
                     const auto scaling = get_option<int>( "CONSTRUCTION_SCALING" );
                     const auto game_opt_mult = scaling == 0 ? 9999.0f : 100.0f / scaling;
@@ -2461,8 +2461,8 @@ float construction::time_scale() const
         // this is hacky, but the player or their followers should only be the ones to ever construct currently.
         return ( get_option<int>( "CONSTRUCTION_SCALING" ) / 100.0f ) /
                get_player_character().mutation_value( "construction_speed_modifier" ) /
-               get_player_character().bonus_from_enchantments( 1.0,
-                       enchantment_value_id( "CONSTRUCTION_SPEED_CON" ) );
+               ( 1.0 + get_player_character().bonus_from_enchantments( 1.0,
+                       enchantment_value_id( "CONSTRUCTION_SPEED_CON" ) ) );
     }
 }
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -59,6 +59,7 @@
 #include "string_input_popup.h"
 #include "string_utils.h"
 #include "trap.h"
+#include "type_id.h"
 #include "type_id_implement.h"
 #include "ui_manager.h"
 #include "uistate.h"
@@ -787,6 +788,8 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                     const auto tools_mult =
                         crafting_tools_speed_multiplier( g->u, current_con->requirements.obj() );
                     const auto mutation_mult = g->u.mutation_value( "construction_speed_modifier" );
+                    const auto ench_mult = g->u.bonus_from_enchantments( 1.0,
+                                           enchantment_value_id( "CONSTRUCTION_SPEED_CON" ) );
                     const auto scaling = get_option<int>( "CONSTRUCTION_SCALING" );
                     const auto game_opt_mult = scaling == 0 ? 9999.0f : 100.0f / scaling;
                     const auto total_mult =
@@ -794,12 +797,13 @@ std::optional<construction_id> construction_menu( const bool blueprint )
 
                     const auto total_label = _( "Total" );
                     const auto multipliers =
-                    std::array<std::pair<std::string, float>, 5> { {
+                    std::array<std::pair<std::string, float>, 6> { {
                             { total_label, total_mult },
                             { _( "Assistants" ), assistants_mult },
                             { _( "Tools" ), tools_mult },
                             { _( "Traits" ), mutation_mult },
-                            { _( "Game option" ), game_opt_mult }
+                            { _( "Game option" ), game_opt_mult },
+                            { _( "Enchantments" ), ench_mult }
                         }
                     };
 
@@ -2456,7 +2460,9 @@ float construction::time_scale() const
     } else {
         // this is hacky, but the player or their followers should only be the ones to ever construct currently.
         return ( get_option<int>( "CONSTRUCTION_SCALING" ) / 100.0f ) /
-               get_player_character().mutation_value( "construction_speed_modifier" );
+               get_player_character().mutation_value( "construction_speed_modifier" ) /
+               get_player_character().bonus_from_enchantments( 1.0,
+                       enchantment_value_id( "CONSTRUCTION_SPEED_CON" ) );
     }
 }
 

--- a/src/enchantments/enchantment.cpp
+++ b/src/enchantments/enchantment.cpp
@@ -322,7 +322,7 @@ double enchantment::get_value_multiply(const enchantment_value_id value) const {
     if (!value.is_valid()) { debugmsg("Tried to get invalid enchantment value \"%s\".", value); }
     double result = 0;
     if (values_multiply.contains(value)) { result += values_multiply.at(value); }
-    if (value->has_parent()) { result += get_value_add(value->get_parent()); }
+    if (value->has_parent()) { result += get_value_multiply(value->get_parent()); }
 
     return result;
 }
@@ -338,7 +338,7 @@ int enchantment::get_value_max(const enchantment_value_id value) const {
 
 double enchantment::calc_bonus(enchantment_value_id value, double base, bool round) const {
     double add = value->can_add ? get_value_add(value) : 0.0;
-    double mul = value->can_mult ? get_value_multiply(value) : 1.0;
+    double mul = value->can_mult ? get_value_multiply(value) : 0.0;
     double max = value->can_max ? get_value_max(value) : 0.0;
     double ret = add + base * mul;
     // This is seperated because apparently adding 0.0 is very scrungly to the computer

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -457,7 +457,7 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
             case 8:
             case 9:
                 const skill_id aSkill = Skill::random_skill();
-                const int level = get_skill_level( aSkill );
+                const int level = get_skill_level( aSkill, true );
 
                 if( level < points.skill_points_left() && level < MAX_SKILL && loops > 10000 ) {
                     points.skill_points -= skill_increment_cost( *this, aSkill );
@@ -2575,7 +2575,7 @@ tab_direction set_profession( avatar &u, points_left &points,
  */
 static int skill_increment_cost( const Character &u, const skill_id &skill )
 {
-    return std::max( 1, ( u.get_skill_level( skill ) + 1 ) / 2 );
+    return std::max( 1, ( u.get_skill_level( skill, true ) + 1 ) / 2 );
 }
 
 tab_direction set_skills( avatar &u, points_left &points )
@@ -2646,7 +2646,7 @@ tab_direction set_skills( avatar &u, points_left &points )
 
         // Write the hint as to upgrade costs
         const int cost = skill_increment_cost( u, currentSkill->ident() );
-        const int level = u.get_skill_level( currentSkill->ident() );
+        const int level = u.get_skill_level( currentSkill->ident(), true );
         const int upgrade_levels = level == 0 ? 2 : 1;
         // We have two different strings to pluralize, so we have to use two
         // translation calls.
@@ -2754,7 +2754,7 @@ tab_direction set_skills( avatar &u, points_left &points )
             if( y < iContentHeight + 5 ) {
                 // Clear the line. 2 for x-coord because category names will be scrolled over.
                 mvwprintz( w, point( 2, y ), c_light_gray, std::string( getmaxx( w ) - 3, ' ' ) );
-                if( u.get_skill_level( thisSkill->ident() ) == 0 ) {
+                if( u.get_skill_level( thisSkill->ident(), true ) == 0 ) {
                     mvwprintz( w, point( 4, y ),
                                ( i == cur_pos ? h_light_gray : c_light_gray ), thisSkill->name() );
                 } else {
@@ -2763,7 +2763,7 @@ tab_direction set_skills( avatar &u, points_left &points )
                                thisSkill->name() );
                     mvwprintz( w, point( 20, y ),
                                ( i == cur_pos ? hilite( COL_SKILL_USED ) : COL_SKILL_USED ),
-                               " (%d)", u.get_skill_level( thisSkill->ident() ) );
+                               " (%d)", u.get_skill_level( thisSkill->ident(), true ) );
                 }
             }
             for( auto &prof_skill : u.prof->skills() ) {
@@ -2794,7 +2794,7 @@ tab_direction set_skills( avatar &u, points_left &points )
         } else if( action == "RANDOMIZE" ) {
             cur_pos = modulo( rng( 0, num_skills - 1 ), num_skills );
         } else if( action == "LEFT" ) {
-            const int level = u.get_skill_level( currentSkill->ident() );
+            const int level = u.get_skill_level( currentSkill->ident(), true );
             if( level > 0 ) {
                 // For balance reasons, increasing a skill from level 0 gives 1 extra level for free, but
                 // decreasing it from level 2 forfeits the free extra level (thus changes it to 0)
@@ -2803,7 +2803,7 @@ tab_direction set_skills( avatar &u, points_left &points )
                 points.skill_points += skill_increment_cost( u, currentSkill->ident() );
             }
         } else if( action == "RIGHT" ) {
-            const int level = u.get_skill_level( currentSkill->ident() );
+            const int level = u.get_skill_level( currentSkill->ident(), true );
             if( level < MAX_SKILL ) {
                 points.skill_points -= skill_increment_cost( u, currentSkill->ident() );
                 // For balance reasons, increasing a skill from level 0 gives 1 extra level for free
@@ -3472,7 +3472,8 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
         profession::StartingSkillList list_skills = you.prof->skills();
         skill_displayType_id last_category = skill_displayType_id::NULL_ID();
         for( auto &elem : skillslist ) {
-            int level = you.get_skill_level( elem->ident() );
+            // Here we can display the actual level because it is not editing it
+            int level = you.get_skill_level( elem->ident(), false );
 
             if( points.limit != points_left::TRANSFER ) {
                 for( auto &prof_skill : you.prof->skills() ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1024,8 +1024,10 @@ static int scale_time( const std::map<skill_id, int> &sk, int mv, const Characte
     } );
     // 10% per excess level (reduced proportionally if >1 skill required) with max 50% reduction
     // 10% reduction per assisting NPC
-    return mv * ( 1.0 - std::min( static_cast<double>( lvl ) / sk.size() / 10.0, 0.5 ) )
-           * ( 10 - character_funcs::get_crafting_helpers( who, 3 ).size() ) / 10;
+    int time_norm = mv * ( 1.0 - std::min( static_cast<double>( lvl ) / sk.size() / 10.0, 0.5 ) )
+                    * ( 10 - character_funcs::get_crafting_helpers( who, 3 ).size() ) / 10;
+    time_norm += who.bonus_from_enchantments( time_norm,
+                 enchantment_value_id( "CONSTRUCTION_SPEED_VEH" ) );
 }
 
 int vpart_info::install_time( const Character &who ) const

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1028,6 +1028,7 @@ static int scale_time( const std::map<skill_id, int> &sk, int mv, const Characte
                     * ( 10 - character_funcs::get_crafting_helpers( who, 3 ).size() ) / 10;
     time_norm += who.bonus_from_enchantments( time_norm,
                  enchantment_value_id( "CONSTRUCTION_SPEED_VEH" ) );
+    return time_norm;
 }
 
 int vpart_info::install_time( const Character &who ) const


### PR DESCRIPTION
## Purpose of change (The Why)
#9317 added construction enchantments but they needed some improvements
- Forgot display
- Did not do vehicle construction

#9547 missed an std::max on clairvoyance enchantments

#9533 missed 
- cutting skill in enchantment value definitions
- character creation needed the raw skill values
- an issue regarding parent skill multiplication


## Describe the solution (The How)
Give CONSTRUCTION_SPEED children CONSTRUCTION_SPEED_CON and CONSTRUCTION_SPEED_VEH
Add support for veh speed speed up

std::max maximum non enchant clairvoyance and enchant clairvoyance

Add cutting as child to SKILL_EXP and SKILL_LEVEL

## Describe alternatives you've considered
None

## Testing
Construction enchantments work as expected

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [07fd216](https://github.com/cataclysmbn/Cataclysm-BN/commit/07fd216825c7df1e6c717ab2115c41e355f84fb8) (fix stupid) on 2026-06-22 19:45:16

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27974371158/artifacts/7802190886)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27974371158/artifacts/7803097089)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27974371158/artifacts/7802196919)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27974371158/artifacts/7801911735)
<!-- END artifact comment -->