### PR TITLE
feat(balance): flour spawns in random amounts or full bags

### DIFF
--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -37,8 +37,8 @@
     "magazine": 100,
     "subtype": "distribution",
     "entries": [
-      { "item": "flour", "prob": 45, "charges": [5, 40] },
-      { "item": "flour", "prob": 5, "charges": [5, 120], "container-item": "box_medium" },
+      { "item": "flour", "prob": 45, "charges": [ 5, 40 ] },
+      { "item": "flour", "prob": 5, "charges": [ 5, 120 ], "container-item": "box_medium" },
       { "item": "yeast", "prob": 50 },
       { "item": "cornmeal", "prob": 40 },
       { "item": "dry_meat", "prob": 10 },

--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -32,11 +32,13 @@
   {
     "type": "item_group",
     "id": "dry_goods",
+    "//": "mostly used for household spawns.",
     "ammo": 75,
     "magazine": 100,
     "subtype": "distribution",
     "entries": [
-      { "item": "flour", "prob": 50, "charges": [ 40, 40 ] },
+      { "item": "flour", "prob": 45, "charges": [5, 40] },
+      { "item": "flour", "prob": 5, "charges": [5, 120], "container-item": "box_medium" },
       { "item": "yeast", "prob": 50 },
       { "item": "cornmeal", "prob": 40 },
       { "item": "dry_meat", "prob": 10 },

--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -36,7 +36,7 @@
     "magazine": 100,
     "subtype": "distribution",
     "entries": [
-      { "item": "flour", "prob": 50 },
+      { "item": "flour", "prob": 50, "charges": [ 40, 40 ] },
       { "item": "yeast", "prob": 50 },
       { "item": "cornmeal", "prob": 40 },
       { "item": "dry_meat", "prob": 10 },
@@ -210,7 +210,7 @@
       { "item": "soup_dumplings", "prob": 15 },
       { "item": "curry_veggy", "prob": 15 },
       { "item": "curry_meat", "prob": 15 },
-      { "item": "flour", "prob": 30 },
+      { "item": "flour", "prob": 30, "charges": [ 5, 40 ] },
       { "item": "milk_powder", "prob": 20 },
       { "item": "cornmeal", "prob": 30 },
       { "item": "powder_eggs", "prob": 20 },

--- a/data/json/itemgroups/defense_mode.json
+++ b/data/json/itemgroups/defense_mode.json
@@ -103,7 +103,7 @@
       { "item": "whiskey" },
       { "item": "can_beans" },
       { "item": "mre_beef" },
-      { "item": "flour" },
+      { "item": "flour", "charges": [ 5, 40 ] },
       { "item": "inhaler" },
       { "item": "codeine" },
       { "item": "oxycodone" },

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -296,7 +296,6 @@
       { "item": "flour", "prob": 5, "charges": 40 },
       { "item": "flour", "prob": 12, "charges": [ 10, 120 ], "container-item": "box_medium" },
       { "item": "flour", "prob": 3, "charges": 120, "container-item": "box_medium" }
-      
     ]
   },
   {

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -280,19 +280,20 @@
     "items": [ [ "pizza_meat", 50 ], [ "pizza_veggy", 50 ] ]
   },
   {
-    "id": "pizza_kitchen",
-    "type": "item_group",
-    "items": [
-      [ "seasoning_italian", 23 ],
-      [ "seasoning_salt", 13 ],
-      [ "pepper", 5 ],
-      [ "yeast", 10 ],
-      [ "sugar", 9 ],
-      [ "cornmeal", 8 ],
-      [ "flour", 25 ],
-      [ "cookbook", 3 ],
-      [ "cookbook_italian", 2 ]
-    ]
+  "id": "pizza_kitchen",
+  "type": "item_group",
+  "subtype": "distribution",
+  "entries": [
+    { "item": "seasoning_italian", "prob": 23 },
+    { "item": "seasoning_salt", "prob": 13 },
+    { "item": "pepper", "prob": 5 },
+    { "item": "yeast", "prob": 10 },
+    { "item": "sugar", "prob": 9 },
+    { "item": "cornmeal", "prob": 8 },
+    { "item": "cookbook", "prob": 3 },
+    { "item": "cookbook_italian", "prob": 2 },
+    { "item": "flour", "prob": 30, "charges": [ 5, 40 ] }
+  ]
   },
   {
     "id": "pizza_fridge",
@@ -576,7 +577,7 @@
       { "item": "can_chicken", "prob": 30 },
       { "item": "sugar", "prob": 40 },
       { "item": "soysauce", "prob": 10 },
-      { "item": "flour", "prob": 40 },
+      { "item": "flour", "prob": 40, "charges": [ 5, 40 ] },
       { "item": "curry_powder", "prob": 40 },
       { "item": "cornmeal", "prob": 52 }
     ]
@@ -713,7 +714,7 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "flour", "prob": 65 },
+      { "item": "flour", "prob": 65, "charges": [ 40, 40 ] },
       { "item": "cornmeal", "prob": 50 },
       { "item": "yeast", "prob": 40 },
       { "item": "powder_eggs", "prob": 55 },
@@ -936,7 +937,7 @@
       [ "pepper", 15 ],
       [ "salt", 20 ],
       [ "sugar", 5 ],
-      [ "flour", 17 ],
+      { "item": "flour", "prob": 17, "charges": [ 5, 40 ] },
       [ "soysauce", 25 ],
       [ "cooking_oil", 20 ],
       [ "cooking_oil2", 20 ],

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -292,10 +292,10 @@
       { "item": "cornmeal", "prob": 8 },
       { "item": "cookbook", "prob": 3 },
       { "item": "cookbook_italian", "prob": 2 },
-      { "item": "flour", "prob": 15, "charges": [ 5, 40 ] },
+      { "item": "flour", "prob": 20, "charges": [ 5, 40 ] },
       { "item": "flour", "prob": 5, "charges": 40 },
-      { "item": "flour", "prob": 8, "charges": [ 10, 120 ], "container-item": "box_medium" },
-      { "item": "flour", "prob": 2, "charges": 120, "container-item": "box_medium" }
+      { "item": "flour", "prob": 12, "charges": [ 10, 120 ], "container-item": "box_medium" },
+      { "item": "flour", "prob": 3, "charges": 120, "container-item": "box_medium" }
       
     ]
   },
