### PR TITLE
feat(balance): fix circular evolutions in acid soldier and acid zombie

### DIFF
--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -62,7 +62,7 @@
     "id": "mon_zombie_kevlar_death_drops",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "group": "mon_zombie_soldier_death_drops" }, { "group": "mon_zombie_cop_death_drops" } ]
+    "entries": [ { "group": "mon_zombie_soldier_death_drops" } ]
   },
   {
     "type": "item_group",

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -97,9 +97,8 @@
     "monsters": [
       { "monster": "mon_zombie_supply_sergeant", "freq": 100, "cost_multiplier": 2 },
       { "monster": "mon_zombie_soldier_blackops_1", "freq": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_soldier_acid_1", "freq": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_soldier_acid_2", "freq": 150, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_soldier_acid_3", "freq": 50, "cost_multiplier": 10 }
+      { "monster": "mon_zombie_soldier_acid_1", "freq": 125, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_soldier_acid_2", "freq": 175, "cost_multiplier": 2 }
     ]
   },
   {
@@ -108,9 +107,8 @@
     "default": "mon_zombie_kevlar_1",
     "monsters": [
       { "monster": "mon_zombie_soldier_blackops_1", "freq": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_soldier_acid_1", "freq": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_soldier_acid_2", "freq": 150, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_soldier_acid_3", "freq": 50, "cost_multiplier": 10 },
+      { "monster": "mon_zombie_soldier_acid_1", "freq": 125, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_soldier_acid_2", "freq": 170, "cost_multiplier": 2 },
       { "monster": "mon_zombie_smoker", "freq": 100, "cost_multiplier": 5 },
       { "monster": "mon_gas_zombie", "freq": 50, "cost_multiplier": 10 },
       { "monster": "mon_zombie_fiend", "freq": 50, "cost_multiplier": 10 }

--- a/data/json/monsters/zed_acid.json
+++ b/data/json/monsters/zed_acid.json
@@ -219,6 +219,7 @@
     "armor_stab": 12,
     "death_drops": "default_zombie_death_drops",
     "starting_ammo": { "acid_artillery_shell": 100 },
+    "upgrades": { "half_life": 42, "into_group": "GROUP_NULL", "into": "mon_zombie_acid_mortar" },
     "extend": {
       "special_attacks": [
         [ "ACID_BARF", 10 ],
@@ -260,6 +261,7 @@
     "vision_day": 45,
     "death_drops": "default_zombie_death_drops",
     "starting_ammo": { "bot_unstable_grub": 200 },
+    "upgrades": { "half_life": 42, "into_group": "GROUP_NULL", "into": "mon_zombie_acid_spawner" },
     "extend": {
       "special_attacks": [ [ "ACID_BARF", 2 ], [ "GRENADIER_ELITE", 10 ], { "id": "slam" } ],
       "death_function": [ "ACID" ],
@@ -308,6 +310,7 @@
       }
     ],
     "death_function": [ "ACID", "NORMAL" ],
+    "upgrades": { "half_life": 42, "into_group": "GROUP_NULL", "into": "mon_zombie_ichor_brute" },
     "extend": { "flags": [ "ACIDPROOF", "ACID_BLOOD" ], "harvest": "zombie_acid" }
   },
   {

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -126,6 +126,7 @@
     "harvest": "zombie_maybe_mil_bionics_acid",
     "relative": { "hp": 20, "speed": 10, "melee_skill": 1, "vision_day": 10, "vision_night": 10 },
     "delete": { "flags": [ "BLEED" ], "categories": [ "CLASSIC" ] },
+    "upgrades": { "half_life": 42, "into_group": "GROUP_NULL", "into": "mon_zombie_soldier_acid_3" },
     "extend": {
       "special_attacks": [
         [ "ACID_BARF", 10 ],
@@ -158,6 +159,7 @@
     "harvest": "zombie_maybe_mil_bionics_acid",
     "relative": { "hp": 40, "speed": -10, "melee_skill": 2, "armor_bash": 5 },
     "delete": { "flags": [ "BLEED" ], "categories": [ "CLASSIC" ] },
+    "upgrades": { "half_life": 42, "into_group": "GROUP_NULL", "into": "mon_zombie_soldier_acid_3" },
     "extend": {
       "special_attacks": [
         [ "ACID_BARF", 5 ],
@@ -191,6 +193,7 @@
     "harvest": "CBM_OP2",
     "relative": { "hp": 160, "speed": -20, "melee_skill": 8, "armor_bash": 15, "armor_cut": 10, "armor_bullet": 10 },
     "delete": { "flags": [ "BLEED" ], "categories": [ "CLASSIC" ] },
+    "upgrades": { "half_life": 42, "into_group": "GROUP_NULL", "into": "mon_zombie_soldier_acid_3" },
     "extend": {
       "special_attacks": [
         [ "ACID_BARF", 3 ],


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Later game had a very low variety of zombies due to the fact that almost every acid zombie can turn around and evolve into a kevlar zombie, even acid juggernauts. This meant that eventually a lot of acid zombies would turn into kevlar zombies or actually devolve instead.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Splits the acid zombie evolutions into two branches, from soldiers and from civilians. Civilian acid zombies cap off at the mortar and spawner, and the mortar and spawner no longer have zombie soldier evolutions for some reason. Likewise, zombie soldiers can no longer directly evolve into acid juggernauts, instead evolving in either acid sniper or acid support zombies, which can then evolve into the acid juggernaut.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Lack of zombie variety
## Testing
Debug tested multiple characters in next summer starts and in worlds with upped evolution settings.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Also removes the cop loot list from kevlar zombies cause zombie cops can no longer actually evolve into kevlar zombies.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3e96422](https://github.com/cataclysmbn/Cataclysm-BN/commit/3e96422c0c13df6571cd3a17489487f9005f590c) (Update zed_soldiers.json) on 2026-06-30 07:14:15

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28413571674/artifacts/7969357071)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28413571674)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28413571674/artifacts/7968762209)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28413571674/artifacts/7968803787)
<!-- END artifact comment -->