### PR TITLE
build: allow adjusting shader targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,13 @@ set(LINKER "" CACHE STRING "Custom Linker to use")
 set(GETTEXT_MSGFMT_BINARY "" CACHE FILEPATH "msgfmt binary name or path.")
 option(BUILD_SDL3 "Force builds SDL3 and its modules from source, instead of using system packages" "OFF")
 option(BUILD_SHADERCROSS "Build SDL_shadercross from source when shadercross is not on PATH" "ON")
+if(WIN32)
+    set(SHADER_TARGETS "dxil;spirv;msl" CACHE STRING "Shaders to build (dxil/spirv/msl)")
+else()
+    set(SHADER_TARGETS "spirv;msl" CACHE STRING "Shaders to build (dxil/spirv/msl)")
+endif()
+#Enforce lowercase
+list(TRANSFORM SHADER_TARGETS TOLOWER OUTPUT_VARIABLE SHADER_TARGETS)
 option(CATA_SDL "Link SDL3 core for GPU platform services used by existing game targets." "OFF")
 option(CATA_GPU_VERIFY "Enable GPU output verification against CPU reference via readback (development only, requires CATA_SDL)." "OFF")
 set(CATA_SHADERS OFF)
@@ -268,8 +275,9 @@ if (LINKER)
     message(STATUS "LINKER                        : ${LINKER}")
 endif ()
 message(STATUS "BUILD_SDL3                    : ${BUILD_SDL3}")
+message(STATUS "BUILD_SHADERCROSS             : ${BUILD_SHADERCROSS}")
+message(STATUS "SHADER_TARGETS                : ${SHADER_TARGETS}")
 message(STATUS "CATA_SDL                      : ${CATA_SDL}")
-message(STATUS "CATA_SHADERS                  : ${CATA_SHADERS}")
 message(STATUS "CATA_GPU_VERIFY               : ${CATA_GPU_VERIFY}")
 
 message(STATUS "See CMake compiling guide for details and more info --")
@@ -516,21 +524,6 @@ if (CATA_SDL)
     file(GLOB_RECURSE CATA_HLSL_SOURCES CONFIGURE_DEPENDS
          "${CMAKE_SOURCE_DIR}/src/shaders/*.hlsl")
 
-    set(CATA_PRECOMPILED_SHADER_OUTPUTS "")
-    foreach (HLSL_SRC ${CATA_HLSL_SOURCES})
-        get_filename_component(SHADER_NAME ${HLSL_SRC} NAME_WE)
-        if (WIN32)
-            list(APPEND CATA_PRECOMPILED_SHADER_OUTPUTS
-                 "${CMAKE_SOURCE_DIR}/data/shaders/${SHADER_NAME}.dxil")
-        elseif (APPLE)
-            list(APPEND CATA_PRECOMPILED_SHADER_OUTPUTS
-                 "${CMAKE_SOURCE_DIR}/data/shaders/${SHADER_NAME}.msl")
-        else ()
-            list(APPEND CATA_PRECOMPILED_SHADER_OUTPUTS
-                 "${CMAKE_SOURCE_DIR}/data/shaders/${SHADER_NAME}.spv")
-        endif ()
-    endforeach ()
-
     if (SHADERCROSS_EXE)
         set(CATA_SHADERS ON)
         message(STATUS "shadercross: ${SHADERCROSS_EXE}")
@@ -547,68 +540,65 @@ if (CATA_SDL)
                 set(STAGE compute)
             endif ()
 
-            set(SPV_OUT  "${CMAKE_SOURCE_DIR}/data/shaders/${SHADER_NAME}.spv")
-            set(MSL_OUT  "${CMAKE_SOURCE_DIR}/data/shaders/${SHADER_NAME}.msl")
+            foreach(SHADER ${SHADER_TARGETS})
 
-            add_custom_command(
-                OUTPUT "${SPV_OUT}"
-                COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_SOURCE_DIR}/data/shaders"
-                COMMAND "${SHADERCROSS_EXE}" "${HLSL_SRC}" -s hlsl -d spirv -t ${STAGE} -o "${SPV_OUT}"
-                DEPENDS "${HLSL_SRC}" ${SHADERCROSS_TARGET}
-                COMMENT "Compiling ${SHADER_NAME}.hlsl -> SPIR-V"
-                VERBATIM)
-            list(APPEND CATA_SHADER_OUTPUTS "${SPV_OUT}")
+                # All Shader extensions besides spv match the -d value passed to shadercross
+                if (SHADER STREQUAL "spirv")
+                    set(SHADER_EXTENSION "spv")
+                else ()
+                    set(SHADER_EXTENSION "${SHADER}")
+                endif()
 
