### PR TITLE
feat(balance): diversify skeleton evolution tree

### DIFF
--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -51,8 +51,18 @@
     "type": "monstergroup",
     "default": "mon_skeleton_brute",
     "monsters": [
-      { "monster": "mon_skeleton_brute", "freq": 80, "cost_multiplier": 2 },
-      { "monster": "mon_skeleton_brute", "freq": 80, "cost_multiplier": 2 }
+      { "monster": "mon_skeleton_electric", "freq": 300, "cost_multiplier": 2 },
+      { "monster": "mon_skeleton_brute", "freq": 700, "cost_multiplier": 2 }
+    ]
+  },
+  {
+    "name": "GROUP_SKELETON_BRUTE_UPGRADE",
+    "type": "monstergroup",
+    "default": "mon_skeleton_hulk",
+    "//": "I'd put skeletal liches in here, but for some reason they disappear as soon as they are placed/spawned",
+    "monsters": [
+      { "monster": "mon_skeleton_master", "freq": 350, "cost_multiplier": 2 },
+      { "monster": "mon_skeleton_hulk", "freq": 650, "cost_multiplier": 2 }
     ]
   },
   {
@@ -74,10 +84,9 @@
     "name": "GROUP_ZOMBIE_ELECTRIC_UPGRADE",
     "default": "mon_null",
     "monsters": [
-      { "monster": "mon_zombie_nullfield", "freq": 550, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_brute_shocker", "freq": 300, "cost_multiplier": 2 },
-      { "monster": "mon_skeleton_electric", "freq": 300, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_stormbringer", "freq": 250, "cost_multiplier": 2, "starts": 500 }
+      { "monster": "mon_zombie_nullfield", "freq": 650, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_brute_shocker", "freq": 400, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_stormbringer", "freq": 350, "cost_multiplier": 2, "starts": 500 }
     ]
   },
   {

--- a/data/json/monsters/zed_skeletal.json
+++ b/data/json/monsters/zed_skeletal.json
@@ -69,7 +69,7 @@
       [ "SMASH", 45 ],
       { "id": "scratch", "damage_max_instance": [ { "damage_type": "cut", "amount": 15, "armor_multiplier": 0.6 } ] }
     ],
-    "upgrades": { "half_life": 12, "into": "mon_skeleton_hulk" },
+    "upgrades": { "half_life": 24, "into_group": "GROUP_SKELETON_BRUTE_UPGRADE" },
     "death_drops": "default_zombie_clothes",
     "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "BLEED", "HARDTOSHOOT", "REVIVES", "NO_BREATHE", "POISON" ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
closes #9488 
The skeleton tree as of now is very one note, with it just going from skeleton to brute to hulk. Also, there are cool enemies like the skeletal master that are basically unused due to only being specifically placed in like 1 location.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Updates the skeleton evolution tree to provide some more variety and slow down the rate at which skeletal hulks start appearing. Now, base skeletons have a 30% chance to become skeletal shockers instead of brutes, while skeletal shockers were removed from generic electric zombie evolution. Skeletal brutes then have a 65% chance to become skeletal hulks, and a 35% chance to become skeletal masters, who can buff other zombies around them. The half life for the skeletal brute's evolutions has been increased from 12 to 24 days to better match other "specialized" zombie evolution speeds.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Boring skeletons
## Testing
Debug tested with a next summer and world settings adjusted world, evolved zombie rates and appearances seem good.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Some day I will clean up the mess that is the normal brute evolution tree but today is not that day.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b4c936a](https://github.com/cataclysmbn/Cataclysm-BN/commit/b4c936aafa20293fc1a2e1811d16f8bf49b2ae5a) (Update zed_skeletal.json) on 2026-06-30 06:52:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28424210824/artifacts/7972509452)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28424210824/artifacts/7972996483)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28424210824/artifacts/7972530667)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28424210824/artifacts/7972597760)
<!-- END artifact comment -->