### PR TITLE
feat(UI): allow ordering npc to sleep

### DIFF
--- a/data/json/npcs/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/TALK_COMMON_ALLY.json
@@ -880,7 +880,7 @@
       {
         "text": "Please go get some sleep.",
         "topic": "TALK_DONE",
-        "condition": { "and": [{"not": "npc_has_activity" }, "npc_is_sleepy"]},
+        "condition": { "and": [ { "not": "npc_has_activity" }, "npc_is_sleepy" ] },
         "effect": "go_to_sleep"
       },
       {

--- a/data/json/npcs/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/TALK_COMMON_ALLY.json
@@ -878,6 +878,12 @@
         "effect": "do_farming"
       },
       {
+        "text": "Please go get some sleep.",
+        "topic": "TALK_DONE",
+        "condition": { "and": [{"not": "npc_has_activity" }, "npc_is_sleepy"]},
+        "effect": "go_to_sleep"
+      },
+      {
         "text": "Can you craft this item?",
         "topic": "TALK_DONE",
         "condition": { "and": [ { "not": "npc_has_activity" }, { "not": { "npc_has_trait": "HALLUCINATION" } } ] },

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1143,8 +1143,8 @@ conditional_t<T>::conditional_t( const std::string &type )
     } else if( type == "npc_has_activity" ) {
         set_has_activity( is_npc );
     } else if( type == "npc_is_riding" ) {
-        set_is_riding( is_npc );    }
-    else if( type == "npc_is_sleepy" ) {
+        set_is_riding( is_npc );
+    } else if( type == "npc_is_sleepy" ) {
         set_npc_is_sleepy();
     } else if( type == "is_day" ) {
         set_is_day();

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -739,6 +739,14 @@ void conditional_t<T>::set_npc_train_styles()
 }
 
 template<class T>
