### PR TITLE
fix: guns covering torso is a fallback instead of mandatory

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -948,14 +948,15 @@ body_part_set item::get_covered_body_parts( const side s ) const
 {
     body_part_set res;
 
-    if( is_gun() ) {
-        // Currently only used for guns with the should strap mod, other guns might
-        // go on another bodypart.
-        res.set( bodypart_str_id( "torso" ) );
-    }
-
     const islot_armor *armor = find_armor_data();
     if( armor == nullptr ) {
+        // Mods currently cannot set armor data
+        // So for the two strap mods, force it to use torso
+        // But as there are worn guns now, this is inapplicable to all guns
+        // Only those without armor data
+        if( is_gun() ) {
+            res.set( bodypart_str_id( "torso" ) );
+        }
         return res;
     }
 


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #9620 

## Describe the solution (The How)
Only check for gun and apply torso if no data

## Describe alternatives you've considered
Do a lot of stuff to allow custom sling data

## Testing
Gun briefcase no longer covers torso

## Additional context
I screm

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7a687fc](https://github.com/cataclysmbn/Cataclysm-BN/commit/7a687fc4b6cf19caf3c5a2dcbf7082e28c29683b) (fix: guns covering torso is a fallback instead of mandatory) on 2026-06-22 22:41:13

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27984635644/artifacts/7805452662)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27984635644/artifacts/7806738911)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27984635644/artifacts/7806137773)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27984635644/artifacts/7805763548)
<!-- END artifact comment -->