### PR TITLE
feat(UI): Add more info to repair menu

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -98,7 +98,7 @@
 #include "vehicle.h"
 #include "vehicle_part.h"
 #include "vpart_position.h"
-#include <string_utils.h>
+#include "string_utils.h"
 
 enum creature_size : int;
 
@@ -2939,15 +2939,17 @@ void activity_handlers::repair_item_finish( player_activity *act, player *p )
                 continue;
             }
             listed_components.emplace( component_id );
+            int nearby_amount = 0;
             if( item::count_by_charges( component_id ) ) {
-                if( crafting_inv.has_charges( component_id, items_needed ) ) {
-                    material_list.emplace_back( string_format( _( "%s (<color_light_blue>%d</color>)" ),
-                                                item::nname( component_id ), crafting_inv.charges_of( component_id ) ) );
+                if( crafting_inv.has_charges( component_id, 1 ) ) {
+                    nearby_amount = crafting_inv.charges_of( component_id );
                 }
-            } else if( crafting_inv.has_amount( component_id, items_needed, false, is_crafting_component ) ) {
-                material_list.emplace_back( string_format( _( "%s (<color_light_blue>%d</color>)" ),
-                                            item::nname( component_id ), crafting_inv.amount_of( component_id, false ) ) );
+            } else if( crafting_inv.has_amount( component_id, 1, false, is_crafting_component ) ) {
+                nearby_amount = crafting_inv.amount_of( component_id, false );
             }
+            std::string color = nearby_amount < items_needed ? "red" : "light_blue";
+            material_list.emplace_back( string_format( _( "%s (<color_%s>%d</color>)" ),
+                                        item::nname( component_id ), color, nearby_amount ) );
         }
         std::string material_list_string = join( material_list, ", " );
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -63,6 +63,7 @@
 #include "iuse_actor.h"
 #include "line.h"
 #include "magic.h"
+#include "material.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "mapdata.h"
@@ -97,6 +98,7 @@
 #include "vehicle.h"
 #include "vehicle_part.h"
 #include "vpart_position.h"
+#include <string_utils.h>
 
 enum creature_size : int;
 
@@ -2925,6 +2927,30 @@ void activity_handlers::repair_item_finish( player_activity *act, player *p )
             action_type = repair_item_actor::RT_PRACTICE;
         }
 
+        int items_needed = actor->get_material_amt_needed( fix, true );
+        const auto valid_materials = actor->get_valid_materials( fix );
+        const auto &crafting_inv = p->crafting_inventory();
+        auto listed_components = std::set<itype_id> {};
+        auto material_list = std::vector<std::string> {};
+
+        for( const auto &entry : valid_materials ) {
+            const itype_id &component_id = entry.obj().repaired_with();
+            if( listed_components.find( component_id ) != listed_components.end() ) {
+                continue;
+            }
+            listed_components.emplace( component_id );
+            if( item::count_by_charges( component_id ) ) {
+                if( crafting_inv.has_charges( component_id, items_needed ) ) {
+                    material_list.emplace_back( string_format( _( "%s (<color_light_blue>%d</color>)" ),
+                                                item::nname( component_id ), crafting_inv.charges_of( component_id ) ) );
+                }
+            } else if( crafting_inv.has_amount( component_id, items_needed, false, is_crafting_component ) ) {
+                material_list.emplace_back( string_format( _( "%s (<color_light_blue>%d</color>)" ),
+                                            item::nname( component_id ), crafting_inv.amount_of( component_id, false ) ) );
+            }
+        }
+        std::string material_list_string = join( material_list, ", " );
+
         std::string title = string_format( _( "%s %s\n" ),
                                            repair_item_actor::action_description( action_type ),
                                            fix.tname() );
@@ -2932,6 +2958,10 @@ void activity_handlers::repair_item_finish( player_activity *act, player *p )
                                 used_tool->ammo_remaining(), used_tool->ammo_capacity(),
                                 item::nname( used_tool->ammo_current() ),
                                 used_tool->ammo_required() );