-            add_custom_command(
-                OUTPUT "${MSL_OUT}"
-                COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_SOURCE_DIR}/data/shaders"
-                COMMAND "${SHADERCROSS_EXE}" "${HLSL_SRC}" -s hlsl -d msl -t ${STAGE} -o "${MSL_OUT}"
-                DEPENDS "${HLSL_SRC}" ${SHADERCROSS_TARGET}
-                COMMENT "Compiling ${SHADER_NAME}.hlsl -> MSL"
-                VERBATIM)
-            list(APPEND CATA_SHADER_OUTPUTS "${MSL_OUT}")
-
-            if (WIN32)
-                set(DXIL_OUT "${CMAKE_SOURCE_DIR}/data/shaders/${SHADER_NAME}.dxil")
+                set(SHADER_OUT  "${CMAKE_SOURCE_DIR}/data/shaders/${SHADER_NAME}.${SHADER_EXTENSION}")
                 add_custom_command(
-                    OUTPUT "${DXIL_OUT}"
+                    OUTPUT "${SHADER_OUT}"
                     COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_SOURCE_DIR}/data/shaders"
-                    COMMAND "${SHADERCROSS_EXE}" "${HLSL_SRC}" -s hlsl -d dxil -t ${STAGE} -o "${DXIL_OUT}"
+                    COMMAND "${SHADERCROSS_EXE}" "${HLSL_SRC}" -s hlsl -d ${SHADER} -t ${STAGE} -o "${SHADER_OUT}"
                     DEPENDS "${HLSL_SRC}" ${SHADERCROSS_TARGET}
-                    COMMENT "Compiling ${SHADER_NAME}.hlsl -> DXIL"
+                    COMMENT "Compiling ${SHADER_NAME}.hlsl -> ${SHADER}"
                     VERBATIM)
-                list(APPEND CATA_SHADER_OUTPUTS "${DXIL_OUT}")
-            endif ()
+                list(APPEND CATA_SHADER_OUTPUTS "${SHADER_OUT}")
+            endforeach()
+
         endforeach ()
 
-        add_custom_target(cata_shaders ALL DEPENDS ${CATA_SHADER_OUTPUTS})
+        add_custom_target(cataclysm-shaders ALL DEPENDS ${CATA_SHADER_OUTPUTS})
         if (SHADERCROSS_TARGET)
-            add_dependencies(cata_shaders ${SHADERCROSS_TARGET})
+            add_dependencies(cataclysm-shaders ${SHADERCROSS_TARGET})
         endif ()
-    elseif (CATA_PRECOMPILED_SHADER_OUTPUTS)
+    else ()
+
+        list(TRANSFORM SHADER_TARGETS REPLACE "spirv" "spv" OUTPUT_VARIABLE SHADER_TARGETS)
+
+        set(CATA_PRECOMPILED_SHADER_OUTPUTS "")
+        foreach (HLSL_SRC ${CATA_HLSL_SOURCES})
+
+            get_filename_component(SHADER_NAME ${HLSL_SRC} NAME_WE)
+
+            foreach(SHADER_EXTENSION ${SHADER_TARGETS})
+                list(APPEND CATA_PRECOMPILED_SHADER_OUTPUTS
+                     "${CMAKE_SOURCE_DIR}/data/shaders/${SHADER_NAME}.${SHADER_EXTENSION}")
+            endforeach()
+        endforeach ()
+
         set(CATA_MISSING_PRECOMPILED_SHADERS "")
         foreach (SHADER_OUT ${CATA_PRECOMPILED_SHADER_OUTPUTS})
             if (NOT EXISTS "${SHADER_OUT}")
-                list(APPEND CATA_MISSING_PRECOMPILED_SHADERS "${SHADER_OUT}")
+                get_filename_component(SHADER_NAME ${SHADER_OUT} NAME)
+                list(APPEND CATA_MISSING_PRECOMPILED_SHADERS "${SHADER_NAME}")
             endif ()
         endforeach ()
 
         if (CATA_MISSING_PRECOMPILED_SHADERS)
             message(FATAL_ERROR
-                "shadercross not found and precompiled platform shaders are missing: "
+                "BUILD_SHADERCROSS disabled and precompiled platform shaders are missing: "
                 "${CATA_MISSING_PRECOMPILED_SHADERS}. "
-                "Run a shader generation job or place shadercross on PATH.")
+                "Run a shader generation job or place shaders in ${CMAKE_SOURCE_DIR}/data/shaders.")
         endif ()
 
         set(CATA_SHADERS ON)
