### PR TITLE
fix: allow sawing stock off Mosin Nagant

### DIFF
--- a/data/json/items/gun/762R.json
+++ b/data/json/items/gun/762R.json
@@ -68,7 +68,8 @@
       [ "mechanism", 4 ],
       [ "muzzle", 1 ],
       [ "sights", 1 ],
-      [ "sling", 1 ]
+      [ "sling", 1 ],
+      [ "stock", 1 ]
     ],
     "magazines": [ [ "762R", [ "762R_clip" ] ] ],
     "flags": [ "RELOAD_ONE" ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

We moved away from guns with wooden stocks not having a stock slot and yet somehow moist nuggets were overlooked, preventing the creation of the classic obrez.

## Describe the solution (The How)

Added stock slot to the standard Mosin Nagant rifle, with the carbine version accordingly inheriting it.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Going the fuck to bed because it's 5:30 AM and I haven't slept yet :<

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Ported changes to test build and load-tested.
2. Confirmed I can saw the barrel and stock off wooden mosin nagants.
3. Confirmed an obrez'd nugget fits in a holster.

For some stupid fucking reason, because the M44 is 500 ml smaller and thus has 500 ml less barrel volume and thus presumably does something stupid when running into the stock volume modifier, an obrez'd M44 inexicably has MORE volume than an obrez'd 1891/30.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6e6dd7f](https://github.com/cataclysmbn/Cataclysm-BN/commit/6e6dd7fcfe35e4def07862691cd7845b07d2f9e4) (fix: allow sawing stock off Mosin Nagant) on 2026-06-25 11:47:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28163764705/artifacts/7875692331)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28163764705/artifacts/7877094778)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28163764705/artifacts/7875741837)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28163764705/artifacts/7875786830)
<!-- END artifact comment -->