+void conditional_t<T>::set_npc_is_sleepy()
+{
+    condition = []( const T & d ) {
+        return d.beta->get_fatigue() >= fatigue_levels::tired;
+    };
+}
+
+template<class T>
 void conditional_t<T>::set_at_safe_space()
 {
     condition = []( const T & d ) {
@@ -1135,7 +1143,9 @@ conditional_t<T>::conditional_t( const std::string &type )
     } else if( type == "npc_has_activity" ) {
         set_has_activity( is_npc );
     } else if( type == "npc_is_riding" ) {
-        set_is_riding( is_npc );
+        set_is_riding( is_npc );    }
+    else if( type == "npc_is_sleepy" ) {
+        set_npc_is_sleepy();
     } else if( type == "is_day" ) {
         set_is_day();
     } else if( type == "u_has_stolen_item" ) {

--- a/src/condition.h
+++ b/src/condition.h
@@ -18,7 +18,7 @@ const std::unordered_set<std::string> simple_string_conds = { {
         "has_no_available_mission", "has_available_mission", "has_many_available_missions",
         "mission_complete", "mission_incomplete", "mission_has_generic_rewards",
         "npc_available", "npc_following", "npc_friend", "npc_hostile",
-        "npc_train_skills", "npc_train_styles",
+        "npc_train_skills", "npc_train_styles", "npc_is_sleepy",
         "at_safe_space", "is_day", "npc_has_activity", "is_outside",
         "u_can_stow_weapon", "npc_can_stow_weapon", "u_has_weapon", "npc_has_weapon",
         "u_driving", "npc_driving",
@@ -116,6 +116,7 @@ struct conditional_t {
         void set_npc_hostile();
         void set_npc_train_skills();
         void set_npc_train_styles();
+        void set_npc_is_sleepy();
         void set_at_safe_space();
         void set_can_stow_weapon( bool is_npc = false );
         void set_has_weapon( bool is_npc = false );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -902,10 +902,11 @@ int npc::best_skill_level() const
     return highest_level;
 }
 
-void npc::wake_up() {
+void npc::wake_up()
+{
     Character::wake_up();  // Call the base implementation first
 
-    if (sleep_at_this_pos.has_value()) {
+    if( sleep_at_this_pos.has_value() ) {
         sleep_at_this_pos = std::nullopt;
     }
 }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -902,6 +902,14 @@ int npc::best_skill_level() const
     return highest_level;
 }
 
+void npc::wake_up() {
+    Character::wake_up();  // Call the base implementation first
+
+    if (sleep_at_this_pos.has_value()) {
+        sleep_at_this_pos = std::nullopt;
+    }
+}
+
 namespace
 {
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -802,6 +802,7 @@ auto npc::clear_transient_movement_state_after_reposition() -> void
     last_player_seen_pos = std::nullopt;
     last_seen_player_turn = 999;
     goto_to_this_pos = std::nullopt;
+    sleep_at_this_pos = std::nullopt;
     wanted_item_pos = tripoint_bub_ms::min();
     guard_pos = tripoint_abs_ms::min();
     goal = no_goal_point;

--- a/src/npc.h
+++ b/src/npc.h
@@ -928,6 +928,7 @@ class npc : public player
         /** Is the item safe or does the NPC trust you enough? */
         bool will_accept_from_player( const item &it ) const;
 
+        void wake_up() override;
         bool wants_to_sell( const item &it ) const;
         bool wants_to_sell( const item &/*it*/, int at_price, int market_price ) const;
         bool wants_to_buy( const item &it ) const;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1277,6 +1277,8 @@ class npc : public player
         std::optional<tripoint_bub_ms> last_player_seen_pos; // Where we last saw the player
         // Player orders a friendly NPC to move to this position
         std::optional<tripoint_abs_ms> goto_to_this_pos;
+        // When the npc wants to sleep it doesn't have to recalculate every turn
+        std::optional<tripoint_abs_ms> sleep_at_this_pos;
         int last_seen_player_turn = 0; // Timeout to forgetting
         tripoint_bub_ms wanted_item_pos; // The square containing an item we want
         tripoint_abs_ms

--- a/src/npc.h
+++ b/src/npc.h
@@ -1036,7 +1036,7 @@ class npc : public player
 
         // Movement; the following are defined in npcmove.cpp
         void move(); // Picks an action & a target and calls execute_action
-        void execute_action(const std::string &action_str);
+        void execute_action( const std::string &action_str );
 
         void execute_action( npc_action action ); // Performs action
         void process_turn() override;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1036,6 +1036,8 @@ class npc : public player
 
         // Movement; the following are defined in npcmove.cpp
         void move(); // Picks an action & a target and calls execute_action
+        void execute_action(const std::string &action_str);
+
         void execute_action( npc_action action ); // Performs action
         void process_turn() override;
         auto action_move_factor() const -> int override;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1034,6 +1034,9 @@ void npc::move()
                      ai_cache.s_abs_pos.x(), ai_cache.s_abs_pos.y() );
         }
     } else {
+        if ( goto_to_this_pos.has_value() ) {
+            action = npc_sleep;
+        }
         // No present danger
         deactivate_combat_cbms();
 
@@ -1076,6 +1079,10 @@ void npc::move()
                      return_guard_pos.x(), return_guard_pos.y() );
             action = npc_return_to_guard_pos;
         }
+    }
+
+    if ( action == npc_undecided && sleep_at_this_pos.has_value() ) {
+        action = npc_sleep;
     }
 
     if( action == npc_undecided && is_walking_with() && goto_to_this_pos ) {
@@ -1263,6 +1270,26 @@ void npc::execute_action( npc_action action )
         case npc_sleep: {
             ZoneScopedN( "npc_exec_sleep" );
             // TODO: Allow stims when not too tired
+            auto sleep_or_move = [this, &player_character](tripoint_abs_ms target_pos) {
+                // TODO: Handle empty path better
+                if( target_pos == abs_pos() || path.empty() ) {
+                    move_pause();
+                    if( !has_effect( effect_lying_down ) ) {
+                        activate_bionic_by_id( bio_soporific );
+                        add_effect( effect_lying_down, 30_minutes, bodypart_str_id::NULL_ID(), 1 );
+                        if( player_character.sees( *this ) && !player_character.in_sleep_state() ) {
+                            add_msg( _( "%s lies down to sleep." ), name );
+                        }
+                    }
+                } else {
+                    move_to_next();
+                }
+            };
+
+            if (sleep_at_this_pos.has_value()) {
+                sleep_or_move( *sleep_at_this_pos );
+            }
+
             // Find a nice spot to sleep
             int best_sleepy = character_funcs::rate_sleep_spot( *this, bub_pos() );
             auto best_spot = bub_pos();
@@ -1281,20 +1308,9 @@ void npc::execute_action( npc_action action )
             if( is_walking_with() ) {
                 complain_about( "napping", 30_minutes, _( "<warn_sleep>" ) );
             }
+            sleep_at_this_pos = bub_to_abs( best_spot );
             update_path( best_spot );
-            // TODO: Handle empty path better
-            if( best_spot == bub_pos() || path.empty() ) {
-                move_pause();
-                if( !has_effect( effect_lying_down ) ) {
-                    activate_bionic_by_id( bio_soporific );
-                    add_effect( effect_lying_down, 30_minutes, bodypart_str_id::NULL_ID(), 1 );
-                    if( player_character.sees( *this ) && !player_character.in_sleep_state() ) {
-                        add_msg( _( "%s lies down to sleep." ), name );
-                    }
-                }
-            } else {
-                move_to_next();
-            }
+            sleep_or_move( *sleep_at_this_pos );
         }
         break;
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1034,7 +1034,7 @@ void npc::move()
                      ai_cache.s_abs_pos.x(), ai_cache.s_abs_pos.y() );
         }
     } else {
-        if ( goto_to_this_pos.has_value() ) {
+        if( goto_to_this_pos.has_value() ) {
             action = npc_sleep;
         }
         // No present danger
@@ -1081,7 +1081,7 @@ void npc::move()
         }
     }
 
