### PR TITLE
feat: expand upon trap checks

### DIFF
--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -12,12 +12,15 @@
 #include "event.h"
 #include "event_bus.h"
 #include "generic_factory.h"
+#include "generic_readers.h"
 #include "int_id.h"
 #include "item.h"
+#include "itype.h"
 #include "json.h"
 #include "line.h"
 #include "map.h"
 #include "map_iterator.h"
+#include "mapgen_functions.h"
 #include "point.h"
 #include "rng.h"
 #include "string_id.h"
@@ -116,7 +119,8 @@ void trap::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "difficulty", difficulty );
     optional( jo, was_loaded, "trap_radius", trap_radius, 0 );
     // TODO: Is there a generic_factory version of this?
-    act = trap_function_from_string( jo.get_string( "action" ) );
+    mandatory( jo, was_loaded, "action", act_string );
+    act = trap_function_from_string( act_string );
 
     optional( jo, was_loaded, "map_regen", map_regen, "none" );
     optional( jo, was_loaded, "benign", benign, false );
@@ -126,7 +130,7 @@ void trap::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "comfort", comfort, 0 );
     optional( jo, was_loaded, "floor_bedding_warmth", floor_bedding_warmth, 0 );
     optional( jo, was_loaded, "spell_data", spell_data );
-    assign( jo, "trigger_weight", trigger_weight );
+    optional( jo, was_loaded, "trigger_weight", trigger_weight, mass_reader(), -1_gram );
     if( was_loaded && jo.has_member( "copy-from" ) && looks_like.empty() ) {
         looks_like = jo.get_string( "copy-from" );
     }
@@ -359,13 +363,45 @@ tr_glass_pit;
 
 void trap::check_consistency()
 {
-    for( const auto &t : trap_factory.get_all() ) {
-        for( auto &i : t.components ) {
-            const itype_id &item_type = std::get<0>( i );
-            if( !item_type.is_valid() ) {
-                debugmsg( "trap %s has unknown item as component %s", t.id.str(), item_type.str() );
+    trap_factory.check();
+}
+
+void trap::check() const
+{
+    for( auto &[ item_type, quantity, charges] : components ) {
+        if( !item_type.is_valid() ) {
+            debugmsg( "trap %s has unknown item %s as a component", id.str(), item_type.str() );
+        } else {
+            if( !item_type->count_by_charges() && charges != 1 ) {
+                debugmsg( "trap %s tries to give charges to component item %s which doesn't support charges",
+                          id.str(), item_type.str() );
             }
         }
+    }
+    for( auto &[item_type, quantity, charges] : trigger_components ) {
+        if( !item_type.is_valid() ) {
+            debugmsg( "trap %s has unknown item %s as a trigger component", id.str(), item_type.str() );
+        } else {
+            if( !item_type->count_by_charges() && charges != 1 ) {
+                debugmsg( "trap %s tries to give charges to trigger component item %s which doesn't support charges",
+                          id.str(), item_type.str() );
+            }
+        }
+    }
+    for( auto &[ item_type, chance] : vehicle_data.spawn_items ) {
+        if( !item_type.is_valid() ) {
+            debugmsg( "trap %s has unknown item %s as a vehicle data spawn item", id.str(), item_type.str() );
+        }
+    }
+    if( !vehicle_data.set_trap.is_valid() ) {
+        debugmsg( "trap %s has unknown trap %s as a vehicle data set trap", id.str(),
+                  vehicle_data.set_trap.str() );
+    }
+    if( funnel_radius_mm < 0 ) {
+        debugmsg( "trap %s has negative funnel radius %s", id.str(), funnel_radius_mm );
+    }
+    if( act_string == "map_regen" && !mapgen::has_update_id( map_regen ) ) {
+        debugmsg( "trap %s has invalid update mapgen id %s.", id.str(), map_regen );
     }
 }
 

--- a/src/trap.h
+++ b/src/trap.h
@@ -105,6 +105,8 @@ struct trap {
         // a valid overmap id, for map_regen action traps
         std::string map_regen;
         trap_function act;
+        // Need this so checks can be properly checked
+        std::string act_string;
         std::string name_;
         /**
          * If an item with this weight or more is thrown onto the trap, it triggers.
@@ -263,6 +265,7 @@ struct trap {
          * Checks internal consistency (reference to other things like item ids etc.)
          */
         static void check_consistency();
+        void check() const;
         /*@}*/
         static size_t count();
 


### PR DESCRIPTION
## Purpose of change (The Why)
#9739 revealed a large problem
Traps weren't checking their data

## Describe the solution (The How)
Check the data so we dont get this error running around for months again

## Describe alternatives you've considered'
Find out who didn't add any consistency checks to traps

## Testing
It errors with the error fixed in #9739 as I have not updated upstream

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ddf043b](https://github.com/cataclysmbn/Cataclysm-BN/commit/ddf043b27da2b8001ad694f915ca030b40271ac1) (feat: expand upon trap checks) on 2026-06-30 18:04:12

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28461009097/artifacts/7987972270)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28461009097/artifacts/7989416504)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28461009097/artifacts/7987993562)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28461009097/artifacts/7988035277)
<!-- END artifact comment -->