### PR TITLE
fix(UI): keep hair style when changing scenario

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -80,6 +80,7 @@ static const std::string flag_CITY_START( "CITY_START" );
 static const std::string flag_SECRET( "SECRET" );
 
 static const std::string type_hair_style( "hair_style" );
+static const std::string type_hair_color( "hair_color" );
 
 static const flag_id json_flag_no_auto_equip( "no_auto_equip" );
 static const flag_id json_flag_auto_wield( "auto_wield" );
@@ -487,7 +488,7 @@ void Character::clear_cosmetic_traits( std::string mutation_type, trait_id new_t
 namespace
 {
 
-void set_cosmetic_trait( Character &c, std::string mutation_type, const trait_id &trait )
+auto set_cosmetic_trait( Character &c, std::string mutation_type, const trait_id &trait ) -> void
 {
     if( trait.is_valid() ) {
         c.clear_cosmetic_traits( mutation_type, trait );
@@ -495,6 +496,43 @@ void set_cosmetic_trait( Character &c, std::string mutation_type, const trait_id
         if( !c.has_trait( trait ) ) {
             c.toggle_trait( trait );
         }
+    }
+}
+
+auto selected_cosmetic_trait( const Character &c,
+                              const std::string &mutation_type ) -> std::optional<trait_id>
+{
+    const auto mutations = get_mutations_in_type( mutation_type );
+    const auto has_trait = std::bind_front( &Character::has_trait, &c );
+    const auto selected = std::ranges::find_if( mutations, has_trait );
+    return selected != mutations.end() ? std::optional<trait_id>( *selected ) : std::nullopt;
+}
+
+auto restore_cosmetic_trait( Character &c, const std::string &mutation_type,
+                             const std::optional<trait_id> &trait ) -> void
+{
+    if( trait && g->scen->traitquery( *trait ) ) {
+        set_cosmetic_trait( c, mutation_type, *trait );
+    }
+}
+
+auto default_hair_style_for( const avatar &u ) -> trait_id
+{
+    static const auto male_default_hair_style = trait_id( "hair_medium" );
+    static const auto female_default_hair_style = trait_id( "hair_long" );
+    return u.male ? male_default_hair_style : female_default_hair_style;
+}
+
+auto set_default_hair_style( avatar &u ) -> void
+{
+    set_cosmetic_trait( u, type_hair_style, default_hair_style_for( u ) );
+}
+
+auto restore_or_default_hair_style( avatar &u, const std::optional<trait_id> &hair_style ) -> void
+{
+    restore_cosmetic_trait( u, type_hair_style, hair_style );
+    if( !selected_cosmetic_trait( u, type_hair_style ) ) {
+        set_default_hair_style( u );
     }
 }
 
@@ -528,16 +566,12 @@ bool avatar::create( character_type type, const std::string &tempname )
     int tab = 0;
     points_left points = points_left();
 
-    static auto male_default_hair_style = trait_id( "hair_medium" );
-    static auto female_default_hair_style = trait_id( "hair_long" );
-
     switch( type ) {
         case character_type::CUSTOM:
             // We can randomize cosmetics for a custom character, it's fine. Not sure I like the idea of a "default" appearance
             randomize_cosmetics();
             // don't make them bald!
-            set_cosmetic_trait( *this, type_hair_style,
-                                male ? male_default_hair_style : female_default_hair_style );
+            set_default_hair_style( *this );
             break;
         case character_type::RANDOM:
             //random scenario, default name if exist
@@ -4242,6 +4276,9 @@ void reset_scenario( avatar &u, const scenario *scen )
     const profession_id &default_prof = *std::min_element( permitted.begin(), permitted.end(),
                                         psorter );
 
+    const auto previous_hair_style = selected_cosmetic_trait( u, type_hair_style );
+    const auto previous_hair_color = selected_cosmetic_trait( u, type_hair_color );
+
     u.random_start_location = true;
     u.str_max = 8;
     u.dex_max = 8;
@@ -4260,6 +4297,8 @@ void reset_scenario( avatar &u, const scenario *scen )
     u.clear_skills();
     u.clear_bionics();
     newcharacter::add_traits( u );
+    restore_cosmetic_trait( u, type_hair_color, previous_hair_color );
+    restore_or_default_hair_style( u, previous_hair_style );
 }
 
 points_left::points_left()

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -29,6 +29,8 @@
 #include "string_id.h"
 #include "type_id.h"
 
+auto reset_scenario( avatar &u, const scenario *scen ) -> void;
+
 static std::ostream &operator<<( std::ostream &s, const std::vector<trait_id> &v )
 {
     for( const auto &e : v ) {
@@ -164,6 +166,38 @@ TEST_CASE( "default_character_respects_scenario_whitelist", "[new_character][sce
     ch.randomize( false, points, true );
 
     CHECK( g->scen->ident() == whitelisted_scenario );
+}
+
+TEST_CASE( "scenario_reset_preserves_or_defaults_hair_style", "[new_character][scenario][traits]" )
+{
+    clear_all_state();
+
+    const auto *target_scenario = &string_id<scenario>( "wilderness" ).obj();
+    const auto default_hair_style = trait_id( "hair_medium" );
+    const auto bald_hair_style = trait_id( "HAIR_BALD" );
+
+    auto ch = get_sanitized_player();
+    ch.male = true;
+    ch.prof = profession::generic();
+    g->scen = scenario::generic();
+
+    SECTION( "uses the default hair style when no hair style is selected" ) {
+        reset_scenario( ch, target_scenario );
+
+        CHECK( ch.has_trait( default_hair_style ) );
+        CHECK( !ch.has_trait( bald_hair_style ) );
+    }
+
+    SECTION( "preserves explicitly selected bald hair style" ) {
+        ch.set_mutation( bald_hair_style );
+
+        reset_scenario( ch, target_scenario );
+
+        CHECK( ch.has_trait( bald_hair_style ) );
+        CHECK( !ch.has_trait( default_hair_style ) );
+    }
+
+    g->scen = scenario::generic();
 }
 
 TEST_CASE( "starting_items", "[slow]" )


### PR DESCRIPTION
## Purpose of change (The Why)

choosing scenarios other than Evacuee always made you bald which is weird

## Describe the solution (The How)

restore hair style/color on scenario changes

## Describe alternatives you've considered

## Testing

<img width="2690" height="1570" alt="image" src="https://github.com/user-attachments/assets/91edda41-ab1b-4884-bd1b-9eecbf31d5e3" />

1. choose a scenario
2. confirm that you are not bald
3. change hairstyle and go back and choose another scenario
4. confirm that your hairstyle is preserved (including explicitly selected 'bald')

## Checklist


### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional


- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b80ccf1](https://github.com/cataclysmbn/Cataclysm-BN/commit/b80ccf105c5138ca4a7b4aa369078636315d2729) (fix: keep hair style when changing scenario) on 2026-06-24 11:51:12

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28093051140/artifacts/7847473416)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28093051140/artifacts/7848027458)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28093051140/artifacts/7847466165)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28093051140/artifacts/7847570433)
<!-- END artifact comment -->