### PR TITLE
feat: add subway tunnels start scenario

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -1118,5 +1118,15 @@
       "bio_geiger"
     ],
     "flags": [ "CHALLENGE", "LONE_START" ]
-  }
+  },
+  {
+    "type": "scenario",
+    "id": "subway",
+    "name": "The Metro",
+    "points": -2,
+    "description": "In the chaos of the Cataclysm, you decided to make a run for the subway tunnels, hoping to find refuge away from the horrors on the surface.  Now, you find yourself in the dark tunnels of the subway system, and yet you feel like you're not alone...",
+    "allowed_locs": [ "sloc_subway" ],
+    "start_name": "Subway Tunnels",
+    "flags": [ "CITY_START", "LONE_START" ]
+  },
 ]

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -1128,5 +1128,5 @@
     "allowed_locs": [ "sloc_subway" ],
     "start_name": "Subway Tunnels",
     "flags": [ "CITY_START", "LONE_START" ]
-  },
+  }
 ]

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -659,5 +659,11 @@
     "id": "sloc_lab_concourse_area",
     "name": "Cargo area Trans-Coast Logistics",
     "terrain": [ { "om_terrain": "lab_CORE_2x1_1DN", "om_terrain_match_type": "TYPE" } ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_subway",
+    "name": "Subway Tunnels",
+    "terrain": [ "subway" ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Someone pointed out that there are no scenarios to start you in the subway tunnels. As well, escaping the dark subway tunnels could make for a decent early game challenge.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds "The Metro" scenario, which starts you alone in the subway tunnels under a city. It gives 2 points.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Lack of content
## Testing
Chose the scenario, everything worked correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [164b8c5](https://github.com/cataclysmbn/Cataclysm-BN/commit/164b8c5329e6860429307e142761d5a9409e9694) (Update scenarios.json) on 2026-06-24 08:49:27

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28083314963/artifacts/7843383940)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28083314963/artifacts/7844010776)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28083314963/artifacts/7843512639)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28083314963/artifacts/7843488756)
<!-- END artifact comment -->