### PR TITLE
feat(UI): Massively expand crafting recipe search filters

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <iterator>
 #include <map>
+#include <regex>
 #include <set>
 #include <string>
 #include <unordered_set>
@@ -1106,66 +1107,152 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
                     do {
                         // Find next ','
                         qry_end = qry.find_first_of( ',', qry_begin );
-
                         auto qry_filter_str = trim( qry.substr( qry_begin, qry_end - qry_begin ) );
-                        // Process filter
-                        if( qry_filter_str.size() > 2 && qry_filter_str[1] == ':' ) {
-                            switch( qry_filter_str[0] ) {
-                                case 't':
-                                    filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
-                                                       recipe_subset::search_type::tool );
-                                    break;
+                        qry_begin = qry_end + 1;
 
-                                case 'c':
-                                    filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
-                                                       recipe_subset::search_type::component );
-                                    break;
-
-                                case 's':
-                                    filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
-                                                       recipe_subset::search_type::skill );
-                                    break;
-
-                                case 'p':
-                                    filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
-                                                       recipe_subset::search_type::primary_skill );
-                                    break;
-
-                                case 'Q':
-                                    filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
-                                                       recipe_subset::search_type::quality );
-                                    break;
-
-                                case 'q':
-                                    filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
-                                                       recipe_subset::search_type::quality_result );
-                                    break;
-
-                                case 'd':
-                                    filtered_recipes = filtered_recipes.reduce( qry_filter_str.substr( 2 ),
-                                                       recipe_subset::search_type::description_result );
-                                    break;
-
-                                case 'm': {
-                                    auto &learned = crafter.get_learned_recipes();
-                                    recipe_subset temp_subset;
-                                    if( query_is_yes( qry_filter_str ) ) {
-                                        temp_subset = shown_recipes.intersection( learned );
-                                    } else {
-                                        temp_subset = shown_recipes.difference( learned );
-                                    }
-                                    filtered_recipes = filtered_recipes.intersection( temp_subset );
-                                    break;
-                                }
-
-                                default:
-                                    current.clear();
-                            }
-                        } else {
-                            filtered_recipes = filtered_recipes.reduce( qry_filter_str );
+                        // If true, we search recipes that match the condition, otherwise we search recipes that do not match
+                        bool mode = true;
+                        if( qry_filter_str[0] == '-' ) {
+                            mode = false;
+                            qry_filter_str.erase( 0, 1 );
                         }
 
-                        qry_begin = qry_end + 1;
+                        // prefix THEN OPTIONAL (:string_to_search) THEN OPTIONAL (><=number); {1,9} guarantees the number won't overflow int
+                        const std::regex filter_pattern( R"(([a-zA-Z]{1,3})(?::(.+?))?(?:(>|>=|<|<=|=)(\d{1,9}))?)" );
+
+                        std::smatch filter_match;
+                        std::regex_match( qry_filter_str, filter_match, filter_pattern );
+
+                        // If we didn't match the pattern or if we have no string and no number, it's a name search
+                        if( filter_match.empty() || ( !filter_match[2].matched && !filter_match[4].matched ) ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::name, qry_filter_str,
+                                               nullptr, mode );
+                            continue;
+                        }
+
+                        const std::string prefix = filter_match[1];
+                        const std::string txt = filter_match[2];
+                        std::function<bool( int )> cond;
+                        std::function<bool( int )> *condPtr = nullptr;
+                        if( filter_match[3].matched ) {
+                            const std::string op = filter_match[3];
+                            const int num = std::stoi( filter_match[4] );
+
+                            if( op == "=" ) {
+                                cond = [num]( int i ) { return i == num; };
+                            } else if( op == ">" ) {
+                                cond = [num]( int i ) { return i > num; };
+                            } else if( op == ">=" ) {
+                                cond = [num]( int i ) { return i >= num; };
+                            } else if( op == "<" ) {
+                                cond = [num]( int i ) { return i < num; };
+                            } else if( op == "<=" ) {
+                                cond = [num]( int i ) { return i <= num; };
+                            }
+                            condPtr = &cond;
+                        }
+
+                        if( prefix == "t" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::tool, txt, condPtr, mode );
+                            continue;
+                        } else if( prefix == "c" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::component, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "Q" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::quality, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "s" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::skill, txt, condPtr, mode );
+                            continue;
+                        } else if( prefix == "p" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::primary_skill, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "r" ) {
+                            if( !query_is_yes( txt ) ) {
+                                mode = !mode;
+                            }
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::reversible, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "m" ) {
+                            auto &learned = crafter.get_learned_recipes();
+                            recipe_subset temp_subset;
+                            if( query_is_yes( txt ) == mode ) {
+                                temp_subset = shown_recipes.intersection( learned );
+                            } else {
+                                temp_subset = shown_recipes.difference( learned );
+                            }
+                            filtered_recipes = filtered_recipes.intersection( temp_subset );
+                            break;
+                        } else if( prefix == "q" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::quality_result, txt,
+                                               condPtr, mode );
+                            continue;
+                        } else if( prefix == "b" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::byproduct, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "dt" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::damage_total, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "db" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::damage_bash, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "dc" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::damage_cut, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "dp" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::damage_pierce, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "pb" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::protection_bash, txt,
+                                               condPtr, mode );
+                            continue;
+                        } else if( prefix == "pc" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::protection_cut, txt,
+                                               condPtr, mode );
+                            continue;
+                        } else if( prefix == "pbl" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::protection_ballistic, txt,
+                                               condPtr, mode );
+                            continue;
+                        } else if( prefix == "pa" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::protection_acid, txt,
+                                               condPtr, mode );
+                            continue;
+                        } else if( prefix == "pf" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::protection_fire, txt,
+                                               condPtr, mode );
+                            continue;
+                        } else if( prefix == "pe" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::protection_env, txt,
+                                               condPtr, mode );
+                            continue;
+                        } else if( prefix == "w" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::warmth, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "st" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::storage, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "en" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::encumbrance, txt, condPtr,
+                                               mode );
+                            continue;
+                        } else if( prefix == "d" ) {
+                            filtered_recipes = filtered_recipes.reduce( recipe_subset::search_type::description_result, txt,
+                                               condPtr, mode );
+                            continue;
+                        }
+
                     } while( qry_end != std::string::npos );
                     picking.insert( picking.end(), filtered_recipes.begin(), filtered_recipes.end() );
                 } else if( subtab.cur() == "CSC_*_FAVORITE" ) {
@@ -1535,59 +1622,75 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
             keepline = true;
         } else if( action == "FILTER" ) {
             struct SearchPrefix {
-                char key;
+                std::string key;
+                std::string sep;
                 std::string example;
                 std::string description;
             };
             std::vector<SearchPrefix> prefixes = {
-                { 'q', _( "metal sawing" ), _( "<color_cyan>quality</color> of resulting item" ) },
-                //~ Example result description search term
-                { 'd', _( "reach attack" ), _( "<color_cyan>full description</color> of resulting item (slow)" ) },
-                { 'c', _( "plank" ), _( "<color_cyan>component</color> required to craft" ) },
-                { 'p', _( "tailoring" ), _( "<color_cyan>primary skill</color> used to craft" ) },
-                { 's', _( "cooking" ), _( "<color_cyan>any skill</color> used to craft" ) },
-                { 'Q', _( "fine bolt turning" ), _( "<color_cyan>quality</color> required to craft" ) },
-                { 't', _( "soldering iron" ), _( "<color_cyan>tool</color> required to craft" ) },
+                { "", "", _( "shirt" ), _( "<color_cyan>name</color> of resulting item" ) },
+                { "t", ":", _( "hotplate" ), _( "<color_cyan>tool</color> required to craft" ) },
+                { "c", ":", _( "plank" ), _( "<color_cyan>component</color> required to craft" ) },
+                { "Q", ":", _( "sewing" ), _( "<color_cyan>quality</color> required to craft (<color_cyan>text and/or numbers</color>)" ) },
+                { "Q", ":", _( "sewing>=3" ), _( "number use example" ) },
+
+                { "s", ":", _( "mechanics" ), _( "<color_cyan>any skill</color> used to craft (<color_cyan>text and/or numbers</color>)" ) },
+                { "p", ":", _( "tailoring" ), _( "<color_cyan>primary skill</color> used to craft (<color_cyan>text and/or numbers</color>)" ) },
                 {
-                    'm', pgettext( "memorized recipe search term", "yes" ),
+                    "r", ":", pgettext( "memorized recipe search term", "yes" ),
+                    _( "recipes which are <color_cyan>reversible</color> or not" )
+                },
+                {
+                    "m", ":", pgettext( "memorized recipe search term", "yes" ),
                     _( "recipes which are <color_cyan>memorized</color> or not" )
                 },
+
+                { "q", ":", _( "metal sawing" ), _( "<color_cyan>quality</color> of resulting item (<color_cyan>text and/or numbers</color>)" ) },
+                { "b", ":", _( "cracklins" ), _( "recipe <color_cyan>byproduct</color>" ) },
+
+                { "dt", ">", _( "15" ), _( "total <color_cyan>damage</color>; <color_white>db, dc, dp</color> for bashing, cutting, piercing" ) },
+
+                { "pb", ">", _( "10" ), _( "bashing <color_cyan>protection</color>; <color_white>pc, pbl, pa, pf, pe</color> for cutting, ballistic, acid, fire, environmental" ) },
+                { "w", "<=", _( "20" ), _( "clothing <color_cyan>warmth</color>" )},
+                { "st", ">=", _( "15" ), _( "<color_cyan>storage</color> in liters" )},
+                { "en", "<=", _( "1" ), _( "clothing <color_cyan>encumbrance</color>" )},
+
+                { "d", ":", _( "reach attack" ), _( "<color_cyan>full description</color> of resulting item (slow)" ) },
             };
             int max_example_length = 0;
             for( const auto &prefix : prefixes ) {
-                max_example_length = std::max( max_example_length, utf8_width( prefix.example ) );
+                max_example_length = std::max( max_example_length,
+                                               utf8_width( prefix.key ) + utf8_width( prefix.sep ) + utf8_width( prefix.example ) );
             }
             std::string spaces( max_example_length, ' ' );
 
             std::string description =
-                _( "The default is to search result names.  Some single-character prefixes "
-                   "can be used with a colon <color_red>:</color> to search in other ways.  Additional filters "
-                   "are separated by commas <color_red>,</color>.\n"
-                   "\n\n"
-                   "<color_white>Examples:</color>\n" );
-
-            {
-                std::string example_name = _( "shirt" );
-                auto padding = max_example_length - utf8_width( example_name );
-                description += string_format(
-                                   _( "  <color_white>%s</color>%.*s    %s\n" ),
-                                   example_name, padding, spaces,
-                                   _( "<color_cyan>name</color> of resulting item" ) );
-            }
+                _( "You can search for result names, or use prefixes to search specific properties.\n"
+                   "To search text, enter it after a colon <color_red>:</color>.\n"
+                   "To search for values, enter one of operators <color_red>=, >, <, >=, <=</color> followed by a number.\n"
+                   "You can search for text, numbers, or both, where applicable. To search both, use <color_red>prefix:text>number</color>.\n"
+                   "You can prefix any filter with a minus <color_red>-</color> to <color_cyan>exclude</color> matching recipes.\n"
+                   "Additional filters are separated by commas <color_red>,</color>.\n\n"
+                   "<color_white>Prefixes:\n</color>" );
 
             for( const auto &prefix : prefixes ) {
-                auto padding = max_example_length - utf8_width( prefix.example );
+                auto padding = max_example_length - utf8_width( prefix.key ) - utf8_width(
+                                   prefix.sep ) - utf8_width( prefix.example );
                 description += string_format(
-                                   _( "  <color_yellow>%c</color><color_white>:%s</color>%.*s  %s\n" ),
-                                   prefix.key, prefix.example, padding, spaces, prefix.description );
+                                   _( " <color_yellow>%s</color><color_white>%s%s</color>%.*s  %s\n" ),
+                                   prefix.key, prefix.sep, prefix.example, padding, spaces, prefix.description );
             }
 
