### PR TITLE
fix: prevent freeze on EMP explosion

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -2141,8 +2141,19 @@ explosion_queue &get_explosion_queue()
 
 void explosion_queue::execute()
 {
+    // Drain deferral (issue #9696) -- the primary fix. An item being processed can
+    // be detached but still in the map stack; a re-entrant drain (e.g. an EMP
+    // bomb's blast killing a searchlight) would re-detonate it forever. Defer to
+    // the turn-loop drain, which runs after processing (same turn).
+    if( drains_deferred() ) {
+        return;
+    }
+
+    // Per-drain backstop (not the #9696 fix): cap one runaway drain that re-feeds
+    // its own queue. Per drain, not per turn, so it never drops a later,
+    // independently-queued explosion.
     explosion_count = 0;
-    while( !elems.empty() ) {
+    while( !elems.empty() && explosion_count < max_pending_explosions ) {
         queued_explosion exp = std::move( elems.front() );
         elems.pop_front();
         explosion_count++;
@@ -2163,6 +2174,14 @@ void explosion_queue::execute()
                 debugmsg( "Explosion type not implemented." );
                 break;
         }
+    }
+    if( !elems.empty() ) {
+        // Leftovers mean the loop stopped at the per-drain cap (a runaway): drop
+        // them to avoid an OOM/hang and report once.
+        const auto dropped = static_cast<int>( elems.size() );
+        elems.clear();
+        debugmsg( "Explosion queue exceeded the per-drain cap of %d; dropped %d "
+                  "queued explosions to avoid a hang.", max_pending_explosions, dropped );
     }
 }
 

--- a/src/explosion_queue.h
+++ b/src/explosion_queue.h
@@ -52,20 +52,48 @@ class explosion_queue
     private:
         std::deque<queued_explosion> elems;
         int explosion_count = 0;
+        /// > 0 while execute() drains are deferred to the turn loop (issue #9696).
+        int drain_deferral_depth = 0;
 
     public:
+        /// OOM/hang backstop (not the #9696 fix): bounds one runaway execute()
+        /// drain and, via add(), the queue size. No legitimate chain comes near it.
+        static constexpr int max_pending_explosions = 2000;
+
         void add( queued_explosion &&exp ) {
-            elems.push_back( std::move( exp ) );
+            // Drop when saturated to bound memory; only a runaway saturates.
+            if( static_cast<int>( elems.size() ) < max_pending_explosions ) {
+                elems.push_back( std::move( exp ) );
+            }
         }
 
         void execute();
 
         void clear() { elems.clear(); }
 
+        auto empty() const -> bool { return elems.empty(); }
+
         auto get_count() const -> int { return explosion_count; }
+
+        /// Drain deferral -- see scoped_drain_deferral (issue #9696).
+        void push_drain_deferral() { drain_deferral_depth++; }
+        void pop_drain_deferral() { drain_deferral_depth--; }
+        auto drains_deferred() const -> bool { return drain_deferral_depth > 0; }
 };
 
 explosion_queue &get_explosion_queue();
+
+/// RAII: defers explosion-queue drains while map item processing runs, so a
+/// re-entrant drain can't sympathetically re-detonate a detached-but-in-stack
+/// item forever (issue #9696). The turn-loop drain empties the queue afterwards.
+class scoped_drain_deferral
+{
+    public:
+        scoped_drain_deferral() { get_explosion_queue().push_drain_deferral(); }
+        ~scoped_drain_deferral() { get_explosion_queue().pop_drain_deferral(); }
+        scoped_drain_deferral( const scoped_drain_deferral & ) = delete;
+        auto operator=( const scoped_drain_deferral & ) -> scoped_drain_deferral & = delete; // *NOPAD*
+};
 
 } // namespace explosion_handler
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -54,6 +54,7 @@
 #include "event.h"
 #include "event_bus.h"
 #include "explosion.h"
+#include "explosion_queue.h"
 #include "field.h"
 #include "field_type.h"
 #include "flag.h"
