### PR TITLE
fix: sounds no longer are displayed when they are visible

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -2968,7 +2968,9 @@ std::vector<tripoint_bub_ms> sounds::get_footstep_markers()
     std::vector<tripoint_bub_ms> footsteps;
     footsteps.reserve( sound_markers.size() );
     for( const auto &mark : sound_markers ) {
-        footsteps.push_back( mark.first );
+        if( !g->u.sees( mark.first ) ) {
+            footsteps.push_back( mark.first );
+        }
     }
     return footsteps;
 }


### PR DESCRIPTION
## Purpose of change (The Why)
closes #9585

## Describe the solution (The How)
Call g->u.sees on every sound marker

## Describe alternatives you've considered
None

## Testing
See sound no marker
No see sound marker

## Additional context
I dunno how much perf this takes away and cant test because tracy segfaults wheneverr I use it right now for unknown reason.

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f4aec57](https://github.com/cataclysmbn/Cataclysm-BN/commit/f4aec57db2f14a02d69d5554158a1c490d1e701e) (fix: sounds no longer are displayed when they are visible) on 2026-06-25 17:23:02

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28184537034/artifacts/7885559146)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28184537034/artifacts/7885162696)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28184537034/artifacts/7884615112)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28184537034/artifacts/7884741231)
<!-- END artifact comment -->