### PR TITLE
feat: add enemies to the military body site

### DIFF
--- a/data/json/mapgen/map_extras/corpses.json
+++ b/data/json/mapgen/map_extras/corpses.json
@@ -101,22 +101,17 @@
     "update_mapgen_id": "mx_military",
     "object": {
       "place_nested": [
-        {
-          "chunks": [ [ "lost_squad_chunk_bodies", 100 ] ],
-          "x": [ 1, 22 ],
-          "y": [ 1, 22 ],
-          "repeat": [ 2, 6 ]
-        },
+        { "chunks": [ [ "lost_squad_chunk_bodies", 100 ] ], "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 2, 6 ] },
         {
           "chunks": [ [ "lost_squad_chunk_zombies", 60 ], [ "lost_squad_chunk_robot", 40 ] ],
           "x": [ 1, 22 ],
           "y": [ 1, 22 ]
         }
       ],
-      "place_loot": [ 
-        { "group": "military", "chance": 50, "x": [ 1, 22 ], "y": [ 1, 22 ] }, 
+      "place_loot": [
+        { "group": "military", "chance": 50, "x": [ 1, 22 ], "y": [ 1, 22 ] },
         { "group": "mass_grave_casings", "chance": 80, "repeat": 30, "x": [ 1, 22 ], "y": [ 1, 22 ] },
-        { "group": "military_standard_guns", "chance": 40, "repeat": 2, "x": [ 1, 22 ], "y": [ 1, 22 ] } 
+        { "group": "military_standard_guns", "chance": 40, "repeat": 2, "x": [ 1, 22 ], "y": [ 1, 22 ] }
       ]
     }
   },
@@ -134,7 +129,14 @@
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "lost_squad_chunk_zombies",
-    "object": { "mapgensize": [ 1, 1 ], "place_monster": [ { "group": "GROUP_MIL_STRONG", "chance": 100, "x": 0, "y": 0, "repeat": [ 1, 2 ] }, { "monster": "mon_zombie_supply_sergeant", "chance": 100, "x": 0, "y": 0 }, { "monster": "mon_feral_soldier", "chance": 100, "x": 0, "y": 0, "repeat": [ 1, 2 ] } ] }
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "place_monster": [
+        { "group": "GROUP_MIL_STRONG", "chance": 100, "x": 0, "y": 0, "repeat": [ 1, 2 ] },
+        { "monster": "mon_zombie_supply_sergeant", "chance": 100, "x": 0, "y": 0 },
+        { "monster": "mon_feral_soldier", "chance": 100, "x": 0, "y": 0, "repeat": [ 1, 2 ] }
+      ]
+    }
   },
   {
     "type": "mapgen",

--- a/data/json/mapgen/map_extras/corpses.json
+++ b/data/json/mapgen/map_extras/corpses.json
@@ -103,7 +103,7 @@
       "place_nested": [
         { "chunks": [ [ "lost_squad_chunk_bodies", 100 ] ], "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 2, 6 ] },
         {
-          "chunks": [ [ "lost_squad_chunk_zombies", 60 ], [ "lost_squad_chunk_robot", 40 ] ],
+          "chunks": [ [ "lost_squad_chunk_zombies", 50 ], [ "lost_squad_chunk_robot", 50 ] ],
           "x": [ 1, 22 ],
           "y": [ 1, 22 ]
         }

--- a/data/json/mapgen/map_extras/corpses.json
+++ b/data/json/mapgen/map_extras/corpses.json
@@ -102,19 +102,28 @@
     "object": {
       "place_nested": [
         {
-          "chunks": [ [ "lost_squad_chunk_1", 90 ], [ "lost_squad_chunk_2", 5 ], [ "lost_squad_chunk_3", 5 ] ],
+          "chunks": [ [ "lost_squad_chunk_bodies", 100 ] ],
           "x": [ 1, 22 ],
           "y": [ 1, 22 ],
           "repeat": [ 2, 6 ]
+        },
+        {
+          "chunks": [ [ "lost_squad_chunk_zombies", 60 ], [ "lost_squad_chunk_robot", 40 ] ],
+          "x": [ 1, 22 ],
+          "y": [ 1, 22 ]
         }
       ],
-      "place_loot": [ { "group": "military", "chance": 50, "x": [ 1, 22 ], "y": [ 1, 22 ] } ]
+      "place_loot": [ 
+        { "group": "military", "chance": 50, "x": [ 1, 22 ], "y": [ 1, 22 ] }, 
+        { "group": "mass_grave_casings", "chance": 80, "repeat": 30, "x": [ 1, 22 ], "y": [ 1, 22 ] },
+        { "group": "military_standard_guns", "chance": 40, "repeat": 2, "x": [ 1, 22 ], "y": [ 1, 22 ] } 
+      ]
     }
   },
   {
     "type": "mapgen",
     "method": "json",
-    "nested_mapgen_id": "lost_squad_chunk_1",
+    "nested_mapgen_id": "lost_squad_chunk_bodies",
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_loot": [ { "group": "map_extra_corpse", "x": 0, "y": 0 } ],
@@ -124,14 +133,21 @@
   {
     "type": "mapgen",
     "method": "json",
-    "nested_mapgen_id": "lost_squad_chunk_2",
-    "object": { "mapgensize": [ 1, 1 ], "place_monster": [ { "group": "GROUP_MIL_STRONG", "chance": 100, "x": 0, "y": 0 } ] }
+    "nested_mapgen_id": "lost_squad_chunk_zombies",
+    "object": { "mapgensize": [ 1, 1 ], "place_monster": [ { "group": "GROUP_MIL_STRONG", "chance": 100, "x": 0, "y": 0, "repeat": [ 1, 2 ] }, { "monster": "mon_zombie_supply_sergeant", "chance": 100, "x": 0, "y": 0 }, { "monster": "mon_feral_soldier", "chance": 100, "x": 0, "y": 0, "repeat": [ 1, 2 ] } ] }
   },
   {
     "type": "mapgen",
     "method": "json",
-    "nested_mapgen_id": "lost_squad_chunk_3",
-    "object": { "mapgensize": [ 1, 1 ], "place_monster": [ { "group": "GROUP_ROBOTS_MIL", "chance": 100, "x": 0, "y": 0 } ] }
+    "nested_mapgen_id": "lost_squad_chunk_robot",
+    "object": { "mapgensize": [ 1, 1 ], "place_monster": [ { "monster": "mon_secubot", "chance": 100, "x": 0, "y": 0 } ] }
+  },
+  {
+    "//": "unused until traps are correctly visible again",
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lost_squad_chunk_portal",
+    "object": { "mapgensize": [ 1, 1 ], "set": [ { "point": "trap", "id": "tr_portal", "x": 0, "y": 0 } ] }
   },
   {
     "type": "mapgen",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
It was agreed upon that military body sites are too risk-free for providing early game military equipment.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds two encounters to military body sites. The first encounter spawns up to 2 zombie soldiers, 2 feral soldiers, and 1 zombie sarge, to imply that some of the squad went feral and caused a chaotic fight which ended up killing the squad. The second encounter is a talon ugv, to imply something else killed the squad and their robot was left. This adds some risk to military body sites and hopefully makes them less of a free loot pinata early game.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Debug spawned in both these variants, everything seems to work correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [61e02b0](https://github.com/cataclysmbn/Cataclysm-BN/commit/61e02b096ff7567b858334ac1e9258445816dfea) (Update corpses.json) on 2026-06-27 02:52:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28274095003/artifacts/7920212202)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28274095003)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28274095003/artifacts/7919742755)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28274095003/artifacts/7919824061)
<!-- END artifact comment -->