### PR TITLE
fix: add missing pipe rifle recipe obsoletion and fix luty SMG recipe obsoletion

### DIFF
--- a/data/json/obsoletion/recipes.json
+++ b/data/json/obsoletion/recipes.json
@@ -1188,11 +1188,6 @@
   },
   {
     "type": "recipe",
-    "result": "smg_luty",
-    "obsolete": true
-  },
-  {
-    "type": "recipe",
     "result": "smg_9mm",
     "obsolete": true
   },
@@ -2360,11 +2355,6 @@
   {
     "type": "recipe",
     "result": "rifle_3006",
-    "obsolete": true
-  },
-  {
-    "type": "recipe",
-    "result": "rifle_308",
     "obsolete": true
   }
 ]

--- a/data/json/obsoletion/recipes.json
+++ b/data/json/obsoletion/recipes.json
@@ -2324,6 +2324,11 @@
   },
   {
     "type": "recipe",
+    "result": "rifle_22",
+    "obsolete": true
+  },
+  {
+    "type": "recipe",
     "result": "rifle_38",
     "obsolete": true
   },
@@ -2355,6 +2360,11 @@
   {
     "type": "recipe",
     "result": "rifle_3006",
+    "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "rifle_308",
     "obsolete": true
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
Someone on discord reported recipe errors, specifically on this screenshot:
<img width="1123" height="508" alt="image" src="https://github.com/user-attachments/assets/5c40e99d-2f68-4915-904b-930dcf26ee20" />
Apparently that's what happened when a save from an earlier version is loaded into a version where old recipes no longer exist but forgot to be obsoleted.
So i inspect the recipe obsoletion json and it's missing the two old pipe rifle recipes (rifle_22 and rifle_308).
I also found the new Luty SMG from #9530 was mistakenly added to that json

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Add the old pipe guns to the recipe obsoletion json and remove the new luty smgs

## Describe alternatives you've considered

Not fixing the obsoletion JSON and potentially break a lot of things

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
1. Get an old save who had learned these two old recipes
2. Upgrade to a newer version and spawn in
3. See that the game no longer throws out errors


## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e4767c7](https://github.com/cataclysmbn/Cataclysm-BN/commit/e4767c7550fb38c23b173292696ab2810ac02a89) (Turns out i accidentally obsoleted the new luty SMG recipe) on 2026-06-26 14:01:11

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28239825876/artifacts/7906746928)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28239825876/artifacts/7907258648)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28239825876/artifacts/7907190703)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28239825876/artifacts/7906934504)
<!-- END artifact comment -->