### PR TITLE
fix(port): check item instead of type when throwing worn item

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1323,7 +1323,7 @@ void avatar_action::plthrow( avatar &you, item *loc,
         }
     }
     // if you're wearing the item you need to be able to take it off
-    if( you.is_wearing( loc->typeId() ) ) {
+    if( you.is_worn( *loc ) ) {
         ret_val<bool> ret = you.can_takeoff( *loc );
         if( !ret.success() ) {
             add_msg( m_info, "%s", ret.c_str() );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
resolves #9612 

## Describe the solution (The How)

Instead of checking if the item type is worn, check if the exact item to be thrown is being worn
Same fix was done in Cataclysm DDA here https://github.com/CleverRaven/Cataclysm-DDA/pull/47056
Corresponding issue in CDDA https://github.com/CleverRaven/Cataclysm-DDA/issues/47044
(Let me know if I should be porting the fix somehow to give credit, do I need to cherry-pick the CDDA commit, then make changes on top of it?)

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

There is the same function is_wearing(item&), we could use the one defined in source instead of is_worn(item&) defined inline.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Tested before and after fix - could not throw backpack while wearing backpack, but with fix could do the throw.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
N/A

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->
N/A

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->
- [x] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [x] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [x] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7c0021f](https://github.com/cataclysmbn/Cataclysm-BN/commit/7c0021fd95b277028a83fcee00cb705a82532548) (fix(port): check item instead of type when throwing worn item) on 2026-06-28 00:48:25

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28305328719/artifacts/7929542769)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28305328719/artifacts/7929394638)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28305328719/artifacts/7929240012)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28305328719/artifacts/7929264652)
<!-- END artifact comment -->