### PR TITLE
feat(balance): buff climate control values slightly

### DIFF
--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -104,7 +104,7 @@
         {
           "has": "WORN",
           "condition": "ACTIVE",
-          "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "CLIMATE_CONTROL", "add": 750 } ]
+          "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
         }
       ]
     },
@@ -174,7 +174,7 @@
         {
           "has": "WORN",
           "condition": "ACTIVE",
-          "values": [ { "value": "STRENGTH", "add": 6 }, { "value": "CLIMATE_CONTROL", "add": 750 } ]
+          "values": [ { "value": "STRENGTH", "add": 6 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
         }
       ]
     },
@@ -243,7 +243,7 @@
         {
           "has": "WORN",
           "condition": "ACTIVE",
-          "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "CLIMATE_CONTROL", "add": 750 } ]
+          "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
         }
       ]
     },
@@ -318,10 +318,7 @@
     "environmental_protection": 16,
     "weight_capacity_bonus": "5500 g",
     "adv_hearing_protection": 80,
-    "hearing_protection": 0,
-    "relic_data": {
-      "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "CLIMATE_CONTROL", "add": 750 } ] } ]
-    }
+    "hearing_protection": 0
   },
   {
     "id": "power_armor_helmet_heavy",
@@ -381,10 +378,7 @@
     "environmental_protection": 16,
     "weight_capacity_bonus": "7500 g",
     "adv_hearing_protection": 80,
-    "hearing_protection": 0,
-    "relic_data": {
-      "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "CLIMATE_CONTROL", "add": 750 } ] } ]
-    }
+    "hearing_protection": 0
   },
   {
     "id": "power_armor_helmet_light",
@@ -444,10 +438,7 @@
     "environmental_protection": 16,
     "weight_capacity_bonus": "2500 g",
     "adv_hearing_protection": 80,
-    "hearing_protection": 0,
-    "relic_data": {
-      "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "CLIMATE_CONTROL", "add": 750 } ] } ]
-    }
+    "hearing_protection": 0
   },
   {
     "id": "power_armor_frame",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -648,7 +648,7 @@
     "name": { "str": "liquid cooling suit (on)", "str_pl": "liquid cooling suits (on)" },
     "description": "This a bodysuit with a number of heatsinks and heating coils tied to a liquid coolant system, and a built-in thermometer.  It is currently working to keep the entire body at an ideal temperature, use it to turn it off.",
     "relic_data": {
-      "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "CLIMATE_CONTROL", "add": 750 } ] } ]
+      "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "CLIMATE_CONTROL", "add": 1250 } ] } ]
     },
     "power_draw": 125000,
     "revert_to": "thermal_cooling_suit",
@@ -965,7 +965,7 @@
           "condition": "ACTIVE",
           "values": [
             { "value": "STRENGTH", "add": 2 },
-            { "value": "CLIMATE_CONTROL", "add": 750 },
+            { "value": "CLIMATE_CONTROL", "add": 1250 },
             { "value": "BLISTER_COUNT", "add": -20 }
           ]
         }
@@ -1099,7 +1099,7 @@
         {
           "has": "WORN",
           "condition": "ALWAYS",
-          "values": [ { "value": "ARMOR_PSI", "add": -25 }, { "value": "CLIMATE_CONTROL", "add": 750 } ]
+          "values": [ { "value": "ARMOR_PSI", "add": -25 }, { "value": "CLIMATE_CONTROL", "add": 1250 } ]
         }
       ]
     },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10745,12 +10745,12 @@ int Character::temp_corrected_by_climate_control( int temperature )
         temperature -= bonus_from_enchantments( temperature,
                                                 enchantment_value_id( "CLIMATE_CONTROL_COOLING" ) );
         if( in_climate_control() ) {
-            temperature -= 750;
+            temperature -= 1250;
         }
         return std::max( BODYTEMP_NORM, temperature );
     } else {
         if( in_climate_control() ) {
-            temperature += 750;
+            temperature += 1250;
         }
         temperature += bonus_from_enchantments( temperature,
                                                 enchantment_value_id( "CLIMATE_CONTROL_HEATING" ) );


### PR DESCRIPTION
## Purpose of change (The Why)
#9699 showed the one exception that I missed
When going beyond freezing, climate control gets a range to stabilize it of 2500 instead of 1500 being the maximum stabilization

## Describe the solution (The How)
Set all defaults to 1250 instead
This way it is still balanced in reasonable temps and helps extreme lab temps
Remove climate control from power armor helmets and buff it to 2000 on armor

## Describe alternatives you've considered
None

## Testing
Number go up

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6ad4e85](https://github.com/cataclysmbn/Cataclysm-BN/commit/6ad4e855080ad14592feca435ab11c1617307a15) (change default from CLIMATE_CONTROL flag too) on 2026-06-27 19:34:34

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28297034397/artifacts/7927446115)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28297034397/artifacts/7927317300)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28297034397/artifacts/7927113007)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28297034397/artifacts/7927030590)
<!-- END artifact comment -->