### PR TITLE
fix: allow traps to be detected again while moving

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -733,7 +733,6 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
     {
         ZoneScopedN( "avatar_move_walk_move" );
         if( g->walk_move( dest_loc, via_ramp ) ) {
-            character_funcs::search_surroundings( you );
             return true;
         }
     }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -733,6 +733,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
     {
         ZoneScopedN( "avatar_move_walk_move" );
         if( g->walk_move( dest_loc, via_ramp ) ) {
+            character_funcs::search_surroundings( you );
             return true;
         }
     }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2124,6 +2124,7 @@ bool game::handle_action()
             case ACTION_MOVE_LEFT:
             case ACTION_MOVE_FORTH_LEFT: {
                 ZoneScopedN( "handle_action_movement" );
+                character_funcs::search_surroundings( u );
                 if( !u.get_value( "remote_controlling" ).empty() &&
                     ( u.has_active_item_with_action( "RADIOCONTROL" ) ||
                       u.has_active_bionic( bio_remote ) ) ) {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
closes #9601 
Traps became only able to be detected while waiting for some reason. This reverts/fixes that
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Calls search_surroundings, which is how you detect traps, every time you move normally.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
idk
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Not sure if this is disastrous for performance, any of the C++ wizards feel free to chime in on how this is a terrible idea.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [688603a](https://github.com/cataclysmbn/Cataclysm-BN/commit/688603ab4346f76edf8c5c944293fa57f09ac93c) (Update avatar_action.cpp) on 2026-07-01 02:26:44

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28485890171/artifacts/7998509885)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28485890171/artifacts/7998189238)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28485890171/artifacts/7997838300)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28485890171/artifacts/7997900027)
<!-- END artifact comment -->