### PR TITLE
fix: fix error message about failing to regen map that could appear in the TCL

### DIFF
--- a/data/json/mapgen/lab/lab_modular/lab_2x2_MUT_Tier_2.json
+++ b/data/json/mapgen/lab/lab_modular/lab_2x2_MUT_Tier_2.json
@@ -308,5 +308,11 @@
     "update_mapgen_id": "light_on_res_8_SW_2",
     "method": "json",
     "object": { "place_terrain": [ { "ter": "t_thconc_floor_olight", "x": 14, "y": 3 } ] }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "light_on_MUT_SE_2",
+    "method": "json",
+    "object": { "place_terrain": [ { "ter": "t_thconc_floor_olight", "x": 14, "y": 3 } ] }
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
In the TCL there was a specific location that could cause an error popup about failing to regenerate the map or something along those lines.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
There was a missing map_regen definition for one of the overhead lights, so the error message triggered as a result.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Walked through the problematic hallway, no error.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e7734c9](https://github.com/cataclysmbn/Cataclysm-BN/commit/e7734c90c57fecfdef951e6841738d63aeab6d49) (Update lab_2x2_MUT_Tier_2.json) on 2026-06-30 05:35:08

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28419907654/artifacts/7971519325)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28419907654/artifacts/7971812200)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28419907654/artifacts/7971651866)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28419907654/artifacts/7971353003)
<!-- END artifact comment -->