### PR TITLE
feat(balance): Use rigid storage first when calculating non-rigid encumbrance

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2902,11 +2902,6 @@ void Character::inv_set_stack_favorite( int position, bool favorite )
     inv.set_stack_favorite( position, favorite );
 }
 
-units::volume Character::inv_volume() const
-{
-    return inv.volume();
-}
-
 void Character::inv_unsort()
 {
     inv.unsort();

--- a/src/character.h
+++ b/src/character.h
@@ -1293,8 +1293,6 @@ class Character : public Creature, public location_visitable<Character>
 
         detached_ptr<item> inv_remove_item( item * );
 
-        units::volume inv_volume() const;
-
         void inv_unsort();
 
         void inv_clear();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4192,22 +4192,10 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
     }
 
     if( parts->test( iteminfo_parts::BASE_RIGIDITY ) ) {
-        if( const islot_armor *armor = find_armor_data() ) {
-            if( !type->rigid ) {
-                info.emplace_back( "BASE",
-                                   _( "* This item is <info>not rigid</info>.  Its"
-                                      " volume and encumbrance increase with contents." ) );
-            } else {
-                bool any_encumb_increase = std::ranges::any_of( armor->data,
-                []( armor_portion_data data ) {
-                    return data.encumber != data.max_encumber;
-                } );
-                if( any_encumb_increase ) {
-                    info.emplace_back( "BASE",
-                                       _( "* This item is <info>not rigid</info>.  Its"
-                                          " volume and encumbrance increase with contents." ) );
-                }
-            }
+        if( is_non_rigid() ) {
+            info.emplace_back( "BASE",
+                               _( "* This item is <info>not rigid</info>.  Its"
+                                  " volume and encumbrance increase with contents." ) );
         }
     }
 
@@ -6127,6 +6115,21 @@ bool item::can_shatter() const
     return only_made_of( is_glass ) || has_flag( flag_SHATTERS );
 }
 
