### PR TITLE
fix(UI): show ranged damage numbers after shooting

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -878,6 +878,9 @@ void Creature::deal_projectile_attack( Creature *source, item *source_weapon,
     const double ammo_severity_bonus = proj.aimedcritbonus;
     const double ammo_severity_max_bonus = proj.aimedcritmaxbonus;
 
+    // Targeting UI teardown can dirty the SDL visibility cache just before a shot resolves.
+    // Ranged damage messages depend on the same visibility query, so refresh it here first.
+    g->refresh_player_visibility_cache_if_needed();
     const bool u_see_this = g->u.sees( *this );
 
     const int avoid_roll = dodge_roll();

--- a/tests/ranged_aiming_test.cpp
+++ b/tests/ranged_aiming_test.cpp
@@ -5,21 +5,26 @@
 #include <list>
 #include <memory>
 #include <ostream>
+#include <ranges>
 #include <string>
 #include <vector>
 
 #include "avatar.h"
 #include "avatar_action.h"
+#include "ballistics.h"
 #include "calendar.h"
 #include "coordinates.h"
+#include "dispersion.h"
 #include "game.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "monster.h"
 #include "npc.h"
 #include "item.h"
+#include "options_helpers.h"
 #include "player.h"
 #include "player_helpers.h"
+#include "projectile.h"
 #include "ranged.h"
 #include "state_helpers.h"
 #include "vehicle.h"
@@ -98,6 +103,46 @@ TEST_CASE( "Aiming at a clearly visible target", "[ranged][aiming]" )
             CHECK( std::count( t.begin(), t.end(), &z2 ) == 0 );
         }
     }
+}
+
+TEST_CASE( "Projectile damage message visibility survives dirty target-ui cache",
+           "[ranged][aiming][issue-9669]" )
+{
+#if defined( CATA_SDL )
+    clear_all_state();
+    set_up_player_vision();
+    const auto no_projectile_animation = override_option( "ANIMATION_PROJECTILES", "false" );
+    auto &shooter = g->u;
+    arm_character( shooter, "glock_19" );
+
+    auto &here = get_map();
+    const auto target_pos = shooter_pos + point( 5, 0 );
+    for( const auto x : std::views::iota( 0, 6 ) ) {
+        const auto pos = shooter_pos + point( x, 0 );
+        here.ter_set( pos, ter_id( "t_dirt" ) );
+        here.furn_set( pos, furn_id( "f_null" ) );
+    }
+
+    auto &z = spawn_test_monster( "debug_mon", target_pos );
+    update_player_visibility_cache();
+    const auto starting_hp = z.get_hp();
+    REQUIRE( shooter.sees( z ) );
+
+    here.invalidate_map_cache( shooter_pos.z() );
+    REQUIRE( here.visibility_caches_dirty() );
+
+    auto test_proj = projectile {};
+    auto &gun = shooter.primary_weapon();
+    test_proj.speed = gun.gun_speed();
+    test_proj.range = gun.gun_range();
+    test_proj.impact = gun.gun_damage();
+    const auto attack = projectile_attack( test_proj, shooter_pos, target_pos, dispersion_sources {},
+                                           &shooter, &gun );
+
+    REQUIRE( attack.hit_critter == &z );
+    REQUIRE( z.get_hp() < starting_hp );
+    CHECK( shooter.sees( z ) );
+#endif // CATA_SDL
 }
 
 TEST_CASE( "Aiming at a loaded target on another z-level", "[ranged][aiming][zlevel]" )


### PR DESCRIPTION
## Purpose of change (The Why)

- fixes #9669
- fixes #9671 
- Ranged shots could skip printing `You hit ... for N damage` after the targeting UI dirtied the SDL visibility cache.
- caused by: #9479

## Describe the solution (The How)

- Refresh the player visibility cache before ranged projectile damage messages decide whether the player sees the hit.


## Testing

1. fire saiga-12 at zombie ~10 tiles away
2. confirm that damage and death message only shows on this branch 

| main (922e1899f06115799ed3dd1623bbdd060929da7b) | this PR |
| - | - |
| <img width="1410" height="1570" alt="image" src="https://github.com/user-attachments/assets/34652413-8bc9-476b-a9d8-737b252138a0" /> | <img width="1410" height="1570" alt="image" src="https://github.com/user-attachments/assets/0eaf022a-e5fe-4c36-bc0b-845d3b213e79" /> |

weren't able to reproduce the same error with AR-10 maybe the bug only happens periodically

## Checklist

### Mandatory

- [x] I linked any relevant issues using github keyword syntax like `closes #1234` in Summary of the PR so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit in the Linux kernel format.

<sub>PR opened by gpt-5.5 xhigh on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [91792ca](https://github.com/cataclysmbn/Cataclysm-BN/commit/91792cae6fbf473522c3de83e136c54fb791ce70) (fix: refresh visibility before ranged damage messages) on 2026-06-26 15:55:42

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28230863209/artifacts/7902691435)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28230863209/artifacts/7903233015)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28230863209/artifacts/7902765456)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28230863209/artifacts/7902814138)
<!-- END artifact comment -->