### PR TITLE
feat: add subsonic variants for 9mm and 8x40mm

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -29,7 +29,8 @@
       { "item": "4570_sp", "prob": 5, "charges": [ 1, 100 ] },
       { "item": "45colt_jhp", "prob": 20, "charges": [ 1, 100 ] },
       { "item": "9mm", "prob": 125, "charges": [ 1, 100 ] },
-      { "item": "9mmfmj", "prob": 125, "charges": [ 1, 100 ] }
+      { "item": "9mmfmj", "prob": 125, "charges": [ 1, 100 ] },
+      { "item": "9mm_subsonic_fmj", "prob": 20, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -553,7 +554,8 @@
       { "item": "4570_sp", "prob": 5 },
       { "item": "45colt_jhp", "prob": 20 },
       { "item": "9mm", "prob": 125 },
-      { "item": "9mmfmj", "prob": 125 }
+      { "item": "9mmfmj", "prob": 125 },
+      { "item": "9mm_subsonic_fmj", "prob": 10 }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -689,10 +689,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "entries": [
-      { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
-      { "group": "nested_mp5_mag", "charges-min": 0, "prob": 80 },
-      { "group": "nested_mp5_mag", "charges-min": 0, "prob": 50 },
-      { "group": "on_hand_9mm", "prob": 25, "charges": [ 10, 20 ], "count": [ 1, 2 ] }
+      { "item": "hk_mp5sd", "ammo-group": "on_hand_9mm_sub", "charges": [ 0, 30 ] },
+      { "group": "nested_mp5_mag", "ammo-group": "on_hand_9mm_sub","charges-min": 0, "prob": 80 },
+      { "group": "nested_mp5_mag", "ammo-group": "on_hand_9mm_sub","charges-min": 0, "prob": 50 },
+      { "group": "on_hand_9mm_sub", "prob": 25, "charges": [ 10, 20 ], "count": [ 1, 2 ] }
     ]
   },
   {
@@ -1278,10 +1278,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "entries": [
-      { "item": "rm11b_sniper_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 10 ] },
-      { "group": "nested_rm103a_mag", "charges-min": 0, "prob": 80 },
-      { "group": "nested_rm103a_mag", "charges-min": 0, "prob": 50 },
-      { "group": "on_hand_8x40", "prob": 25, "charges": [ 10, 20 ], "count": [ 1, 2 ] }
+      { "item": "rm11b_sniper_rifle", "ammo-group": "on_hand_8x40_sub", "charges": [ 0, 10 ] },
+      { "group": "nested_rm103a_mag", "ammo-group": "on_hand_8x40_sub", "charges-min": 0, "prob": 80 },
+      { "group": "nested_rm103a_mag", "ammo-group": "on_hand_8x40_sub", "charges-min": 0, "prob": 50 },
+      { "group": "on_hand_8x40_sub", "prob": 25, "charges": [ 10, 20 ], "count": [ 1, 2 ] }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
@@ -8,8 +8,16 @@
       { "item": "9mm", "prob": 100, "charges": [ 25, 50 ] },
       { "item": "9mmfmj", "prob": 100, "charges": [ 25, 50 ] },
       { "item": "9mmP", "prob": 30, "charges": [ 25, 50 ] },
-      { "item": "9mmP2", "prob": 30, "charges": [ 25, 50 ] }
+      { "item": "9mmP2", "prob": 30, "charges": [ 25, 50 ] },
+      { "item": "9mm_subsonic_fmj", "prob": 30, "charges": [ 25, 50 ] }
     ]
+  },
+  {
+    "id": "on_hand_9mm_sub",
+    "type": "item_group",
+    "//": "a collection of ammo that would be found with a loaded, suppressed gun.",
+    "subtype": "distribution",
+    "entries": [ { "item": "9mm_subsonic_fmj", "prob": 100, "charges": [ 25, 50 ] } ]
   },
   {
     "id": "on_hand_10mm",
@@ -79,7 +87,17 @@
       { "item": "8mm_civilian", "prob": 100, "charges": [ 20, 40 ] },
       { "item": "8mm_jhp", "prob": 100, "charges": [ 20, 40 ] },
       { "item": "8mm_hvp", "prob": 30, "charges": [ 20, 40 ] },
-      { "item": "8mm_inc", "prob": 30, "charges": [ 20, 40 ] }
+      { "item": "8mm_inc", "prob": 30, "charges": [ 20, 40 ] },
+      { "item": "8mm_subsonic", "prob": 30, "charges": [ 20, 40 ] }
+    ]
+  },
+  {
+    "id": "on_hand_8x40_sub",
+    "type": "item_group",
+    "//": "a collection of ammo that would be found with a loaded, suppressed gun.",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "8mm_subsonic", "prob": 100, "charges": [ 20, 40 ] }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -954,10 +954,10 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
-      { "group": "nested_mp5_mag" },
-      { "group": "nested_mp5_mag", "prob": 50 },
-      { "group": "on_hand_9mm" }
+      { "item": "hk_mp5sd", "ammo-group": "on_hand_9mm_sub", "charges": [ 0, 30 ] },
+      { "group": "nested_mp5_mag", "ammo-group": "on_hand_9mm_sub" },
+      { "group": "nested_mp5_mag", "ammo-group": "on_hand_9mm_sub", "prob": 50 },
+      { "group": "on_hand_9mm_sub" }
     ]
   },
   {
@@ -1705,10 +1705,10 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm11b_sniper_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 10 ] },
-      { "group": "nested_rm103a_mag" },
-      { "group": "nested_rm103a_mag", "prob": 50 },
-      { "group": "on_hand_8x40" }
+      { "item": "rm11b_sniper_rifle", "ammo-group": "on_hand_8x40_sub", "charges": [ 0, 10 ] },
+      { "group": "nested_rm103a_mag", "ammo-group": "on_hand_8x40_sub" },
+      { "group": "nested_rm103a_mag", "ammo-group": "on_hand_8x40_sub", "prob": 50 },
+      { "group": "on_hand_8x40_sub" }
     ]
   },
   {

--- a/data/json/items/ammo/8x40mm.json
+++ b/data/json/items/ammo/8x40mm.json
@@ -111,5 +111,20 @@
     "name": { "str": "8x40mm JHP" },
     "description": "8x40mm caseless rounds, jacketed hollowpoint.  Military grade ammunition for Rivtech firearms.  Being caseless rounds, these cannot be disassembled or reloaded.",
     "relative": { "damage": { "damage_type": "bullet", "amount": 11, "armor_penetration": -22 } }
+  },
+  {
+    "id": "8mm_subsonic",
+    "type": "AMMO",
+    "copy-from": "8mm_caseless",
+    "name": { "str_sp": "8x40mm Subsonic" },
+    "//": "MUCH slower than normal rounds, but only lowered recoil and pen by 20%, damage by 10%. Justified by rivtech ballistic tech",
+    "description": "8x40mm caseless, subsonic rounds with a very heavy tip.  Proprietary ammunition for Rivtech firearms.  Designed specifically for the RM11B rifle, which will shoot these incredibly quietly, but will work very well with any suppresesd weapon. Being caseless rounds, these cannot be disassembled or reloaded.",
+    "proportional": {
+      "damage": { "damage_type": "bullet", "amount": 0.85, "armor_penetration": 0.7 },
+      "recoil": 0.7
+      },
+    "loudness": 152,
+    "speed": 320,
+    "effects": [ "NEVER_MISFIRES" ]
   }
 ]

