### PR TITLE
fix(UI): prevent menu moving to random item on use

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -850,9 +850,6 @@ void inventory_column::prepare_paging( const std::string &filter )
             return preset.sort_compare( lhs, rhs );
         }
     };
-    // stable_sort keeps entries that compare equal (same category and name) in their
-    // deterministic insertion order, so the result is identical across stdlib
-    // implementations instead of the unspecified order std::sort leaves equal items in.
     std::ranges::stable_sort( entries, sort_function );
 
     // Recover categories

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -837,10 +837,7 @@ void inventory_column::prepare_paging( const std::string &filter )
         return !entry.is_item() || !filter_fn( entry );
     } );
     entries.erase( new_end, entries.end() );
-    // Refresh the display-name cache the sort comparator relies on. PR #9038 dropped
-    // the only update_cache() call, leaving cached_name empty so the alphabetic
-    // tiebreak was dead and equal-keyed entries sorted in an unspecified,
-    // platform-dependent order (issue #9713).
+    // don't sort with stale names
     std::ranges::for_each( entries, &inventory_entry::update_cache );
     // Then sort them with respect to categories
     auto sort_function = [this]( const inventory_entry & lhs, const inventory_entry & rhs ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -837,6 +837,11 @@ void inventory_column::prepare_paging( const std::string &filter )
         return !entry.is_item() || !filter_fn( entry );
     } );
     entries.erase( new_end, entries.end() );
+    // Refresh the display-name cache the sort comparator relies on. PR #9038 dropped
+    // the only update_cache() call, leaving cached_name empty so the alphabetic
+    // tiebreak was dead and equal-keyed entries sorted in an unspecified,
+    // platform-dependent order (issue #9713).
+    std::ranges::for_each( entries, &inventory_entry::update_cache );
     // Then sort them with respect to categories
     auto sort_function = [this]( const inventory_entry & lhs, const inventory_entry & rhs ) {
         if( *lhs.get_category_ptr() != *rhs.get_category_ptr() ) {
@@ -845,7 +850,10 @@ void inventory_column::prepare_paging( const std::string &filter )
             return preset.sort_compare( lhs, rhs );
         }
     };
-    std::sort( entries.begin(), entries.end(), sort_function );
+    // stable_sort keeps entries that compare equal (same category and name) in their
+    // deterministic insertion order, so the result is identical across stdlib
+    // implementations instead of the unspecified order std::sort leaves equal items in.
+    std::ranges::stable_sort( entries, sort_function );
 
     // Recover categories
     const item_category *current_category = nullptr;

--- a/tests/inventory_ui_test.cpp
+++ b/tests/inventory_ui_test.cpp
@@ -221,3 +221,41 @@ TEST_CASE(
     REQUIRE(selector.restore_selection(invalid_position, map_bandages->typeId()));
     CHECK(selector.get_selected().any_item() == inventory_bandages.get());
 }
+
+TEST_CASE(
+    "inventory selector populates the name cache and sorts deterministically",
+    "[inventory][ui][consume]") {
+    clear_avatar();
+    auto& dummy = get_avatar();
+
+    // Two comestibles share the "food" category, so their relative order is
+    // decided purely by the name tiebreak in the sort comparator.
+    auto orange_soda = item::spawn("orangesoda");
+    auto maple_syrup = item::spawn("syrup");
+    REQUIRE(orange_soda->tname(1) != maple_syrup->tname(1));
+
+    auto selector = inventory_selector(dummy);
+    // Add in non-alphabetical order so the sort has to reorder them.
+    selector.add_item(selector.own_inv_column, orange_soda.get());
+    selector.add_item(selector.own_inv_column, maple_syrup.get());
+
+    // Triggers prepare_paging(): refreshes cached_name and sorts the column.
+    REQUIRE(selector.select_item_type(maple_syrup->typeId()));
+
+    const auto selectable = [](const auto& entry) { return entry.is_selectable(); };
+    const auto entries = selector.own_inv_column.get_entries(selectable);
+    REQUIRE(entries.size() == 2);
+    // Precondition: both items must share a category so the name comparison (not the
+    // category sort) decides their order; otherwise the order check below could pass
+    // via category ordering and silently stop covering the regression.
+    REQUIRE(entries.front()->get_category_ptr() == entries.back()->get_category_ptr());
+
+    // Regression for #9713: PR #9038 dropped the only update_cache() call, leaving
+    // cached_name empty so the alphabetic tiebreak was dead and equal-keyed comestibles
+    // sorted in an unspecified order that differs across stdlib implementations.
+    REQUIRE_FALSE(entries.front()->cached_name.empty());
+    CHECK(entries.front()->cached_name == entries.front()->any_item()->tname(1));
+
+    // The column is now ordered by name deterministically.
+    CHECK(entries.front()->any_item()->tname(1) < entries.back()->any_item()->tname(1));
+}


### PR DESCRIPTION
## Purpose of change
Fixes #9713. After consuming an item, the [E] consume menu reopened with the
cursor moved to an unrelated item ("drank maple syrup, always jumps to orange
soda"), risking accidental use of dangerous items. Appears to be Linux-only and not reliably reproducible
on Windows. Follow-up to #9580 / #9588 / #9682, which only partially addressed it.

## Describe the solution

- Restore the `update_cache()` refresh before sorting in `prepare_paging`.
- Use `std::ranges::stable_sort` so equal-keyed entries keep their deterministic
  insertion order.

Root cause: #9038 removed the only call to `inventory_entry::update_cache()` (the
sole writer of `cached_name`) when it rewrote `inventory_column::prepare_paging`.
With `cached_name` permanently empty, the comparator's alphabetic tiebreak was
dead, so every same-category/same-freshness comestible compared equal; the
non-stable `std::sort` then ordered them differently across stdlib
implementations (libstdc++ vs MSVC) and the cursor-restore
landed on the wrong item.

## Describe alternatives you've considered

Adding a `typeId()` tiebreak to the comparator to force a strict total order. 
This was not used as`itype_id` is a static `string_id`, and `string_id::operator<` compares 
integer ids (not lexicographic, and documented as not stable across builds), which
could itself reintroduce cross-platform divergence. Restoring the name cache plus
`stable_sort` already yields a deterministic, cross-platform order.

## Testing

- Added a regression test in `tests/inventory_ui_test.cpp` asserting `cached_name`
  is populated after paging and that same-category entries sort in a deterministic
  name order.
- `[inventory]` test suite passes (12 cases, 46 assertions).
- Verified Windows build still launches and that the menus still behave correctly, however
 a linux user will be needed to verify if this fix works.

## Additional context

The empty `cached_name` also broke the alphabetic tiebreak in other inventory menus
(drop/pickup/etc.); restoring it fixes those too. The bug was masked on Windows
because MSVC's `std::sort` happened to keep equal elements in a different (here,
non-jumping) order than libstdc++.

## Checklist

### Mandatory

- [x] I linked any relevant issues using github keyword syntax like `closes #1234` in the Summary of the PR so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit in the Linux kernel format.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ad26aa8](https://github.com/cataclysmbn/Cataclysm-BN/commit/ad26aa8d7968e26d5d8f086fe5261ea9b29d33a4) (Update src/inventory_ui.cpp) on 2026-06-30 15:36:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28451100866/artifacts/7983680273)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28451100866/artifacts/7985528159)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28451100866/artifacts/7983853571)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28451100866/artifacts/7983807923)
<!-- END artifact comment -->