### PR TITLE
feat(balance): add magazine wells to several guns that lacked them

### DIFF
--- a/data/json/items/gun/10mm.json
+++ b/data/json/items/gun/10mm.json
@@ -19,6 +19,7 @@
     "ammo": "10mm",
     "blackpowder_tolerance": 24,
     "min_cycle_recoil": 570,
+    "magazine_well": "150 ml",
     "magazines": [ [ "10mm", [ "glock20mag", "glock20bigmag", "glock20drum50rd" ] ] ]
   },
   {

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -16,6 +16,7 @@
     "ups_charges": 5,
     "loudness": 60,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "auto", 3 ] ],
+    "magazine_well": "150 ml",
     "magazines": [ [ "12mm", [ "hk_g80mag" ] ] ]
   }
 ]

--- a/data/json/items/gun/20x66mm.json
+++ b/data/json/items/gun/20x66mm.json
@@ -102,6 +102,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "250 ml",
     "magazines": [ [ "20x66mm", [ "20x66_10_mag" ] ] ],
     "flags": [ "WATERPROOF_GUN", "NEVER_JAMS" ]
   }

--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -180,7 +180,7 @@
     "material": [ "budget_steel" ],
     "color": "dark_gray",
     "ammo": "22",
-    "magazine_well": "55 ml",
+    "magazine_well": "75 ml",
     "dispersion": 600,
     "durability": 5,
     "min_cycle_recoil": 39,

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -18,6 +18,7 @@
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "barrel_volume": "250 ml",
     "built_in_mods": [ "folding_stock" ],
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",
@@ -58,6 +59,7 @@
     "dispersion": 150,
     "durability": 7,
     "min_cycle_recoil": 1350,
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",
@@ -103,6 +105,7 @@
     "durability": 6,
     "min_cycle_recoil": 1350,
     "loudness": 4,
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",
@@ -156,6 +159,7 @@
       [ "sling", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",
@@ -193,6 +197,7 @@
     "dispersion": 180,
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",
@@ -232,6 +237,7 @@
     "dispersion": 150,
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
+    "magazine_well": "150 ml",
     "magazines": [ [ "223", [ "g36mag_30rd", "g36mag_100rd" ] ] ]
   },
   {
@@ -255,6 +261,7 @@
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "burst", 4 ] ],
     "built_in_mods": [ "bipod" ],
+    "magazine_well": "25 ml",
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "barrel", 1 ],
@@ -341,6 +348,7 @@
     "durability": 6,
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",
@@ -381,6 +389,7 @@
     "durability": 7,
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ] ],
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",
@@ -435,6 +444,7 @@
     "dispersion": 380,
     "durability": 6,
     "min_cycle_recoil": 1350,
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",
@@ -489,6 +499,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "223", [ "ruger20", "ruger5", "ruger10", "ruger30", "ruger90", "ruger100", "ruger_makeshiftmag" ] ] ]
   },
   {
@@ -510,6 +521,7 @@
     "dispersion": 150,
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",
@@ -551,6 +563,7 @@
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 4 ] ],
     "built_in_mods": [ "folding_stock" ],
+    "magazine_well": "100 ml",
     "magazines": [
       [
         "223",
@@ -605,6 +618,7 @@
       [ "sling", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "150 ml",
     "magazines": [ [ "223", [ "augmag_30rd", "augmag_10rd", "augmag_42rd", "augmag_100rd" ] ] ]
   },
   {
@@ -624,6 +638,7 @@
     "dispersion": 150,
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 3 ] ],
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "223",

--- a/data/json/items/gun/277.json
+++ b/data/json/items/gun/277.json
@@ -55,6 +55,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "25 ml",
     "magazines": [ [ "277", [ "belt277" ] ] ]
   }
 ]

--- a/data/json/items/gun/300.json
+++ b/data/json/items/gun/300.json
@@ -15,6 +15,7 @@
     "dispersion": 90,
     "min_cycle_recoil": 4770,
     "barrel_volume": "500 ml",
+    "magazine_well": "100 ml",
     "magazines": [ [ "300", [ "m2010mag" ] ] ],
     "flags": [ "NEVER_JAMS" ]
   },

--- a/data/json/items/gun/3006.json
+++ b/data/json/items/gun/3006.json
@@ -103,6 +103,7 @@
     "min_cycle_recoil": 3420,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 3 ] ],
     "barrel_volume": "1000 ml",
