### PR TITLE
fix: remove unusable dialogue about joining your basecamp from Pablo Nunez

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
@@ -202,11 +202,6 @@
         "topic": "TALK_REFUGEE_Pablo_Tacoma",
         "effect": { "u_add_var": "Pablo_ask_tacoma", "type": "recruit", "context": "general", "value": "yes" },
         "condition": { "u_has_var": "tacoma_started", "type": "knowledge", "context": "flag", "value": "yes" }
-      },
-      {
-        "text": "I've got a secure base.  You and your wife could come with me.",
-        "topic": "TALK_REFUGEE_Pablo_Recruit",
-        "effect": { "u_add_var": "Pablo_ask_recruit", "type": "recruit", "context": "general", "value": "yes" }
       }
     ]
   },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Pablo Nunez in the ref center currently has dialogue where you can ask him to join you, and he'll tell you to ask his wife if she agrees. She's supposed to agree if you have sufficient medical facilities in your camp, but this is likely stuff that was cut when faction camps were removed, thus now she has no dialogue, and Pablo's dialogue makes no sense now.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Removes the line from Pablo asking him to join your camp.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Faction Camps.
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0774cf7](https://github.com/cataclysmbn/Cataclysm-BN/commit/0774cf7fba708acf96b19a4a484b25e5f85b1b8a) (Update NPC_Pablo_Nunez.json) on 2026-06-26 04:36:43

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28214911714/artifacts/7896919257)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28214911714/artifacts/7897155575)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28214911714/artifacts/7896533756)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28214911714/artifacts/7896493153)
<!-- END artifact comment -->