### PR TITLE
fix: remove 10000L cargo space restriction

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -906,5 +906,18 @@
     "color": "light_gray",
     "location": "accessories",
     "dispersion_modifier": 0
+  },
+  {
+    "id": "test_large_container",
+    "type": "GENERIC",
+    "name": "TEST large container",
+    "description": "A storage container larger than the old int-based volume limit.",
+    "weight": "1 kg",
+    "volume": "1 L",
+    "price": "0 cent",
+    "material": "steel",
+    "symbol": "]",
+    "color": "light_gray",
+    "container_data": { "contains": "3000000 L" }
   }
 ]

--- a/data/mods/TEST_DATA/vehicle_parts.json
+++ b/data/mods/TEST_DATA/vehicle_parts.json
@@ -4,5 +4,12 @@
     "type": "vehicle_part",
     "copy-from": "wheel_caster",
     "rolling_resistance": 0.5
+  },
+  {
+    "id": "test_large_cargo_space",
+    "type": "vehicle_part",
+    "copy-from": "cargo_space",
+    "name": { "str": "TEST large cargo space" },
+    "size": "3000000 L"
   }
 ]

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -846,7 +846,8 @@ void stash_activity_actor::do_turn( player_activity &, Character &who )
     }
 }
 
-static double get_capacity_fraction( int capacity, int volume )
+static auto get_capacity_fraction( const units::volume capacity,
+                                   const units::volume volume ) -> double
 {
     // fraction of capacity the item would occupy
     // fr = 1 is for capacity smaller than is size of item
@@ -854,7 +855,7 @@ static double get_capacity_fraction( int capacity, int volume )
     double fr = 1;
 
     if( capacity > volume ) {
-        fr = static_cast<double>( volume ) / capacity;
+        fr = units::to_milliliter<double>( volume ) / units::to_milliliter<double>( capacity );
     }
 
     return fr;
@@ -879,12 +880,9 @@ static int move_cost_inv( const item &it, const tripoint_bub_ms &src, const trip
     const int mc_per_tile = 100;
 
     // only free inventory capacity
-    const int inventory_capacity = units::to_milliliter( g->u.volume_capacity() -
-                                   g->u.volume_carried() );
+    const auto inventory_capacity = g->u.volume_capacity() - g->u.volume_carried();
 
-    const int item_volume = units::to_milliliter( it.volume() );
-
-    const double fr = get_capacity_fraction( inventory_capacity, item_volume );
+    const double fr = get_capacity_fraction( inventory_capacity, it.volume() );
 
     // approximation of movement cost between source and destination
     const int move_cost = mc_per_tile * rl_dist( src, dest ) * fr;
@@ -907,12 +905,7 @@ static int move_cost_cart( const item &it, const tripoint_bub_ms &src, const tri
     // typical flat ground move cost
     const int mc_per_tile = 100;
 
-    // only free cart capacity
-    const int cart_capacity = units::to_milliliter( capacity );
-
-    const int item_volume = units::to_milliliter( it.volume() );
-
-    const double fr = get_capacity_fraction( cart_capacity, item_volume );
+    const double fr = get_capacity_fraction( capacity, it.volume() );
 
     // approximation of movement cost between source and destination
     const int move_cost = mc_per_tile * rl_dist( src, dest ) * fr;

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <ctime>
 #include <chrono>
 
@@ -126,9 +127,9 @@ void cata::detail::reg_units( sol::state &lua )
                 luna::no_constructor
             );
 
-        luna::set_fx( ut, "from_milliliter", &units::from_milliliter<int> );
-        luna::set_fx( ut, "from_liter", &units::from_liter<int> );
-        luna::set_fx( ut, "to_milliliter", &units::to_milliliter<int> );
+        luna::set_fx( ut, "from_milliliter", &units::from_milliliter<std::int64_t> );
+        luna::set_fx( ut, "from_liter", &units::from_liter<std::int64_t> );
+        luna::set_fx( ut, "to_milliliter", &units::to_milliliter<std::int64_t> );
         luna::set_fx( ut, "to_liter", &units::to_liter );
 
         luna::set_fx( ut, sol::meta_function::equal_to, &units::volume::operator== );

--- a/src/catalua_luna_doc.h
+++ b/src/catalua_luna_doc.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "action.h"
 #include "coordinates.h"
 #include "calendar.h"
@@ -126,7 +128,7 @@ class mass_in_milligram_tag;
 using mass = quantity<std::int64_t, mass_in_milligram_tag>;
 
 class volume_in_milliliter_tag;
-using volume = quantity<int, volume_in_milliliter_tag>;
+using volume = quantity<std::int64_t, volume_in_milliliter_tag>;
 } // namespace units
 
 struct islot_container;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8528,7 +8528,8 @@ int Character::item_handling_cost( const item &it, bool penalties, int base_cost
     int mv = base_cost;
     if( penalties ) {
         // 40 moves per liter, up to 200 at 5 liters
-        mv += std::min( 200, it.volume() / 20_ml );
+        const auto volume_moves = it.volume() / 20_ml;
+        mv += static_cast<int>( std::min( volume_moves, decltype( volume_moves ) { 200 } ) );
     }
 
     if( primary_weapon().typeId() == itype_e_handcuffs ) {
@@ -9354,8 +9355,10 @@ void Character::on_dodge( Creature *source, int difficulty )
     // dodging throws of our aim unless we are either skilled at dodging or using a small weapon
     const item &weapon = primary_weapon();
     if( is_armed() && weapon.is_gun() ) {
-        recoil += std::max( weapon.volume() / 250_ml - get_skill_level( skill_dodge ), 0 ) * rng( 0,
-                  100 );
+        const auto dodge_volume_recoil = weapon.volume() / 250_ml - get_skill_level( skill_dodge );
+        const auto volume_recoil = std::max( dodge_volume_recoil, decltype( dodge_volume_recoil ) { 0 } );
+        recoil += static_cast<int>( std::min( volume_recoil,
+                                              static_cast<decltype( volume_recoil )>( MAX_RECOIL ) ) ) * rng( 0, 100 );
         recoil = std::min( MAX_RECOIL, recoil );
     }
 

--- a/src/fluid_grid.cpp
+++ b/src/fluid_grid.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <limits>
 #include <memory>
@@ -211,8 +212,7 @@ auto batches_for_inputs( const std::vector<fluid_grid_transform_io> &inputs,
 
     auto max_batches = std::numeric_limits<double>::max();
     std::ranges::for_each( inputs, [&]( const fluid_grid_transform_io & io ) {
-        const auto amount_ml = units::to_milliliter<int>( io.amount );
-        if( amount_ml <= 0 ) {
+        if( io.amount <= 0_ml ) {
             max_batches = 0.0;
             return;
         }
@@ -807,13 +807,13 @@ auto split_storage_state( const fluid_grid::liquid_storage_state &state,
         return { .lhs = lhs_state, .rhs = rhs_state };
     }
 
-    const auto total_capacity_ml = units::to_milliliter<int>( total_capacity );
-    const auto lhs_capacity_ml = units::to_milliliter<int>( lhs_capacity );
+    const auto total_capacity_ml = units::to_milliliter( total_capacity );
+    const auto lhs_capacity_ml = units::to_milliliter( lhs_capacity );
     const auto ratio = static_cast<double>( lhs_capacity_ml ) / total_capacity_ml;
 
     std::ranges::for_each( state.stored_by_type, [&]( const auto & entry ) {
-        const auto liquid_ml = units::to_milliliter<int>( entry.second );
-        const auto lhs_liquid_ml = static_cast<int>( std::round( liquid_ml * ratio ) );
+        const auto liquid_ml = units::to_milliliter( entry.second );
+        const auto lhs_liquid_ml = static_cast<decltype( liquid_ml )>( std::round( liquid_ml * ratio ) );
 
         lhs_state.stored_by_type[entry.first] = units::from_milliliter( lhs_liquid_ml );
         rhs_state.stored_by_type[entry.first] =
@@ -1571,7 +1571,7 @@ auto process_transformers_at( const tripoint_abs_omt &p, time_point to ) -> void
         std::ranges::for_each( request.recipe->inputs, [&]( const fluid_grid_transform_io & io ) {
             const auto amount_ml = units::to_milliliter<double>( io.amount );
             const auto volume_ml = amount_ml * adjusted_batches;
-            const auto volume_ml_floor = static_cast<int>( std::floor( volume_ml ) );
+            const auto volume_ml_floor = static_cast<std::int64_t>( std::floor( volume_ml ) );
             if( volume_ml_floor <= 0 ) {
                 return;
             }
@@ -1591,7 +1591,7 @@ auto process_transformers_at( const tripoint_abs_omt &p, time_point to ) -> void
         std::ranges::for_each( request.recipe->outputs, [&]( const fluid_grid_transform_io & io ) {
             const auto amount_ml = units::to_milliliter<double>( io.amount );
             const auto volume_ml = amount_ml * adjusted_batches;
-            const auto volume_ml_floor = static_cast<int>( std::floor( volume_ml ) );
+            const auto volume_ml_floor = static_cast<std::int64_t>( std::floor( volume_ml ) );
             if( volume_ml_floor <= 0 ) {
                 return;
             }

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -361,7 +361,9 @@ void doors::close_door( map &m, Character &who, const tripoint_bub_ms &closep )
                 didit = true;
                 who.add_msg_if_player( m_info, _( "You push the %s out of the way." ),
                                        items_in_way.size() == 1 ? items_in_way.only_item().tname() : _( "stuff" ) );
-                who.mod_moves( -std::min( items_in_way.stored_volume() / ( max_nudge / 50 ), 100 ) );
+                const auto nudge_moves = items_in_way.stored_volume() / ( max_nudge / 50 );
+                const auto max_nudge_moves = decltype( nudge_moves ) { 100 };
+                who.mod_moves( -static_cast<int>( std::min( nudge_moves, max_nudge_moves ) ) );
 
                 if( m.has_flag( "NOITEM", closep ) ) {
                     // Just plopping items back on their origin square will displace them to adjacent squares

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -271,8 +271,9 @@ void iexamine::cvdmachine( player &p, const tripoint_bub_ms & )
     }
 
     // Require materials proportional to selected item volume
-    auto qty = loc->volume() / units::legacy_volume_factor;
-    qty = std::max( 1, qty );
+    const auto volume_ratio = loc->volume() / units::legacy_volume_factor;
+    const auto volume_qty = std::max( volume_ratio, decltype( volume_ratio ) { 1 } );
+    const auto qty = static_cast<int>( std::min( volume_qty, decltype( volume_qty ) { INT_MAX } ) );
     auto reqs = *requirement_id( "cvd_diamond" ) * qty;
 
     if( !reqs.can_make_with_inventory( p.crafting_inventory(), is_crafting_component ) ) {
@@ -347,8 +348,12 @@ void iexamine::nanofab( player &p, const tripoint_bub_ms &examp )
         menu.text = _( "Choose a recipe:" );
         for( size_t i = 0; i < recipe_ids.size(); ++i ) {
             itype_id item = itype_id( recipe_ids[i] );
+            const auto volume_ratio = item->volume / 250_ml;
+            const auto min_charge_units = decltype( volume_ratio ) { 1 };
+            const auto max_charge_units = decltype( volume_ratio ) { INT_MAX / 5 };
+            const auto charge_units = std::clamp( volume_ratio, min_charge_units, max_charge_units );
             auto button_text = string_format( "%s [%d]", item->nname( 1 ),
-                                              std::max( 1, item->volume / 250_ml ) * 5 );
+                                              static_cast<int>( charge_units * 5 ) );
             menu.addentry( i, true, -1, button_text );
         }
         menu.query();
@@ -380,7 +385,9 @@ void iexamine::nanofab( player &p, const tripoint_bub_ms &examp )
         new_item = item::spawn( itype_id( chosen_recipe ), calendar::turn, item_count );
     }
 
-    auto qty = std::max( 1, new_item->volume() / 250_ml );
+    const auto volume_ratio = new_item->volume() / 250_ml;
+    const auto requested_qty = std::max( volume_ratio, decltype( volume_ratio ) { 1 } );
+    const auto qty = static_cast<int>( std::min( requested_qty, decltype( requested_qty ) { INT_MAX } ) );
     auto reqs = *requirement_id( "nanofabricator" ) * qty;
 
     if( !reqs.can_make_with_inventory( p.crafting_inventory(), is_crafting_component ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1098,16 +1098,20 @@ int item::charges_per_volume( const units::volume &vol ) const
             debugmsg( "Item '%s' with zero volume", tname() );
             return INFINITE_CHARGES;
         }
-        // Type cast to prevent integer overflow with large volume containers like the cargo
-        // dimension
-        return vol * static_cast<int64_t>( type->stack_size ) / type->volume;
+        if( type->stack_size > 0 && vol > units::volume_max / type->stack_size ) {
+            return INFINITE_CHARGES;
+        }
+        const auto result = vol * static_cast<decltype( units::to_milliliter( vol ) )>(
+                                type->stack_size ) / type->volume;
+        return static_cast<int>( std::min( result, static_cast<decltype( result )>( INFINITE_CHARGES ) ) );
     } else {
         units::volume my_volume = volume();
         if( my_volume == 0_ml ) {
             debugmsg( "Item '%s' with zero volume", tname() );
             return INFINITE_CHARGES;
         }
-        return vol / my_volume;
+        const auto result = vol / my_volume;
+        return static_cast<int>( std::min( result, static_cast<decltype( result )>( INFINITE_CHARGES ) ) );
     }
 }
 
@@ -5381,7 +5385,11 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         tagtext += string_format( " (%s)", group_id_str );
     } else if( has_var( "NANOFAB_ITEM_ID" ) ) {
         itype_id item = itype_id( get_var( "NANOFAB_ITEM_ID" ) );
-        tagtext += string_format( " (%s [%d])", nname( item ), std::max( 1, item->volume / 250_ml ) * 5 );
+        const auto volume_ratio = item->volume / 250_ml;
+        const auto min_charge_units = decltype( volume_ratio ) { 1 };
+        const auto max_charge_units = decltype( volume_ratio ) { INT_MAX / 5 };
+        const auto charge_units = std::clamp( volume_ratio, min_charge_units, max_charge_units );
+        tagtext += string_format( " (%s [%d])", nname( item ), static_cast<int>( charge_units * 5 ) );
     }
 
     if( already_used_by_player( you ) ) {
@@ -6849,7 +6857,9 @@ int item::get_avg_coverage() const
     const islot_armor *armor = find_armor_data();
     if( !armor ) {
         // handle wearable guns (e.g. shoulder strap) as special case
-        return is_gun() ? std::min( volume() / 500_ml, 100 ) : 0;
+        const auto volume_coverage = volume() / 500_ml;
+        const auto max_coverage = decltype( volume_coverage ) { 100 };
+        return is_gun() ? static_cast<int>( std::min( volume_coverage, max_coverage ) ) : 0;
     }
     int avg_coverage = 0;
     int avg_ctr = 0;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -286,12 +286,6 @@ void Item_factory::finalize_pre( itype &obj )
         return f.str().starts_with( "LIGHT_" );
     } );
 
-    // Set max volume for containers to prevent integer overflow
-    if( obj.container && obj.container->contains > 10000_liter ) {
-        debugmsg( obj.id.str() + " storage volume is too large, reducing to 10000 liters" );
-        obj.container->contains = 10000_liter;
-    }
-
     if( obj.ammo ) {
         // for ammo not specifying loudness (or an explicit less than zero) derive value from other properties
         // 343 is the speed of sound in atmosphere, but guns are still loud.

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -1,5 +1,6 @@
 #include "itype.h"
 
+#include <algorithm>
 #include <cstdlib>
 
 #include "catalua_icallback_actor.h"
@@ -145,7 +146,14 @@ int itype::charges_per_volume( const units::volume &vol ) const
         // TODO: items should not have 0 volume at all!
         return item::INFINITE_CHARGES;
     }
-    return ( count_by_charges() ? stack_size : 1 ) * vol / volume;
+    const auto effective_stack_size = count_by_charges() ? stack_size : 1;
+    if( effective_stack_size > 0 && vol > units::volume_max / effective_stack_size ) {
+        return item::INFINITE_CHARGES;
+    }
+    const auto result = vol * static_cast<decltype( units::to_milliliter( vol ) )>(
+                            effective_stack_size ) / volume;
+    return static_cast<int>( std::min( result,
+                                       static_cast<decltype( result )>( item::INFINITE_CHARGES ) ) );
 }
 
 // Members of iuse struct, which is slowly morphing into a class.

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4798,9 +4798,9 @@ bool mattack::absorb_meat( monster *z )
             if( current_item_material == material_id( "flesh" ) ||
                 current_item_material == material_id( "hflesh" ) ) {
                 //We have something meaty! Calculate how much it will heal the monster
-                const int ml_of_meat = units::to_milliliter<int>( current_item->volume() );
-                const int total_charges = current_item->count();
-                const int ml_per_charge = ml_of_meat / total_charges;
+                const auto ml_of_meat = units::to_milliliter( current_item->volume() );
+                const auto total_charges = current_item->count();
+                const auto ml_per_charge = ml_of_meat / total_charges;
                 //We have a max size of meat here to avoid absorbing whole corpses.
                 if( ml_per_charge > max_meat_absorbed * 1000 ) {
                     add_msg( m_info, _( "The %1$s quivers hungrily in the direction of the %2$s." ), z->name(),

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3530,8 +3530,10 @@ void npc::drop_items( units::mass drop_weight, units::volume drop_volume, int mi
         // decreasing that variable is not important.
         int dWeight = units::to_gram<int>( drop_weight ) <= 0 ? -1 :
                       units::to_gram<int>( drop_weight - weight_dropped ) / 250;
-        int dVolume = units::to_milliliter<int>( drop_volume ) <= 0 ? -1 :
-                      units::to_milliliter<int>( drop_volume - volume_dropped ) / 250;
+        const auto d_volume = drop_volume <= 0_ml ? -1 : std::min(
+                                  units::to_milliliter( drop_volume - volume_dropped ) / 250,
+                                  static_cast<decltype( units::to_milliliter( drop_volume ) )>( INT_MAX ) );
+        const auto dVolume = static_cast<int>( d_volume );
         int index;
         // Which is more important, weight or volume?
         if( dWeight > dVolume ) {

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1,6 +1,7 @@
 #include "game.h" // IWYU pragma: associated
 
 #include <algorithm>
+#include <cstdint>
 #include <map>
 #include <ranges>
 #include <sstream>
@@ -639,7 +640,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
             while( !jsin.end_array() ) {
                 const auto entry = jsin.get_object();
                 auto origin = tripoint_om_omt{};
-                auto capacity_ml = 0;
+                auto capacity_ml = std::int64_t{ 0 };
                 entry.read( "pos", origin );
                 entry.read( "capacity_ml", capacity_ml );
 
@@ -651,8 +652,10 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                 std::ranges::for_each( std::views::iota( size_t{ 0 }, liquids.size() ),
                 [&]( size_t i ) {
                     const auto liquid_entry = liquids.get_array( i );
-                    const auto liquid_type = itype_id( liquid_entry.get_string( 0 ) );
-                    const auto volume_ml = liquid_entry.get_int( 1 );
+                    auto liquid_entry_iter = liquid_entry.begin();
+                    const auto liquid_type = itype_id( ( *liquid_entry_iter ).get_string() );
+                    ++liquid_entry_iter;
+                    const auto volume_ml = ( *liquid_entry_iter ).get_int64();
                     if( volume_ml > 0 ) {
                         state.stored_by_type[liquid_type] += units::from_milliliter( volume_ml );
                     }
@@ -1247,7 +1250,7 @@ void overmap::serialize( std::ostream &fout ) const
     std::ranges::for_each( fluid_storage, [&]( const auto & entry ) {
         json.start_object();
         json.member( "pos", entry.first );
-        json.member( "capacity_ml", units::to_milliliter<int>( entry.second.capacity ) );
+        json.member( "capacity_ml", units::to_milliliter( entry.second.capacity ) );
         json.member( "liquids" );
         json.start_array();
         std::ranges::for_each( entry.second.stored_by_type, [&]( const auto & liquid_entry ) {
@@ -1256,7 +1259,7 @@ void overmap::serialize( std::ostream &fout ) const
             }
             json.start_array();
             json.write( liquid_entry.first );
-            json.write( units::to_milliliter<int>( liquid_entry.second ) );
+            json.write( units::to_milliliter( liquid_entry.second ) );
             json.end_array();
         } );
         json.end_array();

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "json.h"
 #include "string_formatter.h"
 #include "units.h"
@@ -10,9 +12,9 @@ template<>
 void volume::serialize( JsonOut &jsout ) const
 {
     if( value_ % 1000 == 0 ) {
-        jsout.write( string_format( "%d L", value_ / 1000 ) );
+        jsout.write( std::to_string( value_ / 1000 ) + " L" );
     } else {
-        jsout.write( string_format( "%d ml", value_ ) );
+        jsout.write( std::to_string( value_ ) + " ml" );
     }
 }
 

--- a/src/units_serde.h
+++ b/src/units_serde.h
@@ -4,6 +4,8 @@
  * Measurement units (de-)serialization.
  */
 
+#include <cstdint>
+
 #include "json.h"
 #include "units_def.h"
 
@@ -46,7 +48,7 @@ T read_from_json_string( JsonIn &jsin, const std::vector<std::pair<std::string, 
     }
     T result{};
     do {
-        int sign_value = +1;
+        std::int64_t sign_value = +1;
         if( s[i] == '-' ) {
             sign_value = -1;
             ++i;
@@ -56,7 +58,7 @@ T read_from_json_string( JsonIn &jsin, const std::vector<std::pair<std::string, 
         if( i >= s.size() || !isdigit( s[i] ) ) {
             error( "invalid quantity string: number expected" );
         }
-        int value = 0;
+        std::int64_t value = 0;
         for( ; i < s.size() && isdigit( s[i] ); ++i ) {
             value = value * 10 + ( s[i] - '0' );
         }

--- a/src/units_volume.h
+++ b/src/units_volume.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <algorithm>
+#include <concepts>
+#include <cstdint>
 
 #include "units_def.h"
 
@@ -11,7 +13,7 @@ class volume_in_milliliter_tag
 {
 };
 
-using volume = quantity<int, volume_in_milliliter_tag>;
+using volume = quantity<std::int64_t, volume_in_milliliter_tag>;
 
 const volume volume_min = units::volume( std::numeric_limits<units::volume::value_type>::min(),
                           units::volume::unit_type{} );
@@ -26,7 +28,13 @@ constexpr quantity<value_type, volume_in_milliliter_tag> from_milliliter(
     return quantity<value_type, volume_in_milliliter_tag>( v, volume_in_milliliter_tag{} );
 }
 
-template<typename value_type>
+template<std::integral value_type>
+constexpr volume from_liter( const value_type v )
+{
+    return from_milliliter( static_cast<volume::value_type>( v ) * 1000 );
+}
+
+template<std::floating_point value_type>
 constexpr quantity<value_type, volume_in_milliliter_tag> from_liter( const value_type v )
 {
     return from_milliliter<value_type>( v * 1000 );
@@ -49,7 +57,7 @@ static constexpr volume legacy_volume_factor = from_milliliter( 250 );
 
 } // namespace units
 
-// Implicitly converted to volume, which has int as value_type!
+// Implicitly converted to volume, which has int64_t as value_type!
 constexpr units::volume operator""_ml( const unsigned long long v )
 {
     return units::from_milliliter( v );
@@ -61,7 +69,7 @@ constexpr units::quantity<double, units::volume_in_milliliter_tag> operator""_ml
     return units::from_milliliter( v );
 }
 
-// Implicitly converted to volume, which has int as value_type!
+// Implicitly converted to volume, which has int64_t as value_type!
 constexpr units::volume operator""_liter( const unsigned long long v )
 {
     return units::from_milliliter( v * 1000 );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -384,8 +384,7 @@ detached_ptr<item> vehicle_stack::remove( item *to_remove )
 units::volume vehicle_stack::max_volume() const
 {
     if( myorigin->part_flag( part_num, "CARGO" ) && !myorigin->part( part_num ).is_broken() ) {
-        // Set max volume for vehicle cargo to prevent integer overflow
-        return std::min( myorigin->part( part_num ).info().size, 10000_liter );
+        return myorigin->part( part_num ).info().size;
     }
     return 0_ml;
 }

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -424,7 +424,7 @@ double vehicle_part::consume_energy( const itype_id &ftype, double energy_j )
         }
         //TODO!: push up
         item &fuel_consumed = *item::spawn_temporary( ftype, calendar::turn, charges_to_use );
-        return energy_p_mL * units::to_milliliter<int>( fuel_consumed.volume( true ) );
+        return energy_p_mL * units::to_milliliter( fuel_consumed.volume( true ) );
     }
     return 0.0;
 }

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -2,9 +2,11 @@
 
 #include <initializer_list>
 #include <algorithm>
+#include <cstdint>
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <type_traits>
 
 #include "calendar.h"
 #include "enums.h"
@@ -17,6 +19,8 @@
 #include "units.h"
 #include "value_ptr.h"
 #include "cached_item_options.h"
+
+static_assert( std::is_same_v<units::volume::value_type, std::int64_t> );
 
 TEST_CASE( "item_volume", "[item]" )
 {
@@ -37,6 +41,30 @@ TEST_CASE( "item_volume", "[item]" )
         i.charges++;
         CHECK( i.volume() > v ); // one more charge should not fit
     }
+}
+
+TEST_CASE( "large_item_storage_volumes", "[item][volume]" )
+{
+    constexpr auto legacy_int_limit_ml = static_cast<std::int64_t>( std::numeric_limits<int>::max() );
+    const auto volume_above_legacy_int_limit = units::from_milliliter( legacy_int_limit_ml + 1 );
+    CHECK( units::to_milliliter( volume_above_legacy_int_limit ) == legacy_int_limit_ml + 1 );
+
+    const item &large_container = *item::spawn_temporary( "test_large_container" );
+    CHECK( large_container.get_container_capacity() == 3000000_liter );
+}
+
+TEST_CASE( "charge_volume_calculation_uses_wide_intermediate", "[item][volume]" )
+{
+    item &battery = *item::spawn_temporary( "battery", calendar::start_of_cataclysm,
+                                            item::default_charges_tag() );
+    REQUIRE( battery.count_by_charges() );
+
+    const auto volume_with_int_overflowing_product = units::from_milliliter(
+                static_cast<std::int64_t>( std::numeric_limits<int>::max() ) / 2 + 1 );
+    CHECK( battery.charges_per_volume( volume_with_int_overflowing_product ) ==
+           units::to_milliliter( volume_with_int_overflowing_product ) );
+    CHECK( battery.charges_per_volume( units::volume_max ) == item::INFINITE_CHARGES );
+    CHECK( battery.type->charges_per_volume( units::volume_max ) == item::INFINITE_CHARGES );
 }
 
 TEST_CASE( "simple_item_layers", "[item]" )

--- a/tests/units_test.cpp
+++ b/tests/units_test.cpp
@@ -1,15 +1,25 @@
 #include "catch/catch.hpp"
 
+#include <cstdint>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "calendar.h"
+#include "fstream_utils.h"
 #include "json.h"
 #include "options_helpers.h"
 #include "units.h"
 #include "units_serde.h"
 #include "units_utility.h"
+
+static units::volume parse_volume_quantity( const std::string &json )
+{
+    std::istringstream buffer( json );
+    JsonIn jsin( buffer );
+    return read_from_json_string<units::volume>( jsin, units::volume_units );
+}
 
 TEST_CASE( "units_have_correct_ratios", "[units]" )
 {
@@ -42,6 +52,19 @@ TEST_CASE( "units_have_correct_ratios", "[units]" )
     CHECK( 60_arcmin == 1_degrees );
 
     CHECK( 1_c == units::from_celsius( 1 ) );
+}
+
+TEST_CASE( "large_volume_json_round_trip", "[units][volume]" )
+{
+    const auto large_volume = units::from_milliliter(
+                                  static_cast<std::int64_t>( std::numeric_limits<int>::max() ) + 1 );
+    const auto serialized_volume = serialize_wrapper( [&]( JsonOut & jsout ) {
+        jsout.write( large_volume );
+    } );
+
+    CHECK( units::from_liter( 3000000 ) == 3000000_liter );
+    CHECK( serialized_volume == "\"2147483648 ml\"" );
+    CHECK( parse_volume_quantity( serialized_volume ) == large_volume );
 }
 
 static units::energy parse_energy_quantity( const std::string &json )

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -224,6 +224,25 @@ auto vehicle_with_invalid_part_and_legacy_pivot_json() -> std::string
 
 } // namespace
 
+TEST_CASE( "vehicle_cargo_uses_full_part_volume", "[vehicle][cargo][volume]" )
+{
+    clear_map();
+
+    auto &here = get_map();
+    const auto vehicle_origin = tripoint_bub_ms( 60, 60, 0 );
+    auto *veh_ptr = here.add_vehicle( vproto_id( "none" ), vehicle_origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    REQUIRE( veh_ptr->install_part( tripoint_mnt_veh::zero(), vpart_id( "frame_vertical" ),
+                                    true ) >= 0 );
+
+    const auto cargo_index = veh_ptr->install_part( tripoint_mnt_veh::zero(),
+                             vpart_id( "test_large_cargo_space" ), true );
+    REQUIRE( cargo_index >= 0 );
+
+    CHECK( veh_ptr->max_volume( cargo_index ) == 3000000_liter );
+    CHECK( veh_ptr->free_volume( cargo_index ) == 3000000_liter );
+}
+
 TEST_CASE( "vehicle deserialize accepts legacy two coordinate pivot", "[vehicle][save]" )
 {
     auto json = std::istringstream( vehicle_with_legacy_pivot_json() );


### PR DESCRIPTION
## Purpose of change (The Why)

<img width="530" height="56" alt="image" src="https://github.com/user-attachments/assets/f6904690-c301-4084-92df-fbd6fd639bb5" />

apparently vehicle cargo above 10000L was silently capped to avoid legacy int overflow since https://github.com/CleverRaven/Cataclysm-DDA/pull/26493

## Describe the solution (The How)

- use i64 over int for `units::volume`
- remove the 10000L vehicle cargo/container cap

## Testing

wip

## Checklist

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] Existing volume unit syntax docs still apply; no new localizable fields or save migration needed.
- [x] This PR modifies lua scripts or the lua API.
  - [x] Generated Lua volume annotations were updated for 64-bit volume values.

<sub>PR opened by gpt-5.5 high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [43b8763](https://github.com/cataclysmbn/Cataclysm-BN/commit/43b876331c3213a868b7dc4e613e00276a88d0ee) (fix: allow oversized vehicle storage volumes) on 2026-06-27 05:23:47

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28277989576/artifacts/7921195494)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28277989576/artifacts/7921395387)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28277989576/artifacts/7921174921)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28277989576/artifacts/7921125951)
<!-- END artifact comment -->