+    "magazine_well": "100 ml",
     "magazines": [ [ "3006", [ "m1918mag", "m1918bigmag" ] ] ]
   },
   {

--- a/data/json/items/gun/300BLK.json
+++ b/data/json/items/gun/300BLK.json
@@ -18,6 +18,7 @@
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "barrel_volume": "250 ml",
     "built_in_mods": [ "folding_stock" ],
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "300blk",
@@ -70,6 +71,7 @@
       [ "sling", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "150 ml",
     "magazines": [
       [
         "300blk",

--- a/data/json/items/gun/308.json
+++ b/data/json/items/gun/308.json
@@ -17,6 +17,7 @@
     "min_cycle_recoil": 2700,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "barrel_volume": "500 ml",
+    "magazine_well": "50 ml",
     "magazines": [ [ "308", [ "falmag", "falbigmag", "fal_makeshiftmag" ] ] ]
   },
   {
@@ -37,6 +38,7 @@
     "dispersion": 150,
     "min_cycle_recoil": 2700,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 4 ] ],
+    "magazine_well": "50 ml",
     "magazines": [ [ "308", [ "g3mag", "g3bigmag", "g3_makeshiftmag" ] ] ]
   },
   {
@@ -58,6 +60,7 @@
     "durability": 9,
     "modes": [ [ "DEFAULT", "low auto", 6 ], [ "AUTO", "high auto", 18 ] ],
     "magazines": [ [ "308", [ "belt308" ] ] ],
+    "magazine_well": "25 ml",
     "extend": { "flags": [ "NEVER_JAMS" ] }
   },
   {
@@ -126,6 +129,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "50 ml",
     "magazines": [ [ "308", [ "m14mag", "m14smallmag", "m14_makeshiftmag" ] ] ]
   },
   {
@@ -162,6 +166,7 @@
       [ "sling", 1 ],
       [ "stock", 1 ]
     ],
+    "magazine_well": "25 ml",
     "magazines": [ [ "308", [ "belt308" ] ] ]
   },
   {
@@ -197,6 +202,7 @@
       [ "sling", 1 ],
       [ "stock", 1 ]
     ],
+    "magazine_well": "25 ml",
     "magazines": [ [ "308", [ "belt308" ] ] ]
   },
   {
@@ -286,6 +292,7 @@
     "min_cycle_recoil": 2700,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "default_mods": [ "adjustable_stock" ],
+    "magazine_well": "150 ml",
     "magazines": [ [ "308", [ "hk417mag_20rd", "hk417mag_10rd", "hk417_makeshiftmag" ] ] ]
   },
   {
@@ -306,6 +313,7 @@
     "dispersion": 120,
     "min_cycle_recoil": 2700,
     "default_mods": [ "adjustable_stock", "bipod", "rifle_scope", "suppressor" ],
+    "magazine_well": "150 ml",
     "magazines": [ [ "308", [ "hk417mag_20rd", "hk417mag_10rd", "hk417_makeshiftmag" ] ] ]
   },
   {
@@ -326,6 +334,7 @@
     "dispersion": 150,
     "durability": 7,
     "min_cycle_recoil": 2700,
+    "magazine_well": "150 ml",
     "magazines": [ [ "308", [ "ar10mag_20rd", "ar10_makeshiftmag" ] ] ]
   }
 ]

--- a/data/json/items/gun/357sig.json
+++ b/data/json/items/gun/357sig.json
@@ -69,6 +69,7 @@
     "durability": 10,
     "handling": 30,
     "min_cycle_recoil": 400,
+    "magazine_well": "150 ml",
     "magazines": [ [ "357sig", [ "glock40mag", "glock40bigmag", "glock40drum50rd" ] ] ]
   }
 ]

--- a/data/json/items/gun/380.json
+++ b/data/json/items/gun/380.json
@@ -47,6 +47,7 @@
     "durability": 7,
     "min_cycle_recoil": 270,
     "blackpowder_tolerance": 24,
+    "magazine_well": "75 ml",
     "magazines": [ [ "380", [ "fn1910mag" ] ] ]
   },
   {
@@ -64,6 +65,7 @@
     "color": "dark_gray",
     "ammo": "380",
     "min_cycle_recoil": 270,
+    "magazine_well": "75 ml",
     "magazines": [ [ "380", [ "rugerlcpmag" ] ] ]
   },
   {

--- a/data/json/items/gun/40.json
+++ b/data/json/items/gun/40.json
@@ -209,6 +209,7 @@
     "dispersion": 170,
     "durability": 10,
     "min_cycle_recoil": 400,
+    "magazine_well": "150 ml",
     "magazines": [ [ "40", [ "glock40mag", "glock40bigmag", "glock40drum50rd" ] ] ]
   },
   {

--- a/data/json/items/gun/40x53mm.json
+++ b/data/json/items/gun/40x53mm.json
@@ -29,6 +29,7 @@
       [ "underbarrel", 1 ]
     ],
     "modes": [ [ "DEFAULT", "semi", 1, "NPC_AVOID" ], [ "AUTO", "auto", 2, "NPC_AVOID" ] ],
