### PR TITLE
feat: remove flat roof from the mapgen `roof_4x4_holdout` and `roof_4x4_party`

### DIFF
--- a/data/json/mapgen/nested/roof_nested.json
+++ b/data/json/mapgen/nested/roof_nested.json
@@ -7,11 +7,10 @@
       "mapgensize": [ 4, 4 ],
       "rows": [
         "xxxx",
-        "xct_",
-        "x___",
-        "____"
+        "xct ",
+        "x   ",
+        "    "
       ],
-      "terrain": { "_": "t_flat_roof" },
       "furniture": { "c": "f_camp_chair", "x": "f_sandbag_wall", "t": [ [ "f_table", 9 ], "f_table_flipped" ] },
       "place_loot": [
         { "group": "roof_trash", "x": [ 0, 3 ], "y": 3, "chance": 30, "repeat": [ 1, 2 ] },
@@ -28,12 +27,11 @@
     "object": {
       "mapgensize": [ 4, 4 ],
       "rows": [
-        "_ct_",
-        "____",
-        "_b_c",
-        "c___"
+        " ct ",
+        "    ",
+        " b c",
+        "c   "
       ],
-      "terrain": { "_": "t_flat_roof", "c": "t_flat_roof", "b": "t_flat_roof", "t": "t_flat_roof" },
       "furniture": { "c": "f_camp_chair", "b": "f_brazier", "t": [ [ "f_table", 9 ], "f_table_flipped" ] },
       "place_items": [
         { "item": "roof_trash", "x": [ 0, 3 ], "y": [ 0, 3 ], "chance": 35, "repeat": [ 1, 2 ] },


### PR DESCRIPTION
## Purpose of change (The Why)
These nested mapgens do not need flat roof.
## Describe the solution (The How)
No flat roof
## Describe alternatives you've considered
none
## Testing
I launched a new game; no errors
## Additional context
none
## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c473973](https://github.com/cataclysmbn/Cataclysm-BN/commit/c473973aa817697cbf8c9767f2305300495640d4) (Update roof_nested.json) on 2026-06-30 20:13:45

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28468442596/artifacts/7990872072)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28468442596/artifacts/7992373239)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28468442596/artifacts/7990931418)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28468442596/artifacts/7990982105)
<!-- END artifact comment -->