+        title += string_format( _( "Materials available: %s\n" ),
+                                material_list_string );
+        title += string_format( _( "Materials needed: <color_light_blue>%d</color>\n" ),
+                                items_needed );
         title += string_format( _( "Skill used: <color_light_blue>%s (%s)</color>\n" ),
                                 actor->used_skill->name(), level );
         title += string_format( _( "Success chance: <color_light_blue>%.1f</color>%%\n" ),

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1499,20 +1499,14 @@ class repair_inventory_preset: public inventory_selector_preset
                                  player &character ) :
             actor( actor ), main_tool( main_tool ), character( character ) {
             append_cell( [ this, actor, &character ]( const item * loc ) {
-                const auto comp_needed = std::max<int>( 1,
-                                                        std::ceil( loc->volume() / 250_ml * actor->cost_scaling ) );
-                auto valid_entries = std::set<material_id> {};
-                std::ranges::for_each( actor->materials, [ &valid_entries, &loc ]( const auto & mat ) {
-                    if( loc->made_of( mat ) ) {
-                        valid_entries.emplace( mat );
-                    }
-                } );
+                int comp_needed = actor->get_material_amt_needed( *loc, true );
+                auto valid_entries = actor->get_valid_materials( *loc );
 
                 const auto &crafting_inv = character.crafting_inventory();
                 auto listed_components = std::set<itype_id> {};
                 auto material_list = std::vector<std::string> {};
                 std::ranges::for_each( valid_entries, [ this, &listed_components, &material_list, &crafting_inv,
-                      &comp_needed ]( const auto & entry ) {
+                      comp_needed ]( const auto & entry ) {
                     const auto &component_id = entry.obj().repaired_with();
                     if( listed_components.contains( component_id ) ) {
                         return;
@@ -1531,6 +1525,11 @@ class repair_inventory_preset: public inventory_selector_preset
                 }
                 return ret;
             }, _( "MATERIALS AVAILABLE" ) );
+
+            append_cell( [ this, actor ]( const item * loc ) {
+                const auto amt = actor->get_material_amt_needed( *loc, true );
+                return string_format( _( "%d" ), amt );
+            }, _( "NEED" ) );
 
             append_cell( [ this ]( const item * loc ) {
                 const auto chance = get_cached_repair_chance( *loc );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3301,8 +3301,18 @@ std::unique_ptr<iuse_actor> repair_item_actor::clone() const
     return std::make_unique<repair_item_actor>( *this );
 }
 
-bool repair_item_actor::handle_components( player &pl, const item &fix,
-        bool print_msg, bool just_check ) const
+int repair_item_actor::get_material_amt_needed( const item &fix, bool just_check ) const
+{
+    // Repairing or modifying items requires at least 1 repair item,
+    // otherwise number is related to size of item
+    // Round up if checking, but roll if actually consuming
+    // TODO: should 250_ml be part of the cost_scaling?
+    return std::max<int>( 1, just_check ?
+                          std::ceil( fix.volume() / 250_ml * cost_scaling ) :
+                          roll_remainder( fix.volume() / 250_ml * cost_scaling ) );
+}
+
+std::set<material_id> repair_item_actor::get_valid_materials( const item &fix ) const
 {
     // Entries valid for repaired items
     std::set<material_id> valid_entries;
@@ -3311,6 +3321,13 @@ bool repair_item_actor::handle_components( player &pl, const item &fix,
             valid_entries.insert( mat );
         }
     }
+    return valid_entries;
+}
+
+bool repair_item_actor::handle_components( player &pl, const item &fix,
+        bool print_msg, bool just_check ) const
+{
+    std::set<material_id> valid_entries = get_valid_materials( fix );
 
     if( valid_entries.empty() ) {
         if( print_msg ) {
@@ -3327,15 +3344,7 @@ bool repair_item_actor::handle_components( player &pl, const item &fix,
     }
 
     const inventory &crafting_inv = pl.crafting_inventory();
-
-    // Repairing or modifying items requires at least 1 repair item,
-    //  otherwise number is related to size of item
-    // Round up if checking, but roll if actually consuming
-    // TODO: should 250_ml be part of the cost_scaling?
-    const int items_needed = std::max<int>( 1, just_check ?
-                                            std::ceil( fix.volume() / 250_ml * cost_scaling ) :
-                                            roll_remainder( fix.volume() / 250_ml * cost_scaling ) );
-
+    const int items_needed = get_material_amt_needed( fix, just_check );
 
     // Go through all discovered repair items and see if we have any of them available
     std::vector<item_comp> comps;

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -981,6 +981,10 @@ class repair_item_actor : public iuse_actor
         /** Checks if we are allowed to use the tool. */
         bool can_use_tool( const player &p, const item &tool, bool print_msg ) const;
 
+        /** Returns the number of repair items needed for repair. Will round up if just_check = true, and roll remainder otherwise. */
+        int get_material_amt_needed( const item &fix, bool just_check ) const;
+        /** Returns a list of materials that can be used to repair this item using this tool. */
+        std::set<material_id> get_valid_materials( const item &fix ) const;
         /** Returns if components are available. Consumes them if `just_check` is false. */
         bool handle_components( player &pl, const item &fix, bool print_msg, bool just_check ) const;
         /** Returns the chance to repair and to damage an item. */


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

I'd like to see how many repair items I'll need **before** I use them.

## Describe the solution (The How)

Repair menu now has a new column showing how many materials are needed:
<img width="911" height="400" src="https://github.com/user-attachments/assets/93747051-3799-4194-ab1b-d7e593e6b4cf" />

Repair window also shows both ~~materials available~~ EDIT: all materials that can be used to repair this item with this tool and how many are needed:
<img width="431" height="236" src="https://github.com/user-attachments/assets/fe4ead98-ef07-4977-b92f-b51afd44ab26" />

## Describe alternatives you've considered

I wanted to make one function that would loop over `valid_materials` instead of having similar code in three different places, but these three places all do that loop differently so it's not feasible.

## Testing

Checked that info is shown correctly for items made of one/two materials, and nomad gear (iron + steel, both repaired with metal scraps). Also checked that repairing still works correctly.

## Additional context

I made a similar PR for DDA: https://github.com/CleverRaven/Cataclysm-DDA/pull/45816, but this is not a port, this was written from scratch. I am now older, wiser (maybe), and this PR does more than that one.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [531b0cc](https://github.com/cataclysmbn/Cataclysm-BN/commit/531b0cc9e9cc391cffd92fc4541f3a707994c0ba) (Small fix for repair window) on 2026-06-23 01:24:51

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27992327953/artifacts/7808809038)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27992327953/artifacts/7809188314)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27992327953/artifacts/7808325777)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27992327953/artifacts/7808264546)
<!-- END artifact comment -->