### PR TITLE
fix: correct wrist control computer description

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -316,7 +316,7 @@
     "id": "wrist_comp_control",
     "name": { "str": "wrist control computer" },
     "copy-from": "wrist_comp_budget",
-    "description": "A modified wrist-mounted computer, now capable of transmitting in the ultra-high frequencies utilized by robots.  Activate it to command robots from afar, or to toggle charging via UPS.",
+    "description": "A modified wrist-mounted computer, now capable of transmitting in the ultra-high frequencies utilized by robots.  Activate it to command robots from afar or utilize its other features.",
     "weight": "112 g",
     "price": "120 USD",
     "price_postapoc": "100 USD",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -316,7 +316,7 @@
     "id": "wrist_comp_control",
     "name": { "str": "wrist control computer" },
     "copy-from": "wrist_comp_budget",
-    "description": "A modified wrist computer, now capable of transmitting in the ultra-high frequencies utilized by robots.  Activate it to command robots from afar, or to toggle charging via UPS.",
+    "description": "A modified wrist-mounted computer, now capable of transmitting in the ultra-high frequencies utilized by robots.  Activate it to command robots from afar, or to toggle charging via UPS.",
     "weight": "112 g",
     "price": "120 USD",
     "price_postapoc": "100 USD",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -316,7 +316,7 @@
     "id": "wrist_comp_control",
     "name": { "str": "wrist control computer" },
     "copy-from": "wrist_comp_budget",
-    "description": "A fancy wrist-mounted computer, with a menagerie of useful features, such as SD reading, a built-in thermometer, and even a radiation monitor!",
+    "description": "A modified wrist computer, now capable of transmitting in the ultra-high frequencies utilized by robots.  Activate it to command robots from afar, or to toggle charging via UPS.",
     "weight": "112 g",
     "price": "120 USD",
     "price_postapoc": "100 USD",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

It used to have the same description as the regular wrist computer.

## Describe the solution (The How)

I was checking to see if this item existed, turns out it does, but the description is the same as the mundane one for some reason.

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4dee03e](https://github.com/cataclysmbn/Cataclysm-BN/commit/4dee03e4716916f118b8a82b0d265c4c939091af) (Update electronics.json) on 2026-07-01 08:15:42

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28501179812/artifacts/8003639833)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28501179812/artifacts/8003985293)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28501179812/artifacts/8003492571)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28501179812/artifacts/8003652884)
<!-- END artifact comment -->