+            description +=
+                _( "\nFilters can be as complex as you'd like. For example,"
+                   "\n<color_cyan>s:tailoring<6,st>20</color>"
+                   "\n<color_cyan>p:electronics>=2,s>4,r:yes,-t:soldering iron</color>" );
             description +=
                 _( "\nUse <color_red>up/down arrow</color> to go through your search history." );
 
             string_input_popup()
             .title( _( "Search:" ) )
-            .width( 85 )
+            .width( 160 )
             .description( description )
             .desc_color( c_light_gray )
             .identifier( "craft_recipe_filter" )
@@ -1869,11 +1972,9 @@ int related_menu_fill( uilist &rmenu,
 
 static bool query_is_yes( const std::string &query )
 {
-    const std::string subquery = query.substr( 2 );
-
-    return subquery == "yes" || subquery == "y" || subquery == "1" ||
-           subquery == "true" || subquery == "t" || subquery == "on" ||
-           subquery == pgettext( "memorized recipe search term", "yes" );
+    return query == "yes" || query == "y" || query == "1" ||
+           query == "true" || query == "t" || query == "on" ||
+           query == pgettext( "memorized recipe search term", "yes" );
 }
 
 static void draw_hidden_amount( const catacurses::window &w, int amount, int num_recipe )

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -28,6 +28,8 @@
 #include "units.h"
 #include "value_ptr.h"
 
+const flag_id flag_VARSIZE( "VARSIZE" );
+
 recipe_dictionary recipe_dict;
 
 namespace
@@ -188,8 +190,8 @@ std::vector<const recipe *> recipe_subset::expanded() const
     return res;
 }
 