@@ -6237,6 +6238,10 @@ std::vector<tripoint_abs_sm> map::check_submap_active_item_consistency()
 
 void map::process_items()
 {
+    // Defer explosion drains during processing: an item here can be detached but
+    // still in-stack, and a re-entrant drain would re-detonate it forever (#9696).
+    explosion_handler::scoped_drain_deferral defer_explosion_drains;
+
     auto total_active_items = int64_t{ 0 };
     auto total_rottable_active_items = int64_t{ 0 };
 

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -1,7 +1,9 @@
 #include "avatar.h"
+#include "calendar.h"
 #include "catch/catch.hpp"
 #include "coordinates.h"
 #include "creature.h"
+#include "explosion.h"
 #include "explosion_queue.h"
 #include "game.h"
 #include "item.h"
@@ -11,6 +13,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "monster.h"
+#include "options_helpers.h"
 #include "state_helpers.h"
 #include "string_id.h"
 #include "test_statistics.h"
@@ -263,4 +266,70 @@ TEST_CASE("rotated_vehicle_walls_block_explosions") {
     REQUIRE(m != nullptr);
     CHECK(m == &s);
     CHECK(m->get_hp() == m->get_hp_max());
+}
+
+// Regression tests for issue #9696 ("EMP Bomb Crashes the game"). An active
+// explosive being processed is detached (loc == nullptr) but still in the map
+// stack; draining the explosion queue in that window re-detonates it forever.
+// scoped_drain_deferral defers drains during map::process_items() to the
+// turn-loop drain, which runs after the item is removed, so the chain is finite.
+
+TEST_CASE("explosion queue defers drains during item processing", "[explosion][emp]") {
+    clear_all_state();
+    auto& queue = explosion_handler::get_explosion_queue();
+    queue.clear();
+
+    const auto origin = tripoint_bub_ms{60, 60, 0};
+    const auto ex = explosion_data{.damage = 10, .radius = 2.0f};
+
+    {
+        // Stands in for the map::process_items() window.
+        explosion_handler::scoped_drain_deferral defer;
+        explosion_handler::explosion(origin, ex, nullptr);
+        REQUIRE_FALSE(queue.empty());
+
+        // A re-entrant drain must not run here (it would re-detonate forever).
+        queue.execute();
+        CHECK_FALSE(queue.empty());
+    }
+
+    // The turn-loop drain (outside the window) empties the queue.
+    queue.execute();
+    CHECK(queue.empty());
+}
+
+TEST_CASE("EMP bomb processed next to a searchlight does not run away", "[explosion][emp]") {
+    clear_all_state();
+
+    // Sympathetic detonation must be on for the runaway (default; set explicitly).
+    const auto explodium = override_option("MADE_OF_EXPLODIUM", "30");
+
+    const auto bomb_pos = tripoint_bub_ms{60, 60, 0};
+    const auto sl_pos = tripoint_bub_ms{61, 60, 0};
+    g->m.i_clear(bomb_pos);
+
+    // A searchlight the EMP kills; its FOCUSEDBEAM death drains the queue.
+    auto& searchlight = spawn_test_monster("mon_turret_searchlight", sl_pos);
+    searchlight.set_hp(1);
+
+    // Active EMP bomb on its own tile, charges 0 so it detonates on its tick.
+    auto bomb =
+        item::spawn("EMPbomb_act", calendar::start_of_cataclysm, item::default_charges_tag());
+    bomb->activate();
+    bomb->charges = 0;
+    g->m.add_item(bomb_pos, std::move(bomb));
+
+    auto& queue = explosion_handler::get_explosion_queue();
+    queue.clear();
+
+    // Processing detonates the bomb and kills the searchlight; before the fix the
+    // re-entrant drain looped forever (cap fires + debugmsg -> test fails). Tick a
+    // few times in case the countdown needs more than one pass.
+    for (int i = 0; i < 12 && !searchlight.is_dead(); i++) {
+        g->m.process_items();
+        queue.execute();
+    }
+
+    REQUIRE(searchlight.is_dead()); // scenario actually triggered
+    CHECK(queue.empty());           // ...and terminated with no runaway
 }


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes #9696. With default options (`MADE_OF_EXPLODIUM`), activating or throwing an
EMP bomb next to a `mon_turret_searchlight` (e.g. at a military outpost) could
hard-lock / OOM the game the explosion queue grew without bound (~113M entries
before the game crashed due to my computer running out of memory at this point).

My WinDbg dump was 30gb from the explosion queue


## Describe the solution (The How)

Fix: a small RAII guard (`explosion_handler::scoped_drain_deferral`) brackets
`map::process_items()`, so any `execute()` requested during item processing is
**deferred to the turn-loop drain**  which runs later in the same `do_turn`,
after processing completes and the bomb has been removed. The chain is then
finite. This closes the bug for every active `_act` explosive, not just the EMP
bomb, with no change to explosion damage / smash / cookoff behavior. A simple
per-drain queue cap is kept only as an OOM backstop.


Root cause: while `map::process_items()` runs, an active explosive is detached
(`loc == nullptr`) by `game_object<item>::attempt_detach` but **still physically
in the map item stack**. The EMP bomb's `use_action` queues its blast and runs
`emp_blast` inline, which kills the searchlight; the searchlight's
`mdeath::focused_beam` then drains the explosion queue **re-entrantly**, mid-
processing. That drain smashes the still-in-stack bomb, which (under
`MADE_OF_EXPLODIUM`) sympathetically detonates via `item::detonate`, re-queuing an
identical blast at the bomb's own tile. The bomb is never truly removed, so it
re-detonates every cycle, forever.

## Describe alternatives you've considered

- **Re-entrancy guard on `execute()`** (block nested drains): insufficient  the
  looping drain is the *outermost* `execute()` (the one `focused_beam` calls), so
  a nesting guard never fires. Game still OOMed and crashed
- **Broadening `EXPLOSION_SMASHED` to span the whole drain**: this wasn't used as 
broadening it would make overlapping same-turn explosions under-smash from the explosion.
- **Per-turn work cap alone**: a band-aid that stops the OOM but leaves a debug
  popup and dropped explosions or the game would hang but at least wouldn't OOM 
the system; kept only as a backstop, scoped per-drain.

## Testing

- Reproduced the original hang in-game at a military outpost; with the fix ram doesn't
spiral out of control and the game doesn't crash in the Windows Tiles Build when using the
emp Bomb
- Used an EMP grenade on searchlights, this used to pop-up a debug message before this fix, 
the debug message no longer occurs.
- Detonated a mini-nuke on the military output and other than the usual processing lag the
game worked fine, no debug popup, no crash, and no memory runaway.
- Detonated a mini-nuke in a city building with a crapton of zombies in the blast radius, no issues
- Detonated emp bombs in random dense city areas and inside labs, no issues
- Spawned 4000 grenades in one spot and threw another to detonate them, no crash or issues
- Added `tests/emp_searchlight_hang_test.cpp`: a mechanism test (the deferral
  defers `execute()` and drains after the scope) and an integration repro (active
  `EMPbomb_act` + hp-1 `mon_turret_searchlight` + `MADE_OF_EXPLODIUM`; asserts the
  searchlight dies and the queue drains empty, it hits the cap + debugmsg and
  fails without the fix).
- `cata_test-tiles "[explosion]"` passes (704 assertions, 9 cases)

## Additional context

Reviewer Note: The 2000 queued explosions limit can be adjusted upwards if needed, but this was
put in to prevent a system wide OOM situation like we saw before as a bail out with debug
message. I couldn't trigger this limit even with mini-nukes. However, if someone did actually
manage to reach this limit it can be adjusted.

Root cause was confirmed from a full-memory crash dump: a single flat `execute()`
frame draining a deque of ~113.8M byte-identical `{damage 50, radius 7}`
explosions, all pinned to the EMP bomb's tile, with the bomb (`itype` "active EMP
bomb", `explode_in_fire`, `type->explosion {50,7}`) re-detonated each cycle.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [835b71e](https://github.com/cataclysmbn/Cataclysm-BN/commit/835b71ef4a53e714c9c5895cdd6eaaf5eb49a56c) (fix: prevent freeze on EMP explosion) on 2026-06-30 01:20:52

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28411508578/artifacts/7967952811)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28411508578/artifacts/7968302340)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28411508578/artifacts/7967960507)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28411508578/artifacts/7968015924)
<!-- END artifact comment -->