### PR TITLE
fix: isolate test config dir under user dir

### DIFF
--- a/tests/path_info_test.cpp
+++ b/tests/path_info_test.cpp
@@ -1,0 +1,7 @@
+#include "catch/catch.hpp"
+#include "path_info.h"
+
+TEST_CASE("test harness config directory is isolated under user directory", "[path_info]") {
+    const auto expected = PATH_INFO::user_dir() + "config/";
+    CHECK(PATH_INFO::config_dir() == expected);
+}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -175,6 +175,7 @@ static void init_global_game_state(
     PATH_INFO::init_base_path("");
     PATH_INFO::init_user_dir(user_dir);
     PATH_INFO::set_standard_filenames();
+    PATH_INFO::set_config_dir(PATH_INFO::user_dir() + "config/");
 
     if (!assure_dir_exist(PATH_INFO::config_dir())) {
         assert(!"Unable to make config directory.  Check permissions.");


### PR DESCRIPTION
## Purpose of change (The Why)

`linux-full` test binaries are built with `USE_XDG_DIR=ON`, so test config writes could hit the real XDG config directory. Tests that rewrite keybindings or preload settings could delete or overwrite `~/.config/cataclysm-bn/*.json`.

Related: #6445, #8796, #9413.

## Describe the solution (The How)

- Force the test harness config directory to `--user-dir/config/` after standard path initialization.
- Add regression coverage for the isolated test config path.

## Describe alternatives you've considered

Setting `XDG_CONFIG_HOME` in wrappers would not protect direct `cata_test` runs.

## Testing

- Built `cataclysm-bn-tiles` and `cata_test-tiles` with `linux-full`.
- Ran the config path regression test, the keybindings test, and `[preload_config]` with sentinel files under a temporary `XDG_CONFIG_HOME`; the sentinel files stayed unchanged.

## Checklist

### Mandatory

- [x] I linked any relevant issues using github keyword syntax like `closes #1234` in Summary of the PR so it can be closed automatically, or there is no relevant issue to close.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.

<sub>PR opened by gpt-5.5 xhigh on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ba1c34b](https://github.com/cataclysmbn/Cataclysm-BN/commit/ba1c34baf23271654a12215776588ec7efaa2a2b) (fix: isolate test config dir under user dir) on 2026-07-01 16:31:46

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28528671582/artifacts/8016133112)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28528671582/artifacts/8015693127)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28528671582/artifacts/8015053185)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28528671582/artifacts/8015144678)
<!-- END artifact comment -->