+bool item::is_non_rigid() const
+{
+    if( const islot_armor *armor = find_armor_data() ) {
+        if( !type->rigid ) {
+            return true;
+        }
+        bool any_encumb_increase = std::ranges::any_of( armor->data,
+        []( armor_portion_data data ) {
+            return data.encumber != data.max_encumber;
+        } );
+        return any_encumb_increase;
+    }
+    return false;
+}
+
 void item::unset_flags()
 {
     const bool affects_processing = item_tags.count( flag_RADIO_ACTIVATION ) ||
@@ -6737,16 +6740,22 @@ int item::get_encumber( const Character &who, const bodypart_id &bodypart ) cons
             for( const armor_portion_data &entry : armor->data ) {
                 if( entry.covers.test( bodypart.id() ) ) {
                     if( entry.max_encumber != 0 ) {
-                        units::volume char_storage( 0_ml );
+                        units::volume rigid_storage( 0_ml );
+                        units::volume non_rigid_storage( 0_ml );
+                        const units::volume volume_carried = who.volume_carried();
 
                         for( const item * const &e : who.worn ) {
-                            char_storage += e->get_storage();
+                            if( e->is_non_rigid() ) {
+                                non_rigid_storage += e->get_storage();
+                            } else {
+                                rigid_storage += e->get_storage();
+                            }
                         }
 
-                        if( char_storage != 0_ml ) {
+                        if( volume_carried > rigid_storage ) {
                             // Cast up to 64 to prevent overflow. Dividing before would prevent this but lose data.
                             contents_volume += units::from_milliliter( static_cast<int64_t>( armor->storage.value() ) *
-                                               who.inv_volume().value() / char_storage.value() );
+                                               ( volume_carried - rigid_storage ) / non_rigid_storage );
                         }
                     }
                 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6733,30 +6733,29 @@ int item::get_encumber( const Character &who, const bodypart_id &bodypart ) cons
 
     contents_volume += contents.item_size_modifier();
 
-    if( who.is_worn( *this ) ) {
+    if( who.is_worn( *this ) && this->is_non_rigid() ) {
         const islot_armor *armor = find_armor_data();
 
         if( armor != nullptr ) {
             for( const armor_portion_data &entry : armor->data ) {
-                if( entry.covers.test( bodypart.id() ) ) {
-                    if( entry.max_encumber != 0 ) {
-                        units::volume rigid_storage( 0_ml );
-                        units::volume non_rigid_storage( 0_ml );
-                        const units::volume volume_carried = who.volume_carried();
+                if( entry.max_encumber != 0 && entry.covers.test( bodypart.id() ) ) {
+                    units::volume rigid_storage( 0_ml );
+                    units::volume non_rigid_storage( 0_ml );
+                    const units::volume volume_carried = who.volume_carried();
 
-                        for( const item * const &e : who.worn ) {
-                            if( e->is_non_rigid() ) {
-                                non_rigid_storage += e->get_storage();
-                            } else {
-                                rigid_storage += e->get_storage();
-                            }
+                    for( const item * const &e : who.worn ) {
+                        if( e->is_non_rigid() ) {
+                            non_rigid_storage += e->get_storage();
+                        } else {
+                            rigid_storage += e->get_storage();
                         }
+                    }
 
-                        if( volume_carried > rigid_storage ) {
-                            // Cast up to 64 to prevent overflow. Dividing before would prevent this but lose data.
-                            contents_volume += units::from_milliliter( static_cast<int64_t>( armor->storage.value() ) *
-                                               ( volume_carried - rigid_storage ) / non_rigid_storage );
-                        }
+                    if( volume_carried > rigid_storage && non_rigid_storage > 0_ml ) {
+                        // Cast up to 64 to prevent overflow. Dividing before would prevent this but lose data.
+                        contents_volume += units::from_milliliter( static_cast<int64_t>( armor->storage.value() ) *
+                                           ( static_cast<int64_t>( volume_carried.value() ) - rigid_storage.value() ) /
+                                           non_rigid_storage.value() );
                     }
                 }
             }
@@ -6781,11 +6780,7 @@ int item::get_encumber_when_containing(
         if( entry.covers.test( bodypart.id() ) ) {
             encumber = entry.encumber;
             // Non-rigid items add additional encumbrance proportional to their volume
-            bool any_encumb_increase = std::ranges::any_of( armor->data,
-            []( armor_portion_data data ) {
-                return data.encumber != data.max_encumber;
-            } );
-            if( !type->rigid || any_encumb_increase ) {
+            if( this->is_non_rigid() ) {
                 const int capacity = get_total_capacity().value();
                 if( entry.max_encumber == 0 ) {
                     encumber += contents_volume / 500_ml;

--- a/src/item.h
+++ b/src/item.h
@@ -1728,6 +1728,9 @@ class item : public location_visitable<item>, public game_object<item>
         /**If item made out of glass, or has the SHATTERS flag?*/
         bool can_shatter() const;
 
+        /** If the item is non-rigid: either has rigid = false or max_encumber higher than encumber */
+        bool is_non_rigid() const;
+
         /**
          * @name Item properties
          *


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Picture a survivor that has half inventory capacity in rigid (same encumbrance always) items and half in non-rigid (more encumbrance with more capacity filled), and inventory exactly half full. Logically, they'd put the items into the rigid containers first, so all non-rigid containers would be at minimum encumbrance. However, right now the game assumes volume is spread evenly between all containers so they'd be at the midpoint between minimum and maximum.

## Describe the solution (The How)

I changed the calculation from "current volume / max volume" to "(current volume - rigid storage volume) / non-rigid storage volume". Also `Character::inv_volume()` is a direct copy of `Character::volume_carried()` that is used literally in one place (that I was changing), so I removed it.

## Describe alternatives you've considered

Ideally we'd also fill non-rigid items in the order of their volume-to-extra-encumbrance ratio, but that's a lot more involved and would require some kind of a refactor into a character-scoped function that updates encumbrance of all worn items. That's a big refactor for little gain, as the ratio is actually fairly close for most items.

## Testing

Loaded the same save on two versions of the game. Saw that my duffel bag gives less encumbrance with this change.
Filled inventory to full. Saw that encumbrance becomes the same.
Created a new world and gave a survivor a box backpack (15L), a purse (5L), and 60 rags (15L). Saw that purse has minimum encumbrance.
Gave the survivor 20 more rags. Saw that purse has maximum encumbrance.

## Additional context

Resolves #1636 which I didn't know existed until writing this line.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ece48f3](https://github.com/cataclysmbn/Cataclysm-BN/commit/ece48f30a15dbad9d23de52896f82ab62bb08f89) (Fixes for non-rigid storage) on 2026-06-27 14:05:53

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28289650674/artifacts/7924918352)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28289650674/artifacts/7925100659)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28289650674/artifacts/7924879186)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28289650674/artifacts/7924836573)
<!-- END artifact comment -->