### PR TITLE
feat(mods/MagicalNights): Give the Spirit Armor spell a unique item instead of plate armor

### DIFF
--- a/data/mods/MagicalNights/Spells/animist.json
+++ b/data/mods/MagicalNights/Spells/animist.json
@@ -63,7 +63,7 @@
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
-    "effect_str": "armor_lightplate",
+    "effect_str": "SpiritArmorBasic",
     "spell_class": "ANIMIST",
     "energy_source": "MANA",
     "difficulty": 5,

--- a/data/mods/MagicalNights/Spells/animist.json
+++ b/data/mods/MagicalNights/Spells/animist.json
@@ -63,7 +63,7 @@
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
-    "effect_str": "SpiritArmorBasic",
+    "effect_str": "spirit_armor",
     "spell_class": "ANIMIST",
     "energy_source": "MANA",
     "difficulty": 5,

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -83,7 +83,7 @@
     "flags": [ "VARSIZE" ]
   },
   {
-    "id": "SpiritArmorBasic",
+    "id": "spirit_armor",
     "type": "ARMOR",
     "name": { "str": "Spirit Armor" },
     "description": "A magical barrier made of the user's conviction, will and faith. Feels like super light, permeable bubble arround you and your equipement that hardens on impact. Most of it's power comes from draining inertia from anything that could harm. The magic works more efficiently on faster moving objects with low mass, like bullets, arrows, rain and alpha particles. It does not protect you from getting grabbed. Untill the spell expires or untill the armor is discarded your mana regeneration is used to maintain the effect.",

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -105,10 +105,7 @@
         {
           "has": "WORN",
           "condition": "ALWAYS",
-          "values": [
-            { "value": "ARMOR_BULLET", "add":-3, "multiply": -0.5 },
-            { "value": "MANA_REGEN", "multiply": -0.99 },
-          ]
+          "values": [ { "value": "ARMOR_BULLET", "add": -3, "multiply": -0.5 }, { "value": "MANA_REGEN", "multiply": -0.99 } ]
         }
       ]
     },

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -109,7 +109,7 @@
         }
       ]
     },