-std::vector<const recipe *> recipe_subset::search( const std::string &txt,
-        const search_type key ) const
+std::vector<const recipe *> recipe_subset::search( const search_type key, const std::string &txt,
+        const std::function<bool( int )> *cond, bool mode ) const
 {
     std::vector<const recipe *> res;
 
@@ -197,41 +199,241 @@ std::vector<const recipe *> recipe_subset::search( const std::string &txt,
         if( !*r || r->obsolete ) {
             return false;
         }
+
+        bool match = true;
         switch( key ) {
             case search_type::name:
-                return lcmatch( r->result_name( /*decorated=*/true ), txt );
-
-            case search_type::skill:
-                return lcmatch( r->required_skills_string( nullptr, true, false ), txt );
-
-            case search_type::primary_skill:
-                return lcmatch( r->skill_used->name(), txt );
-
-            case search_type::component:
-                return search_reqs( r->simple_requirements().get_components(), txt );
+                match = lcmatch( r->result_name( /*decorated=*/true ), txt );
+                break;
 
             case search_type::tool:
-                return search_reqs( r->simple_requirements().get_tools(), txt );
+                match = search_reqs( r->simple_requirements().get_tools(), txt );
+                break;
+
+            case search_type::component:
+                match = search_reqs( r->simple_requirements().get_components(), txt );
+                break;
 
             case search_type::quality:
-                return search_reqs( r->simple_requirements().get_qualities(), txt );
+                if( cond ) {
+                    const auto &gp = r->simple_requirements().get_qualities();
+                    match = std::any_of( gp.begin(), gp.end(), [&]( const auto & opts ) {
+                        return std::any_of( opts.begin(),
+                        opts.end(), [&]( const auto & e ) {
+                            return lcmatch( e.to_string(), txt ) && ( *cond )( e.level );
+                        } );
+                    } );
+                } else {
+                    match = search_reqs( r->simple_requirements().get_qualities(), txt );
+                }
+                break;
+
+            case search_type::reversible: {
+                match = r->is_reversible();
+                break;
+            }
+
+            case search_type::skill:
+                if( cond ) {
+                    const auto &skills = r->required_skills;
+                    match = std::any_of( skills.begin(), skills.end(), [&]( const auto pair ) { return lcmatch( pair.first->name(), txt ) && ( *cond )( pair.second ); } )
+                    || lcmatch( r->skill_used->name(), txt ) &&( *cond )( r->difficulty );
+                } else {
+                    match = lcmatch( r->required_skills_string( nullptr, true, false ), txt );
+                }
+                break;
+
+            case search_type::primary_skill:
+                match = lcmatch( r->skill_used->name(), txt ) && ( cond ? ( *cond )( r->difficulty ) : true );
+                break;
+
+            case search_type::byproduct:
+                if( !r->has_byproducts() ) {
+                    match = false;
+                } else {
+                    const auto &byproducts = r->byproducts;
+                    match = std::any_of( byproducts.begin(),
+                    byproducts.end(), [&]( const std::pair<itype_id, int> &e ) {
+                        return lcmatch( e.first->nname( e.second ), txt ) && ( cond ? ( *cond )( e.second ) : true );
+                    } );
+                    break;
+                }
+                break;
 
             case search_type::quality_result: {
                 const auto &quals = r->result()->qualities;
-                return std::any_of( quals.begin(), quals.end(), [&]( const std::pair<quality_id, int> &e ) {
-                    return lcmatch( e.first->name, txt );
+                match = std::any_of( quals.begin(), quals.end(), [&]( const std::pair<quality_id, int> &e ) {
+                    return lcmatch( e.first->name, txt ) && ( cond ? ( *cond )( e.second ) : true );
                 } );
+                break;
+            }
+
+            case search_type::damage_total: {
+                if( !cond ) {
+                    break;
+                }
+                match = ( *cond )( r->result()->melee[DT_BASH] + r->result()->melee[DT_CUT] +
+                                   r->result()->melee[DT_STAB] );
+                break;
+            }
+
+            case search_type::damage_bash: {
+                if( !cond ) {
+                    break;
+                }
+                match = ( *cond )( r->result()->melee[DT_BASH] );
+                break;
+            }
+
+            case search_type::damage_cut: {
+                if( !cond ) {
+                    break;
+                }
+                match = ( *cond )( r->result()->melee[DT_CUT] );
+                break;
+            }
+
+            case search_type::damage_pierce: {
+                if( !cond ) {
+                    break;
+                }
+                match = ( *cond )( r->result()->melee[DT_STAB] );
+                break;
+            }
+
+            case search_type::protection_bash: {
+                if( !cond ) {
+                    break;
+                }
+                const auto &armor = r->result()->armor;
+                if( !armor ) {
+                    match = false;
+                    break;
+                }
+                match = ( *cond )( armor->resistance.type_resist( DT_BASH ) );
+                break;
+            }
+
+            case search_type::protection_cut: {
+                if( !cond ) {
+                    break;
+                }
+                const auto &armor = r->result()->armor;
+                if( !armor ) {
+                    match = false;
+                    break;
+                }
+                match = ( *cond )( armor->resistance.type_resist( DT_CUT ) );
+                break;
+            }
+
+            case search_type::protection_ballistic: {
+                if( !cond ) {
+                    break;
+                }
+                const auto &armor = r->result()->armor;
+                if( !armor ) {
+                    match = false;
+                    break;
+                }
+                match = ( *cond )( armor->resistance.type_resist( DT_BULLET ) );
+                break;
+            }
+
+            case search_type::protection_acid: {
+                if( !cond ) {
+                    break;
+                }
+                const auto &armor = r->result()->armor;
+                if( !armor ) {
+                    match = false;
+                    break;
+                }
+                const detached_ptr<item> result = r->create_result();
+                match = ( *cond )( result->acid_resist() ) ||
+                        ( *cond )( result->acid_resist( false, result->get_base_env_resist_w_filter() ) );
+                break;
+            }
+
+            case search_type::protection_fire: {
+                if( !cond ) {
+                    break;
+                }
+                const auto &armor = r->result()->armor;
+                if( !armor ) {
+                    match = false;
+                    break;
+                }
+                const detached_ptr<item> result = r->create_result();
+                match = ( *cond )( result->fire_resist() ) ||
+                        ( *cond )( result->fire_resist( false, result->get_base_env_resist_w_filter() ) );
+                break;
+            }
+
+            case search_type::protection_env: {
+                if( !cond ) {
+                    break;
+                }
+                const auto &armor = r->result()->armor;
+                if( !armor ) {
+                    match = false;
+                    break;
+                }
+                match = ( *cond )( armor->env_resist ) || ( *cond )( armor->env_resist_w_filter );
+                break;
+            }
+
+            case search_type::warmth: {
+                if( !cond ) {
+                    break;
+                }
+                const auto &armor = r->result()->armor;
+                if( !armor ) {
+                    match = false;
+                    break;
+                }
+                match = ( *cond )( armor->warmth );
+                break;
+            }
+
+            case search_type::storage: {
+                if( !cond ) {
+                    break;
+                }
+                const auto &armor = r->result()->armor;
+                if( !armor ) {
+                    match = false;
+                    break;
+                }
+                match = ( *cond )( units::to_liter( armor->storage ) );
+                break;
+            }
+
+            case search_type::encumbrance: {
+                if( !cond ) {
+                    break;
+                }
+                const auto &armor = r->result()->armor;
+                if( !armor ) {
+                    match = false;
+                    break;
+                }
+                const bool resize = r->result()->has_flag( flag_VARSIZE );
+                const auto &data = armor->data;
+                match = std::any_of( data.begin(), data.end(), [&]( const armor_portion_data & e ) {
+                    // This formula is from item.cpp, get_encumber_when_containing, consider putting that into a separate function
+                    return resize ? ( *cond )( std::max( e.encumber / 2, e.encumber - 10 ) ) : ( *cond )( e.encumber );
+                } );
+                break;
             }
 
             case search_type::description_result: {
-                //TODO!: push this up, it's a potentially infinite one I think
-                detached_ptr<item> result = r->create_result();
-                return lcmatch( remove_color_tags( result->info_string( iteminfo_query::no_conditions ) ), txt );
+                const detached_ptr<item> result = r->create_result();
+                match = lcmatch( remove_color_tags( result->info_string( iteminfo_query::no_conditions ) ), txt );
+                break;
             }
-
-            default:
-                return false;
         }
+        return match == mode;
     } );
 
     return res;
@@ -244,9 +446,10 @@ recipe_subset::recipe_subset( const recipe_subset &src, const std::vector<const 
     }
 }
 
-recipe_subset recipe_subset::reduce( const std::string &txt, const search_type key ) const
+recipe_subset recipe_subset::reduce( const search_type key, const std::string &txt,
+                                     const std::function<bool( int )> *cond, bool mode ) const
 {
-    return recipe_subset( *this, search( txt, key ) );
+    return recipe_subset( *this, search( key, txt, cond, mode ) );
 }
 recipe_subset recipe_subset::intersection( const recipe_subset &subset ) const
 {

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -127,13 +127,34 @@ class recipe_subset
 
         enum class search_type {
             name,
+
+            tool,
+            component,
+            quality,
+            reversible,
+
             skill,
             primary_skill,
-            component,
-            tool,
-            quality,
+
+            byproduct,
             quality_result,
-            description_result
+            description_result,
+
+            damage_total,
+            damage_bash,
+            damage_cut,
+            damage_pierce,
+
+            protection_bash,
+            protection_cut,
+            protection_ballistic,
+            protection_acid,
+            protection_fire,
+            protection_env,
+
+            warmth,
+            storage,
+            encumbrance,
         };
 
         /** Find marked favorite recipes */
@@ -152,10 +173,11 @@ class recipe_subset
         std::vector<const recipe *> expanded() const;
 
         /** Find recipes matching query (left anchored partial matches are supported) */
-        std::vector<const recipe *> search( const std::string &txt,
-                                            search_type key = search_type::name ) const;
+        std::vector<const recipe *> search( const search_type key, const std::string &txt,
+                                            const std::function<bool( int )> *cond, bool mode ) const;
         /** Find recipes matching query and return a new recipe_subset */
-        recipe_subset reduce( const std::string &txt, search_type key = search_type::name ) const;
+        recipe_subset reduce( const search_type key, const std::string &txt,
+                              const std::function<bool( int )> *cond, bool mode ) const;
         /** Set intersection between recipe_subsets */
         recipe_subset intersection( const recipe_subset &subset ) const;
         /** Set difference between recipe_subsets */


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

I always thought that crafting search is kind of barebones when you don't know what exactly you're looking for, in particular the inability to search for number ranges.

## Describe the solution (The How)

The search system has been expanded with extra prefixes, and an ability to search for certain numbers with a comparer.

You can now search for:

* Reversible recipes
* Byproducts
* Total melee damage and individual melee damage
* Each of the 6 armor values
* Warmth, storage, and encumbrance

...with the latter three supportin searching for `=, >, <, >=, <=`. You can also now search for skill levels and qualities with a number comparer as well, so you can, e.g. use `s:electronics>=5` to find recipes with an electronics skill of at least 5.

And in addition to that, ANY filter can be prefixed with a minus to exclude the matching numbers instead.

## Describe alternatives you've considered

There were some other variables I considered:

* Throwing stats
* Calories
* Food enjoyability
* Capacity/sealability/waterproofness for containers

But ultimately decided it's not worth the clutter. However, this system is now much easier to expand, so if these or other stats are desired, they can be added easily.

## Testing

Checked that all filters search properly and also that typing dt>99999999999999999999 doesn't crash it.

## Additional context

New search window and an example of searching for weapons with a total damage over 50:
<img width="924" height="782" src="https://github.com/user-attachments/assets/5ab9dd38-77c3-4c18-956e-7a0052c919bc" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [520d41c](https://github.com/cataclysmbn/Cataclysm-BN/commit/520d41c7fafce46f8665b8def2fe385df77165a2) (Massively expand crafting recipe search filters) on 2026-07-02 00:33:19

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28534057080/artifacts/8025638376)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28534057080/artifacts/8026005312)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28534057080/artifacts/8025919569)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28534057080/artifacts/8025785612)
<!-- END artifact comment -->