### PR TITLE
fix: furniture now properly blocks line of sight

### DIFF
--- a/src/shaders/transparency_compute.hlsl
+++ b/src/shaders/transparency_compute.hlsl
@@ -59,7 +59,7 @@ void main(uint3 group_id : SV_GroupID, uint3 thread_id : SV_GroupThreadID)
     bool furn_transparent = furn_lut[sm.furn_ids[tile]] != 0;
 
     float value;
-    if (ter_transparent || !furn_transparent) {
+    if (ter_transparent && furn_transparent) {
         value = LIGHT_TRANSPARENCY_OPEN_AIR;
         if (sm.outside_flags[tile] != 0) {
             value *= sight_penalty;

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -619,7 +619,7 @@ auto submap::rebuild_transparency_cache( const map &m, const tripoint_bub_sm &gr
     const float sight_penalty = get_weather().weather_id->sight_penalty;
 
     for( const auto &sp : submap_tiles() ) {
-        if( ( get_ter( sp ).obj().transparent || !get_furn( sp ).obj().transparent ) ) {
+        if( ( get_ter( sp ).obj().transparent && get_furn( sp ).obj().transparent ) ) {
             auto value = LIGHT_TRANSPARENCY_OPEN_AIR;
             if( outside_cache[sp.x()][sp.y()] ) {
                 value *= sight_penalty;


### PR DESCRIPTION
## Purpose of change (The Why)
When looking into #9097 yesterday I determined that it was not the furniture's transparency value
I was scrungled
Come today `if( ( get_ter( sp ).obj().transparent || !get_furn( sp ).obj().transparent ) )`
It made much more sense
Closes #9097 

## Describe the solution (The How)
First: if it says it's transparent it is
Second: either terrain or furniture could occlude things
Change this in both shaderland and cpuland

## Describe alternatives you've considered
None

## Testing
Air conditioner blocks line of sight

## Additional context
I am ashamed I did not look sooner

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [65bb5cb](https://github.com/cataclysmbn/Cataclysm-BN/commit/65bb5cb6c3ecc5a2ae98d3a226f2ca58f6a0a6db) (fix: furniture now properly blocks line of sight) on 2026-06-26 22:58:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28267572331/artifacts/7918081103)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28267572331/artifacts/7917839719)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28267572331/artifacts/7917515836)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28267572331/artifacts/7917535981)
<!-- END artifact comment -->