-    "flags": [ "RAINPROOF", "STURDY", "RAD_PROOF", "AURA", "POWERARMOR_COMPATIBLE", "NO_SALVAGE", "ONLY_ONE", "PSYSHIELD_PARTIAL" ]
+    "flags": [ "RAINPROOF", "STURDY", "RAD_RESIST", "AURA", "POWERARMOR_COMPATIBLE", "NO_SALVAGE", "ONLY_ONE", "PSYSHIELD_PARTIAL" ]
   },
   {
     "id": "debug_fireball_hammer",

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -86,7 +86,7 @@
     "id": "SpiritArmorBasic",
     "type": "ARMOR",
     "name": { "str": "Spirit Armor" },
-    "description": "A magical barrier made of the user's conviction, will and faith, draining inertia from anything that could harm the user. Physically protective, the magic works better against fast moving objects with low mass, like bullets, arrows, rain and alpha particles. Untill the spell expires or untill the armor is discarded your mana regeneration is used to maintain the effect. ",
+    "description": "A magical barrier made of the user's conviction, will and faith. Feels like super light, permeable bubble arround you and your equipement that hardens on impact. Most of it's power comes from draining inertia from anything that could harm. The magic works more efficiently on faster moving objects with low mass, like bullets, arrows, rain and alpha particles. It does not protect you from getting grabbed. Untill the spell expires or untill the armor is discarded your mana regeneration is used to maintain the effect.",
     "weight": "1 g",
     "volume": "1 ml",
     "price": "0 USD",

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -83,6 +83,38 @@
     "flags": [ "VARSIZE" ]
   },
   {
+    "id": "SpiritArmorBasic",
+    "type": "ARMOR",
+    "name": { "str": "Spirit Armor" },
+    "description": "A magical barrier made of the user's conviction, will and faith, draining inertia from anything that could harm the user. Physically protective, the magic works better against fast moving objects with low mass, like bullets, arrows, rain and alpha particles. Untill the spell expires or untill the armor is discarded your mana regeneration is used to maintain the effect. ",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "price": "0 USD",
+    "price_postapoc": "0 USD",
+    "material": [ "plastic" ],
+    "symbol": "[",
+    "color": "light_red",
+    "covers": [ "head", "eyes", "mouth", "torso", "legs", "arms", "hands", "feet" ],
+    "coverage": 100,
+    "encumbrance": 0,
+    "warmth": 0,
+    "material_thickness": 4,
+    "environmental_protection": 9,
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "values": [
+            { "value": "ARMOR_BULLET", "add":-3, "multiply": -0.5 },
+            { "value": "MANA_REGEN", "multiply": -0.99 },
+          ]
+        }
+      ]
+    },
+    "flags": [ "RAINPROOF", "STURDY", "RAD_PROOF", "AURA", "POWERARMOR_COMPATIBLE", "NO_SALVAGE", "ONLY_ONE", "PSYSHIELD_PARTIAL" ]
+  },
+  {
     "id": "debug_fireball_hammer",
     "type": "GENERIC",
     "name": "fireball hammer",

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -86,7 +86,7 @@
     "id": "spirit_armor",
     "type": "ARMOR",
     "name": { "str": "Spirit Armor" },
-    "description": "A magical barrier made of the user's conviction, will and faith. Feels like super light, permeable bubble arround you and your equipement that hardens on impact. Most of it's power comes from draining inertia from anything that could harm. The magic works more efficiently on faster moving objects with low mass, like bullets, arrows, rain and alpha particles. It does not protect you from getting grabbed. Untill the spell expires or untill the armor is discarded your mana regeneration is used to maintain the effect.",
+    "description": "A magical barrier made of the user's conviction, will, and faith. Feels like a super light, permeable bubble around you and your equipment that hardens on impact. Most of it's power comes from draining inertia from anything that could harm the user.",
     "weight": "1 g",
     "volume": "1 ml",
     "price": "0 USD",

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -98,7 +98,7 @@
     "coverage": 100,
     "encumbrance": 0,
     "warmth": 0,
-    "material_thickness": 4,
+    "material_thickness": 1,
     "environmental_protection": 9,
     "relic_data": {
       "passive_effects": [

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -105,7 +105,14 @@
         {
           "has": "WORN",
           "condition": "ALWAYS",
-          "values": [ { "value": "ARMOR_BULLET", "add": -3, "multiply": -0.5 }, { "value": "MANA_REGEN", "multiply": -0.99 } ]
+          "values": [ 
+            { "value": "ARMOR_HEAT", "add":-2, "multiply": -0.5 },
+            { "value": "ARMOR_COLD", "add":-2, "multiply": -0.5 },
+            { "value": "ARMOR_LIGHT", "add":-2, "multiply": -0.5 },
+            { "value": "ARMOR_DARK", "add":-2, "multiply": -0.5 },
+            { "value": "ARMOR_PSI ", "add":-2, "multiply": -0.5 },
+            { "value": "ARMOR_ELECTRIC", "add":-2, "multiply": -0.5 },
+          ]
         }
       ]
     },

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -110,7 +110,6 @@
             { "value": "ARMOR_COLD", "add": -2, "multiply": -0.5 },
             { "value": "ARMOR_LIGHT", "add": -2, "multiply": -0.5 },
             { "value": "ARMOR_DARK", "add": -2, "multiply": -0.5 },
-            { "value": "ARMOR_PSI ", "add": -2, "multiply": -0.5 },
             { "value": "ARMOR_ELECTRIC", "add": -2, "multiply": -0.5 }
           ]
         }

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -105,13 +105,13 @@
         {
           "has": "WORN",
           "condition": "ALWAYS",
-          "values": [ 
-            { "value": "ARMOR_HEAT", "add":-2, "multiply": -0.5 },
-            { "value": "ARMOR_COLD", "add":-2, "multiply": -0.5 },
-            { "value": "ARMOR_LIGHT", "add":-2, "multiply": -0.5 },
-            { "value": "ARMOR_DARK", "add":-2, "multiply": -0.5 },
-            { "value": "ARMOR_PSI ", "add":-2, "multiply": -0.5 },
-            { "value": "ARMOR_ELECTRIC", "add":-2, "multiply": -0.5 },
+          "values": [
+            { "value": "ARMOR_HEAT", "add": -2, "multiply": -0.5 },
+            { "value": "ARMOR_COLD", "add": -2, "multiply": -0.5 },
+            { "value": "ARMOR_LIGHT", "add": -2, "multiply": -0.5 },
+            { "value": "ARMOR_DARK", "add": -2, "multiply": -0.5 },
+            { "value": "ARMOR_PSI ", "add": -2, "multiply": -0.5 },
+            { "value": "ARMOR_ELECTRIC", "add": -2, "multiply": -0.5 }
           ]
         }
       ]

