### PR TITLE
docs: fix typos

### DIFF
--- a/docs/en/mod/json/reference/map/weather_type.md
+++ b/docs/en/mod/json/reference/map/weather_type.md
@@ -53,7 +53,7 @@ All members are mandatory.
 ##### Names
 
 - `morale`: Gives player morale, requires additional defined fields
-- `effect`: Gives playerrs an effect, requires additional defined fields
+- `effect`: Gives player an effect, requires additional defined fields
 - `wet`: Causes players to become wet, amount is intensity
 - `thunder`: Thunder is caused with a one in intensity chance
 - `lightning`: Lighning is caused with a one in intensity chance
@@ -102,8 +102,8 @@ All members are mandatory.
 | effect_msg_frequency         | (_mandatory_) Percent chance to display the message on gaining effect                                                                                          |
 | effect_msg_blocked_frequency | (_mandatory_) Percent chance to display the protection message on preventing effect                                                                            |
 | message_type                 | (_mandatory_) Type of message; 0 == Good, 1 == Bad, 2 == Mixed, 3 == Warning, 4 == Info, 5 == Neutral                                                          |
-| precipitation_name           | (_mandatory_) Name to display in string "The <field> is blocked by your umbrella!" messages appear                                                             |
-| protection_data              | (_mandatory_) Array of `check` flags or traits ( along with `DEFAULT` which is always applied ) and `odds` ( one in x chance ) to be protected from the effect |
+| precipitation_name           | (_mandatory_) Name to display in string "Your umbrella protects you from the `precipitation_name`." messages appear                                                             |
+| protection_data              | (_optional_) Array of `check` flags or traits ( along with `DEFAULT` which is always applied ) and `odds` ( one in x chance ) to be protected from the effect |
 
 ##### Example:
 

--- a/docs/en/mod/json/reference/map/weather_type.md
+++ b/docs/en/mod/json/reference/map/weather_type.md
@@ -91,18 +91,18 @@ All members are mandatory.
 
 #### Effect
 
-| Identifier                   | Description                                                                                                                                                    |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| intensity                    | (_mandatory_) This effect will be applied every x turns                                                                                                        |
-| duration                     | (_mandatory_) How long the effect lasts                                                                                                                        |
-| effect_id_str                | (_mandatory_) String of the effect id to give                                                                                                                  |
-| effect_intensity             | (_mandatory_) Intensity of the effect to give                                                                                                                  |
-| bodypart_string              | (_optional_) Bodypart to apply the effect to, default whole body                                                                                               |
-| effect_msg                   | (_mandatory_) Message to give when gaining the effect                                                                                                          |
-| effect_msg_frequency         | (_mandatory_) Percent chance to display the message on gaining effect                                                                                          |
-| effect_msg_blocked_frequency | (_mandatory_) Percent chance to display the protection message on preventing effect                                                                            |
-| message_type                 | (_mandatory_) Type of message; 0 == Good, 1 == Bad, 2 == Mixed, 3 == Warning, 4 == Info, 5 == Neutral                                                          |
-| precipitation_name           | (_mandatory_) Name to display in string "Your umbrella protects you from the `precipitation_name`"                                                             |
+| Identifier                   | Description                                                                                                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| intensity                    | (_mandatory_) This effect will be applied every x turns                                                                                                       |
+| duration                     | (_mandatory_) How long the effect lasts                                                                                                                       |
+| effect_id_str                | (_mandatory_) String of the effect id to give                                                                                                                 |
+| effect_intensity             | (_mandatory_) Intensity of the effect to give                                                                                                                 |
+| bodypart_string              | (_optional_) Bodypart to apply the effect to, default whole body                                                                                              |
+| effect_msg                   | (_mandatory_) Message to give when gaining the effect                                                                                                         |
+| effect_msg_frequency         | (_mandatory_) Percent chance to display the message on gaining effect                                                                                         |
+| effect_msg_blocked_frequency | (_mandatory_) Percent chance to display the protection message on preventing effect                                                                           |
+| message_type                 | (_mandatory_) Type of message; 0 == Good, 1 == Bad, 2 == Mixed, 3 == Warning, 4 == Info, 5 == Neutral                                                         |
+| precipitation_name           | (_mandatory_) Name to display in string "Your umbrella protects you from the `precipitation_name`"                                                            |
 | protection_data              | (_optional_) Array of `check` flags or traits ( along with `DEFAULT` which is always applied ) and `odds` ( one in x chance ) to be protected from the effect |
 
 ##### Example:

--- a/docs/en/mod/json/reference/map/weather_type.md
+++ b/docs/en/mod/json/reference/map/weather_type.md
@@ -102,7 +102,7 @@ All members are mandatory.
 | effect_msg_frequency         | (_mandatory_) Percent chance to display the message on gaining effect                                                                                          |
 | effect_msg_blocked_frequency | (_mandatory_) Percent chance to display the protection message on preventing effect                                                                            |
 | message_type                 | (_mandatory_) Type of message; 0 == Good, 1 == Bad, 2 == Mixed, 3 == Warning, 4 == Info, 5 == Neutral                                                          |
