### PR TITLE
fix: active tile data is now set on mapgen

### DIFF
--- a/src/mapgen_constructor.cpp
+++ b/src/mapgen_constructor.cpp
@@ -484,6 +484,13 @@ auto mapgen_constructor::furn_set( const point_omt_ms &p, const furn_id &furnitu
         return false;
     }
     sm->set_furn( local, furniture );
+    const auto &new_furniture = furniture.obj();
+    if( new_furniture.active ) {
+        cata::poly_serialized<active_tile_data> atd;
+        atd.reset( new_furniture.active->clone() );
+        atd->set_last_updated( calendar::turn );
+        sm->active_furniture[local] = atd;
+    }
     return true;
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Caused by: #9543
Closes: #9649

## Describe the solution (The How)
Mapgen constructor ::furn_set did not set active tile data for furniture
Well now it does

## Describe alternatives you've considered
None

## Testing
Ref center battery charges again initially

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7d287ba](https://github.com/cataclysmbn/Cataclysm-BN/commit/7d287ba951e9b5c14da9d034f379677b40858fcb) (fix: active tile data is now set on mapgen) on 2026-06-25 21:40:15

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28182138506/artifacts/7884597528)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28182138506/artifacts/7885089271)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28182138506/artifacts/7883610573)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28182138506/artifacts/7883622557)
<!-- END artifact comment -->