### PR TITLE
feat(balance): RM360 spawn rate buff

### DIFF
--- a/data/mods/exotic_ammo/itemgroups/guns.json
+++ b/data/mods/exotic_ammo/itemgroups/guns.json
@@ -43,7 +43,7 @@
     "items": [
       { "group": "everyday_skorpion_82", "prob": 100 },
       { "group": "everyday_ppsh", "prob": 150 },
-      { "group": "everyday_rm360", "prob": 150 }
+      { "group": "everyday_rm360", "prob": 50 }
     ]
   },
   {

--- a/data/mods/exotic_ammo/itemgroups/guns.json
+++ b/data/mods/exotic_ammo/itemgroups/guns.json
@@ -40,8 +40,8 @@
     "type": "item_group",
     "id": "carried_guns_smg_obscure",
     "//": "Imported or otherwise very obscure SMGs. Just mags, no loose ammo.",
-    "items": [ 
-      { "group": "everyday_skorpion_82", "prob": 100 }, 
+    "items": [
+      { "group": "everyday_skorpion_82", "prob": 100 },
       { "group": "everyday_ppsh", "prob": 150 },
       { "group": "everyday_rm360", "prob": 150 }
     ]

--- a/data/mods/exotic_ammo/itemgroups/guns.json
+++ b/data/mods/exotic_ammo/itemgroups/guns.json
@@ -40,7 +40,11 @@
     "type": "item_group",
     "id": "carried_guns_smg_obscure",
     "//": "Imported or otherwise very obscure SMGs. Just mags, no loose ammo.",
-    "items": [ { "group": "everyday_skorpion_82", "prob": 100 }, { "group": "everyday_ppsh", "prob": 150 } ]
+    "items": [ 
+      { "group": "everyday_skorpion_82", "prob": 100 }, 
+      { "group": "everyday_ppsh", "prob": 150 },
+      { "group": "everyday_rm360", "prob": 150 }
+    ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
Simply add RM360 to carried_guns_smg_obscure- 
Combined with #9648 it should make the gun reliably (but rarely) spawn in gunshops and on survivor zombies

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5566a15](https://github.com/cataclysmbn/Cataclysm-BN/commit/5566a15f5e88065b248f1cfccd7ac6fbededead9) (Update data/mods/exotic_ammo/itemgroups/guns.json) on 2026-06-25 10:16:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28158668821/artifacts/7873533244)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28158668821/artifacts/7875148036)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28158668821/artifacts/7873595499)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28158668821/artifacts/7873703355)
<!-- END artifact comment -->