### PR TITLE
fix: fix chris isherwood quest error

### DIFF
--- a/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
@@ -167,7 +167,7 @@
     "value": 50000,
     "start": {
       "effect": "follow",
-      "assign_mission_target": { "om_terrain": "mi-go_scout_tower_3", "om_special": "Mi-Go Scout Tower", "reveal_radius": 3 },
+      "assign_mission_target": { "om_terrain": "mi-go_scout_tower_3", "om_special": "Mi-Go Scout Tower", "reveal_radius": 3, "z": 2 },
       "update_mapgen": { "place_npcs": [ { "class": "isherwood_barry", "x": 18, "y": 15, "target": true } ] }
     },
     "origins": [ "ORIGIN_SECONDARY" ],


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
closes #7367 
The chris isherwood quest where he asks you to help save barry from the mi-go scout tower always causes an error when you start it and doesn't work correctly.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds the correct z level for the terrain so it works correctly now
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [301f1ad](https://github.com/cataclysmbn/Cataclysm-BN/commit/301f1adaf89bd5331970cb2c25aae3698e7a8902) (Update NPC_Chris_Isherwood.json) on 2026-06-26 04:57:33

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28215514809/artifacts/7897133709)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28215514809/artifacts/7897417030)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28215514809/artifacts/7896703525)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28215514809/artifacts/7896702921)
<!-- END artifact comment -->