### PR TITLE
fix: prevent pets from waiting too long on play

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4338,11 +4338,14 @@ void activity_handlers::fill_pit_finish( player_activity *act, player *p )
 
 void activity_handlers::play_with_pet_finish( player_activity *act, player *p )
 {
-    const auto mon = act->monsters[0].lock();
+    if (!act->monsters.empty()) {
+        const auto mon = act->monsters[0].lock();
+        mon->remove_effect( effect_ai_waiting );
+    }
+
     p->add_morale( MORALE_PLAY_WITH_PET, rng( 3, 10 ), 10, 5_hours, 25_minutes );
     p->add_msg_if_player( m_good, _( "Playing with your %s has lifted your spirits a bit." ),
                           act->str_values[0] );
-    mon->remove_effect( effect_ai_waiting );
     act->set_to_null();
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4338,7 +4338,7 @@ void activity_handlers::fill_pit_finish( player_activity *act, player *p )
 
 void activity_handlers::play_with_pet_finish( player_activity *act, player *p )
 {
-    if (!act->monsters.empty()) {
+    if( !act->monsters.empty() ) {
         const auto mon = act->monsters[0].lock();
         mon->remove_effect( effect_ai_waiting );
     }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4338,9 +4338,11 @@ void activity_handlers::fill_pit_finish( player_activity *act, player *p )
 
 void activity_handlers::play_with_pet_finish( player_activity *act, player *p )
 {
+    const auto mon = act->monsters[0].lock();
     p->add_morale( MORALE_PLAY_WITH_PET, rng( 3, 10 ), 10, 5_hours, 25_minutes );
     p->add_msg_if_player( m_good, _( "Playing with your %s has lifted your spirits a bit." ),
                           act->str_values[0] );
+    mon->remove_effect( effect_ai_waiting );
     act->set_to_null();
 }
 

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -886,7 +886,7 @@ void monexamine::play_with( monster &z )
     you.assign_activity( ACT_PLAY_WITH_PET, turns );
     you.activity->monsters.push_back( g->shared_from( z ) );
     you.activity->str_values.push_back( pet_name );
-    z.add_effect( effect_ai_waiting, time_duration::from_seconds( turns ) );
+    z.add_effect( effect_ai_waiting, time_duration::from_turns( turns ) );
     z.on_pet_bonding( you.as_character() );
 }
 

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -882,10 +882,11 @@ void monexamine::play_with( monster &z )
 {
     std::string pet_name = z.get_name();
     avatar &you = get_avatar();
-    int turns = rng( 50, 125 ) * 100;
+    const int turns = rng( 50, 125 ) * 100;
     you.assign_activity( ACT_PLAY_WITH_PET, turns );
+    you.activity->monsters.push_back( g->shared_from( z ) );
     you.activity->str_values.push_back( pet_name );
-    z.add_effect( effect_ai_waiting, time_duration::from_turns( turns ) );
+    z.add_effect( effect_ai_waiting, time_duration::from_seconds( turns ) );
     z.on_pet_bonding( you.as_character() );
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

Pets would freeze a long time after playing

## Describe the solution (The How)

Add the pet to the activity and explicitly remove the waiting effect.

## Describe alternatives you've considered

Fixing the duration, I'm not sure why the effect lasts significantly longer than it should.
Would be riskier to attempt to change that.

## Testing

- Start with dog lover profession
- Play with dog
- Move around to confirm

## Additional context

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c0da786](https://github.com/cataclysmbn/Cataclysm-BN/commit/c0da786fd248320c3b3a507aaa4d9f0f64091195) (style(autofix.ci): automated formatting) on 2026-06-23 14:20:19

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28030024708/artifacts/7822679803)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28030024708/artifacts/7823659570)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28030024708/artifacts/7822744244)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28030024708/artifacts/7822867260)
<!-- END artifact comment -->