### PR TITLE
fix: fix vehicle part graphics when copying looks like from an abstract

### DIFF
--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -537,7 +537,15 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
 
     // This was used in old copy from logic, force looks like of the parent
     if( jo.has_string( "copy-from" ) ) {
-        looks_like = jo.get_string( "copy-from" );
+        const auto copied = jo.get_string( "copy-from" );
+        if( vpart_id( copied ).is_valid() ) {
+            // If not abstract, always look like parent unless overwritten below
+            looks_like = copied;
+        } else if( looks_like.empty() ) {
+            // If abstract, dont look like abstract if there is a looks like
+            // Due to graphics logic being unable to work with abstracts
+            looks_like = copied;
+        }
     }
 
     jo.read( "looks_like", looks_like );


### PR DESCRIPTION
## Purpose of change (The Why)
Caused by: #9639
Missed logic around abstract parts and looks like

## Describe the solution (The How)
Dont looks like abstract unless absolutely needed

## Describe alternatives you've considered
Fix that `crafting.json` vehicle part selection to be more sane too

## Testing
Advanced 3d printer has image again

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [30b5517](https://github.com/cataclysmbn/Cataclysm-BN/commit/30b55172355bda0382baf8fd35791fb91737a92c) (fix: fix vehicle part graphics when copying looks like from an abstract) on 2026-06-27 17:42:30

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28295009207/artifacts/7926254172)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28295009207/artifacts/7926702592)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28295009207/artifacts/7926339340)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28295009207/artifacts/7926283999)
<!-- END artifact comment -->