### PR TITLE
fix: Fix Skills Through Kills permanently setting skill XP rate to 0 even outside of the world it's in

### DIFF
--- a/data/json/game_balance.json
+++ b/data/json/game_balance.json
@@ -264,5 +264,12 @@
     "info": "If true, always display the mana in the sidebar. Primarily useful for magic-related mods.",
     "stype": "bool",
     "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SKILL_TRAINING_SPEED",
+    "info": "A multiplier on the amount of XP you gain from skills. 0 completely disables it (a la skills through kills)",
+    "stype": "float",
+    "value": 1.0
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

fixes: #9238 

Skills through kills was disabling skill XP gain permanently even in worlds without the mod once it was loaded even just once, because nothing actually reset the value before in worlds without it.

This was highly confusing, and all-around a very bad experience for all involved.

## Describe the solution (The How)

Add the default value as a definition to game_balance.json in the vanilla data, so that it correctly gets reset for any worlds not using the mod.

## Describe alternatives you've considered

- Be lazy
- Overengineer some solution that automatically does it without needing it to be defined in game_balance.json

## Testing

The file lints, and the values are logical. This is what most other game balance external options do.

## Additional context

Prompted by having to help a user in the Discord

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0158e66](https://github.com/cataclysmbn/Cataclysm-BN/commit/0158e66e4a7020a96f34db5011f1ca12278ca9bb) (Add SKILL_TRAINING_SPEED default value) on 2026-06-24 09:28:33

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28085431389/artifacts/7844278027)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28085431389/artifacts/7844865822)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28085431389/artifacts/7844433871)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28085431389/artifacts/7844405009)
<!-- END artifact comment -->