--- a/data/json/items/ammo/9mm.json
+++ b/data/json/items/ammo/9mm.json
@@ -96,7 +96,7 @@
     "type": "AMMO",
     "name": { "str": "9x19mm Subsonic FMJ" },
     "//": "based on the Fiocchi 158 Grain FMJ. 250 ft-lbs of energy vs 364 for normal fmj, so 31% less. Settled on 10% less damage, as well as 20% less recoil and pen. Also, this makes me hate the imperial system.",
-    "description": "9x19mm ammunition with a heavy brass-jacketed 158gr bullet.  This slower bullet has sligtly lower penetration and bit more stopping power.  More importantly, beign subsonic makes it really quiet when used with a suppressor.",
+    "description": "9x19mm ammunition with a heavy brass-jacketed 158gr bullet.  This slower bullet has sligthly lower penetration and bit more stopping power.  More importantly, beign subsonic makes it really quiet when used with a suppressor.",
     "proportional": {
       "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.8 }
     },

--- a/data/json/items/ammo/9mm.json
+++ b/data/json/items/ammo/9mm.json
@@ -89,5 +89,19 @@
       "dispersion": 1.2
     },
     "extend": { "effects": [ "RECYCLED", "BLACKPOWDER", "MUZZLE_SMOKE" ] }
