### PR TITLE
fix: recomment the mapgen stairs code

### DIFF
--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -4209,6 +4209,8 @@ auto mapbuffer::run_omt_pillar_post_pass( const point_abs_omt &omt_pos ) -> void
             auto changed = false;
             for( const auto local : submap_tiles() ) {
                 const auto terrain_here = sub_here->get_ter( local );
+                /* DO NOT UNCOMMENT THIS UNTIL IT IS MADE TOGGLEABLE ON A OMT BY OMT
+                   BADLY EFFECTED MAPGENS INCLUDE: REF CENTER, LMOE SHELTER, and multiple modded OMTs
                 if( const auto target = vertical_transition_target_below( terrain_here );
                     target && zlev > -OVERMAP_DEPTH ) {
                     ensure_vertical_transition_link( {
@@ -4225,7 +4227,7 @@ auto mapbuffer::run_omt_pillar_post_pass( const point_abs_omt &omt_pos ) -> void
                         .desired = *target,
                     } );
                 }
-
+                */
                 if( terrain_here != t_open_air ) {
                     continue;
                 }

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -4209,7 +4209,7 @@ auto mapbuffer::run_omt_pillar_post_pass( const point_abs_omt &omt_pos ) -> void
             auto changed = false;
             for( const auto local : submap_tiles() ) {
                 const auto terrain_here = sub_here->get_ter( local );
-                /* DO NOT UNCOMMENT THIS UNTIL IT IS MADE TOGGLEABLE ON A OMT BY OMT
+                /* DO NOT UNCOMMENT THIS UNTIL IT IS MADE TOGGLEABLE BY OMT OR TILE
                    BADLY EFFECTED MAPGENS INCLUDE: REF CENTER, LMOE SHELTER, and multiple modded OMTs
                 if( const auto target = vertical_transition_target_below( terrain_here );
                     target && zlev > -OVERMAP_DEPTH ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Caused by: #9567
Related: #9566 was the one to add and comment it
Closes: #9602
Closes: #9629 ( the other half of the issues is documented in #9649 )

## Describe the solution (The How)
Comment it
In very nice capital letters explain why it was commented

## Describe alternatives you've considered
Delete the code instead of commenting it

## Testing
Ref center no longer has funny stairs

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3d99dcb](https://github.com/cataclysmbn/Cataclysm-BN/commit/3d99dcbd259482f673d3854b260bf5dd4b6fa9eb) (comment better me) on 2026-06-24 23:42:54

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28134149412/artifacts/7864982370)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28134149412/artifacts/7864779579)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28134149412/artifacts/7864399305)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28134149412/artifacts/7864448596)
<!-- END artifact comment -->