### PR TITLE
fix: fix handmade revolver possibly spawning with incorrect ammo for its caliber conversion

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -2360,11 +2360,7 @@
     "//": "Handmade revolver with 50% chance of a caliber conversion kit installed.",
     "subtype": "distribution",
     "entries": [
-      {
-        "item": "handmade_revolver",
-        "contents-group": "gunmod_hmr_conversion",
-        "prob": 50
-      },
+      { "item": "handmade_revolver", "contents-group": "gunmod_hmr_conversion", "prob": 50 },
       { "item": "handmade_revolver", "prob": 50 }
     ]
   }

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -2362,12 +2362,10 @@
     "entries": [
       {
         "item": "handmade_revolver",
-        "charges-min": 0,
-        "charges-max": 6,
         "contents-group": "gunmod_hmr_conversion",
         "prob": 50
       },
-      { "item": "handmade_revolver", "charges-min": 0, "charges-max": 6, "prob": 50 }
+      { "item": "handmade_revolver", "prob": 50 }
     ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The handmade revolver's default ammo is 357, but it has a change to spawn with a conversion kit that converts it to a different caliber. The nested version of this weapon has a chance to spawn with up to 6 bullets, but that means that it could possibly spawn with 357 in the gun while it has a caliber conversion to a different caliber.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Removes the "charges" from the nested handmade revolver, consistent with other nested handmade guns.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Bugs everywhere
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
thanks to goldfish on discord for pointing this out
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [55a5986](https://github.com/cataclysmbn/Cataclysm-BN/commit/55a598642345b3a82083c5068754b94bc69245c9) (style(autofix.ci): automated formatting) on 2026-06-30 01:38:49

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28397936348/artifacts/7962834093)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28397936348)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28397936348/artifacts/7963081575)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28397936348/artifacts/7962988574)
<!-- END artifact comment -->