@@ -581,7 +581,7 @@
       { "item": "can_chicken", "prob": 30 },
       { "item": "sugar", "prob": 40 },
       { "item": "soysauce", "prob": 10 },
-      { "item": "flour", "prob": 15, "charges": [ 5, 40 ] },
+      { "item": "flour", "prob": 25, "charges": [ 5, 40 ] },
       { "item": "flour", "prob": 5, "charges": 40 },
       { "item": "flour", "prob": 8, "charges": [ 10, 120 ], "container-item": "box_medium" },
       { "item": "flour", "prob": 2, "charges": 120, "container-item": "box_medium" },

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -292,7 +292,11 @@
       { "item": "cornmeal", "prob": 8 },
       { "item": "cookbook", "prob": 3 },
       { "item": "cookbook_italian", "prob": 2 },
-      { "item": "flour", "prob": 30, "charges": [ 5, 40 ] }
+      { "item": "flour", "prob": 15, "charges": [ 5, 40 ] },
+      { "item": "flour", "prob": 5, "charges": 40 },
+      { "item": "flour", "prob": 8, "charges": [ 10, 120 ], "container-item": "box_medium" },
+      { "item": "flour", "prob": 2, "charges": 120, "container-item": "box_medium" }
+      
     ]
   },
   {
@@ -577,7 +581,10 @@
       { "item": "can_chicken", "prob": 30 },
       { "item": "sugar", "prob": 40 },
       { "item": "soysauce", "prob": 10 },
-      { "item": "flour", "prob": 40, "charges": [ 5, 40 ] },
+      { "item": "flour", "prob": 15, "charges": [ 5, 40 ] },
+      { "item": "flour", "prob": 5, "charges": 40 },
+      { "item": "flour", "prob": 8, "charges": [ 10, 120 ], "container-item": "box_medium" },
+      { "item": "flour", "prob": 2, "charges": 120, "container-item": "box_medium" },
       { "item": "curry_powder", "prob": 40 },
       { "item": "cornmeal", "prob": 52 }
     ]
@@ -714,7 +721,8 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "flour", "prob": 65, "charges": [ 40, 40 ] },
+      { "item": "flour", "prob": 60, "charges": 40 },
+      { "item": "flour", "prob": 5, "charges": 120, "container-item": "box_medium" },
       { "item": "cornmeal", "prob": 50 },
       { "item": "yeast", "prob": 40 },
       { "item": "powder_eggs", "prob": 55 },