-| precipitation_name           | (_mandatory_) Name to display in string "Your umbrella protects you from the `precipitation_name`." messages appear                                                             |
+| precipitation_name           | (_mandatory_) Name to display in string "Your umbrella protects you from the `precipitation_name`"                                                             |
 | protection_data              | (_optional_) Array of `check` flags or traits ( along with `DEFAULT` which is always applied ) and `odds` ( one in x chance ) to be protected from the effect |
 
 ##### Example:

--- a/docs/en/mod/json/reference/map/weather_type.md
+++ b/docs/en/mod/json/reference/map/weather_type.md
@@ -53,7 +53,7 @@ All members are mandatory.
 ##### Names
 
 - `morale`: Gives player morale, requires additional defined fields
-- `effect`: Gives player an effect, requires additional defined fields
+- `effect`: Gives players an effect, requires additional defined fields
 - `wet`: Causes players to become wet, amount is intensity
 - `thunder`: Thunder is caused with a one in intensity chance
 - `lightning`: Lighning is caused with a one in intensity chance

--- a/docs/en/mod/json/reference/misc/damage.md
+++ b/docs/en/mod/json/reference/misc/damage.md
@@ -16,7 +16,7 @@ The other is below
 
 | Identifier | Description                                           |
 | ---------- | ----------------------------------------------------- |
-| values     | (_mandatory_) A array of [damage units](#damage-unit) |
+| values     | (_mandatory_) An array of [damage units](#damage-unit) |
 
 ### Example
 

--- a/docs/en/mod/json/reference/misc/damage.md
+++ b/docs/en/mod/json/reference/misc/damage.md
@@ -14,8 +14,8 @@ The other is below
 
 ### Fields
 
-| Identifier | Description                                           |
-| ---------- | ----------------------------------------------------- |
+| Identifier | Description                                            |
+| ---------- | ------------------------------------------------------ |
 | values     | (_mandatory_) An array of [damage units](#damage-unit) |
 
 ### Example

--- a/docs/en/mod/json/reference/misc/explosions.md
+++ b/docs/en/mod/json/reference/misc/explosions.md
@@ -13,8 +13,8 @@ Kept here for global reference.
 
 | Identifier      | Description                                                                  |
 | --------------- | ---------------------------------------------------------------------------- |
-| damage          | (_optional_) the amount of damage the explosion does                          |
-| radius          | (_optional_) the radius of the explosion                                     |
+| damage          | (_optional_) The amount of damage the explosion does                          |
+| radius          | (_optional_) The radius of the explosion                                     |
 | fragment        | (_optional_) See [projectiles](/mod/json/reference/misc/projectiles/#fields) |
 | fragment_effect | (_optional_) Array of [fragment effects](#fragment-effect)                   |
 | fire            | (_optional_) Also spawns fire fields                                         |

--- a/docs/en/mod/json/reference/misc/explosions.md
+++ b/docs/en/mod/json/reference/misc/explosions.md
@@ -13,7 +13,7 @@ Kept here for global reference.
 
 | Identifier      | Description                                                                  |
 | --------------- | ---------------------------------------------------------------------------- |
-| damage          | (_optional_)the amount of damage the explosion does                          |
+| damage          | (_optional_) the amount of damage the explosion does                          |
 | radius          | (_optional_) the radius of the explosion                                     |
 | fragment        | (_optional_) See [projectiles](/mod/json/reference/misc/projectiles/#fields) |
 | fragment_effect | (_optional_) Array of [fragment effects](#fragment-effect)                   |

--- a/docs/en/mod/json/reference/misc/explosions.md
+++ b/docs/en/mod/json/reference/misc/explosions.md
@@ -13,7 +13,7 @@ Kept here for global reference.
 
 | Identifier      | Description                                                                  |
 | --------------- | ---------------------------------------------------------------------------- |
-| damage          | (_optional_) The amount of damage the explosion does                          |
+| damage          | (_optional_) The amount of damage the explosion does                         |
 | radius          | (_optional_) The radius of the explosion                                     |
 | fragment        | (_optional_) See [projectiles](/mod/json/reference/misc/projectiles/#fields) |
 | fragment_effect | (_optional_) Array of [fragment effects](#fragment-effect)                   |


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

fix a few typos introduced in #9736 

## Describe the solution (The How)

playerrs -> players

A array of -> An array of

(_optional_)the -> (_optional_) the

correct the description of precipitation_name as <field> didnt show up so it just looked liked `The is blocked by your umbrella!` plus that message isnt what actually shows up in game

mark protection_data as optional instead of mandatory, as it is (technically) optional

## Describe alternatives you've considered

typos eternal?

## Testing

Looked at it with my eyes

## Additional context

Just the stuff I could immediately spot in a once over

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN docs comment -->

## Translations

| post                                   | changed | stale | missing |
| -------------------------------------- | ------- | ----- | ------- |
| mod/json/reference/map/weather_type.md | en      | ko    | ja      |
| mod/json/reference/misc/damage.md      | en      |       | ja, ko  |
| mod/json/reference/misc/explosions.md  | en      |       | ja, ko  |

<!-- END docs comment -->