### PR TITLE
perf: prevent active bionic scanners from slowing long activities

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -40,14 +40,13 @@ void active_item_cache::remove( const item *it )
             reset_queue_state( queue );
         }
     }
-    if( it->can_revive() ) {
-        std::vector<cache_reference<item>> &corpse = special_items[ special_item_type::corpse ];
-        corpse.erase( std::remove( corpse.begin(), corpse.end(), it ), corpse.end() );
-    }
-    if( it->get_use( "explosion" ) ) {
-        std::vector<cache_reference<item>> &explosive = special_items[ special_item_type::explosive ];
-        explosive.erase( std::remove( explosive.begin(), explosive.end(), it ), explosive.end() );
-    }
+    const auto remove_special = [this, it]( const special_item_type type ) {
+        std::vector<cache_reference<item>> &items = special_items[type];
+        items.erase( std::remove( items.begin(), items.end(), it ), items.end() );
+    };
+    remove_special( special_item_type::corpse );
+    remove_special( special_item_type::bionic_scannable_corpse );
+    remove_special( special_item_type::explosive );
 }
 
 void active_item_cache::add( item &it )
@@ -71,6 +70,9 @@ void active_item_cache::add( item &it )
     }
     if( it.can_revive() ) {
         special_items[ special_item_type::corpse ].emplace_back( it );
+    }
+    if( it.is_corpse() ) {
+        special_items[ special_item_type::bionic_scannable_corpse ].emplace_back( it );
     }
     if( it.get_use( "explosion" ) ) {
         special_items[ special_item_type::explosive ].emplace_back( it );

--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -16,16 +16,16 @@ static auto reset_queue_state( active_item_queue &queue ) -> void
 
 void active_item_cache::remove( const item *it )
 {
-    for( auto &list : active_items ) {
-        active_item_queue &queue = list.second;
-        int count = 0;
-        queue.items.erase( std::remove_if( queue.items.begin(),
-        queue.items.end(), [it, &count, &queue]( const cache_reference<item> &active_item ) {
+    for( auto &[processing_speed, queue] : active_items ) {
+        static_cast<void>( processing_speed );
+        auto count = 0;
+        std::erase_if( queue.items,
+        [it, &count, &queue]( const auto & active_item ) {
             if( !active_item ) {
                 count++;
                 return true;
             }
-            item *const target = &*active_item;
+            const auto target = &*active_item;
             if( !target || target == it ) {
                 if( count >= queue.cursor ) {
                     queue.cursor = std::max( 0, queue.cursor - 1 );
@@ -35,14 +35,14 @@ void active_item_cache::remove( const item *it )
             }
             count++;
             return false;
-        } ), queue.items.end() );
+        } );
         if( queue.items.empty() ) {
             reset_queue_state( queue );
         }
     }
     const auto remove_special = [this, it]( const special_item_type type ) {
-        std::vector<cache_reference<item>> &items = special_items[type];
-        items.erase( std::remove( items.begin(), items.end(), it ), items.end() );
+        auto &items = special_items[type];
+        std::erase_if( items, [it]( const auto & ref ) { return ref == it; } );
     };
     remove_special( special_item_type::corpse );
     remove_special( special_item_type::bionic_scannable_corpse );
@@ -52,9 +52,9 @@ void active_item_cache::remove( const item *it )
 void active_item_cache::add( item &it )
 {
     // If the item is already in the cache for some reason, don't add a second reference
-    active_item_queue &queue = active_items[it.processing_speed()];
-    std::vector<cache_reference<item>> &target_list = queue.items;
-    const auto references_item = [&it]( const cache_reference<item> &active_item ) { return active_item == it; };
+    auto &queue = active_items[it.processing_speed()];
+    auto &target_list = queue.items;
+    const auto references_item = [&it]( const auto & active_item ) { return active_item == it; };
     if( std::ranges::any_of( target_list, references_item ) ) {
         return;
     }

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -14,6 +14,7 @@ class item;
 enum class special_item_type : int {
     none,
     corpse,
+    bionic_scannable_corpse,
     explosive
 };
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -10,6 +10,7 @@
 #include <list>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <type_traits>
 
 #include "action.h"
@@ -2001,9 +2002,9 @@ void Character::process_bionic( bionic &bio )
         add_morale( MORALE_FEELING_GOOD, 20, 20, 30_minutes, 20_minutes, true );
     } else if( bio.id == bio_electrosense_bscanner ) {
         // This is a horrible mess but can't use the active iuse behavior directly
-        map &here = get_map();
-        bool visibility_cache_updated = false;
-        for( item *const corpse : here.get_active_items_in_radius( bub_pos(), PICKUP_RANGE,
+        auto &here = get_map();
+        auto visibility_cache_updated = false;
+        for( const auto corpse : here.get_active_items_in_radius( bub_pos(), PICKUP_RANGE,
                 special_item_type::bionic_scannable_corpse ) ) {
             if( corpse == nullptr || !corpse->is_corpse() ||
                 corpse->get_var( "bionics_scanned_by", -1 ) == getID().get_value() ) {
@@ -2018,14 +2019,13 @@ void Character::process_bionic( bionic &bio )
                 continue;
             }
 
-            std::vector<const item *> cbms;
-            for( const item * const &maybe_cbm : corpse->get_components() ) {
-                if( maybe_cbm->is_bionic() ) {
-                    cbms.push_back( maybe_cbm );
-                }
-            }
+            using namespace std::views;
+            namespace ranges = std::ranges;
+            auto cbms = corpse->get_components()
+                        | filter( &item::is_bionic )
+                        | ranges::to<std::vector>();
 
-            units::energy enrg = cbms.size() * bio.info().power_trigger;
+            auto enrg = static_cast<int>( cbms.size() ) * bio.info().power_trigger;
             if( get_power_level() >= enrg ) {
                 mod_power_level( -enrg );
             } else {
@@ -2042,11 +2042,8 @@ void Character::process_bionic( bionic &bio )
             corpse->set_var( "bionics_scanned_by", getID().get_value() );
             if( !cbms.empty() ) {
                 corpse->set_flag( flag_CBM_SCANNED );
-                std::string bionics_string =
-                    enumerate_as_string( cbms.begin(), cbms.end(),
-                []( const item * entry ) -> std::string {
-                    return entry->display_name();
-                }, enumeration_conjunction::none );
+                auto bionics_string = enumerate_as_string( cbms.begin(), cbms.end(),
+                []( const auto entry ) { return entry->display_name(); }, enumeration_conjunction::none );
                 //~ %1 is corpse name, %2 is direction, %3 is bionic name
                 add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s." ),
                                    corpse->display_name().c_str(),

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2002,52 +2002,57 @@ void Character::process_bionic( bionic &bio )
     } else if( bio.id == bio_electrosense_bscanner ) {
         // This is a horrible mess but can't use the active iuse behavior directly
         map &here = get_map();
-        for( const auto &pt : here.points_in_radius( bub_pos(), PICKUP_RANGE ) ) {
-            if( !here.has_items( pt ) || !sees( pt ) ) {
+        bool visibility_cache_updated = false;
+        for( item *const corpse : here.get_active_items_in_radius( bub_pos(), PICKUP_RANGE,
+                special_item_type::bionic_scannable_corpse ) ) {
+            if( corpse == nullptr || !corpse->is_corpse() ||
+                corpse->get_var( "bionics_scanned_by", -1 ) == getID().get_value() ) {
                 continue;
             }
-            for( item * const &corpse : here.i_at( pt ) ) {
-                if( !corpse->is_corpse() ||
-                    corpse->get_var( "bionics_scanned_by", -1 ) == getID().get_value() ) {
+            const auto pt = corpse->bub_pos();
+            if( !visibility_cache_updated && here.visibility_caches_dirty() ) {
+                here.update_visibility_cache( bub_pos().z() );
+                visibility_cache_updated = true;
+            }
+            if( !sees( pt ) ) {
+                continue;
+            }
+
+            std::vector<const item *> cbms;
+            for( const item * const &maybe_cbm : corpse->get_components() ) {
+                if( maybe_cbm->is_bionic() ) {
+                    cbms.push_back( maybe_cbm );
+                }
+            }
+
+            units::energy enrg = cbms.size() * bio.info().power_trigger;
+            if( get_power_level() >= enrg ) {
+                mod_power_level( -enrg );
+            } else {
+                add_msg_if_player( m_bad,
+                                   _( "Your %s doesn't have enough power for the %s" ),
+                                   bio.info().name, corpse->display_name().c_str() );
+                if( get_power_level() < bio.info().power_trigger ) {
+                    break;
+                } else {
                     continue;
                 }
+            }
 
-                std::vector<const item *> cbms;
-                for( const item * const &maybe_cbm : corpse->get_components() ) {
-                    if( maybe_cbm->is_bionic() ) {
-                        cbms.push_back( maybe_cbm );
-                    }
-                }
-
-                units::energy enrg = cbms.size() * bio.info().power_trigger;
-                if( get_power_level() >= enrg ) {
-                    mod_power_level( -enrg );
-                } else {
-                    add_msg_if_player( m_bad,
-                                       _( "Your %s doesn't have enough power for the %s" ),
-                                       bio.info().name, corpse->display_name().c_str() );
-                    if( get_power_level() < bio.info().power_trigger ) {
-                        break;
-                    } else {
-                        continue;
-                    }
-                }
-
-                corpse->set_var( "bionics_scanned_by", getID().get_value() );
-                if( !cbms.empty() ) {
-                    corpse->set_flag( flag_CBM_SCANNED );
-                    std::string bionics_string =
-                        enumerate_as_string( cbms.begin(), cbms.end(),
-                    []( const item * entry ) -> std::string {
-                        return entry->display_name();
-                    }, enumeration_conjunction::none );
-                    //~ %1 is corpse name, %2 is direction, %3 is bionic name
-                    add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s." ),
-                                       corpse->display_name().c_str(),
-                                       direction_name( direction_from( bub_pos(), pt ) ).c_str(),
-                                       bionics_string.c_str()
-                                     );
-                }
+            corpse->set_var( "bionics_scanned_by", getID().get_value() );
+            if( !cbms.empty() ) {
+                corpse->set_flag( flag_CBM_SCANNED );
+                std::string bionics_string =
+                    enumerate_as_string( cbms.begin(), cbms.end(),
+                []( const item * entry ) -> std::string {
+                    return entry->display_name();
+                }, enumeration_conjunction::none );
+                //~ %1 is corpse name, %2 is direction, %3 is bionic name
+                add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s." ),
+                                   corpse->display_name().c_str(),
+                                   direction_name( direction_from( bub_pos(), pt ) ).c_str(),
+                                   bionics_string.c_str()
+                                 );
             }
             if( get_power_level() < bio.info().power_trigger ) {
                 add_msg_if_player( m_bad, _( "Your %s doesn't have enough power and shuts down." ),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2244,9 +2244,9 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint_bub_ms &pos 
     }
 
     // Try to minimize the use of has_enough_charges() because it's kind of expensive.
-    bool no_charges = false;
-    bool visibility_cache_updated = false;
-    for( item *const corpse : here.get_active_items_in_radius( pos, PICKUP_RANGE,
+    auto no_charges = false;
+    auto visibility_cache_updated = false;
+    for( const auto corpse : here.get_active_items_in_radius( pos, PICKUP_RANGE,
             special_item_type::bionic_scannable_corpse ) ) {
         if( corpse == nullptr || !corpse->is_corpse() ||
             corpse->get_var( "bionics_scanned_by", -1 ) == p->getID().get_value() ) {
@@ -2261,14 +2261,13 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint_bub_ms &pos 
             continue;
         }
 
-        std::vector<const item *> cbms;
-        for( const item * const &maybe_cbm : corpse->get_components() ) {
-            if( maybe_cbm->is_bionic() ) {
-                cbms.push_back( maybe_cbm );
-            }
-        }
+        using namespace std::views;
+        namespace ranges = std::ranges;
+        auto cbms = corpse->get_components()
+                    | filter( &item::is_bionic )
+                    | ranges::to<std::vector>();
 
-        int charges = std::max( 1, static_cast<int>( cbms.size() ) );
+        auto charges = std::max( 1, static_cast<int>( cbms.size() ) );
         charges -= it->ammo_consume( charges, pos );
         if( possess && it->has_flag( flag_USE_UPS ) ) {
             if( p->use_charges_if_avail( itype_UPS, charges ) ) {
@@ -2289,11 +2288,8 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint_bub_ms &pos 
         corpse->set_var( "bionics_scanned_by", p->getID().get_value() );
         if( !cbms.empty() ) {
             corpse->set_flag( flag_CBM_SCANNED );
-            std::string bionics_string =
-                enumerate_as_string( cbms.begin(), cbms.end(),
-            []( const item * entry ) -> std::string {
-                return entry->display_name();
-            }, enumeration_conjunction::none );
+            auto bionics_string = enumerate_as_string( cbms.begin(), cbms.end(),
+            []( const auto entry ) { return entry->display_name(); }, enumeration_conjunction::none );
             //~ %1 is corpse name, %2 is direction, %3 is bionic name
             p->add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s." ),
                                   corpse->display_name().c_str(),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2243,68 +2243,69 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint_bub_ms &pos 
         return 0;
     }
 
-    if( here.visibility_caches_dirty() ) {
-        here.update_visibility_cache( p->bub_pos().z() );
-    }
-
     // Try to minimize the use of has_enough_charges() because it's kind of expensive.
     bool no_charges = false;
-    for( const tripoint_bub_ms &pt : here.points_in_radius( pos, PICKUP_RANGE ) ) {
-        if( !here.has_items( pt ) || !p->sees( pt ) ) {
+    bool visibility_cache_updated = false;
+    for( item *const corpse : here.get_active_items_in_radius( pos, PICKUP_RANGE,
+            special_item_type::bionic_scannable_corpse ) ) {
+        if( corpse == nullptr || !corpse->is_corpse() ||
+            corpse->get_var( "bionics_scanned_by", -1 ) == p->getID().get_value() ) {
             continue;
         }
-        for( item * const &corpse : here.i_at( pt ) ) {
-            if( !corpse->is_corpse() ||
-                corpse->get_var( "bionics_scanned_by", -1 ) == p->getID().get_value() ) {
+        const auto pt = corpse->bub_pos();
+        if( !visibility_cache_updated && here.visibility_caches_dirty() ) {
+            here.update_visibility_cache( p->bub_pos().z() );
+            visibility_cache_updated = true;
+        }
+        if( !p->sees( pt ) ) {
+            continue;
+        }
+
+        std::vector<const item *> cbms;
+        for( const item * const &maybe_cbm : corpse->get_components() ) {
+            if( maybe_cbm->is_bionic() ) {
+                cbms.push_back( maybe_cbm );
+            }
+        }
+
+        int charges = std::max( 1, static_cast<int>( cbms.size() ) );
+        charges -= it->ammo_consume( charges, pos );
+        if( possess && it->has_flag( flag_USE_UPS ) ) {
+            if( p->use_charges_if_avail( itype_UPS, charges ) ) {
+                charges = 0;
+            }
+        }
+        if( charges ) {
+            p->add_msg_if_player( m_bad, "Your %s doesn't have enough power for the %s", it->tname(),
+                                  corpse->display_name().c_str() );
+            if( !p->has_enough_charges( *it, false ) ) {
+                no_charges = true;
+                break;
+            } else {
                 continue;
             }
-
-            std::vector<const item *> cbms;
-            for( const item * const &maybe_cbm : corpse->get_components() ) {
-                if( maybe_cbm->is_bionic() ) {
-                    cbms.push_back( maybe_cbm );
-                }
-            }
-
-            int charges = std::max( 1, static_cast<int>( cbms.size() ) );
-            charges -= it->ammo_consume( charges, pos );
-            if( possess && it->has_flag( flag_USE_UPS ) ) {
-                if( p->use_charges_if_avail( itype_UPS, charges ) ) {
-                    charges = 0;
-                }
-            }
-            if( charges ) {
-                p->add_msg_if_player( m_bad, "Your %s doesn't have enough power for the %s", it->tname(),
-                                      corpse->display_name().c_str() );
-                if( !p->has_enough_charges( *it, false ) ) {
-                    no_charges = true;
-                    break;
-                } else {
-                    continue;
-                }
-            }
-
-            corpse->set_var( "bionics_scanned_by", p->getID().get_value() );
-            if( !cbms.empty() ) {
-                corpse->set_flag( flag_CBM_SCANNED );
-                std::string bionics_string =
-                    enumerate_as_string( cbms.begin(), cbms.end(),
-                []( const item * entry ) -> std::string {
-                    return entry->display_name();
-                }, enumeration_conjunction::none );
-                //~ %1 is corpse name, %2 is direction, %3 is bionic name
-                p->add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s." ),
-                                      corpse->display_name().c_str(),
-                                      direction_name( direction_from( p->bub_pos(), pt ) ).c_str(),
-                                      bionics_string.c_str()
-                                    );
-            }
         }
-        if( no_charges ) {
-            it->revert( p );
-            it->deactivate();
-            return 0;
+
+        corpse->set_var( "bionics_scanned_by", p->getID().get_value() );
+        if( !cbms.empty() ) {
+            corpse->set_flag( flag_CBM_SCANNED );
+            std::string bionics_string =
+                enumerate_as_string( cbms.begin(), cbms.end(),
+            []( const item * entry ) -> std::string {
+                return entry->display_name();
+            }, enumeration_conjunction::none );
+            //~ %1 is corpse name, %2 is direction, %3 is bionic name
+            p->add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s." ),
+                                  corpse->display_name().c_str(),
+                                  direction_name( direction_from( p->bub_pos(), pt ) ).c_str(),
+                                  bionics_string.c_str()
+                                );
         }
+    }
+    if( no_charges ) {
+        it->revert( p );
+        it->deactivate();
+        return 0;
     }
 
     return 0;

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -11,6 +11,7 @@
 #include "item.h"
 #include "map.h"
 #include "state_helpers.h"
+#include "type_id.h"
 
 TEST_CASE( "active_item_cache_ignores_expired_references", "[item]" )
 {
@@ -23,6 +24,22 @@ TEST_CASE( "active_item_cache_ignores_expired_references", "[item]" )
         REQUIRE_FALSE( cache.empty() );
     }
     CHECK( cache.empty() );
+}
+
+TEST_CASE( "active_item_cache_tracks_bionic_scannable_corpses", "[item]" )
+{
+    auto cache = active_item_cache();
+    auto corpse = item::make_corpse( mtype_id( "mon_zombie_soldier" ), calendar::turn, "" );
+    REQUIRE( corpse->is_corpse() );
+    REQUIRE( corpse->needs_processing() );
+
+    cache.add( *corpse );
+    auto scannable_corpses = cache.get_special( special_item_type::bionic_scannable_corpse );
+    REQUIRE( scannable_corpses.size() == 1 );
+    CHECK( scannable_corpses.front() == corpse.get() );
+
+    cache.remove( corpse.get() );
+    CHECK( cache.get_special( special_item_type::bionic_scannable_corpse ).empty() );
 }
 
 TEST_CASE( "nonperishable_food_does_not_enter_active_item_cache", "[item]" )

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -1,6 +1,7 @@
 #include "catch/catch.hpp"
 
 #include <array>
+#include <cstddef>
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -8,6 +9,7 @@
 
 #include "avatar.h"
 #include "bodypart.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character_id.h"
@@ -30,6 +32,91 @@ auto restore_bionic_scanner_avatar_id( avatar &you ) -> on_out_of_scope
     const auto previous_id = you.getID();
     you.setID( character_id( 1 ), true );
     return on_out_of_scope( [&you, previous_id]() { you.setID( previous_id, true ); } );
+}
+
+struct active_bionic_scanner_benchmark_options {
+    std::size_t item_tile_count = 17;
+    std::size_t items_per_tile = 96;
+    int scanner_charges = 100;
+};
+
+struct active_bionic_scanner_benchmark_fixture {
+    avatar *you = nullptr;
+    item *scanner = nullptr;
+    item *corpse = nullptr;
+    std::size_t nearby_item_count = 0;
+};
+
+auto add_nearby_bionic_scanner_benchmark_items( map &here, const tripoint_bub_ms &center,
+        const active_bionic_scanner_benchmark_options &opts ) -> std::size_t
+{
+    auto item_tiles = std::vector<tripoint_bub_ms> {};
+    for( const tripoint_bub_ms &pt : here.points_in_radius( center, PICKUP_RANGE ) ) {
+        if( pt == center ) {
+            continue;
+        }
+        item_tiles.push_back( pt );
+        if( item_tiles.size() == opts.item_tile_count ) {
+            break;
+        }
+    }
+    REQUIRE( item_tiles.size() == opts.item_tile_count );
+
+    auto item_count = std::size_t{ 0 };
+    for( const tripoint_bub_ms &item_pos : item_tiles ) {
+        for( auto item_index = std::size_t{ 0 }; item_index < opts.items_per_tile; ++item_index ) {
+            auto rock = item::spawn( "rock", calendar::turn );
+            rock->set_var( "benchmark_item_index", static_cast<int>( item_count ) );
+            here.add_item( item_pos, std::move( rock ) );
+            ++item_count;
+        }
+    }
+    return item_count;
+}
+
+auto add_bionic_scanner_benchmark_corpse( map &here,
+        const tripoint_bub_ms &corpse_pos ) -> item * // *NOPAD*
+{
+    auto corpse = item::make_corpse( mtype_id( "mon_zombie_soldier" ), calendar::turn, "" );
+    corpse->add_component( item::spawn( "bio_power_storage", calendar::turn ) );
+    auto *const corpse_ptr = corpse.get();
+    here.add_item( corpse_pos, std::move( corpse ) );
+    return corpse_ptr;
+}
+
+auto make_active_bionic_scanner_benchmark_fixture( avatar &you,
+        const active_bionic_scanner_benchmark_options &opts ) -> active_bionic_scanner_benchmark_fixture
+{
+    auto &here = get_map();
+    g->place_player( tripoint_bub_ms( 60, 60, 0 ) );
+    set_time( calendar::turn_zero + 12_hours );
+    you.recalc_sight_limits();
+
+    const auto item_count = add_nearby_bionic_scanner_benchmark_items( here, you.bub_pos(), opts );
+    const auto corpse_pos = you.bub_pos() + tripoint_east;
+    auto *const corpse_ptr = add_bionic_scanner_benchmark_corpse( here, corpse_pos );
+    REQUIRE( you.sees( corpse_pos ) );
+
+    auto backpack = item::spawn( "backpack", calendar::turn );
+    auto scanner = item::spawn( "bionic_scanner_on", calendar::turn );
+    scanner->ammo_set( itype_id( "battery" ), opts.scanner_charges );
+    scanner->activate();
+    auto *const scanner_ptr = scanner.get();
+    backpack->put_in( std::move( scanner ) );
+    REQUIRE( backpack->needs_processing() );
+    REQUIRE_FALSE( you.wear_item( std::move( backpack ), false ) );
+    REQUIRE( scanner_ptr->is_active() );
+    REQUIRE( scanner_ptr->needs_processing() );
+
+    here.build_map_cache( you.bub_pos().z() );
+    here.update_visibility_cache( you.bub_pos().z() );
+
+    return active_bionic_scanner_benchmark_fixture{
+        .you = &you,
+        .scanner = scanner_ptr,
+        .corpse = corpse_ptr,
+        .nearby_item_count = item_count,
+    };
 }
 
 } // namespace
@@ -459,6 +546,37 @@ TEST_CASE( "scanned corpse bionic stack comparison benchmark",
 
     BENCHMARK( "display_stacked_with duplicate scanned bionics" ) {
         return left_corpse->display_stacked_with( *right_corpse );
+    };
+}
+
+TEST_CASE( "active bionic scanner process_items benchmark near map items",
+           "[.][benchmark][item][bionic_scanner]" )
+{
+    const auto restore_turn = restore_on_out_of_scope<time_point>( calendar::turn );
+    clear_map();
+    clear_avatar();
+
+    auto &you = get_avatar();
+    const auto restore_avatar_id = restore_bionic_scanner_avatar_id( you );
+    static constexpr auto item_tile_count = std::size_t{ 17 };
+    static constexpr auto items_per_tile = std::size_t{ 96 };
+    const auto fixture = make_active_bionic_scanner_benchmark_fixture( you, {
+        .item_tile_count = item_tile_count,
+        .items_per_tile = items_per_tile,
+    } );
+    REQUIRE( fixture.nearby_item_count == item_tile_count * items_per_tile );
+
+    fixture.you->process_items();
+    REQUIRE( fixture.corpse->get_var( "bionics_scanned_by", -1 ) == you.getID().get_value() );
+    REQUIRE( fixture.corpse->has_flag( flag_CBM_SCANNED ) );
+    REQUIRE( fixture.scanner->is_active() );
+
+    BENCHMARK_ADVANCED( "process_items with worn active scanner near 1632 map items" )
+    ( Catch::Benchmark::Chronometer meter ) {
+        meter.measure( [&fixture]() {
+            fixture.you->process_items();
+            return fixture.scanner->ammo_remaining();
+        } );
     };
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

close #9586

#9567 made active bionic scanners scan nearby item piles every tick, slowing long activities when many map items were nearby.

## Describe the solution (The How)

- Add a special active-item cache bucket for bionic-scannable corpses.
- Make item and electrosense bionic scanners iterate cached corpse candidates instead of every nearby item stack.
- Skip visibility cache refresh unless an unscanned corpse candidate exists.
- Add a focused Catch2 benchmark and cache coverage.

## Testing

| Case | Before | After | Change |
|---|---:|---:|---:|
| Castlewood read-to-level, scanner on | 76.151s | 22.179s | 70.9% less time, 3.4x faster |
| Catch2 active scanner benchmark, tiles | 38.434us | 2.136us | 94.4% less time, 18.0x faster |
| Castlewood read-to-level, scanner off control | ~20s (#9586 report) | 20.170s | scanner-on after is near scanner-off |

- Built `cataclysm-bn-tiles` and `cata_test-tiles` locally.
- `cata_test-tiles "[iuse][bionic_scanner]"` passed.
- `cata_test-tiles "active_item_cache_tracks_bionic_scannable_corpses"` passed.
- `cata_test-tiles "active bionic scanner process_items benchmark near map items"` passed.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<sub>PR opened by gpt-5.5 xhigh on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [13e2e66](https://github.com/cataclysmbn/Cataclysm-BN/commit/13e2e66f7f61cb258710cce940f8a89704ee0f1e) (refactor: use ranges removal for active item cache) on 2026-06-24 17:03:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28111037854/artifacts/7856061071)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28111037854/artifacts/7856696686)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28111037854/artifacts/7855921705)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28111037854/artifacts/7855838420)
<!-- END artifact comment -->