### PR TITLE
feat(balance): follow up to ammo rebalance for rivtech, 277, and shotguns

### DIFF
--- a/data/json/items/ammo/20x66mm.json
+++ b/data/json/items/ammo/20x66mm.json
@@ -20,7 +20,7 @@
     "type": "AMMO",
     "name": { "str": "20x66mm flechette, handmade", "str_pl": "20x66mm flechettes, handmade" },
     "description": "Handmade duplicates of Rivtech 20x66mm caseless flechette rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
-    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.6 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -30,7 +30,7 @@
     "type": "AMMO",
     "name": { "str": "20x66mm buckshot, handmade" },
     "description": "Handmade duplicates of Rivtech 20x66mm caseless buckshot rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
-    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.6 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -40,7 +40,7 @@
     "type": "AMMO",
     "name": { "str": "20x66mm slug, handmade", "str_pl": "20x66mm slugs, handmade" },
     "description": "Handmade duplicates of Rivtech 20x66mm caseless solid projectile rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
-    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.6 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -87,7 +87,7 @@
     "//": "Balanced as AP.",
     "loudness": 160,
     "speed": 750,
-    "damage": { "damage_type": "bullet", "amount": 8, "armor_penetration": 36 },
+    "damage": { "damage_type": "bullet", "amount": 8, "armor_penetration": 68 },
     "shot": { "count": 10, "half_angle": 2 }
   },
   {
@@ -130,7 +130,7 @@
     "stack_size": 20,
     "ammo_type": "20x66mm",
     "range": 20,
-    "damage": { "damage_type": "bullet", "amount": 20, "armor_penetration": 10 },
+    "damage": { "damage_type": "bullet", "amount": 20, "armor_penetration": 32 },
     "recoil": 2500,
     "loudness": 158,
     "speed": 340,
@@ -154,7 +154,7 @@
     "price": "15 USD",
     "price_postapoc": "40 USD",
     "//": "Balanced as FMJ",
-    "damage": { "damage_type": "bullet", "amount": 84, "armor_penetration": 21 },
+    "damage": { "damage_type": "bullet", "amount": 84, "armor_penetration": 32 },
     "relative": { "range": 20 },
     "proportional": { "dispersion": 1.3 },
     "loudness": 158,

--- a/data/json/items/ammo/277.json
+++ b/data/json/items/ammo/277.json
@@ -17,7 +17,7 @@
     "ammo_type": "277",
     "casing": "277_casing",
     "range": 65,
-    "damage": { "damage_type": "bullet", "amount": 60, "armor_penetration": 27 },
+    "damage": { "damage_type": "bullet", "amount": 45, "armor_penetration": 27 },
     "dispersion": 15,
     "recoil": 2500,
     "loudness": 164,
@@ -33,7 +33,7 @@
     "loudness": 166,
     "speed": 980,
     "description": "A rimless cartridge that was planned to be adopted by the US military to combat advances in modern body armor, but was quietly abandoned soon after the development of caseless. These full-power Hybrid rounds offer significant armor penetration but greatly increase recoil.",
-    "relative": { "damage": { "damage_type": "bullet", "amount": 5, "armor_penetration": 20 } },
+    "relative": { "damage": { "damage_type": "bullet", "amount": 25, "armor_penetration": 30 } },
     "proportional": { "recoil": 1.3 }
   },
   {

--- a/data/json/items/ammo/5x50.json
+++ b/data/json/items/ammo/5x50.json
@@ -16,7 +16,7 @@
     "casing": "5x50_hull",
     "range": 60,
     "//": "Balanced as AP",
-    "damage": { "damage_type": "bullet", "amount": 30, "armor_penetration": 50 },
+    "damage": { "damage_type": "bullet", "amount": 30, "armor_penetration": 70 },
     "dispersion": 60,
     "recoil": 400,
     "speed": 1000,

--- a/data/json/items/ammo/8x40mm.json
+++ b/data/json/items/ammo/8x40mm.json
@@ -5,7 +5,7 @@
     "type": "AMMO",
     "name": { "str": "8x40mm JHP, handmade" },
     "description": "Handmade duplicates of Rivtech 8x40mm JHP rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
-    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.6 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -15,7 +15,7 @@
     "type": "AMMO",
     "name": { "str": "8x40mm caseless, handmade" },
     "description": "Handmade duplicates of Rivtech 8x40mm caseless rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
-    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.6 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -25,7 +25,7 @@
     "type": "AMMO",
     "name": { "str": "8x40mm HVP, handmade" },
     "description": "Handmade duplicates of Rivtech 8x40mm HVP rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
-    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.6 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -35,7 +35,7 @@
     "type": "AMMO",
     "name": { "str": "8x40mm tracer, handmade" },
     "description": "Handmade duplicates of Rivtech 8x40mm tracer rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
-    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.6 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -56,7 +56,7 @@
     "stack_size": 40,
     "ammo_type": "8x40mm",
     "range": 42,
-    "damage": { "damage_type": "bullet", "amount": 45, "armor_penetration": 35 },
+    "damage": { "damage_type": "bullet", "amount": 45, "armor_penetration": 55 },
     "dispersion": 75,
     "recoil": 2200,
     "loudness": 158,

--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -82,7 +82,7 @@
     "ammo_type": "shot",
     "casing": "shot_hull",
     "range": 20,
-    "damage": { "damage_type": "bullet", "amount": 16, "armor_penetration": 8 },
+    "damage": { "damage_type": "bullet", "amount": 16, "armor_penetration": 24 },
     "recoil": 2500,
     "loudness": 160,
     "speed": 370,
@@ -148,7 +148,7 @@
     "price_postapoc": "8 USD",
     "count": 10,
     "//": "Balanced as standard AP.",
-    "damage": { "damage_type": "bullet", "amount": 6, "armor_penetration": 15 },
+    "damage": { "damage_type": "bullet", "amount": 6, "armor_penetration": 42 },
     "shot": { "count": 10, "half_angle": 2 }
   },
   {

--- a/data/json/items/ammo/shotpaper.json
+++ b/data/json/items/ammo/shotpaper.json
@@ -17,7 +17,7 @@
     "stack_size": 20,
     "ammo_type": "shotpaper",
     "range": 20,
-    "damage": { "damage_type": "bullet", "amount": 13, "armor_penetration": 6 },
+    "damage": { "damage_type": "bullet", "amount": 13, "armor_penetration": 24 },
     "recoil": 2000,
     "loudness": 144,
     "speed": 200,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
following the previous pr which buffed armor values across the board, rounds which were meant to be late game were suddenly unable to penetrate basic body armor.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Buffs the armor penetration of 8x40, 5x50, 20x66, 277, and shot to be able to deal with the new armor values. Caseless, 5x50, and 277 were buffed under the assumption that they were supposed to be able to defeat "modern body armor", which to me means being able to do reasonable damage through the 90 ballistic armor of a ceramic plate. 277 fmj was nerfed a bit as it has much lower power than hybrid irl. both rivtech and normal shotgun shot were also rebalanced, rivtech shotgun rounds were balanced around the idea that rivtech flechette and slugs should be able to do reasonable damage through 5.56 rated armor, and normal shot is able to deal damage through a kevlar vest. Regular shotgun shells were balanced around the idea that flechette should be able to do damage through an empty mbr vest, and 00 shot should be able to do some damage through a kevlar vest.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Useless shotguns
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Not really based on any math, just kinda went for it
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [655c082](https://github.com/cataclysmbn/Cataclysm-BN/commit/655c0821db520650a6a3c6ceb30f3c7c0d150bdf) (Update shotpaper.json) on 2026-06-30 03:18:42

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28416242762/artifacts/7969756887)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28416242762/artifacts/7970142334)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28416242762/artifacts/7969874533)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28416242762/artifacts/7969838939)
<!-- END artifact comment -->