@@ -937,7 +945,10 @@
       [ "pepper", 15 ],
       [ "salt", 20 ],
       [ "sugar", 5 ],
-      { "item": "flour", "prob": 17, "charges": [ 5, 40 ] },
+      { "item": "flour", "prob": 10, "charges": [ 5, 40 ] },
+      { "item": "flour", "prob": 2, "charges": 40 },
+      { "item": "flour", "prob": 4, "charges": [ 10, 120 ], "container-item": "box_medium" },
+      { "item": "flour", "prob": 1, "charges": 120, "container-item": "box_medium" },
       [ "soysauce", 25 ],
       [ "cooking_oil", 20 ],
       [ "cooking_oil2", 20 ],

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -280,20 +280,20 @@
     "items": [ [ "pizza_meat", 50 ], [ "pizza_veggy", 50 ] ]
   },
   {
-  "id": "pizza_kitchen",
-  "type": "item_group",
-  "subtype": "distribution",
-  "entries": [
-    { "item": "seasoning_italian", "prob": 23 },
-    { "item": "seasoning_salt", "prob": 13 },
-    { "item": "pepper", "prob": 5 },
-    { "item": "yeast", "prob": 10 },
-    { "item": "sugar", "prob": 9 },
-    { "item": "cornmeal", "prob": 8 },
-    { "item": "cookbook", "prob": 3 },
-    { "item": "cookbook_italian", "prob": 2 },
-    { "item": "flour", "prob": 30, "charges": [ 5, 40 ] }
-  ]
+    "id": "pizza_kitchen",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "seasoning_italian", "prob": 23 },
+      { "item": "seasoning_salt", "prob": 13 },
+      { "item": "pepper", "prob": 5 },
+      { "item": "yeast", "prob": 10 },
+      { "item": "sugar", "prob": 9 },
+      { "item": "cornmeal", "prob": 8 },
+      { "item": "cookbook", "prob": 3 },
+      { "item": "cookbook_italian", "prob": 2 },
+      { "item": "flour", "prob": 30, "charges": [ 5, 40 ] }
+    ]
   },
   {
     "id": "pizza_fridge",

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -702,7 +702,7 @@
       {
         "distribution": [
           { "item": "hardtack", "charges": [ 1, 40 ], "container-item": "bag_canvas_small", "prob": 50 },
-          { "item": "flour", "charges": [ 1, 20 ], "container-item": "bag_canvas_small", "prob": 25 },
+          { "item": "flour", "charges": [ 1, 40 ], "container-item": "bag_canvas_small", "prob": 25 },
           { "item": "dry_beans", "charges": [ 1, 12 ], "container-item": "bag_canvas_small", "prob": 25 }
         ],
         "prob": 75


### PR DESCRIPTION
## Purpose of change (The Why)

I was annoyed I had to raid 3 pizzerias for enough to flour to make 1 (one) pizza, while other ingredients are abundant. 
Additionally, pizza parlors had very low amounts of food for a location that is very food-related, especially compared to houses. 

## Describe the solution (The How)

Flour spawns in random values between 5 and 40, instead of 10 units for each cardboard box. 40 is the max that fits in the box.
Additionally, "brand new" boxes found in grocery stores and in cargo crates will always be full. 
Balance-wise, this should double / triple the amount of flour in an average world. I think that is acceptable and in line with the abundance of other ingredients. 

## Describe alternatives you've considered

Increasing the amount of boxes. 
Using larger boxes for pizzerias (might still do this afterwards). 
Having an additional chance for boxes in pizza parlors and houses to be 100% full. Seemed like too much work, if anyone else has a smart way to implement this, please let me know, I'd be happy to do it.

## Testing

Tested every single affected itemgroup individually. 

## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bc6e373](https://github.com/cataclysmbn/Cataclysm-BN/commit/bc6e373b8dc2977b7cdcc78c6a0ded9fb2796ca6) (style(autofix.ci): automated formatting) on 2026-06-23 19:49:43

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28049940374/artifacts/7830919915)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28049940374/artifacts/7831705059)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28049940374/artifacts/7830997516)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28049940374/artifacts/7831100342)
<!-- END artifact comment -->