### PR TITLE
ci: shard Windows desktop tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -789,7 +789,7 @@ jobs:
           $target = if ("${{ matrix.tiles }}" -eq "true") { "cata_test-tiles" } else { "cata_test" }
           cmake --build $buildDir --target $target --config Release
 
-      - name: Run tests (desktop)
+      - name: Run sharded tests (desktop)
         if: inputs.run-tests && (runner.os == 'Windows' || (runner.os == 'Linux' && (matrix.android == '' || matrix.android == 'none')))
         shell: pwsh
         run: |
@@ -814,39 +814,17 @@ jobs:
             "--rng-seed", "time",
             "--error-format=github-action"
           )
-          if ($IsLinux) {
+          if ($IsLinux -and "${{ matrix.tiles }}" -eq "true") {
             $testOpts += "--gpu-backend=software"
           }
-          $filters = @("[slow] ~starting_items", "~[slow] ~[.],starting_items")
-          $jobs = @()
-          for ($i = 0; $i -lt $filters.Count; ++$i) {
-            $userDir = "test_user_dir_$($i + 1)"
-            $jobs += Start-Job -Name "cata-test-$($i + 1)" -ScriptBlock {
-              param($bin, $opts, $filter, $userDir)
-              & $bin @opts "--user-dir=$userDir" $filter
-              if ($LASTEXITCODE -ne 0) {
-                throw "Test shard '$filter' exited with code $LASTEXITCODE"
-              }
-            } -ArgumentList $testBin, $testOpts, $filters[$i], $userDir
-          }
-
-          while ($jobs | Where-Object { $_.State -eq "Running" }) {
-            Start-Sleep -Seconds 30
-            $running = ($jobs | Where-Object { $_.State -eq "Running" }).Name -join ", "
-            Write-Host "Still running: $running"
-          }
-
-          $failed = $false
-          foreach ($job in $jobs) {
-            Receive-Job $job -ErrorAction Continue
-            if ($job.State -ne "Completed") {
-              $failed = $true
-              Write-Host "$($job.Name) failed with state $($job.State)"
-            }
-          }
-          if ($failed) {
-            throw "One or more test shards failed"
-          }
+          deno run --allow-read --allow-write --allow-run --allow-env `
+            build-scripts/run-linux-test-shards.ts `
+            --mode file-tags `
+            --jobs 4 `
+            --non-slow-shards 8 `
+            $testBin `
+            -- `
+            @testOpts
 
       # Upload artifacts
       - name: Upload packaged build artifact

--- a/build-scripts/run-linux-test-shards.ts
+++ b/build-scripts/run-linux-test-shards.ts
@@ -2,7 +2,7 @@
 /**
  * @module
  *
- * Runs Cataclysm: Bright Nights Linux tests as filename-tag shards.
+ * Runs Cataclysm: Bright Nights tests as filename-tag shards.
  *
  * The runner discovers Catch2 filename tags, builds deterministic shards, starts the heaviest shards
  * first, and defaults local runs to the detected CPU count while CI can pass explicit limits.
@@ -276,6 +276,9 @@ const discoverTags = async (
   return { allTags: extractFileTags(all.stdout), slowTags: extractFileTags(slow.stdout), testOpts }
 }
 
+const defaultCpuShardCompute = (): string | undefined =>
+  Deno.build.os === "windows" ? undefined : "cpu"
+
 const runShard = async (
   options: Options & { jobs: number; nonSlowShards: number },
   testOpts: string[],
@@ -285,19 +288,20 @@ const runShard = async (
   const compute = explicitCompute ??
     (shard.compute === "gpu_software"
       ? Deno.env.get("CATA_TEST_VISIBILITY_COMPUTE_ACCELERATION") ?? "gpu_software"
-      : "cpu")
+      : defaultCpuShardCompute())
   const userDirPrefix = Deno.env.get("CATA_TEST_USER_DIR_PREFIX") ?? "test_user_dir"
   const userDir = `${userDirPrefix}_${shard.name}`
   const filter = shard.filters.join(",")
   const start = Date.now()
-  console.log(`Starting shard ${shard.name} with ${compute} compute`)
+  console.log(`Starting shard ${shard.name} with ${compute ?? "default"} compute`)
+  const env: Record<string, string> = compute === undefined
+    ? {}
+    : { CATA_TEST_COMPUTE_ACCELERATION: compute }
   const result = await commandOutput(options.testBin, [
     ...testOpts,
     `--user-dir=${userDir}`,
     filter,
-  ], {
-    CATA_TEST_COMPUTE_ACCELERATION: compute,
-  })
+  ], env)
   if (result.stdout) {
     console.log(result.stdout.trimEnd())
   }
@@ -377,8 +381,8 @@ Deno.test("buildShardPlan keeps visibility on its GPU shard", () => {
 if (import.meta.main) {
   try {
     const { options, args, literal } = await new Command()
-      .name("run-linux-test-shards")
-      .description("Run Cataclysm: Bright Nights Linux tests as filename-tag shards")
+      .name("run-test-shards")
+      .description("Run Cataclysm: Bright Nights tests as filename-tag shards")
       .option("--mode <mode:string>", "auto, file-tags, tiles, or legacy", { default: "auto" })
       .option("--jobs <jobs:string>", "concurrent shard jobs, or auto", { default: "auto" })
       .option("--slow-shards <slowShards:string>", "accepted for compatibility", { default: "4" })

--- a/tests/filesystem_test.cpp
+++ b/tests/filesystem_test.cpp
@@ -55,7 +55,7 @@ static void filesystem_test_group( int serial, const std::string &s1, const std:
     std::string writebuf2 = s2;
     std::string readbuf;
     const auto reader = [&readbuf]( std::istream & s ) {
-        s >> readbuf;
+        safe_getline( s, readbuf );
     };
     const auto writer = [&writebuf]( std::ostream & s ) {
         s << writebuf;


### PR DESCRIPTION
## Purpose of change (The Why)

Windows PR CI spends most warm-cache time in desktop tests. This extends the filename-tag shard runner from #9515 and #9528 to Windows instead of retuning ccache (#9391, #9159).

Baseline is the average of recent upstream Windows MSVC jobs: [28011416221](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28011416221), [28007076850](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28007076850), [28006105888](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28006105888). After is the fork Windows MSVC job from [28025067793](https://github.com/scarf005/Cataclysm-BN/actions/runs/28025067793/job/82952012632).

| Scope | Before | After | Change |
|---|---:|---:|---:|
| Windows MSVC job | 37:01 | 32:53 | -4:08, 11.2% less |
| Desktop test step | 23:14 | 16:43 | -6:31, 28.0% less |

## Describe the solution (The How)

- Run Windows desktop tests through `build-scripts/run-linux-test-shards.ts` with 4 jobs and 8 generated CPU shards.
- Let Windows CPU shards use the default compute backend while keeping the visibility shard on software GPU compute.
- Read the filesystem UTF-8 test fixture with `safe_getline` so Windows locale parsing does not truncate non-ASCII bytes.

## Testing

- `deno fmt --check build-scripts/run-linux-test-shards.ts`
- `deno check build-scripts/run-linux-test-shards.ts`
- `deno test --allow-read --allow-write --allow-run --allow-env build-scripts/run-linux-test-shards.ts`
- `actionlint .github/workflows/build.yml`
- `git diff --check upstream/main..HEAD`
- Fork Windows MSVC job passed; `Run sharded tests (desktop)` passed all shards in 16:43. ccache stayed healthy at 635/637 hits (99.69%).

## Checklist

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This PR modifies CI/build automation only; no player build requirements or docs changed.

<sub>PR opened by gpt-5.5 xhigh on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [abd3a15](https://github.com/cataclysmbn/Cataclysm-BN/commit/abd3a1517bac1cd4b47acc9f02dba5ba7e4e9ead) (test: read filesystem fixture bytes without locale parsing) on 2026-06-23 18:43:53

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28035502447/artifacts/7825050774)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28035502447/artifacts/7830188449)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28035502447/artifacts/7825207426)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28035502447/artifacts/7825205364)
<!-- END artifact comment -->