+  },
+  {
+    "id": "9mm_subsonic_fmj",
+    "copy-from": "9mmfmj",
+    "type": "AMMO",
+    "name": { "str": "9x19mm Subsonic FMJ" },
+    "//": "based on the Fiocchi 158 Grain FMJ. 250 ft-lbs of energy vs 364 for normal fmj, so 31% less. Settled on 10% less damage, as well as 20% less recoil and pen. Also, this makes me hate the imperial system.",
+    "description": "9x19mm ammunition with a heavy brass-jacketed 158gr bullet.  This slower bullet has sligtly lower penetration and bit more stopping power.  More importantly, beign subsonic makes it really quiet when used with a suppressor.",
+    "proportional": {
+      "damage": { "damage_type": "bullet", "amount": 0.9, "armor_penetration": 0.8 }
+    },
+    "recoil": 400,
+    "loudness": 155,
+    "speed": 260
   }
 ]

--- a/data/json/items/gun/8x40mm.json
+++ b/data/json/items/gun/8x40mm.json
@@ -76,7 +76,8 @@
     "magazine_well": "250 ml",
     "magazines": [ [ "8x40mm", [ "8x40_10_mag", "8x40_25_mag" ] ] ],
     "flags": [ "WATERPROOF_GUN", "NEVER_JAMS" ],
-    "faults": [  ]
+    "faults": [  ],
+    "default_ammo": "8mm_subsonic"
   },
   {
     "id": "rm2000_smg",

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -164,7 +164,8 @@
       [ "stock", 1 ]
     ],
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 4 ] ],
-    "built_in_mods": [ "mp5sd_suppressor" ]
+    "built_in_mods": [ "mp5sd_suppressor" ],
+    "default_ammo": "9mm_subsonic_fmj"
   },
   {
     "id": "hk_mp5k",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -559,8 +559,8 @@
     "subtype": "collection",
     "id": "army_mags_rm11b",
     "entries": [
-      { "item": "8x40_10_mag", "ammo-item": "8mm_caseless", "charges": 10 },
-      { "item": "8x40_10_mag", "ammo-item": "8mm_caseless", "charges": 10 }
+      { "item": "8x40_10_mag", "ammo-item": "8mm_subsonic", "charges": 10 },
+      { "item": "8x40_10_mag", "ammo-item": "8mm_subsonic", "charges": 10 }
     ]
   },
   {
@@ -4339,7 +4339,7 @@
           { "item": "knife_hunting", "container-item": "sheath" },
           {
             "item": "rm11b_sniper_rifle",
-            "ammo-item": "8mm_caseless",
+            "ammo-item": "8mm_subsonic",
             "charges": 10,
             "contents-item": [ "shoulder_strap", "bipod" ]
           },


### PR DESCRIPTION
## Purpose of change (The Why)

Follow up to #9748
Mp5SD and RM11B are both integrally suppressed. It makes sense for them to have subsonic ammo, and creates a powerful niche. 

## Describe the solution (The How)

Add 9mm subsonic and 8x40mm subsonic. 
Make spawns of Mp5SD and RM11B have subsonic ammo instead of random 9mm variants. 
Also adjust the one profession that spawns with RM11B 
Also, the mp5sd nested and everyday itemgroups were borked and spawned normal Mp5s. Fixed now. 

## Describe alternatives you've considered

Giving up
Adding more subsonic variant (jhp, for example). Decided against to avoid bloat, **but** I did create nested subsonic itemgroups that would make it easy to add in the future

## Testing

**IMPORTANT: The itemgroups do not behave as intended**.
- The extra mags in everydaycarry and nested itemgroups have random ammo variants, not just subsonic
- Spawning the gun alone does not spawn it with subsonic ammo

I highlighted the parts of the JSON that don't work as desired. I believe the function doesn't really exist, and there is no way to specify an ammo group for specific guns, or for specific magazine entries in itemgroups. I tried everything I knew.
This PR should not be merged until this has been fixed, either by figuring out an alternative solution, or adding the necessary code functions.

<img width="819" height="233" alt="Exhibit 1" src="https://github.com/user-attachments/assets/7fcc83b2-f55a-4d79-8c92-ca949379df47" />
<img width="375" height="476" alt="Exhibit 2" src="https://github.com/user-attachments/assets/8b51b3d4-2b11-4267-8fe3-1dfa43405872" />

## Additional context

I haven't added crafting recipes yet. 

## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [21d16b7](https://github.com/cataclysmbn/Cataclysm-BN/commit/21d16b7acf54d1bbc3d2340c9ccbf09710d1b99e) (typo 1) on 2026-07-01 11:27:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28510453508/artifacts/8008295218)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28510453508)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28510453508/artifacts/8007210282)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28510453508/artifacts/8007320803)
<!-- END artifact comment -->