### PR TITLE
feat: limit transforming furniture with bashing using `BASH_TRANSFORM` flag

### DIFF
--- a/data/json/furniture_and_terrain/furniture-seats.json
+++ b/data/json/furniture_and_terrain/furniture-seats.json
@@ -12,7 +12,7 @@
     "floor_bedding_warmth": -1500,
     "bonus_fire_warmth_feet": 1000,
     "required_str": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SHORT", "CAN_SIT" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SHORT", "CAN_SIT", "BASH_TRANSFORM" ],
     "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "nail", "charges": 10 } ] },
     "bash": {
       "str_min": 12,
@@ -50,7 +50,7 @@
     "transforms_into": "f_bench",
     "prompt": "Set bench upright",
     "message": "You set the bench back upright.",
-    "delete": { "flags": [ "CAN_SIT" ] }
+    "delete": { "flags": [ "CAN_SIT", "BASH_TRANSFORM" ] }
   },
   {
     "type": "furniture",
@@ -287,7 +287,7 @@
     "comfort": 1,
     "floor_bedding_warmth": -2000,
     "bonus_fire_warmth_feet": 1000,
-    "flags": [ "TRANSPARENT", "MOUNTABLE", "SHORT", "CAN_SIT" ],
+    "flags": [ "TRANSPARENT", "MOUNTABLE", "SHORT", "CAN_SIT", "BASH_TRANSFORM" ],
     "bash": {
       "str_min": 15,
       "str_max": 200,
@@ -333,7 +333,7 @@
     "transforms_into": "f_metal_bench",
     "prompt": "Set metal bench upright",
     "message": "You set the metal bench back upright.",
-    "delete": { "flags": [ "CAN_SIT" ] }
+    "delete": { "flags": [ "CAN_SIT", "BASH_TRANSFORM" ] }
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-surfaces.json
+++ b/data/json/furniture_and_terrain/furniture-surfaces.json
@@ -312,7 +312,7 @@
     "required_str": 5,
     "deployed_item": "tourist_table",
     "looks_like": "f_table",
-    "flags": [ "TRANSPARENT", "MOUNTABLE", "SHORT", "FLAT_SURF" ],
+    "flags": [ "TRANSPARENT", "MOUNTABLE", "SHORT", "FLAT_SURF", "BASH_TRANSFORM" ],
     "deconstruct": { "items": [ { "item": "tourist_table", "count": 1 } ] },
     "bash": {
       "str_min": 16,
@@ -359,7 +359,7 @@
     "prompt": "Set tourist table upright",
     "message": "You set the tourist table back upright.",
     "extend": { "flags": [ "CLIMB_SIMPLE" ] },
-    "delete": { "flags": [ "FLAT_SURF" ], "workbench": { "multiplier": 1.05, "mass": "100 kg", "volume": "35L" } }
+    "delete": { "flags": [ "FLAT_SURF", "BASH_TRANSFORM" ], "workbench": { "multiplier": 1.05, "mass": "100 kg", "volume": "35L" } }
   },
   {
     "type": "furniture",
@@ -371,7 +371,7 @@
     "move_cost_mod": 2,
     "coverage": 40,
     "required_str": 5,
-    "flags": [ "TRANSPARENT", "FLAMMABLE", "ORGANIC", "MOUNTABLE", "SHORT", "FLAT_SURF" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "ORGANIC", "MOUNTABLE", "SHORT", "FLAT_SURF", "BASH_TRANSFORM" ],
     "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": 8 } ] },
     "bash": {
       "str_min": 12,
@@ -420,7 +420,7 @@
     "prompt": "Set table upright",
     "message": "You set the table back on its feet.",
     "extend": { "flags": [ "CLIMB_SIMPLE" ] },
-    "delete": { "flags": [ "FLAT_SURF" ], "workbench": { "multiplier": 1.1, "mass": "200 kg", "volume": "75L" } }
+    "delete": { "flags": [ "FLAT_SURF", "BASH_TRANSFORM" ], "workbench": { "multiplier": 1.1, "mass": "200 kg", "volume": "75L" } }
   },
   {
     "type": "furniture",
@@ -433,7 +433,7 @@
     "move_cost_mod": 2,
     "coverage": 20,
     "required_str": 5,
-    "flags": [ "TRANSPARENT", "FLAMMABLE", "ORGANIC", "MOUNTABLE", "SHORT", "FLAT_SURF" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "ORGANIC", "MOUNTABLE", "SHORT", "FLAT_SURF", "BASH_TRANSFORM" ],
     "deconstruct": { "items": [ { "item": "2x4", "count": 2 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": 8 } ] },
     "bash": {
       "str_min": 10,
@@ -481,6 +481,6 @@
     "transforms_into": "f_coffee_table",
     "prompt": "Set coffee table upright",
     "message": "You tip the coffee table back onto its feet.",
-    "delete": { "flags": [ "FLAT_SURF" ], "workbench": { "multiplier": 0.85, "mass": "200 kg", "volume": "75L" } }
+    "delete": { "flags": [ "FLAT_SURF", "BASH_TRANSFORM" ], "workbench": { "multiplier": 0.85, "mass": "200 kg", "volume": "75L" } }
   }
 ]

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -554,6 +554,8 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `BARRICADABLE_DOOR` Door that can be barricaded.
 - `BARRICADABLE_WINDOW_CURTAINS`
 - `BARRICADABLE_WINDOW` Window that can be barricaded.
+- `BASH_TRANSFORM` If this furniture possesses the `transform` examine action, bashing has a chance
+  to trigger (e.g. flipping tables).
 - `BASHABLE` Players + Monsters can bash this.
 - `BLOCK_WIND` This terrain will block the effects of wind.
 - `BURROWABLE` Burrowing monsters can travel under this terrain, while most others can't (e.g.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4687,7 +4687,7 @@ bash_results map::bash_ter_furn( const tripoint_bub_ms &p, const bash_params &pa
             sounds::sound( se );
         }
 
-        if( !smash_ter && smax > 0 ) {
+        if( !smash_ter && has_flag( TFLAG_BASH_TRANSFORM, p ) && smax > 0 ) {
             const auto flipped_version = get_furn_transforms_into( p );
             if( flipped_version != furn_str_id::NULL_ID() ) {
                 const int damage_percent = ( params.strength * 100 ) / smax;

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -180,6 +180,7 @@ static const std::unordered_map<std::string, ter_bitflags> ter_bitflags_map = { 
         { "ELEVATOR",                 TFLAG_ELEVATOR },       // This is an elevator.
         { "NO_MEMORY",                TFLAG_NO_MEMORY },      // This should not be added to map memory
         { "ROAD",                     TFLAG_ROAD },           // Some floors have this flag, as do some passable transformation of otherwise impassible terrain/furniture. Very notably, open doors.
+        { "BASH_TRANSFORM",           TFLAG_BASH_TRANSFORM }, // Bashing this terrain/furniture but failing to destroy it has a chance to transform it, if it's capable of transforming.
     }
 };
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -330,6 +330,7 @@ enum ter_bitflags : int {
     TFLAG_ELEVATOR,
     TFLAG_NO_MEMORY,
     TFLAG_ROAD,
+    TFLAG_BASH_TRANSFORM,
     NUM_TERFLAGS
 };
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Belated followup to https://github.com/cataclysmbn/Cataclysm-BN/pull/7774 to implement sanity-checking I'd planned to do.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. In map.cpp, `map::bash_ter_furn` now includes a check for a new `BASH_TRANSFORM` flag, and doesn't roll to try and transform unless present.
2. Added definition of `BASH_TRANSFORM` to mapdata.cpp and mapdata.h

JSON changes:
1. Set it so benches, metal benches, tourist tables, tables, and coffee tables gain `BASH_TRANSFORM` while the flipped variants remove them via `delete`.

Documentation changes:
1. Documented new flag in json_flags.md

## Describe alternatives you've considered

1. Letting you flip and unflip tables infinitely.
2. Letting you knock out appliances by hitting them.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Bonked a bench until it flipped.
3. Kept slapping it, no longer unflips.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6a076f6](https://github.com/cataclysmbn/Cataclysm-BN/commit/6a076f6a372947db5a00bc762f4fb159ba81f8d9) (feat: limit transforming furniture with bashing using `BASH_TRANSFORM` flag) on 2026-06-26 08:31:06

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28221046424/artifacts/7899144669)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28221046424/artifacts/7899665089)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28221046424/artifacts/7899330403)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28221046424/artifacts/7899012695)
<!-- END artifact comment -->