--- a/data/mods/MagicalNights/items/enchanted/enchanted.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted.json
@@ -91,7 +91,7 @@
     "volume": "1 ml",
     "price": "0 USD",
     "price_postapoc": "0 USD",
-    "material": [ "plastic" ],
+    "material": [ "concentrated_mana" ],
     "symbol": "[",
     "color": "light_red",
     "covers": [ "head", "eyes", "mouth", "torso", "legs", "arms", "hands", "feet" ],


### PR DESCRIPTION
## Purpose of change (The Why)

Spirit Armor spell is currently just summoning plate armor and doesn't feel very magical. 

In my opinion it should not create an item you can get elsewhere so in stead we replace summoning actual physical piece of armor that you can get elsewhere in game with magic feeling armor that covers the user and equipment and cannot be found. 

## Describe the solution (The How)

Make it into a supplemental magic that is useful but not replacement for other gear and feels like good protection regardless of when you find it. 

I believe items in enchanted.json do not appear in loot tabled which is the intent here. Item should not appear in world. 

Changes: 
-Nerfed protection values (reduced from plate armor, still should be at about leather armor level or protection of 8 across the board so still quite useful if you happen to get it early or like to be fashionable, while remaining useful even if you are in best endgame armor)
-Encumbrance is now 0 (It's magic)
-Is now aura effect (aura in stead of personal, side effect may be reduction in other equipment damage consistent with fluff) 
-added supplemental effects to make it more magical:
--roughly 50% reduction in ranged damage to anything I could think of that was "energy" or "magic" (removed ARMOR_BULLET )
--radiation resistance (particle go fast, stop completely by magic inertia bullshit)

--PSYSHIELD_PARTIAL for that protection from evil feel. Only thing I could think of. 

Side effect I did not consider initially: May reduce instances of equipment damage since in the outermost layer. Fits thought. 

## Describe alternatives you've considered

Skip the reduces bullet velocity angle and just make the armor itself tougher. Feels less magical and more like any other equipment. 

Also make it negate or drastically reduce fall damage through FALL_DAMAGE_MULT 

Make it glow. Ideally without blinding the user at night. 

Considered a very slow mana drain effect on the armor to "maintain" the spell but could not find a json only way to do it. 

Removing protective values completely and assigning percentage based damage reduction across the board using the various ARMOR_ modifiers. Pro: Super magical. Con: Maybe too run defining. Would require a lot of balance testing. 

It would be nice if it had progression. Make it weaker initially and then have leveling the spell could end up with stronger variant. Downside: Lua madness I am not capable of. 

Possible other things to adjust to the spell itself: 
Make it much more protective in stead. Much shorter duration, shorter casting time while keeping the mana cost high. An "Oh shit" button in stead of daily carry. 

## Testing

Passes validation check and works as intended in my game but I don't use latest experimental. 

Should not cause issues with nightly,  baring some drastic base game changes I missed. Should not cause conflicts with any other items or spells unless I am drastically mistaken. 

## Additional context


## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [+] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

Not related to any current active issues so I believe no additional tasks were needed here. 

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

None seem applicable. I will appreciate discord ping if this was incorrect.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bb7e95a](https://github.com/cataclysmbn/Cataclysm-BN/commit/bb7e95af8fe0b4da09d73efd997c38d60936e273) (Update data/mods/MagicalNights/items/enchanted/enchanted.json) on 2026-07-15 03:17:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29077397960/artifacts/8331367762)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29077397960/artifacts/8222801997)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29077397960/artifacts/8222231066)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29077397960/artifacts/8223066899)
<!-- END artifact comment -->