### PR TITLE
refactor: move type id implementation to existing template

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -19,6 +19,7 @@
 #include "skill.h"
 #include "stats_tracker.h"
 #include "string_formatter.h"
+#include "type_id_implement.h"
 
 // Some details about how achievements work
 // ========================================
@@ -57,19 +58,7 @@ generic_factory<achievement> achievement_factory( "achievement" );
 
 } // namespace
 
-/** @relates string_id */
-template<>
-const achievement &string_id<achievement>::obj() const
-{
-    return achievement_factory.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<achievement>::is_valid() const
-{
-    return achievement_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( achievement, achievement_factory );
 
 namespace io
 {

--- a/src/ammo_effect.cpp
+++ b/src/ammo_effect.cpp
@@ -6,6 +6,7 @@
 #include "generic_factory.h"
 #include "int_id.h"
 #include "json.h"
+#include "type_id_implement.h"
 
 namespace
 {
@@ -14,53 +15,7 @@ generic_factory<ammo_effect> all_ammo_effects( "ammo effects" );
 
 } // namespace
 
-/** @relates int_id */
-template<>
-bool int_id<ammo_effect>::is_valid() const
-{
-    return all_ammo_effects.is_valid( *this );
-}
-
-/** @relates int_id */
-template<>
-const ammo_effect &int_id<ammo_effect>::obj() const
-{
-    return all_ammo_effects.obj( *this );
-}
-
-/** @relates int_id */
-template<>
-const string_id<ammo_effect> &int_id<ammo_effect>::id() const
-{
-    return all_ammo_effects.convert( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<ammo_effect>::is_valid() const
-{
-    return all_ammo_effects.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-const ammo_effect &string_id<ammo_effect>::obj() const
-{
-    return all_ammo_effects.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-int_id<ammo_effect> string_id<ammo_effect>::id() const
-{
-    return all_ammo_effects.convert( *this, AE_NULL );
-}
-
-/** @relates int_id */
-template<>
-int_id<ammo_effect>::int_id( const string_id<ammo_effect> &id ) : _id( id.id() )
-{
-}
+IMPLEMENT_STRING_AND_INT_IDS( ammo_effect, all_ammo_effects );
 
 void ammo_effect::load( const JsonObject &jo, const std::string & )
 {

--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -16,6 +16,7 @@
 #include "messages.h"
 #include "rng.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "weighted_list.h"
 
 anatomy_id human_anatomy( "human_anatomy" );
@@ -27,17 +28,7 @@ generic_factory<anatomy> anatomy_factory( "anatomy" );
 
 } // namespace
 
-template<>
-bool anatomy_id::is_valid() const
-{
-    return anatomy_factory.is_valid( *this );
-}
-
-template<>
-const anatomy &anatomy_id::obj() const
-{
-    return anatomy_factory.obj( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( anatomy, anatomy_factory );
 
 void anatomy::load_anatomy( const JsonObject &jo, const std::string &src )
 {

--- a/src/ascii_art.cpp
+++ b/src/ascii_art.cpp
@@ -8,6 +8,7 @@
 #include "generic_factory.h"
 #include "output.h"
 #include "string_id.h"
+#include "type_id_implement.h"
 
 static const int ascii_art_width = 42;
 
@@ -16,17 +17,7 @@ namespace
 generic_factory<ascii_art> ascii_art_factory( "ascii_art" );
 } // namespace
 
-template<>
-const ascii_art &string_id<ascii_art>::obj() const
-{
-    return ascii_art_factory.obj( *this );
-}
-
-template<>
-bool string_id<ascii_art>::is_valid() const
-{
-    return ascii_art_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( ascii_art, ascii_art_factory );
 
 void ascii_art::reset()
 {

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -11,6 +11,7 @@
 #include "generic_factory.h"
 #include "debug.h"
 #include "json.h"
+#include "type_id_implement.h"
 
 using namespace behavior;
 
@@ -83,11 +84,7 @@ generic_factory<behavior::node_t> behavior_factory( "behavior" );
 std::list<node_data> temp_node_data;
 } // namespace
 
-template<>
-const node_t &string_id<node_t>::obj() const
-{
-    return behavior_factory.obj( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( behavior::node_t, behavior_factory );
 
 void behavior::load_behavior( const JsonObject &jo, const std::string &src )
 {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -71,6 +71,7 @@
 #include "pldata.h"
 #include "point.h"
 #include "projectile.h"
+#include "type_id_implement.h"
 #include "requirements.h"
 #include "regen.h"
 #include "rng.h"
@@ -220,21 +221,7 @@ auto scaled_operation_duration( const int difficulty ) -> time_duration
 }
 } //namespace
 
-/** @relates string_id */
-template<>
-const bionic_data &string_id<bionic_data>::obj() const
-{
-    return bionic_factory.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<bionic_data>::is_valid() const
-{
-    return bionic_factory.is_valid( *this );
-}
-
-
+IMPLEMENT_STRING_AND_INT_IDS( bionic_data, bionic_factory );
 
 std::vector<bodypart_id> get_occupied_bodyparts( const bionic_id &bid )
 {

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -14,6 +14,7 @@
 #include "json.h"
 #include "pldata.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "locations.h"
 
 const bodypart_str_id body_part_head( "head" );
@@ -108,6 +109,7 @@ namespace
 generic_factory<body_part_type> body_part_factory( "body part" );
 
 } // namespace
+IMPLEMENT_STRING_AND_INT_IDS( body_part_type, body_part_factory );
 
 bool is_legacy_bodypart_id( const std::string &id )
 {
@@ -170,52 +172,6 @@ static body_part legacy_id_to_enum( const std::string &legacy_id )
 
     return iter->second;
 }
-
-/**@relates string_id*/
-template<>
-bool string_id<body_part_type>::is_valid() const
-{
-    return body_part_factory.is_valid( *this );
-}
-
-/** @relates int_id */
-template<>
-bool int_id<body_part_type>::is_valid() const
-{
-    return body_part_factory.is_valid( *this );
-}
-
-/**@relates string_id*/
-template<>
-const body_part_type &string_id<body_part_type>::obj() const
-{
-    return body_part_factory.obj( *this );
-}
-
-/** @relates int_id */
-template<>
-const body_part_type &int_id<body_part_type>::obj() const
-{
-    return body_part_factory.obj( *this );
-}
-
-/** @relates int_id */
-template<>
-const bodypart_str_id &int_id<body_part_type>::id() const
-{
-    return body_part_factory.convert( *this );
-}
-
-/**@relates string_id*/
-template<>
-bodypart_id string_id<body_part_type>::id() const
-{
-    return body_part_factory.convert( *this, bodypart_id( 0 ) );
-}
-
-/** @relates int_id */
-template<>
-int_id<body_part_type>::int_id( const string_id<body_part_type> &id ) : _id( id.id() ) {}
 
 body_part get_body_part_token( const std::string &id )
 {

--- a/src/clothing_mod.cpp
+++ b/src/clothing_mod.cpp
@@ -13,6 +13,7 @@
 #include "item.h"
 #include "json.h"
 #include "string_id.h"
+#include "type_id_implement.h"
 
 namespace
 {
@@ -21,21 +22,8 @@ generic_factory<clothing_mod> all_clothing_mods( "clothing mods" );
 
 } // namespace
 
+IMPLEMENT_STRING_AND_INT_IDS( clothing_mod, all_clothing_mods );
 static std::map<clothing_mod_type, std::vector<clothing_mod>> clothing_mods_by_type;
-
-/** @relates string_id */
-template<>
-bool string_id<clothing_mod>::is_valid() const
-{
-    return all_clothing_mods.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-const clothing_mod &string_id<clothing_mod>::obj() const
-{
-    return all_clothing_mods.obj( *this );
-}
 
 namespace io
 {

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -40,6 +40,7 @@
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "translations.h"
+#include "type_id_implement.h"
 #include "ui.h"
 #include "value_ptr.h"
 #include "vehicle.h"
@@ -133,17 +134,7 @@ auto rectangle_points( const zone_bounds &bounds ) -> std::vector<tripoint_abs_m
 }
 } // namespace
 
-template<>
-const zone_type &string_id<zone_type>::obj() const
-{
-    return zone_type_factory.obj( *this );
-}
-
-template<>
-bool string_id<zone_type>::is_valid() const
-{
-    return zone_type_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( zone_type, zone_type_factory );
 
 const std::vector<zone_type> &zone_type::get_all()
 {

--- a/src/disease.cpp
+++ b/src/disease.cpp
@@ -4,23 +4,14 @@
 #include "debug.h"
 #include "generic_factory.h"
 #include "string_id.h"
+#include "type_id_implement.h"
 
 namespace
 {
 generic_factory<disease_type> disease_factory( "disease_type" );
 } // namespace
 
-template<>
-const disease_type &string_id<disease_type>::obj() const
-{
-    return disease_factory.obj( *this );
-}
-
-template<>
-bool string_id<disease_type>::is_valid() const
-{
-    return disease_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( disease_type, disease_factory );
 
 void disease_type::load_disease_type( const JsonObject &jo, const std::string &src )
 {

--- a/src/enchantments/enchantment.cpp
+++ b/src/enchantments/enchantment.cpp
@@ -16,6 +16,7 @@
 #include "rng.h"
 #include "string_id.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "units.h"
 
 #include <algorithm>
@@ -87,13 +88,7 @@ namespace {
 generic_factory<enchantment> enchant_factory("enchantment");
 } // namespace
 
-template <> const enchantment& string_id<enchantment>::obj() const {
-    return enchant_factory.obj(*this);
-}
-
-template <> bool string_id<enchantment>::is_valid() const {
-    return enchant_factory.is_valid(*this);
-}
+IMPLEMENT_STRING_AND_INT_IDS(enchantment, enchant_factory);
 
 void enchantment::load_enchantment(const JsonObject& jo, const std::string& src) {
     enchant_factory.load(jo, src);

--- a/src/enchantments/enchantment_value.cpp
+++ b/src/enchantments/enchantment_value.cpp
@@ -3,6 +3,7 @@
 #include "assign.h"
 #include "debug.h"
 #include "generic_factory.h"
+#include "type_id_implement.h"
 
 #include <optional>
 
@@ -10,40 +11,7 @@ namespace {
 generic_factory<enchantment_value> all_enchantment_values("Enchantment Values");
 }
 
-/** @relates string_id */
-template <> const enchantment_value& string_id<enchantment_value>::obj() const {
-    return all_enchantment_values.obj(*this);
-}
-
-/** @relates int_id */
-template <> const enchantment_value& int_id<enchantment_value>::obj() const {
-    return all_enchantment_values.obj(*this);
-}
-
-/** @relates string_id */
-template <> bool string_id<enchantment_value>::is_valid() const {
-    return all_enchantment_values.is_valid(*this);
-}
-
-/** @relates int_id */
-template <> bool int_id<enchantment_value>::is_valid() const {
-    return all_enchantment_values.is_valid(*this);
-}
-
-/** @relates string_id */
-template <> int_id<enchantment_value> string_id<enchantment_value>::id() const {
-    return all_enchantment_values.convert(*this, int_id<enchantment_value>(INVALID_CID));
-}
-
-/** @relates int_id */
-template <> const string_id<enchantment_value>& int_id<enchantment_value>::id() const {
-    return all_enchantment_values.convert(*this);
-}
-
-/** @relates int_id */
-template <> int_id<enchantment_value>::int_id(const enchantment_value_id& id) {
-    *this = all_enchantment_values.convert(id, int_id<enchantment_value>(INVALID_CID));
-}
+IMPLEMENT_STRING_AND_INT_IDS(enchantment_value, all_enchantment_values);
 
 void enchantment_value::load_enchantment_values(const JsonObject& jo, const std::string& src) {
     all_enchantment_values.load(jo, src);

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -18,6 +18,7 @@
 #include "json.h"
 #include "stats_tracker.h"
 #include "string_formatter.h"
+#include "type_id_implement.h"
 
 // event_transformation and event_statistic are both objects defined in json
 // and managed via generic_factory.
@@ -54,17 +55,9 @@ generic_factory<score> score_factory( "score" );
 
 } // namespace
 
-template<>
-const event_transformation &string_id<event_transformation>::obj() const
-{
-    return event_transformation_factory.obj( *this );
-}
-
-template<>
-bool string_id<event_transformation>::is_valid() const
-{
-    return event_transformation_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( event_transformation, event_transformation_factory );
+IMPLEMENT_STRING_AND_INT_IDS( event_statistic, event_statistic_factory );
+IMPLEMENT_STRING_AND_INT_IDS( score, score_factory );
 
 void event_transformation::load_transformation( const JsonObject &jo, const std::string &src )
 {
@@ -81,18 +74,6 @@ void event_transformation::reset()
     event_transformation_factory.reset();
 }
 
-template<>
-const event_statistic &string_id<event_statistic>::obj() const
-{
-    return event_statistic_factory.obj( *this );
-}
-
-template<>
-bool string_id<event_statistic>::is_valid() const
-{
-    return event_statistic_factory.is_valid( *this );
-}
-
 void event_statistic::load_statistic( const JsonObject &jo, const std::string &src )
 {
     event_statistic_factory.load( jo, src );
@@ -106,18 +87,6 @@ void event_statistic::check_consistency()
 void event_statistic::reset()
 {
     event_statistic_factory.reset();
-}
-
-template<>
-const score &string_id<score>::obj() const
-{
-    return score_factory.obj( *this );
-}
-
-template<>
-bool string_id<score>::is_valid() const
-{
-    return score_factory.is_valid( *this );
 }
 
 void score::load_score( const JsonObject &jo, const std::string &src )

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -11,6 +11,7 @@
 #include "int_id.h"
 #include "json.h"
 #include "string_id.h"
+#include "type_id_implement.h"
 
 namespace io
 {
@@ -81,53 +82,7 @@ generic_factory<field_type> all_field_types( "field types" );
 
 } // namespace
 
-/** @relates int_id */
-template<>
-bool int_id<field_type>::is_valid() const
-{
-    return all_field_types.is_valid( *this );
-}
-
-/** @relates int_id */
-template<>
-const field_type &int_id<field_type>::obj() const
-{
-    return all_field_types.obj( *this );
-}
-
-/** @relates int_id */
-template<>
-const string_id<field_type> &int_id<field_type>::id() const
-{
-    return all_field_types.convert( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<field_type>::is_valid() const
-{
-    return all_field_types.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-const field_type &string_id<field_type>::obj() const
-{
-    return all_field_types.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-int_id<field_type> string_id<field_type>::id() const
-{
-    return all_field_types.convert( *this, fd_null );
-}
-
-/** @relates int_id */
-template<>
-int_id<field_type>::int_id( const string_id<field_type> &id ) : _id( id.id() )
-{
-}
+IMPLEMENT_STRING_AND_INT_IDS( field_type, all_field_types );
 
 const field_intensity_level &field_type::get_intensity_level( int level ) const
 {

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -5,6 +5,7 @@
 #include "debug.h"
 #include "json.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "generic_factory.h"
 
 const flag_id flag_NULL = flag_id( "null" ); // intentionally invalid flag
@@ -392,19 +393,7 @@ namespace
 generic_factory<json_flag> json_flags_all( "json_flags" );
 } // namespace
 
-/** @relates string_id */
-template<>
-bool flag_id ::is_valid() const
-{
-    return json_flags_all.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-const json_flag &flag_id::obj() const
-{
-    return json_flags_all.obj( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( json_flag, json_flags_all );
 
 json_flag::operator bool() const
 {

--- a/src/flag_trait.cpp
+++ b/src/flag_trait.cpp
@@ -4,6 +4,7 @@
 #include "flag_trait.h"
 #include "json.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "generic_factory.h"
 
 namespace
@@ -11,53 +12,7 @@ namespace
 generic_factory<json_trait_flag> json_trait_flags_all( "json_trait_flags" );
 } // namespace
 
-/** @relates int_id */
-template<>
-bool trait_flag_id ::is_valid() const
-{
-    return json_trait_flags_all.is_valid( *this );
-}
-
-/** @relates int_id */
-template<>
-const json_trait_flag &trait_flag_id::obj() const
-{
-    return json_trait_flags_all.obj( *this );
-}
-
-/** @relates int_id */
-template<>
-const trait_flag_str_id &trait_flag_id::id() const
-{
-    return json_trait_flags_all.convert( *this );
-}
-
-/** @relates string_id */
-template<>
-bool trait_flag_str_id ::is_valid() const
-{
-    return json_trait_flags_all.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-const json_trait_flag &trait_flag_str_id::obj() const
-{
-    return json_trait_flags_all.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-trait_flag_id trait_flag_str_id::id() const
-{
-    return json_trait_flags_all.convert( *this, trait_flag_id( -1 ) );
-}
-
-/** @relates int_id */
-template<>
-trait_flag_id::int_id( const trait_flag_str_id &id ) : _id( id.id() )
-{
-}
+IMPLEMENT_STRING_AND_INT_IDS( json_trait_flag, json_trait_flags_all );
 
 json_trait_flag::operator bool() const
 {

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -31,6 +31,7 @@
 #include "string_id.h"
 #include "translations.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "units.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
@@ -82,6 +83,8 @@ gate_id get_gate_id( const tripoint_bub_ms &pos )
 generic_factory<gate_data> gates_data( "gate type" );
 
 } // namespace
+
+IMPLEMENT_STRING_AND_INT_IDS( gate_data, gates_data );
 
 void gate_data::load( const JsonObject &jo, const std::string & )
 {

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -6,23 +6,14 @@
 #include "item.h"
 #include "json.h"
 #include "string_id.h"
+#include "type_id_implement.h"
 
 namespace
 {
 generic_factory<item_category> item_category_factory( "item_category" );
 } // namespace
 
-template<>
-const item_category &string_id<item_category>::obj() const
-{
-    return item_category_factory.obj( *this );
-}
-
-template<>
-bool string_id<item_category>::is_valid() const
-{
-    return item_category_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( item_category, item_category_factory );
 
 void zone_priority_data::deserialize( JsonIn &jsin )
 {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -50,6 +50,7 @@
 #include "string_id.h"
 #include "translations.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "ui.h"
 #include "units.h"
 #include "faction.h"
@@ -130,17 +131,7 @@ namespace
 generic_factory<spell_type> spell_factory( "spell" );
 } // namespace
 
-template<>
-const spell_type &string_id<spell_type>::obj() const
-{
-    return spell_factory.obj( *this );
-}
-
-template<>
-bool string_id<spell_type>::is_valid() const
-{
-    return spell_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( spell_type, spell_factory );
 
 void spell_type::load_spell( const JsonObject &jo, const std::string &src )
 {

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -16,6 +16,7 @@
 #include "mapgen_constructor.h"
 #include "string_id.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 
 struct tripoint;
 template <typename T> struct weighted_int_list;
@@ -25,17 +26,7 @@ namespace
 generic_factory<ter_furn_transform> ter_furn_transform_factory( "ter_furn_transform" );
 } // namespace
 
-template<>
-const ter_furn_transform &string_id<ter_furn_transform>::obj() const
-{
-    return ter_furn_transform_factory.obj( *this );
-}
-
-template<>
-bool string_id<ter_furn_transform>::is_valid() const
-{
-    return ter_furn_transform_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( ter_furn_transform, ter_furn_transform_factory );
 
 void ter_furn_transform::load_transform( const JsonObject &jo, const std::string &src )
 {

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -29,6 +29,7 @@
 #include "translations.h"
 #include "trap.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 
 static const std::string flag_TRANSPARENT( "TRANSPARENT" );
 
@@ -118,101 +119,8 @@ auto parse_fluid_grid_role( const std::string &role ) -> std::optional<fluid_gri
 
 } // namespace
 
-/** @relates int_id */
-template<>
-bool int_id<ter_t>::is_valid() const
-{
-    return terrain_data.is_valid( *this );
-}
-
-/** @relates int_id */
-template<>
-const ter_t &int_id<ter_t>::obj() const
-{
-    return terrain_data.obj( *this );
-}
-
-/** @relates int_id */
-template<>
-const string_id<ter_t> &int_id<ter_t>::id() const
-{
-    return terrain_data.convert( *this );
-}
-
-/** @relates int_id */
-template<>
-int_id<ter_t> string_id<ter_t>::id() const
-{
-    return terrain_data.convert( *this, t_null );
-}
-
-/** @relates int_id */
-template<>
-int_id<ter_t>::int_id( const string_id<ter_t> &id ) : _id( id.id() )
-{
-}
-
-/** @relates string_id */
-template<>
-const ter_t &string_id<ter_t>::obj() const
-{
-    return terrain_data.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<ter_t>::is_valid() const
-{
-    return terrain_data.is_valid( *this );
-}
-
-/** @relates int_id */
-template<>
-bool int_id<furn_t>::is_valid() const
-{
-    return furniture_data.is_valid( *this );
-}
-
-/** @relates int_id */
-template<>
-const furn_t &int_id<furn_t>::obj() const
-{
-    return furniture_data.obj( *this );
-}
-
-/** @relates int_id */
-template<>
-const string_id<furn_t> &int_id<furn_t>::id() const
-{
-    return furniture_data.convert( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<furn_t>::is_valid() const
-{
-    return furniture_data.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-const furn_t &string_id<furn_t>::obj() const
-{
-    return furniture_data.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-int_id<furn_t> string_id<furn_t>::id() const
-{
-    return furniture_data.convert( *this, f_null );
-}
-
-/** @relates int_id */
-template<>
-int_id<furn_t>::int_id( const string_id<furn_t> &id ) : _id( id.id() )
-{
-}
+IMPLEMENT_STRING_AND_INT_IDS( ter_t, terrain_data );
+IMPLEMENT_STRING_AND_INT_IDS( furn_t, furniture_data );
 
 static const std::unordered_map<std::string, ter_bitflags> ter_bitflags_map = { {
         { "DESTROY_ITEM",             TFLAG_DESTROY_ITEM },   // add/spawn_item*()

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -38,6 +38,7 @@
 #include "string_id.h"
 #include "string_utils.h"
 #include "translations.h"
+#include "type_id_implement.h"
 #include "ui_manager.h"
 #include "value_ptr.h"
 
@@ -57,18 +58,10 @@ generic_factory<martialart> martialarts( "martial art style" );
 generic_factory<ma_buff> ma_buffs( "martial art buff" );
 } // namespace
 
-template<>
-const weapon_category &weapon_category_id::obj() const
-{
-    return weapon_category_factory.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool weapon_category_id::is_valid() const
-{
-    return weapon_category_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( weapon_category, weapon_category_factory );
+IMPLEMENT_STRING_AND_INT_IDS( ma_technique, ma_techniques );
+IMPLEMENT_STRING_AND_INT_IDS( martialart, martialarts );
+IMPLEMENT_STRING_AND_INT_IDS( ma_buff, ma_buffs );
 
 void weapon_category::load_weapon_categories( const JsonObject &jo, const std::string &src )
 {
@@ -230,23 +223,6 @@ void ma_technique::load( const JsonObject &jo, const std::string &src )
     bonuses.load( jo );
 }
 
-// Not implemented on purpose (martialart objects have no integer id)
-// int_id<T> string_id<mabuff>::id() const;
-
-/** @relates string_id */
-template<>
-const ma_technique &string_id<ma_technique>::obj() const
-{
-    return ma_techniques.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<ma_technique>::is_valid() const
-{
-    return ma_techniques.is_valid( *this );
-}
-
 void ma_buff::load( const JsonObject &jo, const std::string &src )
 {
     mandatory( jo, was_loaded, "name", name );
@@ -264,23 +240,6 @@ void ma_buff::load( const JsonObject &jo, const std::string &src )
 
     reqs.load( jo, src );
     bonuses.load( jo );
-}
-
-// Not implemented on purpose (martialart objects have no integer id)
-// int_id<T> string_id<mabuff>::id() const;
-
-/** @relates string_id */
-template<>
-const ma_buff &string_id<ma_buff>::obj() const
-{
-    return ma_buffs.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<ma_buff>::is_valid() const
-{
-    return ma_buffs.is_valid( *this );
 }
 
 void load_martial_art( const JsonObject &jo, const std::string &src )
@@ -343,23 +302,6 @@ void martialart::load( const JsonObject &jo, const std::string & )
 
     optional( jo, was_loaded, "arm_block_with_bio_armor_arms", arm_block_with_bio_armor_arms, false );
     optional( jo, was_loaded, "leg_block_with_bio_armor_legs", leg_block_with_bio_armor_legs, false );
-}
-
-// Not implemented on purpose (martialart objects have no integer id)
-// int_id<T> string_id<martialart>::id() const;
-
-/** @relates string_id */
-template<>
-const martialart &string_id<martialart>::obj() const
-{
-    return martialarts.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<martialart>::is_valid() const
-{
-    return martialarts.is_valid( *this );
 }
 
 std::vector<matype_id> all_martialart_types()

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -14,6 +14,7 @@
 #include "mapdata.h"
 #include "string_id.h"
 #include "translations.h"
+#include "type_id_implement.h"
 
 namespace
 {
@@ -22,19 +23,7 @@ generic_factory<material_type> material_data( "material" );
 
 } // namespace
 
-/** @relates string_id */
-template<>
-bool string_id<material_type>::is_valid() const
-{
-    return material_data.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-const material_type &string_id<material_type>::obj() const
-{
-    return material_data.obj( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( material_type, material_data );
 
 material_type::material_type() :
     id( material_id::NULL_ID() ),

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -14,6 +14,7 @@
 #include "item.h"
 #include "json.h"
 #include "npc.h"
+#include "type_id_implement.h"
 #include "rng.h"
 
 enum legacy_mission_type_id {
@@ -198,19 +199,7 @@ std::string enum_to_string<mission_goal>( mission_goal data )
 generic_factory<mission_type> mission_type_factory( "mission_type" );
 static DynamicDataLoader::deferred_json deferred;
 
-/** @relates string_id */
-template<>
-const mission_type &string_id<mission_type>::obj() const
-{
-    return mission_type_factory.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<mission_type>::is_valid() const
-{
-    return mission_type_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( mission_type, mission_type_factory );
 
 void mission_type::load_mission_type( const JsonObject &jo, const std::string &src )
 {

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -220,6 +220,7 @@ std::string enum_to_string<m_flag>( m_flag data )
 
 } // namespace io
 
+// TODO: Make this like any other generic factory so we can use type_id_implement
 /** @relates string_id */
 template<>
 const mtype &string_id<mtype>::obj() const

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -9,6 +9,8 @@
 #include "json.h"
 #include "string_formatter.h"
 #include "debug.h"
+#include "type_id.h"
+#include "type_id_implement.h"
 
 // Legacy crap
 const morale_type MORALE_NULL( "morale_null" );
@@ -94,18 +96,7 @@ generic_factory<morale_type_data> morale_data( "morale type" );
 
 } // namespace
 
-template<>
-const morale_type_data &morale_type::obj() const
-{
-    return morale_data.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool morale_type::is_valid() const
-{
-    return morale_data.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( morale_type_data, morale_data );
 
 void morale_type_data::load_type( const JsonObject &jo, const std::string &src )
 {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -21,6 +21,7 @@
 #include "string_id.h"
 #include "trait_group.h"
 #include "translations.h"
+#include "type_id_implement.h"
 
 using TraitGroupMap =
     std::map<trait_group::Trait_group_tag, shared_ptr_fast<Trait_group>>;
@@ -35,21 +36,11 @@ namespace
 generic_factory<mutation_branch> trait_factory( "trait" );
 } // namespace
 
+IMPLEMENT_STRING_AND_INT_IDS( mutation_branch, trait_factory );
+
 static std::vector<dream> all_dreams;
 std::map<mutation_category_id, std::vector<trait_id> > mutations_category;
 std::map<mutation_category_id, mutation_category_trait> mutation_category_traits;
-
-template<>
-const mutation_branch &string_id<mutation_branch>::obj() const
-{
-    return trait_factory.obj( *this );
-}
-
-template<>
-bool string_id<mutation_branch>::is_valid() const
-{
-    return trait_factory.is_valid( *this );
-}
 
 template<>
 bool string_id<Trait_group>::is_valid() const

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -17,6 +17,7 @@
 #include "rng.h"
 #include "skill.h"
 #include "trait_group.h"
+#include "type_id_implement.h"
 #include "json.h"
 
 static const std::array<npc_class_id, 19> legacy_ids = {{
@@ -64,19 +65,7 @@ npc_class_id NC_HALLU( "NC_HALLU" );
 
 generic_factory<npc_class> npc_class_factory( "npc_class" );
 
-/** @relates string_id */
-template<>
-const npc_class &string_id<npc_class>::obj() const
-{
-    return npc_class_factory.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<npc_class>::is_valid() const
-{
-    return npc_class_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( npc_class, npc_class_factory );
 
 npc_class::npc_class() : id( NC_NONE )
 {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -76,6 +76,7 @@
 #include "text_snippets.h"
 #include "translations.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "weighted_list.h"
 #include "world.h"
 #include "world_type.h"
@@ -273,30 +274,10 @@ generic_factory<oter_t> terrains( "overmap terrain" );
 generic_factory<overmap_special> specials( "overmap special" );
 
 } // namespace
-
-template<>
-const overmap_land_use_code &overmap_land_use_code_id::obj() const
-{
-    return land_use_codes.obj( *this );
-}
-
-template<>
-bool overmap_land_use_code_id::is_valid() const
-{
-    return land_use_codes.is_valid( *this );
-}
-
-template<>
-const overmap_special &overmap_special_id::obj() const
-{
-    return specials.obj( *this );
-}
-
-template<>
-bool overmap_special_id::is_valid() const
-{
-    return specials.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( overmap_land_use_code, land_use_codes );
+IMPLEMENT_STRING_AND_INT_IDS( oter_type_t, terrain_types );
+IMPLEMENT_STRING_AND_INT_IDS( oter_t, terrains );
+IMPLEMENT_STRING_AND_INT_IDS( overmap_special, specials );
 
 city::city( const point_om_omt &P, int const S )
     : pos( P )
@@ -317,90 +298,6 @@ radio_tower::radio_tower( const point_om_sm &p, int S, const std::string &M, rad
     pos( p ), strength( S ), type( T ), message( M )
 {
     frequency = rng( 0, std::numeric_limits<int32_t>::max() );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<oter_type_t>::is_valid() const
-{
-    return terrain_types.is_valid( *this );
-}
-
-/** @relates int_id */
-template<>
-const string_id<oter_type_t> &int_id<oter_type_t>::id() const
-{
-    return terrain_types.convert( *this );
-}
-
-/** @relates string_id */
-template<>
-int_id<oter_type_t> string_id<oter_type_t>::id() const
-{
-    return terrain_types.convert( *this, int_id<oter_type_t>( 0 ) );
-}
-
-/** @relates int_id */
-template<>
-int_id<oter_type_t>::int_id( const string_id<oter_type_t> &id ) : _id( id.id() ) {}
-
-template<>
-const oter_type_t &int_id<oter_type_t>::obj() const
-{
-    return terrain_types.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-const oter_type_t &string_id<oter_type_t>::obj() const
-{
-    return terrain_types.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<oter_t>::is_valid() const
-{
-    return terrains.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-const oter_t &string_id<oter_t>::obj() const
-{
-    return terrains.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-int_id<oter_t> string_id<oter_t>::id() const
-{
-    return terrains.convert( *this, ot_null );
-}
-
-/** @relates int_id */
-template<>
-int_id<oter_t>::int_id( const string_id<oter_t> &id ) : _id( id.id() ) {}
-
-/** @relates int_id */
-template<>
-bool int_id<oter_t>::is_valid() const
-{
-    return terrains.is_valid( *this );
-}
-
-/** @relates int_id */
-template<>
-const oter_t &int_id<oter_t>::obj() const
-{
-    return terrains.obj( *this );
-}
-
-/** @relates int_id */
-template<>
-const string_id<oter_t> &int_id<oter_t>::id() const
-{
-    return terrains.convert( *this );
 }
 
 bool operator==( const int_id<oter_t> &lhs, const char *rhs )

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -15,6 +15,7 @@
 #include "overmap_location.h"
 #include "debug.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "weighted_list.h"
 namespace
 {
@@ -22,6 +23,8 @@ namespace
 generic_factory<overmap_connection> connections( "overmap connection" );
 
 } // namespace
+
+IMPLEMENT_STRING_AND_INT_IDS( overmap_connection, connections );
 
 namespace io
 {
@@ -47,18 +50,6 @@ static const std::map<std::string, overmap_connection::subtype::flag> connection
 = {
     { "ORTHOGONAL", overmap_connection::subtype::flag::orthogonal },
 };
-
-template<>
-bool string_id<overmap_connection>::is_valid() const
-{
-    return connections.is_valid( *this );
-}
-
-template<>
-const overmap_connection &string_id<overmap_connection>::obj() const
-{
-    return connections.obj( *this );
-}
 
 bool overmap_connection::subtype::allows_terrain( const oter_id &oter ) const
 {

--- a/src/overmap_location.cpp
+++ b/src/overmap_location.cpp
@@ -11,6 +11,7 @@
 #include "omdata.h"
 #include "overmap.h"
 #include "rng.h"
+#include "type_id_implement.h"
 
 namespace
 {
@@ -19,17 +20,7 @@ generic_factory<overmap_location> locations( "overmap location" );
 
 } // namespace
 
-template<>
-bool string_id<overmap_location>::is_valid() const
-{
-    return locations.is_valid( *this );
-}
-
-template<>
-const overmap_location &string_id<overmap_location>::obj() const
-{
-    return locations.obj( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( overmap_location, locations );
 
 bool overmap_location::test( const oter_id &oter ) const
 {

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -24,12 +24,15 @@
 #include "pldata.h"
 #include "translations.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 
 namespace
 {
 generic_factory<profession> all_profs( "profession" );
 const profession_id generic_profession_id( "unemployed" );
 } // namespace
+
+IMPLEMENT_STRING_AND_INT_IDS( profession, all_profs );
 
 static class json_item_substitution
 {
@@ -64,20 +67,6 @@ static class json_item_substitution
         std::vector<detached_ptr<item>> get_substitution( const item &it,
                                      const std::vector<trait_id> &traits ) const;
 } item_substitutions;
-
-/** @relates string_id */
-template<>
-const profession &string_id<profession>::obj() const
-{
-    return all_profs.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<profession>::is_valid() const
-{
-    return all_profs.is_valid( *this );
-}
 
 profession::profession()
     : _name_male( no_translation( "null" ) ),

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -12,7 +12,7 @@
 #include "string_id.h"
 #include "translations.h"
 #include "type_id.h"
-
+#include "type_id_implement.h"
 // recipe_groups namespace
 
 namespace
@@ -36,6 +36,8 @@ struct recipe_group_data {
 generic_factory<recipe_group_data> recipe_groups_data( "recipe group type" );
 
 } // namespace
+
+IMPLEMENT_STRING_AND_INT_IDS( recipe_group_data, recipe_groups_data );
 
 void recipe_group_data::load( const JsonObject &jo, const std::string & )
 {

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -12,6 +12,7 @@
 #include "mutation.h"
 #include "profession.h"
 #include "translations.h"
+#include "type_id_implement.h"
 #include "rng.h"
 #include "start_location.h"
 
@@ -21,19 +22,7 @@ generic_factory<scenario> all_scenarios( "scenario" );
 const string_id<scenario> generic_scenario_id( "evacuee" );
 } // namespace
 
-/** @relates string_id */
-template<>
-const scenario &string_id<scenario>::obj() const
-{
-    return all_scenarios.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<scenario>::is_valid() const
-{
-    return all_scenarios.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( scenario, all_scenarios );
 
 scen_blacklist sc_blacklist;
 

--- a/src/skill_boost.cpp
+++ b/src/skill_boost.cpp
@@ -5,12 +5,15 @@
 #include <set>
 
 #include "generic_factory.h"
+#include "type_id_implement.h"
 #include "json.h"
 
 namespace
 {
 generic_factory<skill_boost> all_skill_boosts( "skill boost", "stat" );
 } // namespace
+
+IMPLEMENT_STRING_AND_INT_IDS( skill_boost, all_skill_boosts );
 
 const std::vector<skill_boost> &skill_boost::get_all()
 {

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -30,6 +30,7 @@
 #include "pldata.h"
 #include "point.h"
 #include "rng.h"
+#include "type_id_implement.h"
 #include "string_id.h"
 
 class item;
@@ -41,26 +42,7 @@ namespace
 generic_factory<start_location> all_start_locations( "start locations" );
 } // namespace
 
-/** @relates string_id */
-template<>
-const start_location &string_id<start_location>::obj() const
-{
-    return all_start_locations.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<start_location>::is_valid() const
-{
-    return all_start_locations.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-int_id<start_location> string_id<start_location>::id() const
-{
-    return all_start_locations.convert( *this, int_id<start_location>( INVALID_CID ) );
-}
+IMPLEMENT_STRING_AND_INT_IDS( start_location, all_start_locations );
 
 std::string start_location::name() const
 {

--- a/src/vehicle_palette.cpp
+++ b/src/vehicle_palette.cpp
@@ -19,6 +19,7 @@
 #include "string_id.h"
 #include "translations.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "units_angle.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
@@ -29,26 +30,7 @@ namespace
 generic_factory<VehiclePalette> all_palettes( "Vehicle Palettes" );
 }
 
-/** @relates string_id */
-template<>
-const VehiclePalette &string_id<VehiclePalette>::obj() const
-{
-    return all_palettes.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<VehiclePalette>::is_valid() const
-{
-    return all_palettes.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-int_id<VehiclePalette> string_id<VehiclePalette>::id() const
-{
-    return all_palettes.convert( *this, int_id<VehiclePalette>( INVALID_CID ) );
-}
+IMPLEMENT_STRING_AND_INT_IDS( VehiclePalette, all_palettes );
 
 void VehiclePalette::load_palette( const JsonObject &jo, const std::string &src )
 {

--- a/src/vitamin.cpp
+++ b/src/vitamin.cpp
@@ -13,6 +13,7 @@
 #include "json.h"
 #include "string_id.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "units.h"
 #include "units_serde.h"
 
@@ -21,26 +22,7 @@ namespace
 generic_factory<vitamin> all_vitamins( "Vitamins" );
 }
 
-/** @relates string_id */
-template<>
-bool string_id<vitamin>::is_valid() const
-{
-    return all_vitamins.is_valid( *this );
-}
-
-/** @relates string_id */
-template<>
-const vitamin &string_id<vitamin>::obj() const
-{
-    return all_vitamins.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-int_id<vitamin> string_id<vitamin>::id() const
-{
-    return all_vitamins.convert( *this, int_id<vitamin>( INVALID_CID ) );
-}
+IMPLEMENT_STRING_AND_INT_IDS( vitamin, all_vitamins );
 
 void vitamin::load_vitamin( const JsonObject &jo, const std::string &src )
 {

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -4,6 +4,7 @@
 #include "game_constants.h"
 #include "generic_factory.h"
 #include "bodypart.h"
+#include "type_id_implement.h"
 #include "weather.h"
 
 namespace
@@ -11,6 +12,7 @@ namespace
 generic_factory<weather_type> weather_type_factory( "weather_type" );
 } // namespace
 
+IMPLEMENT_STRING_AND_INT_IDS( weather_type, weather_type_factory );
 
 namespace io
 {
@@ -97,19 +99,6 @@ std::string enum_to_string<weather_sound_category>( weather_sound_category data 
 }
 
 } // namespace io
-
-template<>
-const weather_type &weather_type_id::obj() const
-{
-    return weather_type_factory.obj( *this );
-}
-
-/** @relates string_id */
-template<>
-bool string_id<weather_type>::is_valid() const
-{
-    return weather_type_factory.is_valid( *this );
-}
 
 void weather_type::check() const
 {

--- a/src/world_type.cpp
+++ b/src/world_type.cpp
@@ -4,6 +4,7 @@
 #include "generic_factory.h"
 #include "json.h"
 #include "mapdata.h"
+#include "type_id_implement.h"
 
 namespace
 {
@@ -11,17 +12,7 @@ generic_factory<world_type> world_type_factory( "world_type" );
 const world_type_id default_world_type_id( "default" );
 } // namespace
 
-template<>
-const world_type &world_type_id::obj() const
-{
-    return world_type_factory.obj( *this );
-}
-
-template<>
-bool string_id<world_type>::is_valid() const
-{
-    return world_type_factory.is_valid( *this );
-}
+IMPLEMENT_STRING_AND_INT_IDS( world_type, world_type_factory );
 
 void world_type::load( const JsonObject &jo, const std::string & )
 {


### PR DESCRIPTION
## Purpose of change (The Why)
In #9575 I discovered `type_id_implement` which implemented all of the string_id and int_id functions ( many of which are not defined see #3142 ).

## Describe the solution (The How)
Move everything that uses a generic factory ( excempt monsters which do generic factories weirdly ) over to type_id_implement instead of manually defining the functions.

## Describe alternatives you've considered
Leave scrungly compile bugs and redundant code in

## Testing
It compiles and loads, honestly that's really all this could impact

## Additional context
~~I love line shrinking PRs~~

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2e39139](https://github.com/cataclysmbn/Cataclysm-BN/commit/2e391397f154b07e50a5f1a3663591a61b0bf37c) (refactor: move type id implementation to existing template) on 2026-06-24 04:22:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28073206079/artifacts/7839625483)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28073206079/artifacts/7839952132)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28073206079/artifacts/7839644317)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28073206079/artifacts/7839680666)
<!-- END artifact comment -->