### PR TITLE
feat(balance): Remove `"location": "armor"` from shock absorber

### DIFF
--- a/data/json/vehicleparts/armor.json
+++ b/data/json/vehicleparts/armor.json
@@ -26,7 +26,6 @@
     "type": "vehicle_part",
     "name": { "str": "shock absorber" },
     "item": "spring_plate",
-    "location": "armor",
     "symbol": "X",
     "broken_symbol": "*",
     "color": "dark_gray",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Currently, shock absorbers have the same location as armor plating. However, they fulfil an entirely different, non-overlapping purpose: plating protects the parts from the direct damage on that tile, and shock absorbers protect them from shock damage when a collision happens elsewhere. Thus, it makes no sense to me that you can't have both.

## Describe the solution (The How)

Removed location from shock absorbers so they can be placed on the same tile as plating.

## Testing

Booted up the game and checked that shock absorber shows up in the install menu of a tile that has plating.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e550af6](https://github.com/cataclysmbn/Cataclysm-BN/commit/e550af655fbe8f3ffa91ad08aee2fbf8e3396394) (Remove `"location": "armor"` from shock absorber) on 2026-06-30 15:43:27

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28451710071/artifacts/7983878573)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28451710071/artifacts/7985753617)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28451710071/artifacts/7983908789)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28451710071/artifacts/7984075413)
<!-- END artifact comment -->