+    "magazine_well": "75 ml",
     "magazines": [ [ "40x53mm", [ "belt40mm" ] ] ],
     "flags": [ "MOUNTED_GUN" ]
   },

--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -46,6 +46,7 @@
     "blackpowder_tolerance": 24,
     "built_in_mods": [ "folding_stock" ],
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "45", [ "ump45mag", "ump45_makeshiftmag" ] ] ]
   },
   {
@@ -231,6 +232,7 @@
     "dispersion": 170,
     "durability": 10,
     "min_cycle_recoil": 400,
+    "magazine_well": "150 ml",
     "magazines": [ [ "45", [ "glock_21mag", "glock_21mag26", "glock21drum40rd" ] ] ]
   }
 ]

--- a/data/json/items/gun/50.json
+++ b/data/json/items/gun/50.json
@@ -49,6 +49,7 @@
       [ "rail", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "50 ml",
     "magazines": [ [ "50", [ "belt50" ] ] ],
     "flags": [ "MOUNTED_GUN" ]
   },

--- a/data/json/items/gun/762.json
+++ b/data/json/items/gun/762.json
@@ -31,6 +31,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "762", [ "akmag30", "akmag10", "akmag20", "akmag40", "akdrum75" ] ] ]
   },
   {
@@ -53,6 +54,7 @@
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "barrel_volume": "250 ml",
     "default_mods": [ "folding_stock" ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "762", [ "akmag30", "akmag10", "akmag20", "akmag40" ] ] ]
   },
   {
@@ -109,6 +111,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "762", [ "akmag30", "akmag10", "akmag20", "akmag40", "akdrum75" ] ] ]
   },
   {
@@ -144,6 +147,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "762", [ "akmag30", "akmag10", "akmag20", "akmag40", "akdrum75" ] ] ]
   }
 ]

--- a/data/json/items/gun/8x40mm.json
+++ b/data/json/items/gun/8x40mm.json
@@ -73,6 +73,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "250 ml",
     "magazines": [ [ "8x40mm", [ "8x40_10_mag", "8x40_25_mag" ] ] ],
     "flags": [ "WATERPROOF_GUN", "NEVER_JAMS" ],
     "faults": [  ]

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -137,6 +137,7 @@
       [ "sling", 1 ],
       [ "stock", 1 ]
     ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "9mm", [ "mp5mag", "mp5bigmag" ] ] ]
   },
   {
@@ -238,6 +239,7 @@
     "armor_data": { "covers": [ "arm_either", "hand_either" ], "coverage": 10, "encumbrance": 30, "material_thickness": 2 },
     "flags": [ "OVERSIZE", "RELOAD_EJECT", "BELTED", "RESTRICT_HANDS", "WORN_GUN" ],
     "valid_mod_locations": [  ],
+    "magazine_well": "500 ml",
     "magazines": [ [ "9mm", [ "mp5mag" ] ] ]
   },
   {
@@ -365,6 +367,7 @@
       [ "sights", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "9mm", [ "stenmag", "survivor9mm_mag" ] ] ]
   },
   {
@@ -663,6 +666,7 @@
     "handling": 40,
     "built_in_mods": [ "folding_stock" ],
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 2 ], [ "AUTO", "auto", 6 ] ],
+    "magazine_well": "500 ml",
     "magazines": [
       [ "9mm", [ "kriss_vector_9mm_mag", "glock17_17", "glock17_22", "glock_drum_50rd", "glock_drum_100rd", "glockbigmag" ] ]
     ]
@@ -691,6 +695,7 @@
     "loudness": 0,
     "modes": [ [ "DEFAULT", "burst", 5 ] ],
     "barrel_volume": "250 ml",
+    "magazine_well": "100 ml",
     "magazines": [ [ "9mm", [ "survivor9mm_mag", "stenmag" ] ] ]
   }
 ]

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -52,6 +52,7 @@
     "reload": 200,
     "loudness": -2,
     "valid_mod_locations": [ [ "accessories", 4 ], [ "sights", 1 ], [ "rail", 1 ] ],
