### PR TITLE
fix(UI): keep consume cursor on selected item stack

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -223,17 +223,15 @@ static item *inv_internal( player &u, const inventory_selector_preset &preset,
             inv_s.set_filter( init_filter );
             has_init_filter = false;
         }
-        // Set position after filter to keep cursor at the right position
-        auto restored_type_selection = false;
-        if( has_init_type ) {
-            restored_type_selection = inv_s.select_item_type( init_type );
-            init_selection = init_selection && !restored_type_selection;
-            has_init_type = false;
+        // Set position after filter to keep cursor at the right position.
+        // Stored types guard against restoring a stale row that now holds another item.
+        if( init_selection && has_init_type ) {
+            inv_s.restore_selection( init_pair, init_type );
+        } else if( has_init_type ) {
+            inv_s.select_item_type( init_type );
         }
-        if( init_selection && !restored_type_selection ) {
-            inv_s.select_position( init_pair );
-            init_selection = false;
-        }
+        init_selection = false;
+        has_init_type = false;
 
         if( inv_s.empty() ) {
             const std::string msg = none_message.empty()

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -899,6 +899,17 @@ bool inventory_column::select( const item *loc )
     return false;
 }
 
+auto inventory_column::select_position_if_item_type( const size_t new_index,
+        const itype_id &type ) -> bool
+{
+    if( new_index >= entries.size() || !entries[new_index].is_selectable() ||
+        entries[new_index].any_item()->typeId() != type ) {
+        return false;
+    }
+    select( new_index, scroll_direction::FORWARD );
+    return true;
+}
+
 size_t inventory_column::get_entry_indent( const inventory_entry &entry ) const
 {
     if( !entry.is_item() ) {
@@ -1394,10 +1405,22 @@ bool inventory_selector::select( const item *loc )
 
 auto inventory_selector::select_item_type( const itype_id &type ) -> bool
 {
+    return select_item_type( type, 0 );
+}
+
+auto inventory_selector::select_item_type( const itype_id &type,
+        const size_t preferred_column ) -> bool
+{
     namespace ranges = std::ranges;
 
     prepare_layout();
-    for( const auto index : std::views::iota( size_t{}, columns.size() ) ) {
+    auto search_order = std::views::iota( size_t{}, columns.size() ) | ranges::to<std::vector>();
+    if( preferred_column < columns.size() ) {
+        std::erase( search_order, preferred_column );
+        search_order.insert( search_order.begin(), preferred_column );
+    }
+
+    for( const auto index : search_order ) {
         auto *column = columns[index];
         if( !column->visible() || !column->activatable() ) {
             continue;
@@ -1412,6 +1435,46 @@ auto inventory_selector::select_item_type( const itype_id &type ) -> bool
         }
     }
     return false;
+}
+
+auto inventory_selector::select_position_if_item_type( const std::pair<size_t, size_t> position,
+        const itype_id &type ) -> bool
+{
+    prepare_layout();
+    if( position.first >= columns.size() ) {
+        return false;
+    }
+
+    auto *column = columns[position.first];
+    if( !column->visible() || !column->activatable() ||
+        !column->select_position_if_item_type( position.second, type ) ) {
+        return false;
+    }
+
+    set_active_column( position.first );
+    return true;
+}
+
+auto inventory_selector::restore_selection( const std::pair<size_t, size_t> position,
+        const itype_id &type ) -> bool
+{
+    const auto restored = select_position_if_item_type( position, type ) ||
+                          select_item_type( type, position.first );
+    if( !restored ) {
+        prepare_layout();
+        for( const auto index : std::views::iota( size_t{}, columns.size() ) ) {
+            auto *column = columns[index];
+            if( !column->visible() || !column->activatable() ) {
+                continue;
+            }
+            column->select( 0, scroll_direction::FORWARD );
+            if( column->get_selected() ) {
+                set_active_column( index );
+                break;
+            }
+        }
+    }
+    return restored;
 }
 
 inventory_entry *inventory_selector::find_entry_by_invlet( int invlet ) const

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -292,6 +292,7 @@ class inventory_column
 
         /** Selects the specified location. */
         bool select( const item *loc );
+        auto select_position_if_item_type( size_t new_index, const itype_id &type ) -> bool;
 
         /**
          * Change the selection.
@@ -584,6 +585,10 @@ class inventory_selector
          */
         bool select( const item *loc );
         auto select_item_type( const itype_id &type ) -> bool;
+        auto select_item_type( const itype_id &type, size_t preferred_column ) -> bool;
+        auto select_position_if_item_type( std::pair<size_t, size_t> position,
+                                           const itype_id &type ) -> bool;
+        auto restore_selection( std::pair<size_t, size_t> position, const itype_id &type ) -> bool;
 
         const inventory_entry &get_selected() {
             return get_active_column().get_selected();

--- a/tests/inventory_ui_test.cpp
+++ b/tests/inventory_ui_test.cpp
@@ -35,11 +35,11 @@ TEST_CASE( "inventory selector restores saved position before same type in anoth
     selector.add_item( selector.own_inv_column, inventory_bandages.get() );
     selector.add_item( selector.map_column, map_bandages.get() );
 
-    REQUIRE( selector.select( map_bandages.get() ) );
+    REQUIRE( selector.select_item_type( map_bandages->typeId(), 1 ) );
     const auto saved_position = selector.get_selection_position();
     REQUIRE( selector.select( inventory_bandages.get() ) );
 
-    REQUIRE( selector.select_position_if_item_type( saved_position, map_bandages->typeId() ) );
+    REQUIRE( selector.restore_selection( saved_position, map_bandages->typeId() ) );
     CHECK( selector.get_selected().any_item() == map_bandages.get() );
 }
 
@@ -56,13 +56,37 @@ TEST_CASE( "inventory selector rejects saved position when the type changed",
     selector.add_item( selector.own_inv_column, inventory_bandages.get() );
     selector.add_item( selector.map_column, map_heroin.get() );
 
-    REQUIRE( selector.select( map_heroin.get() ) );
+    REQUIRE( selector.select_item_type( map_heroin->typeId(), 1 ) );
     const auto stale_position = selector.get_selection_position();
     REQUIRE( selector.select( inventory_bandages.get() ) );
 
     CHECK_FALSE( selector.select_position_if_item_type( stale_position,
                  inventory_bandages->typeId() ) );
     CHECK( selector.get_selected().any_item() == inventory_bandages.get() );
+}
+
+TEST_CASE( "inventory selector restores saved row before same type fallback in the same column",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto inventory_bandages = item::spawn( "bandages" );
+    auto first_map_bandages = item::spawn( "bandages" );
+    auto second_map_bandages = item::spawn( "bandages" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, inventory_bandages.get() );
+    selector.add_item( selector.map_column, first_map_bandages.get() );
+    selector.add_item( selector.map_column, second_map_bandages.get() );
+
+    REQUIRE( selector.select_item_type( first_map_bandages->typeId(), 1 ) );
+    REQUIRE( selector.select( second_map_bandages.get() ) );
+    const auto saved_position = selector.get_selection_position();
+    REQUIRE( selector.select( inventory_bandages.get() ) );
+
+    REQUIRE( selector.restore_selection( saved_position, second_map_bandages->typeId() ) );
+    CHECK( selector.get_selected().any_item() == second_map_bandages.get() );
 }
 
 TEST_CASE( "inventory selector type fallback starts in the saved column",
@@ -80,12 +104,11 @@ TEST_CASE( "inventory selector type fallback starts in the saved column",
     selector.add_item( selector.map_column, map_heroin.get() );
     selector.add_item( selector.map_column, map_bandages.get() );
 
-    REQUIRE( selector.select( map_heroin.get() ) );
+    REQUIRE( selector.select_item_type( map_heroin->typeId(), 1 ) );
     const auto stale_position = selector.get_selection_position();
     REQUIRE( selector.select( inventory_bandages.get() ) );
 
-    REQUIRE_FALSE( selector.select_position_if_item_type( stale_position, map_bandages->typeId() ) );
-    REQUIRE( selector.select_item_type( map_bandages->typeId(), stale_position.first ) );
+    REQUIRE( selector.restore_selection( stale_position, map_bandages->typeId() ) );
     CHECK( selector.get_selected().any_item() == map_bandages.get() );
 }
 
@@ -102,16 +125,89 @@ TEST_CASE( "inventory selector type fallback leaves saved column when needed",
     selector.add_item( selector.own_inv_column, inventory_bandages.get() );
     selector.add_item( selector.map_column, map_heroin.get() );
 
-    REQUIRE( selector.select( map_heroin.get() ) );
+    REQUIRE( selector.select_item_type( map_heroin->typeId(), 1 ) );
     const auto stale_position = selector.get_selection_position();
 
-    REQUIRE_FALSE( selector.select_position_if_item_type( stale_position,
-                   inventory_bandages->typeId() ) );
-    REQUIRE( selector.select_item_type( inventory_bandages->typeId(), stale_position.first ) );
+    REQUIRE( selector.restore_selection( stale_position, inventory_bandages->typeId() ) );
     CHECK( selector.get_selected().any_item() == inventory_bandages.get() );
 }
 
-TEST_CASE( "inventory selector ignores invalid saved consume position",
+TEST_CASE( "inventory selector type fallback resumes default order after saved column",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto inventory_bandages = item::spawn( "bandages" );
+    auto gear_bandages = item::spawn( "bandages" );
+    auto map_heroin = item::spawn( "heroin" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, inventory_bandages.get() );
+    selector.add_item( selector.own_gear_column, gear_bandages.get() );
+    selector.add_item( selector.map_column, map_heroin.get() );
+
+    REQUIRE( selector.select_item_type( map_heroin->typeId(), 1 ) );
+    const auto stale_position = selector.get_selection_position();
+
+    REQUIRE( selector.restore_selection( stale_position, inventory_bandages->typeId() ) );
+    CHECK( selector.get_selected().any_item() == inventory_bandages.get() );
+}
+
+TEST_CASE( "inventory selector does not restore a stale row when saved type is gone",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto inventory_aspirin = item::spawn( "aspirin" );
+    auto inventory_heroin = item::spawn( "heroin" );
+    auto map_heroin = item::spawn( "heroin" );
+    auto missing_bandages = item::spawn( "bandages" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, inventory_aspirin.get() );
+    selector.add_item( selector.own_inv_column, inventory_heroin.get() );
+    selector.add_item( selector.map_column, map_heroin.get() );
+
+    REQUIRE( selector.select_item_type( map_heroin->typeId(), 1 ) );
+    const auto stale_position = selector.get_selection_position();
+
+    selector.clear_items();
+    selector.add_item( selector.own_inv_column, inventory_aspirin.get() );
+    selector.add_item( selector.own_inv_column, inventory_heroin.get() );
+    selector.add_item( selector.map_column, map_heroin.get() );
+    REQUIRE( selector.select_item_type( map_heroin->typeId(), 1 ) );
+    const auto expected_entries = selector.own_inv_column.get_entries( []( const auto & entry ) { return entry.is_selectable(); } );
+    const auto expected_default = expected_entries.front()->any_item();
+
+    CHECK_FALSE( selector.restore_selection( stale_position, missing_bandages->typeId() ) );
+    CHECK( selector.get_selected().any_item() == expected_default );
+}
+
+TEST_CASE( "inventory selector falls back from out of range saved row",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto inventory_bandages = item::spawn( "bandages" );
+    auto map_bandages = item::spawn( "bandages" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, inventory_bandages.get() );
+    selector.add_item( selector.map_column, map_bandages.get() );
+
+    REQUIRE( selector.select_item_type( map_bandages->typeId(), 1 ) );
+    auto invalid_position = selector.get_selection_position();
+    invalid_position.second = 999;
+    REQUIRE( selector.select( inventory_bandages.get() ) );
+
+    REQUIRE( selector.restore_selection( invalid_position, map_bandages->typeId() ) );
+    CHECK( selector.get_selected().any_item() == map_bandages.get() );
+}
+
+TEST_CASE( "inventory selector falls back from invalid saved consume column",
            "[inventory][ui][consume]" )
 {
     clear_avatar();
@@ -125,8 +221,8 @@ TEST_CASE( "inventory selector ignores invalid saved consume position",
     selector.add_item( selector.map_column, map_bandages.get() );
 
     REQUIRE( selector.select( inventory_bandages.get() ) );
-    const auto invalid_position = std::pair<size_t, size_t>{ 99, 0 };
+    const auto invalid_position = std::pair<size_t, size_t> { 99, 0 };
 
-    CHECK_FALSE( selector.select_position_if_item_type( invalid_position, map_bandages->typeId() ) );
+    REQUIRE( selector.restore_selection( invalid_position, map_bandages->typeId() ) );
     CHECK( selector.get_selected().any_item() == inventory_bandages.get() );
 }

--- a/tests/inventory_ui_test.cpp
+++ b/tests/inventory_ui_test.cpp
@@ -21,3 +21,112 @@ TEST_CASE( "inventory selector restores consume selection by item type",
     REQUIRE( selector.select_item_type( bandages->typeId() ) );
     CHECK( selector.get_selected().any_item()->typeId() == bandages->typeId() );
 }
+
+TEST_CASE( "inventory selector restores saved position before same type in another column",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto inventory_bandages = item::spawn( "bandages" );
+    auto map_bandages = item::spawn( "bandages" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, inventory_bandages.get() );
+    selector.add_item( selector.map_column, map_bandages.get() );
+
+    REQUIRE( selector.select( map_bandages.get() ) );
+    const auto saved_position = selector.get_selection_position();
+    REQUIRE( selector.select( inventory_bandages.get() ) );
+
+    REQUIRE( selector.select_position_if_item_type( saved_position, map_bandages->typeId() ) );
+    CHECK( selector.get_selected().any_item() == map_bandages.get() );
+}
+
+TEST_CASE( "inventory selector rejects saved position when the type changed",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto inventory_bandages = item::spawn( "bandages" );
+    auto map_heroin = item::spawn( "heroin" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, inventory_bandages.get() );
+    selector.add_item( selector.map_column, map_heroin.get() );
+
+    REQUIRE( selector.select( map_heroin.get() ) );
+    const auto stale_position = selector.get_selection_position();
+    REQUIRE( selector.select( inventory_bandages.get() ) );
+
+    CHECK_FALSE( selector.select_position_if_item_type( stale_position,
+                 inventory_bandages->typeId() ) );
+    CHECK( selector.get_selected().any_item() == inventory_bandages.get() );
+}
+
+TEST_CASE( "inventory selector type fallback starts in the saved column",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto inventory_bandages = item::spawn( "bandages" );
+    auto map_heroin = item::spawn( "heroin" );
+    auto map_bandages = item::spawn( "bandages" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, inventory_bandages.get() );
+    selector.add_item( selector.map_column, map_heroin.get() );
+    selector.add_item( selector.map_column, map_bandages.get() );
+
+    REQUIRE( selector.select( map_heroin.get() ) );
+    const auto stale_position = selector.get_selection_position();
+    REQUIRE( selector.select( inventory_bandages.get() ) );
+
+    REQUIRE_FALSE( selector.select_position_if_item_type( stale_position, map_bandages->typeId() ) );
+    REQUIRE( selector.select_item_type( map_bandages->typeId(), stale_position.first ) );
+    CHECK( selector.get_selected().any_item() == map_bandages.get() );
+}
+
+TEST_CASE( "inventory selector type fallback leaves saved column when needed",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto inventory_bandages = item::spawn( "bandages" );
+    auto map_heroin = item::spawn( "heroin" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, inventory_bandages.get() );
+    selector.add_item( selector.map_column, map_heroin.get() );
+
+    REQUIRE( selector.select( map_heroin.get() ) );
+    const auto stale_position = selector.get_selection_position();
+
+    REQUIRE_FALSE( selector.select_position_if_item_type( stale_position,
+                   inventory_bandages->typeId() ) );
+    REQUIRE( selector.select_item_type( inventory_bandages->typeId(), stale_position.first ) );
+    CHECK( selector.get_selected().any_item() == inventory_bandages.get() );
+}
+
+TEST_CASE( "inventory selector ignores invalid saved consume position",
+           "[inventory][ui][consume]" )
+{
+    clear_avatar();
+    auto &dummy = get_avatar();
+
+    auto inventory_bandages = item::spawn( "bandages" );
+    auto map_bandages = item::spawn( "bandages" );
+
+    auto selector = inventory_selector( dummy );
+    selector.add_item( selector.own_inv_column, inventory_bandages.get() );
+    selector.add_item( selector.map_column, map_bandages.get() );
+
+    REQUIRE( selector.select( inventory_bandages.get() ) );
+    const auto invalid_position = std::pair<size_t, size_t>{ 99, 0 };
+
+    CHECK_FALSE( selector.select_position_if_item_type( invalid_position, map_bandages->typeId() ) );
+    CHECK( selector.get_selected().any_item() == inventory_bandages.get() );
+}


### PR DESCRIPTION
## Purpose of change (The Why)

fixes #9673
caused by #9588

## Describe the solution (The How)

- Restore the saved row only when its item type still matches.
- Fall back to the same item type starting from the saved column.
- Reset stale selections when the saved type is gone.
- Add regression coverage for duplicate sources, stale rows, invalid positions, and same-column duplicates.

## Testing

| main | this PR |
| - | - |
| <img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/6f9d29d5-390f-4ea3-b85b-ab3dd8a94b08" /> | <img width="1410" height="1570" alt="Cataclysm: Bright Nights - 599c5d693d3 (2026-06-26)_01" src="https://github.com/user-attachments/assets/15695d14-c6d6-4e92-be58-419564d2b86f" /> |

1. spawned 2 cotton ball on inventory, 2 on floor
2. set all body hitpoints to 70
3. using (E)at, used cotton ball on floor
4. confirmed that cursor is pointing at cotton ball in floor correctly
5. using (E)at, used cotton ball in inventory
6. confirmed that cursor is pointing at cotton ball in inventory correctly

## Additional context

Related: #9588, #9580

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<sub>PR opened by gpt-5.5 xhigh on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [56bef1f](https://github.com/cataclysmbn/Cataclysm-BN/commit/56bef1f3664fa629ccd2680a0033de143fe31073) (fix(UI): restore consume selection by position and type) on 2026-06-26 10:58:04

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28231873994/artifacts/7903093638)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28231873994/artifacts/7903604702)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28231873994/artifacts/7903155261)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28231873994/artifacts/7903222484)
<!-- END artifact comment -->