### PR TITLE
test: load vehicle turrets with ammo items

### DIFF
--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -43,18 +43,13 @@ static std::vector<const vpart_info *> turret_types()
     return res;
 }
 
-static auto biggest_tank( const ammotype &ammo ) -> const vpart_info *
+static auto biggest_tank( const itype_id &ammo ) -> const vpart_info *
 {
     std::vector<const vpart_info *> res;
 
     for( const auto &e : vpart_info::all() ) {
         const auto &vp = e.second;
-        if( !item::spawn_temporary( vp.item )->is_watertight_container() ) {
-            continue;
-        }
-
-        const itype *fuel = &*vp.fuel_type;
-        if( fuel->ammo && fuel->ammo->type == ammo ) {
+        if( item::spawn_temporary( vp.item )->can_reload_with( ammo ) ) {
             res.push_back( &vp );
         }
     }
@@ -89,8 +84,8 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine][.]" )
             REQUIRE( veh->install_part( tripoint_mnt_veh::zero(), vpart_id( "storage_battery" ), true ) >= 0 );
             veh->charge_battery( 10000 );
 
-            auto ammo =
-                ammotype( veh->turret_query( veh->part( idx ) ).base().ammo_default().str() );
+            auto &gun = veh->part( idx ).get_base();
+            const auto ammo = gun.ammo_default();
 
             if( veh->part_flag( idx, "USE_TANKS" ) ) {
                 auto *tank = biggest_tank( ammo );
@@ -99,15 +94,14 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine][.]" )
 
                 auto tank_idx = veh->install_part( tripoint_mnt_veh::zero(), tank->get_id(), true );
                 REQUIRE( tank_idx >= 0 );
-                REQUIRE( veh->part( tank_idx ).ammo_set( ammo->default_ammotype() ) );
+                REQUIRE( veh->part( tank_idx ).ammo_set( ammo ) );
 
-            } else if( ammo ) {
-                veh->part( idx ).ammo_set( ammo->default_ammotype() );
+            } else if( !ammo.is_null() ) {
+                veh->part( idx ).ammo_set( ammo );
             }
 
             auto qry = veh->turret_query( veh->part( idx ) );
             REQUIRE( qry );
-
             REQUIRE( qry.query() == turret_data::status::ready );
             REQUIRE( qry.range() > 0 );
 


### PR DESCRIPTION
## Purpose of change (The Why)

The hidden `vehicle_turret` test treated `ammo_default()` item ids like ammo type ids, causing invalid ammo such as `556` and leaving turrets unloaded.

Related: #3908

## Describe the solution (The How)

- Use the default ammo item id directly when loading turret ammo.
- Pick a compatible vehicle tank by whether its item can reload with that ammo.

## Testing

- `cmake --build --preset linux-full --target format`
- `cmake --build --preset linux-full --target cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "vehicle_turret"` passed.

## Checklist

### Mandatory

- [x] Related prior issue is linked above; this PR does not close an open issue.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [02269a5](https://github.com/cataclysmbn/Cataclysm-BN/commit/02269a5e013903b981b29a08be67ed0678d4082e) (test: load vehicle turrets with ammo items) on 2026-06-23 01:41:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993757298/artifacts/7809255070)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993757298/artifacts/7809181249)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993757298/artifacts/7808843996)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993757298/artifacts/7808781408)
<!-- END artifact comment -->