### PR TITLE
feat: Give the Survivor Backpack MOLLE straps, rename to survivor MOLLE pack

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -958,7 +958,7 @@
   {
     "id": "survivor_pack",
     "type": "ARMOR",
-    "name": { "str": "survivor backpack" },
+    "name": { "str": "survivor MOLLE pack" },
     "description": "A custom-built backpack.  Durable and carefully crafted to hold as much stuff as possible, as well as covered with equipment straps for quick access to weapons.",
     "weight": "600 g",
     "volume": "2500 ml",

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -976,6 +976,17 @@
     "storage": "16 L",
     "material_thickness": 2,
     "valid_mods": [ "resized_large", "resized_small" ],
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Stow gear",
+      "holster_msg": "You stow your %s",
+      "min_volume": "250ml",
+      "max_volume": "2500ml",
+      "multi": 2,
+      "draw_cost": 120,
+      "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "SHEATH_AXE", "MAG_COMPACT", "MAG_BULKY", "MAG_BELT", "SPEEDLOADER", "BELT_CLIP" ],
+      "skills": [ "pistol", "smg", "shotgun", "rifle", "launcher" ]
+    },
     "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "ALLOWS_WINGS" ]
   },
   {

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -959,7 +959,7 @@
     "id": "survivor_pack",
     "type": "ARMOR",
     "name": { "str": "survivor backpack" },
-    "description": "A custom-built backpack.  Durable and carefully crafted to hold as much stuff as possible.",
+    "description": "A custom-built backpack.  Durable and carefully crafted to hold as much stuff as possible, as well as covered with equipment straps for quick access to weapons.",
     "weight": "600 g",
     "volume": "2500 ml",
     "price": "240 USD",


### PR DESCRIPTION
## Purpose of change (The Why)

Without holsters, survivor backpack feels like a downgrade from the MOLLE pack.

## Describe the solution (The How)

Give the survivor backpack the same holsters as MOLLE

## Describe alternatives you've considered

Give the survivor rucksack a single MOLLE slot with slightly slower draw time

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0b42359](https://github.com/cataclysmbn/Cataclysm-BN/commit/0b42359d5f0c6dd27db2057ff09ba90854eef52f) (Update storage.json) on 2026-06-24 15:45:22

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28108292775/artifacts/7853912899)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28108292775/artifacts/7854674904)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28108292775/artifacts/7854019398)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28108292775/artifacts/7854114951)
<!-- END artifact comment -->