### PR TITLE
fix: clear vision after folding opaque vehicles

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1046,6 +1046,41 @@ std::unique_ptr<vehicle> map::detach_vehicle( vehicle *veh )
         z = veh->abs_sm_pos.z() = z > OVERMAP_HEIGHT ? OVERMAP_HEIGHT : -OVERMAP_DEPTH;
     }
 
+    struct detached_vehicle_footprint {
+        tripoint_abs_sm min;
+        tripoint_abs_sm max;
+    };
+
+    auto footprints = std::array<std::optional<detached_vehicle_footprint>, OVERMAP_LAYERS> {};
+    for( const vpart_reference &vp : veh->get_all_parts() ) {
+        if( vp.part().removed ) {
+            continue;
+        }
+        const auto part_sm = project_to<coords::sm>( veh->abs_part_location( vp.part() ) );
+        if( !inbounds_z( part_sm.z() ) ) {
+            continue;
+        }
+        auto &footprint = footprints[part_sm.z() + OVERMAP_DEPTH];
+        if( !footprint ) {
+            footprint = detached_vehicle_footprint{ .min = part_sm, .max = part_sm };
+            continue;
+        }
+        footprint->min.x() = std::min( footprint->min.x(), part_sm.x() );
+        footprint->min.y() = std::min( footprint->min.y(), part_sm.y() );
+        footprint->max.x() = std::max( footprint->max.x(), part_sm.x() );
+        footprint->max.y() = std::max( footprint->max.y(), part_sm.y() );
+    }
+
+    const auto mark_detached_vehicle_footprint_dirty = [&]() {
+        for( const auto &footprint : footprints ) {
+            if( !footprint ) {
+                continue;
+            }
+            on_vehicle_moved( abs_to_bub( footprint->min ), abs_to_bub( footprint->max ),
+                              footprint->min.z() );
+        }
+    };
+
     // Unboard all passengers before detaching
     for( auto const &part : veh->get_avail_parts( VPFLAG_BOARDABLE ) ) {
         player *passenger = part.get_passenger();
@@ -1061,6 +1096,7 @@ std::unique_ptr<vehicle> map::detach_vehicle( vehicle *veh )
                   veh->name, veh->abs_sm_pos.x(), veh->abs_sm_pos.y(), veh->abs_sm_pos.z() );
         get_mapbuffer().unregister_vehicle( veh );
         dirty_vehicle_list.erase( veh );
+        mark_detached_vehicle_footprint_dirty();
         return std::unique_ptr<vehicle>();
     }
     level_cache &ch = get_cache( z );
@@ -1076,6 +1112,7 @@ std::unique_ptr<vehicle> map::detach_vehicle( vehicle *veh )
                 get_overmapbuffer( bound_dimension_ ).remove_vehicle( veh );
             }
             dirty_vehicle_list.erase( veh );
+            mark_detached_vehicle_footprint_dirty();
             veh->detach();
             veh->refresh_position();
             return result;
@@ -1101,6 +1138,10 @@ void map::on_vehicle_moved( const tripoint_bub_sm &sm_min, const tripoint_bub_sm
     }
 
     auto &ch = get_cache( smz );
+    // Vehicle-only caches are cleared by build_map_cache() when a z-level has vehicle
+    // cache effects.  Keep that cleanup path active even if this movement is a
+    // removal of the last vehicle on the level.
+    ch.veh_in_active_range = true;
     invalidate_lightmap_caches();
     set_seen_cache_dirty( smz );
     mark_visibility_cache_dirty( smz );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -267,6 +267,30 @@ TEST_CASE( "detaching_vehicle_unboards_passengers" )
     REQUIRE( !player_character.in_vehicle );
 }
 
+TEST_CASE( "detaching_opaque_vehicle_invalidates_transparency_cache", "[vehicle][map_cache]" )
+{
+    clear_all_state();
+    auto &here = get_map();
+    build_test_map( ter_id( "t_pavement" ) );
+
+    const auto origin = tripoint_bub_ms( 60, 60, 0 );
+    auto *veh_ptr = here.add_vehicle( vproto_id( "none" ), origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    REQUIRE( veh_ptr->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_horizontal" ), true ) >= 0 );
+    const auto board = veh_ptr->install_part( tripoint_mnt_veh::zero(), vpart_id( "clothboard_horizontal" ), true );
+    REQUIRE( board >= 0 );
+
+    const auto board_pos = veh_ptr->bub_part_location( board );
+    here.add_vehicle_to_cache( veh_ptr );
+    here.build_map_cache( board_pos.z(), true );
+    REQUIRE_FALSE( here.is_transparent( board_pos ) );
+
+    here.destroy_vehicle( veh_ptr );
+    here.build_map_cache( board_pos.z(), true );
+
+    CHECK( here.is_transparent( board_pos ) );
+}
+
 TEST_CASE( "destroy_grabbed_vehicle_section" )
 {
     clear_all_state();

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -276,8 +276,10 @@ TEST_CASE( "detaching_opaque_vehicle_invalidates_transparency_cache", "[vehicle]
     const auto origin = tripoint_bub_ms( 60, 60, 0 );
     auto *veh_ptr = here.add_vehicle( vproto_id( "none" ), origin, 0_degrees, 0, 0 );
     REQUIRE( veh_ptr != nullptr );
-    REQUIRE( veh_ptr->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_horizontal" ), true ) >= 0 );
-    const auto board = veh_ptr->install_part( tripoint_mnt_veh::zero(), vpart_id( "clothboard_horizontal" ), true );
+    REQUIRE( veh_ptr->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_horizontal" ),
+                                    true ) >= 0 );
+    const auto board = veh_ptr->install_part( tripoint_mnt_veh::zero(),
+                       vpart_id( "clothboard_horizontal" ), true );
     REQUIRE( board >= 0 );
 
     const auto board_pos = veh_ptr->bub_part_location( board );


### PR DESCRIPTION
## Purpose of change (The Why)

Opaque foldable vehicle parts could keep blocking sight after the vehicle was folded/destroyed until the part was redeployed and removed.

External report: https://m.dcinside.com/board/rlike/519975
Related cache work: #8888
Related symptom class: #8668

## Describe the solution (The How)

- Record the detached vehicle footprint before removal.
- Dirty the same visibility/transparency/floor cache paths used for vehicle movement after detach.
- Keep vehicle-only cache cleanup active when the removed vehicle was the last one on the z-level.
- Add regression coverage for an OPAQUE foldable cloth board.

## Describe alternatives considered

Limited invalidation to `vehicle::fold_up()`, but detach/destroy can leave the same stale cache behind.

## Testing

- Regression test failed before the fix and passes after.
- `cmake --build --preset linux-full --target cataclysm-bn-tiles cata_test-tiles`
- `./out/build/linux-full/tests/cata_test-tiles "detaching_opaque_vehicle_invalidates_transparency_cache"`
- `./out/build/linux-full/tests/cata_test-tiles "[vehicle]"` still has base failures on `147933c49be` in vehicle turret data/lost-grid debug logging.

## Checklist

- [x] This PR used AI assistance.
  - [x] `Assisted-by:` trailer is present on every commit.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7aa7588](https://github.com/cataclysmbn/Cataclysm-BN/commit/7aa75886760e07db98cd157b107a71d532c8c5d6) (fix: invalidate cache when detaching vehicles) on 2026-06-23 04:31:00

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993965261/artifacts/7809400077)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993965261/artifacts/7809371872)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993965261/artifacts/7809131542)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/27993965261/artifacts/7809063905)
<!-- END artifact comment -->