### PR TITLE
fix: Actually cap magic sound values, reduce volume of spells, allow manually defining spell volume

### DIFF
--- a/docs/en/mod/json/reference/creatures/magic.md
+++ b/docs/en/mod/json/reference/creatures/magic.md
@@ -63,6 +63,7 @@ In `data/json/debug_spells.json` there is a template spell, copied here for your
   "max_field_intensity": 10,
   "field_intensity_increment": 1,
   "field_intensity_variance": 0.1, // the field can range in intensity from -variance as a percent to +variance as a percent i.e. this spell would be 9-11
+  "volume": 90, // The volume of noise that the spell produces. This is a flat value that doesn't differ depending on level. Measured in decibels.
   "sound_type": "combat", // the type of sound. possible types are: background, weather, music, movement, speech, activity, destructive_activity, alarm, combat, alert, order
   "sound_description": "a whoosh", // the sound description. in the form of "You hear %s" by default it is "an explosion"
   "sound_ambient": true, // whether or not this is treated as an ambient sound or not

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -355,6 +355,8 @@ void spell_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "final_casting_time", final_casting_time, base_casting_time );
     optional( jo, was_loaded, "casting_time_increment", casting_time_increment, 0.0f );
 
+    optional(jo, was_loaded, "volume", volume, -255); // -255 used as default because it would never be set that low on purpose otherwise
+
     std::vector<std::string> temp_vector;
     std::vector<std::string> default_vector;
     optional( jo, was_loaded, "melee_dam", temp_vector, default_vector );
@@ -697,6 +699,23 @@ std::string spell::duration_string() const
 time_duration spell::duration_turns() const
 {
     return 1_turns * duration() / 100;
+}
+
+short spell::volume() const {
+    // If the spell is flagged to be silent, then it is silent
+    if( has_flag( spell_flag::SILENT ) ) {
+        return -255;
+    }
+    // If the spell has a manually-defined volume, use that
+    if (type->volume > -255) {
+        return type->volume;
+    }
+    // If none of the above, calculate it manually
+    int loudness = ( 40 + ( ( std::abs( damage() ) ) / 3 ) );
+    if( has_flag( spell_flag::LOUD ) ) {
+        loudness += 20 + ( damage() / 2 );
+    }
+    return loudness;
 }
 
 void spell::gain_level()
@@ -1108,13 +1127,12 @@ void spell::create_field( const tripoint_bub_ms &at ) const
 
 void spell::make_sound( const tripoint_bub_ms &target, Creature &caster ) const
 {
-    if( !has_flag( spell_flag::SILENT ) ) {
-        int loudness = ( 40 + ( std::abs( damage() ) ) );
-        if( has_flag( spell_flag::LOUD ) ) {
-            loudness += 20 + ( damage() / 2 );
-        }
-        make_sound( target, caster, loudness );
+    short const loudness = volume();
+    // The spell is silent, so let's return early
+    if (loudness == -255){
+        return;
     }
+    make_sound( target, caster, loudness );
 }
 
 void spell::make_sound( const tripoint_bub_ms & /*target*/, Creature &caster, int loudness ) const

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -355,7 +355,8 @@ void spell_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "final_casting_time", final_casting_time, base_casting_time );
     optional( jo, was_loaded, "casting_time_increment", casting_time_increment, 0.0f );
 
-    optional(jo, was_loaded, "volume", volume, -255); // -255 used as default because it would never be set that low on purpose otherwise
+    optional( jo, was_loaded, "volume", volume,
+              -255 ); // -255 used as default because it would never be set that low on purpose otherwise
 
     std::vector<std::string> temp_vector;
     std::vector<std::string> default_vector;
@@ -701,13 +702,14 @@ time_duration spell::duration_turns() const
     return 1_turns * duration() / 100;
 }
 
-short spell::volume() const {
+short spell::volume() const
+{
     // If the spell is flagged to be silent, then it is silent
     if( has_flag( spell_flag::SILENT ) ) {
         return -255;
     }
     // If the spell has a manually-defined volume, use that
-    if (type->volume > -255) {
+    if( type->volume > -255 ) {
         return type->volume;
     }
     // If none of the above, calculate it manually
@@ -1129,7 +1131,7 @@ void spell::make_sound( const tripoint_bub_ms &target, Creature &caster ) const
 {
     short const loudness = volume();
     // The spell is silent, so let's return early
-    if (loudness == -255){
+    if( loudness == -255 ) {
         return;
     }
     make_sound( target, caster, loudness );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1121,7 +1121,7 @@ void spell::make_sound( const tripoint_bub_ms & /*target*/, Creature &caster, in
 {
     sound_event se;
     se.origin = caster.bub_pos();
-    se.volume = std::max( 190, loudness );
+    se.volume = std::min( 150, loudness );
     se.category = type->sound_type;
     se.description = type->sound_description.translated();
     se.movement_noise = ( type->sound_type == sounds::sound_t::movement );

--- a/src/magic.h
+++ b/src/magic.h
@@ -290,6 +290,9 @@ class spell_type
         // max or min casting time
         int final_casting_time = 0;
 
+        // Manually defined flat sound value for people who are interested. Directly used as loudness instead of calculating.
+        short volume;
+
         // Does leveling this spell lead to learning another spell?
         std::map<std::string, int> learn_spells;
 
@@ -409,6 +412,8 @@ class spell
         // how long does this spell's effect last
         int duration() const;
         time_duration duration_turns() const;
+        // How loud is the spell?
+        short volume() const;
         // how often does the spell fail
         // based on difficulty, level of spell, spellcraft skill, intelligence
         float spell_fail( const Character &guy ) const;


### PR DESCRIPTION
## Purpose of change (The Why)

In order:
1. #9609 did not actually fix the issue because it used std::max instead of std::min (and thus instead created a sound FLOOR so that everything not higher than 190 was now set to 190, not sure how this got past testing)
2. Even still, spells made waaaay too much sound after Retagin's changes given that they directly added the damage to the loudness
3. Maybe people don't want to have to worry about how their spell's volume changes as it gets stronger or weaker

## Describe the solution (The How)

1. Uses std::min instead of std::max for the capping
  - Also lowers the cap a little to 150 so it isn't right up against the wall
2. Divides the damage contribution to spell loudness by 3.
3. Adds a `volume` field to spells so they can be manually specified.

## Describe alternatives you've considered

- Just fix the cap
Cap is really a bandaid fix, spells shouldn't be anywhere near how loud they would be before.
- Convert the old values into the new ones more directly
I really don't care about what the values were before, I just care about not blowing people's eardrums out constantly
- Just apply the fixes without the additional field
- Make the field into a scaling one
I just don't see the point.

## Testing

Loaded into a game, a 76 damage spell with "LOUD" only got up to 95 dB in my testing
Level 15 Smite, doing a casual 400+ damage, does not exceed the 150 dB cap and thus does not instantly deafen you upon being cast. It will still make your ears ring after multiple casts though.

## Additional context

Also did a little refactoring of the volume stuff, namely splitting it off into its own function instead of being done in the make_sound one. 

Open to value tweaking suggestions.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a7ef0eb](https://github.com/cataclysmbn/Cataclysm-BN/commit/a7ef0eb77786ae11bfca80797bbadaf5aef6cd59) (style(autofix.ci): automated formatting) on 2026-06-26 06:44:23

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28219002115/artifacts/7898302311)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28219002115/artifacts/7898803302)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28219002115/artifacts/7898138396)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28219002115/artifacts/7898127021)
<!-- END artifact comment -->