+    "magazine_well": "50 ml",
     "magazines": [ [ "shot", [ "shotbelt_20" ] ] ],
     "flags": [ "MOUNTED_GUN" ]
   },

--- a/data/json/items/gun/tankguns.json
+++ b/data/json/items/gun/tankguns.json
@@ -23,6 +23,7 @@
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "low auto", 2 ], [ "AUTO", "high auto", 4 ] ],
     "reload": 500,
     "ups_charges": 10,
+    "magazine_well": "75 ml",
     "magazines": [ [ "25mm", [ "belt25mm" ] ] ]
   },
   {
@@ -100,6 +101,7 @@
     "modes": [ [ "DEFAULT", "auto", 10 ] ],
     "reload": 500,
     "ups_charges": 12,
+    "magazine_well": "75 ml",
     "magazines": [ [ "25mm", [ "belt25mm" ] ] ],
     "extend": { "flags": [ "STR_RELOAD", "NEVER_JAMS" ] }
   },

--- a/data/mods/exotic_ammo/gun/545x39.json
+++ b/data/mods/exotic_ammo/gun/545x39.json
@@ -17,6 +17,7 @@
     "dispersion": 150,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "barrel_volume": "250 ml",
+    "magazine_well": "100 ml",
     "magazines": [ [ "545x39", [ "ak74mag", "rpk74mag" ] ] ],
     "blackpowder_tolerance": 24,
     "flags": [ "NEVER_JAMS" ]
@@ -40,6 +41,7 @@
     "durability": 7,
     "barrel_volume": "250 ml",
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "2 rd.", 2 ], [ "AUTO", "auto", 4 ] ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "545x39", [ "ak74mag", "rpk74mag" ] ] ]
   }
 ]

--- a/data/mods/exotic_ammo/items/gun/223.json
+++ b/data/mods/exotic_ammo/items/gun/223.json
@@ -47,6 +47,7 @@
     "min_cycle_recoil": 1350,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 3 ] ],
     "valid_mod_locations": [ [ "accessories", 2 ], [ "brass catcher", 1 ], [ "muzzle", 1 ], [ "sling", 1 ] ],
+    "magazine_well": "100 ml",
     "magazines": [ [ "223", [ "lw223mag", "lw223bigmag" ] ] ],
     "flags": [ "DISABLE_SIGHTS" ]
   },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Several guns lacked magazine wells where one could argue for them having at least a baseline, a few were clearly inconsistent with related guns, etc. Lil less bulk when playing with firearms as a result.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Fixed various pistols and SMGs lacking a basic magazine well definition when their real-world counterparts tend to have at least enough to justify 
2. Likewise some rifles such as AR-pattern rifles lacked any at all despite the mag well jutting out from AR-pattern guns being a prominent feature.
3. Most belt-fed weapons now have a small magazine well to represent the feed tray. :3
4. Fixed several weird misc lil inconsistencies such as one Vector variant not having a magwell despite the others having it, one .22 pistol having slightly less magwell space than its magazine size despite all other saturday night specials being able to fit their mag completely, the MP5 briefcase not being able to actually hide its magazine, etc.
5. Updated exotic ammo mod weapons accordingly.

Notably excluded the A-180, Thompson, USAS-12, and Ppps-41 since those all seem like they have little actual mag well visible.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<details><summary>Relevant images:</summary>
<img width="1920" height="883" alt="Flickr_-_~Steve_Z~_-_OA_K23_Pistol" src="https://github.com/user-attachments/assets/3ca4a424-83df-442c-a02c-84b1c3f17f21" />
<img width="596" height="335" alt="images" src="https://github.com/user-attachments/assets/1a4260f0-0c90-4ffe-bcc3-c2115eff335d" />
<img width="1200" height="305" alt="Kriss-Vector-CRB" src="https://github.com/user-attachments/assets/7cd5544e-0c45-4ed1-af0b-97d23e0d1a38" />
<img width="675" height="450" alt="RECP-202405-249-DETAIL-R51_2956-675x450" src="https://github.com/user-attachments/assets/45c182fc-7e0a-4ed2-b250-e7ae9388566d" />
</details>

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [68d931c](https://github.com/cataclysmbn/Cataclysm-BN/commit/68d931cc03073852d70fabcffb71d93f7ad404b0) (feat(balance): add magazine wells to several guns that lacked them) on 2026-06-25 09:03:38

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28153529000/artifacts/7871442984)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28153529000/artifacts/7871993101)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28153529000/artifacts/7871482801)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28153529000/artifacts/7871563951)
<!-- END artifact comment -->