### PR TITLE
fix: fix huge_ok mutation profession-only override

### DIFF
--- a/data/mods/Aftershock/mutations/mutations.json
+++ b/data/mods/Aftershock/mutations/mutations.json
@@ -533,8 +533,7 @@
     "type": "mutation",
     "id": "HUGE_OK",
     "copy-from": "HUGE_OK",
-    "extend": { "category": [ "MASTODON" ], "threshreq": [ "THRESH_MASTODON" ] },
-    "profession": true
+    "extend": { "category": [ "MASTODON" ], "threshreq": [ "THRESH_MASTODON" ] }
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
fixes #9726

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Removes the "profession" field from AFS mod's huge_ok extend so you can actually get it from mutations.

## Describe alternatives you've considered

Make the game think being huge and okay is a job

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
1. Get bear serums
2. Mutate until you get huge
3. mutate again and get huge_ok

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0756ca0](https://github.com/cataclysmbn/Cataclysm-BN/commit/0756ca06c3d850c53b0b1595744d8811e49373dc) (Fix huge_ok profession-only override) on 2026-07-01 15:41:15

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28525392789/artifacts/8014908350)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28525392789/artifacts/8014322615)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28525392789/artifacts/8013654012)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28525392789/artifacts/8013731018)
<!-- END artifact comment -->