### PR TITLE
fix: accessing vehicle resources for crafting functions in airborne vehicles

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7948,8 +7948,14 @@ void map::reachable_flood_steps( std::vector<tripoint_bub_ms> &reachable_pts,
     for( const tripoint_bub_ms &p : points_in_radius( f, range ) ) {
         const tripoint_bub_ms tp = { p.xy(), f.z() };
         const int tp_cost = move_cost( tp );
+        const auto &veh = veh_at( tp );
+        const auto &veh_wall = veh.obstacle_at_part();
+        // Move cost is in right bounds
+        const bool bad_move_cost = tp_cost < cost_min || tp_cost > cost_max;
+        // It lacks floor in terrain or in veh
+        const bool no_floor = !has_floor_or_support( tp ) && ( veh_wall || !veh );
         // rejection conditions
-        if( tp_cost < cost_min || tp_cost > cost_max || !has_floor_or_support( tp ) ) {
+        if( bad_move_cost || no_floor || veh_wall ) {
             continue;
         }
         // set initial cost for grid point


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #9653 

## Describe the solution (The How)
`reachable_flood_steps` used for getting what tiles to fetch crafting resources did not count vehicle tiles
Make vehicle walls block it and vehicle floors work for it

## Describe alternatives you've considered
Do something to `has_floor` and the like, but I sense there is something I am missing there

## Testing
Compiled and load tested
Put rocks in a blimp seat
Couldn't craft before
Now can craft
Boolean seems to be right for all cases

## Additional Context
Sorry that this isn't a one line change, my brain couldn't wrap around the booleans well enough today...

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [eb080ff](https://github.com/cataclysmbn/Cataclysm-BN/commit/eb080ff1183a373062d594b9911d5c62f35d8461) (fix: accessing vehicle resources for crafting functions in airborne vehicles) on 2026-06-26 23:48:53

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28270347371/artifacts/7918437458)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28270347371/artifacts/7918726033)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28270347371/artifacts/7918448054)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28270347371/artifacts/7918481686)
<!-- END artifact comment -->