### PR TITLE
fix: prevent hallucinations from affecting the real world

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1784,8 +1784,11 @@ void monster::execute_action( const monster_action_t &action )
         }
         case monster_action_kind::open_door: {
             ZoneScopedN( "mon_execute_open_door" );
-            did_something = !pacified && can_open_doors &&
-                            here.open_door( this, dest, !here.is_outside( bub_pos() ) );
+            if( !pacified && can_open_doors ) {
+                did_something = is_hallucination()
+                                ? move_to( dest, false, false, resolved_action.stagger_adjust )
+                                : here.open_door( this, dest, !here.is_outside( bub_pos() ) );
+            }
             break;
         }
         case monster_action_kind::bash: {
@@ -1943,7 +1946,7 @@ void monster::nursebot_operate( player *dragged_foe )
 // Values converted from tiles to dB
 void monster::footsteps( const tripoint_bub_ms &p )
 {
-    if( made_footstep ) {
+    if( is_hallucination() || made_footstep ) {
         return;
     }
     made_footstep = true;
@@ -2969,6 +2972,9 @@ int monster::turns_to_reach( const point_bub_ms &p )
 void monster::shove_vehicle( const tripoint_bub_ms &remote_destination,
                              const tripoint_bub_ms &nearby_destination )
 {
+    if( is_hallucination() ) {
+        return;
+    }
     if( this->has_flag( MF_PUSH_VEH ) ) {
         auto vp = g->m.veh_at( nearby_destination );
         if( vp ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3049,7 +3049,7 @@ void monster::process_turn()
         }
     }
     // We update electrical fields here since they act every turn.
-    if( has_flag( MF_ELECTRIC_FIELD ) ) {
+    if( !is_hallucination() && has_flag( MF_ELECTRIC_FIELD ) ) {
         if( has_effect( effect_emp ) ) {
             if( action_time_scale::once_every_this_tick( 10_turns ) ) {
                 sound_event se;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2720,7 +2720,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         // Let NPCs push each other when non-hostile
         // TODO: Have them attack each other when hostile
         npc *np = dynamic_cast<npc *>( critter );
-        if( np != nullptr && !np->in_sleep_state() ) {
+        if( !is_hallucination() && np != nullptr && !np->in_sleep_state() ) {
             std::unique_ptr<std::set<tripoint_bub_ms>> newnomove;
             std::set<tripoint_bub_ms> *realnomove;
             if( nomove != nullptr ) {
@@ -2838,6 +2838,9 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
             facing = FD_RIGHT;
         } else {
             facing = FD_LEFT;
+        }
+        if( is_hallucination() ) {
+            return;
         }
         if( is_mounted() ) {
             if( mounted_creature->bub_pos() != bub_pos() ) {
@@ -4050,6 +4053,10 @@ bool npc::alt_attack()
 
 void npc::activate_item( int item_index )
 {
+    if( is_hallucination() ) {
+        move_pause();
+        return;
+    }
     const int oldmoves = moves;
     item &it = i_at( item_index );
     if( it.is_tool() || it.is_food() ) {
@@ -4107,6 +4114,10 @@ void npc:: pretend_heal( Character &patient, item &used )
 
 void npc::heal_self()
 {
+    if( is_hallucination() ) {
+        move_pause();
+        return;
+    }
     if( has_effect( effect_asthma ) ) {
         item *treatment = &null_item_reference();
         std::string iusage = "OXYGEN_BOTTLE";
@@ -4144,6 +4155,10 @@ void npc::heal_self()
 
 void npc::use_painkiller()
 {
+    if( is_hallucination() ) {
+        move_pause();
+        return;
+    }
     // First, find the best painkiller for our pain level
     item *it = inv.most_appropriate_painkiller( get_pain() );
 
@@ -4248,6 +4263,10 @@ static float rate_food( const item &it, int want_nutr, int want_quench )
 
 bool npc::consume_food()
 {
+    if( is_hallucination() ) {
+        move_pause();
+        return false;
+    }
     float best_weight = 0.0f;
     int index = -1;
     int want_hunger = std::max<int>( 0, ( max_stored_kcal() - get_stored_kcal() ) / 10 );
@@ -4942,6 +4961,10 @@ bool npc::complain()
 
 void npc::do_reload( item &it )
 {
+    if( is_hallucination() ) {
+        move_pause();
+        return;
+    }
     item_reload_option reload_opt = character_funcs::select_ammo( *this, it );
 
     if( !reload_opt ) {

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -14,10 +14,12 @@
 #include "action_time_scale.h"
 #include "avatar.h"
 #include "coordinates.h"
+#include "field_type.h"
 #include "game.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "monster.h"
+#include "monster_action.h"
 #include "options_helpers.h"
 #include "options.h"
 #include "player.h"
@@ -31,6 +33,44 @@
 #include "vpart_position.h"
 
 using move_statistics = statistics<int>;
+
+TEST_CASE( "hallucination_monsters_do_not_open_real_doors", "[monster][hallucination]" )
+{
+    clear_all_state();
+    move_player_out_of_the_way();
+    auto &here = get_map();
+    build_test_map( ter_id( "t_floor" ) );
+
+    const auto monster_pos = tripoint_bub_ms( 60, 60, 0 );
+    const auto door_pos = tripoint_bub_ms( 61, 60, 0 );
+    REQUIRE( here.ter_set( door_pos, ter_id( "t_door_c" ) ) );
+
+    auto &hallucination = spawn_test_monster( "mon_zombie_scientist", monster_pos );
+    hallucination.hallucination = true;
+    REQUIRE( hallucination.is_hallucination() );
+    hallucination.execute_action( { .kind = monster_action_kind::open_door, .dest = door_pos } );
+
+    CHECK( here.ter( door_pos ) == ter_id( "t_door_c" ) );
+}
+
+TEST_CASE( "hallucination_electric_field_does_not_ignite_items", "[monster][hallucination]" )
+{
+    clear_all_state();
+    move_player_out_of_the_way();
+    auto &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+
+    const auto monster_pos = tripoint_bub_ms( 60, 60, 0 );
+    const auto fuel_pos = tripoint_bub_ms( 61, 60, 0 );
+    here.add_item_or_charges( fuel_pos, item::spawn( "gasoline" ) );
+
+    auto &hallucination = spawn_test_monster( "mon_zombie_nullfield", monster_pos );
+    hallucination.hallucination = true;
+    REQUIRE( hallucination.is_hallucination() );
+    hallucination.process_turn();
+
+    CHECK( here.get_field( fuel_pos, fd_fire ) == nullptr );
+}
 
 TEST_CASE( "MONSTER_SPEED scales monster move credit", "[monster][speed]" )
 {

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -56,6 +56,50 @@ TEST_CASE( "hallucination_npcs_do_not_drop_inventory", "[npc][hallucination]" )
     CHECK_FALSE( get_avatar().has_item_with_id( itype_id( "rock" ) ) );
 }
 
+TEST_CASE( "hallucination_npcs_do_not_push_real_npcs", "[npc][hallucination]" )
+{
+    clear_all_state();
+    build_test_map( ter_id( "t_floor" ) );
+
+    const auto hallucination_pos = tripoint_bub_ms( 50, 50, 0 );
+    const auto bystander_pos = tripoint_bub_ms( 51, 50, 0 );
+    npc &bystander = spawn_npc( bystander_pos, "test_talker" );
+    npc &hallucination_npc = spawn_npc( hallucination_pos, "test_talker" );
+    hallucination_npc.hallucination = true;
+    REQUIRE( hallucination_npc.is_hallucination() );
+    REQUIRE( hallucination_npc.bub_pos() == hallucination_pos );
+    REQUIRE( bystander.bub_pos() == bystander_pos );
+
+    hallucination_npc.move_to( bystander_pos, true, nullptr );
+
+    CHECK( hallucination_npc.bub_pos() == hallucination_pos );
+    CHECK( bystander.bub_pos() == bystander_pos );
+}
+
+TEST_CASE( "hallucination_npcs_do_not_board_real_vehicles", "[npc][hallucination]" )
+{
+    clear_all_state();
+    auto &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+    clear_vehicles();
+
+    const auto npc_pos = tripoint_bub_ms( 63, 59, 0 );
+    const auto seat_pos = tripoint_bub_ms( 63, 60, 0 );
+    auto *veh_ptr = here.add_vehicle( vproto_id( "bicycle_test" ), seat_pos, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    REQUIRE( here.veh_at( seat_pos ).part_with_feature( VPFLAG_BOARDABLE, true ).has_value() );
+
+    npc &hallucination_npc = spawn_npc( npc_pos, "test_talker" );
+    hallucination_npc.hallucination = true;
+    REQUIRE( hallucination_npc.is_hallucination() );
+    hallucination_npc.move_to( seat_pos, true, nullptr );
+
+    CHECK( hallucination_npc.bub_pos() == seat_pos );
+    CHECK_FALSE( hallucination_npc.in_vehicle );
+    CHECK( veh_ptr->get_passenger( here.veh_at( seat_pos ).part_with_feature( VPFLAG_BOARDABLE,
+                                   true )->part_index() ) == nullptr );
+}
+
 static void on_load_test( npc &who, const time_duration &from, const time_duration &to )
 {
     calendar::turn = calendar::turn_zero + from;

--- a/tests/vehicle_collision_test.cpp
+++ b/tests/vehicle_collision_test.cpp
@@ -5,6 +5,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "monster.h"
+#include "mtype.h"
 #include "state_helpers.h"
 #include "type_id.h"
 #include "vehicle.h"
@@ -66,6 +67,30 @@ TEST_CASE( "vehicle_collision_with_wall_terminates", "[vehicle]" )
 
     CHECK( ret.type != veh_coll_nothing );
     CHECK( std::abs( veh_ptr->velocity ) < 222 );
+}
+
+TEST_CASE( "hallucination_monsters_do_not_shove_vehicles", "[vehicle][monster][hallucination]" )
+{
+    clear_all_state();
+    move_player_out_of_the_way();
+    auto &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+    clear_vehicles();
+
+    const auto monster_pos = tripoint_bub_ms( 60, 60, 0 );
+    const auto veh_pos = tripoint_bub_ms( 60, 59, 0 );
+    auto *veh_ptr = here.add_vehicle( vproto_id( "bicycle_test" ), veh_pos, 270_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    auto &hallucination = spawn_test_monster( "mon_zombie_seaweed_brute", monster_pos );
+    hallucination.hallucination = true;
+    REQUIRE( hallucination.is_hallucination() );
+    REQUIRE( hallucination.has_flag( MF_PUSH_VEH ) );
+
+    hallucination.shove_vehicle( veh_pos + tripoint_north, veh_pos );
+
+    CHECK( veh_ptr->velocity == 0 );
+    CHECK( here.veh_at( veh_pos ).has_value() );
 }
 
 TEST_CASE( "vehicle_collision_with_hallucination_terminates", "[vehicle]" )


### PR DESCRIPTION
## Purpose of change (The Why)

Hallucinations can still change real-world state after #9615. A reported swamp shell hallucination could push a real vehicle while moving.

Related: https://m.dcinside.com/board/rlike/519969, #9615, #9170, #9133

## Describe the solution (The How)

- Guard hallucination monster door opening, footsteps, vehicle shoving, and electric fields.
- Guard hallucination NPC pushing, vehicle boarding, and item-consuming actions.
- Add regression coverage for the affected monster, NPC, and vehicle paths.

## Testing

- Built `cataclysm-bn-tiles` and `cata_test-tiles` with the `linux-full` preset.
- `./out/build/linux-full/tests/cata_test-tiles "[hallucination]"` passed.

## Checklist

### Mandatory

- [x] Related reports/issues/PRs are linked above; this PR does not close an open issue.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5d6a267](https://github.com/cataclysmbn/Cataclysm-BN/commit/5d6a26793174ff82f41a36ae199fdf22e8976a51) (fix: guard hallucination side effects) on 2026-06-23 01:58:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993754230/artifacts/7809392141)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993754230/artifacts/7809322234)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993754230/artifacts/7809026752)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993754230/artifacts/7808815466)
<!-- END artifact comment -->