### PR TITLE
fix: climate control no longer adjusts to the wrong value with mutated temps

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10738,22 +10738,20 @@ int Character::bodytemp_modifier_traits_floor() const
 
 int Character::temp_corrected_by_climate_control( int temperature )
 {
-    int mutated_norm = BODYTEMP_NORM + ( ( bodytemp_modifier_traits( false ) - bodytemp_modifier_traits(
-            true ) ) / 2 );
-    if( temperature > mutated_norm ) {
+    if( temperature > BODYTEMP_NORM ) {
         temperature -= bonus_from_enchantments( temperature,
                                                 enchantment_value_id( "CLIMATE_CONTROL_COOLING" ) );
         if( in_climate_control() ) {
             temperature -= 750;
         }
-        return std::max( mutated_norm, temperature );
+        return std::max( BODYTEMP_NORM, temperature );
     } else {
         if( in_climate_control() ) {
             temperature += 750;
         }
         temperature += bonus_from_enchantments( temperature,
                                                 enchantment_value_id( "CLIMATE_CONTROL_HEATING" ) );
-        return std::min( mutated_norm, temperature );
+        return std::min( BODYTEMP_NORM, temperature );
     }
     return temperature;
 }


### PR DESCRIPTION
## Purpose of change (The Why)
In #9547 I misunderstood mutation temp mods, improperly assumed that it adjusted what was good temp bounds and instead it adjusted parts of the calculation for getting to ideal temp, meaning that for climate control it is unneeded

## Describe the solution (The How)
Change from using mutated_norm to BODYTEMP_NORM

## Describe alternatives you've considered
Redo temperature code so that the habitable range changes based off those mutations

## Testing
Mutated one of those traits
Climate control moves to 0 again...

## Additional context
~~I love temp code~~

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a0be699](https://github.com/cataclysmbn/Cataclysm-BN/commit/a0be699e5bd6c621822663dd81dbf7a2a1e9e097) (fix: climate control no longer overcompensates) on 2026-06-24 15:45:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28108221287/artifacts/7853902143)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28108221287/artifacts/7854686968)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28108221287/artifacts/7854036607)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28108221287/artifacts/7854059710)
<!-- END artifact comment -->