-        message(STATUS "shadercross not found; using precompiled shaders from data/shaders")
-        add_custom_target(cata_shaders DEPENDS ${CATA_PRECOMPILED_SHADER_OUTPUTS})
-    elseif (TILES)
-        message(FATAL_ERROR
-            "shadercross not found — tiles builds require compiled shaders. "
-            "Either enable BUILD_SHADERCROSS or place shadercross on PATH.")
-    else ()
-        message(STATUS "shadercross not found — shaders will not be compiled")
+        message(STATUS "BUILD_SHADERCROSS disabled; using precompiled shaders from data/shaders")
+        add_custom_target(cataclysm-shaders DEPENDS ${CATA_PRECOMPILED_SHADER_OUTPUTS})
     endif ()
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,9 +562,9 @@ if (CATA_SDL)
 
         endforeach ()
 
-        add_custom_target(cataclysm-shaders ALL DEPENDS ${CATA_SHADER_OUTPUTS})
+        add_custom_target(cata_shaders ALL DEPENDS ${CATA_SHADER_OUTPUTS})
         if (SHADERCROSS_TARGET)
-            add_dependencies(cataclysm-shaders ${SHADERCROSS_TARGET})
+            add_dependencies(cata_shaders ${SHADERCROSS_TARGET})
         endif ()
     else ()
 
@@ -598,7 +598,7 @@ if (CATA_SDL)
 
         set(CATA_SHADERS ON)
         message(STATUS "BUILD_SHADERCROSS disabled; using precompiled shaders from data/shaders")
-        add_custom_target(cataclysm-shaders DEPENDS ${CATA_PRECOMPILED_SHADER_OUTPUTS})
+        add_custom_target(cata_shaders DEPENDS ${CATA_PRECOMPILED_SHADER_OUTPUTS})
     endif ()
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,7 +201,7 @@ if (TILES)
     endif()
 
     if (CATA_SHADERS)
-        add_dependencies(cataclysm-bn-tiles-common cataclysm-shaders)
+        add_dependencies(cataclysm-bn-tiles-common cata_shaders)
     endif ()
 endif ()
 
@@ -237,7 +237,7 @@ if (CURSES)
     target_link_libraries(cataclysm-bn PRIVATE cataclysm-bn-common)
 
     if (CATA_SHADERS)
-        add_dependencies(cataclysm-bn-common cataclysm-shaders)
+        add_dependencies(cataclysm-bn-common cata_shaders)
     endif ()
 
     if (RELEASE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,7 +201,7 @@ if (TILES)
     endif()
 
     if (CATA_SHADERS)
-        add_dependencies(cataclysm-bn-tiles-common cata_shaders)
+        add_dependencies(cataclysm-bn-tiles-common cataclysm-shaders)
     endif ()
 endif ()
 
@@ -237,7 +237,7 @@ if (CURSES)
     target_link_libraries(cataclysm-bn PRIVATE cataclysm-bn-common)
 
     if (CATA_SHADERS)
-        add_dependencies(cataclysm-bn-common cata_shaders)
+        add_dependencies(cataclysm-bn-common cataclysm-shaders)
     endif ()
 
     if (RELEASE)


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Currently when building with cmake and BUILD_SHADERCROSS=ON, metal shaders are always compiled on linux/windows
And a developer may wish to not build them when compiling locally (cus its pointless)
Additionally despite shadercross on linux being compiled such that it can support dxil shaders, its impossible to actually compile them normally if you really wanted to for some reason (idk why)

## Describe the solution (The How)

Adds a SHADER_TARGETS cmake option, to adjust which shaders are built
defaults to dxil;spirv;msl on windows and spirv;msl on linux (same as prior behaviour)

Additionally changes the missing shader message when BUILD_SHADERCROSS=OFF to look a bit better maybe

<img width="934" height="165" alt="2026-06-30-08:09:32" src="https://github.com/user-attachments/assets/4f4f6ba5-c4d9-46a6-8f9a-8310f2cb9654" />


~~note that the build workflow might use the generate-shaders script instead of any of this~~
despite workflows doing the whole upload/download generated-shaders artifact dance, they all build shadercross anyway which uhhh sure

## Describe alternatives you've considered

Not doing this I guess?

## Testing

compiled with -DSHADER_TARGETS=spirv on linux and only the vulkan shaders were built

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [dd08798](https://github.com/cataclysmbn/Cataclysm-BN/commit/dd08798d4d6d85ab6d36a6e31a8cf4dbe3e6e8c6) (e) on 2026-06-29 23:32:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28407788465/artifacts/7966674168)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28407788465/artifacts/7967101010)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28407788465/artifacts/7966739211)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28407788465/artifacts/7966820099)
<!-- END artifact comment -->