### PR TITLE
fix: planes no longer magically lose velocity after takeoff

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1758,6 +1758,8 @@ void vehicle::check_falling_or_floating()
 
     map &here = get_map();
 
+    is_falling = true;
+
     if( is_flying && is_aircraft() ) {
         is_falling = false;
     } else {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fixes https://github.com/cataclysmbn/Cataclysm-BN/issues/9641

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Applies a simple change in `vehicle::check_falling_or_floating` supplied by Wishduck for testing while they were busy working on another thing.

## Describe alternatives you've considered

Leaving it unfixed solely to torment the user that was spamming the discord with demands that it be fixed.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned a plane.
3. Got up to speed and took off.
4. Waited 1 turn, I no longer magically lose velocity.
5. Can go up and down freely.
6. Landed, repeated but immediately ascended twice on getting up to speed, no error message.
7. Checked that going below takeoff speed while in the air still leads to the expected lithobraking.
8. Checked I can't take off from a standstill nor below stall speed.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Suspected cause: https://github.com/cataclysmbn/Cataclysm-BN/pull/9543

If this one-line change Wisduck gave me the patch file for done by AI I will vomit. :V

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1f9b50d](https://github.com/cataclysmbn/Cataclysm-BN/commit/1f9b50df9790faaed5527f5a84569b5bd1e45145) (fix: planes no longer magically lose velocity after takeoff) on 2026-06-24 02:03:51

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28068720923/artifacts/7837969948)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28068720923/artifacts/7838336626)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28068720923/artifacts/7837980983)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28068720923/artifacts/7838088740)
<!-- END artifact comment -->