### PR TITLE
fix: waiting while aiming now waits when fully aimed

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -245,7 +245,8 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
         }
     }
 
-    if( !get_option<bool>( "AIM_AFTER_FIRING" ) || who.recoil <= ranged::calculate_aim_cap( who, fin_trajectory.back() ) ) {
+    if( !get_option<bool>( "AIM_AFTER_FIRING" ) ||
+        who.recoil <= ranged::calculate_aim_cap( who, fin_trajectory.back() ) ) {
         restore_view();
         return;
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -245,8 +245,7 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
         }
     }
 
-    if( !get_option<bool>( "AIM_AFTER_FIRING" ) &&
-        who.recoil > ranged::calculate_aim_cap( who, fin_trajectory.back() ) ) {
+    if( !get_option<bool>( "AIM_AFTER_FIRING" ) || who.recoil <= ranged::calculate_aim_cap( who, fin_trajectory.back() ) ) {
         restore_view();
         return;
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -245,7 +245,8 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
         }
     }
 
-    if( !get_option<bool>( "AIM_AFTER_FIRING" ) ) {
+    if( !get_option<bool>( "AIM_AFTER_FIRING" ) &&
+        who.recoil > ranged::calculate_aim_cap( who, fin_trajectory.back() ) ) {
         restore_view();
         return;
     }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2210,7 +2210,7 @@ static bool pl_sees( const Creature &cr )
 }
 
 // Handle capping aim level when the player cannot see the target tile or there is nothing to aim at.
-static double calculate_aim_cap( const Character &p, const tripoint_bub_ms &target )
+double ranged::calculate_aim_cap( const Character &p, const tripoint_bub_ms &target )
 {
     double min_recoil = 0.0;
     const Creature *victim = g->critter_at( target, true );
@@ -2239,7 +2239,7 @@ static int print_aim( const Character &p, const catacurses::window &w, int line_
     dispersion_sources dispersion = ranged::get_weapon_dispersion( p, weapon );
     dispersion.add_range( ranged::recoil_vehicle( p ) );
 
-    const double min_recoil = calculate_aim_cap( p, pos );
+    const double min_recoil = ranged::calculate_aim_cap( p, pos );
     const double effective_recoil = ranged::effective_dispersion( p,
                                     p.primary_weapon().sight_dispersion() );
     const double min_dispersion = std::max( min_recoil, effective_recoil );
@@ -3910,7 +3910,7 @@ bool target_ui::action_aim()
 {
     set_last_target();
     apply_aim_turning_penalty();
-    const double min_recoil = calculate_aim_cap( *you, dst );
+    const double min_recoil = ranged::calculate_aim_cap( *you, dst );
     for( int i = 0; i < 10; ++i ) {
         do_aim( *you, *relevant, min_recoil );
     }
@@ -3936,7 +3936,7 @@ bool target_ui::action_aim_and_shoot( const std::string &action )
     int aim_threshold = it->threshold;
     set_last_target();
     apply_aim_turning_penalty();
-    const double min_recoil = calculate_aim_cap( *you, dst );
+    const double min_recoil = ranged::calculate_aim_cap( *you, dst );
     do {
         do_aim( *you, relevant ? *relevant : null_item_reference(), min_recoil );
     } while( you->moves > 0 && you->recoil > aim_threshold &&

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1969,6 +1969,9 @@ static void do_aim( avatar &you, const item &relevant, const double min_recoil )
         // Increase aim at the cost of moves
         you.mod_moves( -1 );
         you.recoil = std::max( min_recoil, you.recoil - aim_amount );
+    } else {
+        // If aim is already maxed, we're just waiting, so pass the turn.
+        you.set_moves( 0 );
     }
 }
 

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -73,6 +73,7 @@ int range_with_even_chance_of_good_hit( int dispersion );
 namespace ranged
 {
 
+double calculate_aim_cap( const Character &p, const tripoint_bub_ms &target );
 /**
  * Common checks for gunmode (when firing a weapon / manually firing turret)
  * @param messages Used to store messages describing failed checks


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #9670

## Describe the solution (The How)
Moves are set to 0 when aiming when full again
When aim is full, do not auto aim

## Describe alternatives you've considered
None

## Testing
Hold down wait
I wait

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b5cd877](https://github.com/cataclysmbn/Cataclysm-BN/commit/b5cd8778973fed29993239de03ee7b0ce8344f30) (style(autofix.ci): automated formatting) on 2026-06-25 22:21:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28201076282/artifacts/7892204068)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28201076282/artifacts/7891994714)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28201076282/artifacts/7891522447)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28201076282/artifacts/7891511334)
<!-- END artifact comment -->