-    if ( action == npc_undecided && sleep_at_this_pos.has_value() ) {
+    if( action == npc_undecided && sleep_at_this_pos.has_value() ) {
         action = npc_sleep;
     }
 
@@ -1270,7 +1270,7 @@ void npc::execute_action( npc_action action )
         case npc_sleep: {
             ZoneScopedN( "npc_exec_sleep" );
             // TODO: Allow stims when not too tired
-            auto sleep_or_move = [this, &player_character](tripoint_abs_ms target_pos) {
+            auto sleep_or_move = [this, &player_character]( tripoint_abs_ms target_pos ) {
                 // TODO: Handle empty path better
                 if( target_pos == abs_pos() || path.empty() ) {
                     move_pause();
@@ -1286,7 +1286,7 @@ void npc::execute_action( npc_action action )
                 }
             };
 
-            if (sleep_at_this_pos.has_value()) {
+            if( sleep_at_this_pos.has_value() ) {
                 sleep_or_move( *sleep_at_this_pos );
             }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1289,6 +1289,7 @@ void npc::execute_action( npc_action action )
 
             if( sleep_at_this_pos.has_value() ) {
                 sleep_or_move( *sleep_at_this_pos );
+                break;
             }
 
             // Find a nice spot to sleep

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1193,9 +1193,10 @@ void npc::move()
     }
 }
 
-void npc::execute_action( const std::string &action_str ) {
-    if (const auto _act = npc_action_map.find(action_str); _act != npc_action_map.end()) {
-        this->execute_action(_act->second);
+void npc::execute_action( const std::string &action_str )
+{
+    if( const auto _act = npc_action_map.find( action_str ); _act != npc_action_map.end() ) {
+        this->execute_action( _act->second );
     } else {
         debugmsg( "Unknown npc action %s", action_str );
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -11,6 +11,7 @@
 #include <ostream>
 #include <tuple>
 #include <unordered_set>
+#include <unordered_map>
 
 #include "action_time_scale.h"
 #include "active_item_cache.h"
@@ -247,6 +248,34 @@ enum npc_action : int {
     npc_return_to_guard_pos,
     npc_player_activity,
     num_npc_actions
+};
+
+static const std::unordered_map<std::string, npc_action> npc_action_map = {
+    {"npc_pause", npc_pause},
+    {"npc_reload", npc_reload},
+    {"npc_sleep", npc_sleep},
+    {"npc_pickup", npc_pickup},
+    {"npc_heal", npc_heal},
+    {"npc_use_painkiller", npc_use_painkiller},
+    {"npc_drop_items", npc_drop_items},
+    {"npc_flee", npc_flee},
+    {"npc_melee", npc_melee},
+    {"npc_shoot", npc_shoot},
+    {"npc_look_for_player",  npc_look_for_player},
+    {"npc_heal_player",  npc_heal_player},
+    {"npc_follow_player",  npc_follow_player},
+    {"npc_follow_embarked", npc_follow_embarked},
+    {"npc_talk_to_player",  npc_talk_to_player},
+    {"npc_mug_player", npc_mug_player},
+    {"npc_goto_to_this_pos", npc_goto_to_this_pos},
+    {"npc_goto_destination", npc_goto_destination},
+    {"npc_avoid_friendly_fire", npc_avoid_friendly_fire},
+    {"npc_escape_explosion", npc_escape_explosion},
+    {"npc_reach_attack", npc_reach_attack},
+    {"npc_aim", npc_aim},
+    {"npc_investigate_sound", npc_investigate_sound},
+    {"npc_return_to_guard_pos", npc_return_to_guard_pos},
+    {"npc_player_activity", npc_player_activity},
 };
 
 namespace
@@ -1161,6 +1190,14 @@ void npc::move()
     {
         ZoneScopedN( "npc_execute_action" );
         execute_action( action );
+    }
+}
+
+void npc::execute_action( const std::string &action_str ) {
+    if (const auto _act = npc_action_map.find(action_str); _act != npc_action_map.end()) {
+        this->execute_action(_act->second);
+    } else {
+        debugmsg( "Unknown npc action %s", action_str );
     }
 }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1034,7 +1034,7 @@ void npc::move()
                      ai_cache.s_abs_pos.x(), ai_cache.s_abs_pos.y() );
         }
     } else {
-        if ( goto_to_this_pos.has_value() ) {
+        if ( sleep_at_this_pos.has_value() ) {
             action = npc_sleep;
         }
         // No present danger
@@ -1273,6 +1273,7 @@ void npc::execute_action( npc_action action )
             auto sleep_or_move = [this, &player_character](tripoint_abs_ms target_pos) {
                 // TODO: Handle empty path better
                 if( target_pos == abs_pos() || path.empty() ) {
+                    sleep_at_this_pos = std::nullopt;
                     move_pause();
                     if( !has_effect( effect_lying_down ) ) {
                         activate_bionic_by_id( bio_soporific );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3206,6 +3206,7 @@ void talk_effect_t::parse_string_effect( const std::string &effect_id, const Jso
             WRAP( npc_die ),
             WRAP( npc_thankful ),
             WRAP( clear_overrides ),
+            WRAP( go_to_sleep ),
             WRAP( nothing )
 #undef WRAP
         }

--- a/src/npctalk.h
+++ b/src/npctalk.h
@@ -87,6 +87,7 @@ void set_npc_pickup( npc &p );
 void npc_die( npc &p );
 void npc_thankful( npc &p );
 void clear_overrides( npc &p );
+void go_to_sleep( npc &p );
 } // namespace talk_function
 
 time_duration calc_skill_training_time( const npc &p, const skill_id &skill );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -374,6 +374,7 @@ void talk_function::wake_up( npc &p )
     p.remove_effect( effect_lying_down );
     p.remove_effect( effect_npc_suspend );
     p.remove_effect( effect_sleep );
+    p.sleep_at_this_pos = std::nullopt;
     // TODO: Get mad at player for waking us up unless we're in danger
 }
 

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -986,3 +986,8 @@ void talk_function::clear_overrides( npc &p )
 {
     p.rules.clear_overrides();
 }
+
+void talk_function::go_to_sleep( npc &p )
+{
+    p.execute_action( "npc_sleep" );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

Sometimes when you have a time constraint and a friendly npc you might want to control each individually in their own schedule, like having one character sleep while the other goes looting.
Currently, npcs will only go to sleep when they feel like it and are super tired.

## Describe the solution (The How)

Allow the player to order the npc to sleep

## Describe alternatives you've considered

A sleep option to switch control as you go to sleep.
Seemed a lot more work and edge cases than ordering an npc.

## Testing

- Chat with NPC, option isn't there.
- Control NPC, wait until Tired
- Control Player, option is there, use it and npc goes to sleep on the floor.
- Wake him up, spawn a blanket and pillow on a nearby bench, repeat, he goes to sleep there.

## Additional context

This will be super useful with @shmakota's blood_moon mod ;)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.


## Build Artifacts

PR build for commit [a107747](https://github.com/cataclysmbn/Cataclysm-BN/commit/a107747c4e01a14d00b2088841dd969edf50ef92) (Add dialog for sleep order) on 2026-06-25 11:50:43

- [⏳ Linux tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28168011253)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28168011253)
- [⏳ macOS tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28168011253)
- [⏳ Android tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28168011253)
<!-- END artifact comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bc7f757](https://github.com/cataclysmbn/Cataclysm-BN/commit/bc7f757000aecdc73d9a934f9be350eb84811524) (Apply suggestion from @scarf005) on 2026-06-30 19:17:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28464329649/artifacts/7990161111)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28464329649/artifacts/7991154370)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28464329649/artifacts/7990069624)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28464329649/artifacts/7989965369)
<!-- END artifact comment -->