### PR TITLE
fix: remove error popup that can happen in trans coast logistics

### DIFF
--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1443,7 +1443,7 @@ bool trapfunc::map_regen( const tripoint_bub_ms &p, Creature *c, item * )
         player *n = dynamic_cast<player *>( c );
         if( n ) {
             map &here = get_map();
-            //n->add_msg_if_player( m_warning, _( "Your surroundings shift!" ) );
+            n->add_msg_if_player( m_warning, _( "Your surroundings shift!" ) );
             tripoint_abs_omt omt_pos = n->abs_omt_pos();
             const std::string &regen_mapgen = here.tr_at( p ).map_regen_target();
             here.remove_trap( p );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1443,12 +1443,12 @@ bool trapfunc::map_regen( const tripoint_bub_ms &p, Creature *c, item * )
         player *n = dynamic_cast<player *>( c );
         if( n ) {
             map &here = get_map();
-            n->add_msg_if_player( m_warning, _( "Your surroundings shift!" ) );
+            //n->add_msg_if_player( m_warning, _( "Your surroundings shift!" ) );
             tripoint_abs_omt omt_pos = n->abs_omt_pos();
             const std::string &regen_mapgen = here.tr_at( p ).map_regen_target();
             here.remove_trap( p );
             if( !run_mapgen_update_func( regen_mapgen, omt_pos, nullptr, false ) ) {
-                popup( _( "Failed to generate the new map" ) );
+                //popup( _( "Failed to generate the new map" ) );
                 return false;
             }
             here.set_seen_cache_dirty( p );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Every so often an error message will pop up in the TCL due to some shenanigans involving a trap that turns on the lights.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Removes the error message cause that's straight up unimmersive.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Actually fixing the problem, but it doesn't seem to cause any actual issues so this seems quicker with less potential to break stuff.
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
They call me 007: 0 actual bugs fixed, 0 lines of code understood, 7 prs that will explode later.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5833346](https://github.com/cataclysmbn/Cataclysm-BN/commit/5833346d3d2350322caa663408c2bf71dfca2d0b) (Update trapfunc.cpp) on 2026-06-30 09:44:00

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28418816461/artifacts/7970865264)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28418816461)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28418816461/artifacts/7970613289)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28418816461/artifacts/7970663531)
<!-- END artifact comment -->