### PR TITLE
fix(UI): keep zoom levels in sync when switching between map and overmap

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10252,6 +10252,25 @@ void game::zoom_in_overmap()
 #endif
 }
 
+auto game::reapply_overmap_zoom() -> void
+{
+#if defined(TILES)
+    // a failed in-game tileset reload can leave a context with no tileset loaded
+    if( use_tiles && use_tiles_overmap && overmap_tilecontext &&
+        overmap_tilecontext->current_tileset() ) {
+        overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
+    }
+#endif
+}
+
+auto game::reset_overmap_zoom() -> void
+{
+#if defined(TILES)
+    overmap_tileset_zoom = DEFAULT_TILESET_ZOOM;
+    reapply_overmap_zoom();
+#endif
+}
+
 void game::reset_zoom()
 {
 #if defined(TILES)
@@ -10270,6 +10289,16 @@ void game::set_zoom( const float level )
 #else
     static_cast<void>( level );
 #endif // TILES
+}
+
+auto game::reapply_zoom() -> void
+{
+#if defined(TILES)
+    // rescale unconditionally: a shared overmap context may have changed the scale behind our back
+    if( use_tiles && tilecontext ) {
+        rescale_tileset( tileset_zoom );
+    }
+#endif
 }
 
 float game::get_zoom() const

--- a/src/game.h
+++ b/src/game.h
@@ -741,10 +741,16 @@ class game : public submap_load_listener
         void reenter_fullscreen();
         void zoom_in_overmap();
         void zoom_out_overmap();
+        /// Applies the stored overmap zoom to the overmap tile context; call when the overmap opens.
+        auto reapply_overmap_zoom() -> void;
+        /// Resets the stored overmap zoom to the default and applies it to the overmap tile context.
+        auto reset_overmap_zoom() -> void;
         void zoom_in();
         void zoom_out();
         void reset_zoom();
         void set_zoom( float level );
+        /// Applies the stored main-view zoom to the tile context even when the value is unchanged.
+        auto reapply_zoom() -> void;
         float get_zoom() const;
         int get_moves_since_last_save() const;
         int get_user_action_counter() const;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2093,16 +2093,13 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
     }
 }
 
-static float overmap_zoom_level = DEFAULT_TILESET_ZOOM;
-
 static tripoint_abs_omt display( const tripoint_abs_omt &orig,
                                  const draw_data_t &data = draw_data_t() )
 {
-    const float previous_zoom = g->get_zoom();
-    g->set_zoom( overmap_zoom_level );
-    on_out_of_scope reset_zoom( [&]() {
-        overmap_zoom_level = g->get_zoom();
-        g->set_zoom( previous_zoom );
+    // the overmap context may be shared with the main view's; each view re-asserts zoom on takeover
+    g->reapply_overmap_zoom();
+    on_out_of_scope reset_zoom( []() {
+        g->reapply_zoom();
         g->mark_main_ui_adaptor_resize();
     } );
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4285,6 +4285,11 @@ const SDL_Renderer_Ptr &get_sdl_renderer()
     return renderer;
 }
 
+auto set_sdl_renderer( SDL_Renderer_Ptr r ) -> void
+{
+    renderer = std::move( r );
+}
+
 const SDL_Window_Ptr &get_sdl_window()
 {
     return window;

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -58,6 +58,10 @@ void draw_sdl_text_outlined( const sdl_text_outline_options &opts );
 const SDL_Renderer_Ptr &get_sdl_renderer();
 const SDL_Window_Ptr &get_sdl_window();
 
+/// Installs the renderer returned by get_sdl_renderer(); tests must provide one
+/// before loading tilesets (the game sets it up in init_interface()).
+auto set_sdl_renderer( SDL_Renderer_Ptr r ) -> void;
+
 #endif // TILES
 
 

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -189,3 +189,141 @@ TEST_CASE("mutable_overmap_placement", "[overmap][slow]") {
         CHECK(successes > num_trials_per_overmap / 2);
     }
 }
+
+#if defined(TILES)
+
+// Regression tests for issue #9688: the main view and the (possibly shared) overmap
+// tile context each track their own zoom, and switching views must re-assert the
+// taking-over view's zoom on the context. The old overmap_ui.cpp save/restore shim
+// forced the overmap to the default scale on open and relied on game::set_zoom's
+// equality guard on close, desyncing the rendered scale from the stored zoom in
+// both directions.
+
+#    include "cached_options.h"
+#    include "cata_tiles.h"
+#    include "game.h"
+#    include "options_helpers.h"
+#    include "sdltiles.h"
+#    include "tile_helpers.h"
+
+#    include <cmath>
+#    include <map>
+
+namespace {
+
+/// Tile widths at each canonical zoom scale, used to read back which zoom a context
+/// is actually rendering at. Distinctness is what makes that read-back unambiguous.
+auto zoom_scale_widths() -> std::map<float, int> {
+    std::map<float, int> widths;
+    for (const float scale : {4.f, 8.f, 16.f, 32.f, 64.f}) {
+        tilecontext->set_draw_scale(scale);
+        widths[scale] = tilecontext->get_tile_width();
+    }
+    REQUIRE(widths.at(4.f) > 0);
+    REQUIRE(widths.at(4.f) < widths.at(8.f));
+    REQUIRE(widths.at(8.f) < widths.at(16.f));
+    REQUIRE(widths.at(16.f) < widths.at(32.f));
+    REQUIRE(widths.at(32.f) < widths.at(64.f));
+    return widths;
+}
+
+} // namespace
+
+TEST_CASE("zoom_bookkeeping_matches_rendered_scale", "[overmap][zoom][tiles]") {
+    clear_all_state();
+    tile_context_fixture fixture(/*alias_overmap_context=*/true);
+    if (!fixture.valid()) {
+        WARN("skipped: this environment cannot set up a headless tile context");
+        return;
+    }
+    const auto widths = zoom_scale_widths();
+    // Start every section from a known state: both views at the default scale.
+    g->reset_overmap_zoom();
+    g->set_zoom(DEFAULT_TILESET_ZOOM);
+    g->reapply_zoom();
+    REQUIRE(tilecontext->get_tile_width() == widths.at(16.f));
+
+    SECTION("main view steps through the zoom ladder and wraps at both ends") {
+        for (const float expected : {32.f, 64.f, 4.f, 8.f}) { // wraps 64 -> 4
+            g->zoom_in();
+            CHECK(g->get_zoom() == expected);
+            CHECK(tilecontext->get_tile_width() == widths.at(expected));
+        }
+        for (const float expected : {4.f, 64.f}) { // wraps 4 -> 64
+            g->zoom_out();
+            CHECK(g->get_zoom() == expected);
+            CHECK(tilecontext->get_tile_width() == widths.at(expected));
+        }
+    }
+
+    SECTION("zoom stepping recovers from an off-grid zoom value") {
+        g->set_zoom(20.f); // between the 16 and 32 steps
+        REQUIRE(g->get_zoom() == 20.f);
+        g->zoom_in(); // rounds to the nearest step index, then steps
+        CHECK(g->get_zoom() == 32.f);
+        g->set_zoom(20.f);
+        g->zoom_out();
+        CHECK(g->get_zoom() == 8.f);
+    }
+
+    SECTION("half steps with ZOOM_STEP_COUNT 2") {
+        const override_option zoom_steps("ZOOM_STEP_COUNT", "2");
+        g->zoom_in();
+        CHECK(g->get_zoom() == Approx(std::pow(2., 4.5)));
+        g->zoom_in();
+        CHECK(g->get_zoom() == Approx(32.f));
+    }
+
+    SECTION("overmap zoom does not leak into the main view on a shared context") {
+        // "Open" the overmap and zoom it fully out; the main view's bookkeeping
+        // must not move.
+        g->reapply_overmap_zoom();
+        REQUIRE(overmap_tilecontext->get_tile_width() == widths.at(16.f));
+        g->zoom_out_overmap();
+        g->zoom_out_overmap();
+        REQUIRE(overmap_tilecontext->get_tile_width() == widths.at(4.f));
+        CHECK(g->get_zoom() == 16.f);
+
+        // "Close" it: the main view must re-assert its own scale even though
+        // tileset_zoom never changed - set_zoom's equality guard would skip this,
+        // which was the main-view half of issue #9688.
+        g->reapply_zoom();
+        CHECK(tilecontext->get_tile_width() == widths.at(16.f));
+
+        // "Reopen": the overmap comes back at its own remembered zoom, not the
+        // default the legacy shim forced - the overmap half of issue #9688...
+        g->reapply_overmap_zoom();
+        CHECK(overmap_tilecontext->get_tile_width() == widths.at(4.f));
+        // ...and the zoom keys step from the displayed level.
+        g->zoom_in_overmap();
+        CHECK(overmap_tilecontext->get_tile_width() == widths.at(8.f));
+
+        g->reapply_zoom();
+        CHECK(tilecontext->get_tile_width() == widths.at(16.f));
+    }
+}
+
+TEST_CASE("separate_overmap_tile_context_keeps_independent_scale", "[overmap][zoom][tiles]") {
+    clear_all_state();
+    tile_context_fixture fixture(/*alias_overmap_context=*/false);
+    if (!fixture.valid()) {
+        WARN("skipped: this environment cannot set up a headless tile context");
+        return;
+    }
+    REQUIRE(tilecontext != overmap_tilecontext);
+    const auto widths = zoom_scale_widths();
+    g->reset_overmap_zoom();
+    g->set_zoom(DEFAULT_TILESET_ZOOM);
+    g->reapply_zoom();
+
+    // Main-view zooming leaves the overmap context alone...
+    g->zoom_in();
+    CHECK(tilecontext->get_tile_width() == widths.at(32.f));
+    CHECK(overmap_tilecontext->get_tile_width() == widths.at(16.f));
+    // ...and overmap zooming leaves the main context alone.
+    g->zoom_out_overmap();
+    CHECK(overmap_tilecontext->get_tile_width() == widths.at(8.f));
+    CHECK(tilecontext->get_tile_width() == widths.at(32.f));
+}
+
+#endif // TILES

--- a/tests/tile_helpers.cpp
+++ b/tests/tile_helpers.cpp
@@ -1,0 +1,113 @@
+#include "tile_helpers.h"
+
+#if defined(TILES)
+
+#    include "cached_options.h"
+#    include "cata_tiles.h"
+#    include "game.h"
+#    include "sdl_geometry.h"
+#    include "sdl_wrappers.h"
+#    include "sdltiles.h"
+#    include "type_id.h"
+
+#    include <SDL3/SDL.h>
+#    include <exception>
+#    include <utility>
+#    include <vector>
+
+// defined in sdltiles.cpp with no header declaration (cata_tiles.cpp redeclares them
+// the same way); set_draw_scale divides by them and only init_interface() sets them
+extern int fontwidth;
+extern int fontheight;
+
+struct tile_context_fixture::impl {
+    SDL_Window_Ptr window;
+    GeometryRenderer_Ptr geometry;
+    std::shared_ptr<cata_tiles> tiles;
+    std::shared_ptr<cata_tiles> overmap_tiles;
+    std::shared_ptr<cata_tiles> saved_tilecontext;
+    std::shared_ptr<cata_tiles> saved_overmap_tilecontext;
+    float saved_zoom = DEFAULT_TILESET_ZOOM;
+    int saved_fontwidth = 0;
+    int saved_fontheight = 0;
+    bool saved_use_tiles = false;
+    bool saved_use_tiles_overmap = false;
+    bool installed_renderer = false;
+    bool globals_installed = false;
+};
+
+tile_context_fixture::tile_context_fixture(const bool alias_overmap_context)
+    : pimpl_(std::make_unique<impl>()) {
+    pimpl_->saved_fontwidth = std::exchange(fontwidth, 8);
+    pimpl_->saved_fontheight = std::exchange(fontheight, 16);
+    if (!SDL_WasInit(SDL_INIT_VIDEO)) { return; }
+    // dynamic_atlas creates textures through the get_sdl_renderer() global, not the
+    // renderer handed to cata_tiles, so a headless one must be installed there
+    if (!get_sdl_renderer()) {
+        pimpl_->window.reset(SDL_CreateWindow("cata_test_tiles", 640, 480, SDL_WINDOW_HIDDEN));
+        if (!pimpl_->window) { return; }
+        auto renderer = SDL_Renderer_Ptr(SDL_CreateRenderer(pimpl_->window.get(), "software"));
+        if (!renderer) { return; }
+        set_sdl_renderer(std::move(renderer));
+        pimpl_->installed_renderer = true;
+    }
+    // smallest shipped tileset; the tests only assert relative scale changes
+    const std::vector<mod_id> no_mods;
+    try {
+        pimpl_->geometry = std::make_unique<DefaultGeometryRenderer>();
+        pimpl_->tiles = std::make_shared<cata_tiles>(get_sdl_renderer(), pimpl_->geometry);
+        pimpl_->tiles->load_tileset(
+            "ASCIITiles", no_mods, /*precheck=*/false, /*force=*/true,
+            /*pump_events=*/false);
+        if (alias_overmap_context) {
+            pimpl_->overmap_tiles = pimpl_->tiles;
+        } else {
+            pimpl_->overmap_tiles =
+                std::make_shared<cata_tiles>(get_sdl_renderer(), pimpl_->geometry);
+            pimpl_->overmap_tiles->load_tileset(
+                "ASCIITiles", no_mods, /*precheck=*/false,
+                /*force=*/true, /*pump_events=*/false);
+        }
+    } catch (const std::exception&) {
+        // leave the fixture invalid; the destructor uninstalls the renderer in safe order
+        return;
+    }
+
+    if (g) { pimpl_->saved_zoom = g->get_zoom(); }
+    pimpl_->saved_tilecontext = std::exchange(tilecontext, pimpl_->tiles);
+    pimpl_->saved_overmap_tilecontext = std::exchange(overmap_tilecontext, pimpl_->overmap_tiles);
+    pimpl_->saved_use_tiles = std::exchange(use_tiles, true);
+    pimpl_->saved_use_tiles_overmap = std::exchange(use_tiles_overmap, true);
+    pimpl_->globals_installed = true;
+    valid_ = true;
+}
+
+tile_context_fixture::~tile_context_fixture() {
+    if (pimpl_->globals_installed) {
+        // restore the main zoom and reset the overmap zoom (it has no getter to save)
+        // while the fixture contexts are still installed so the rescale is safe
+        if (g) {
+            g->set_zoom(pimpl_->saved_zoom);
+            g->reset_overmap_zoom();
+        }
+        tilecontext = std::move(pimpl_->saved_tilecontext);
+        overmap_tilecontext = std::move(pimpl_->saved_overmap_tilecontext);
+        use_tiles = pimpl_->saved_use_tiles;
+        use_tiles_overmap = pimpl_->saved_use_tiles_overmap;
+    }
+    // destroy tile contexts before the renderer, and the renderer before the window
+    pimpl_->overmap_tiles.reset();
+    pimpl_->tiles.reset();
+    if (pimpl_->installed_renderer) { set_sdl_renderer(SDL_Renderer_Ptr()); }
+    fontwidth = pimpl_->saved_fontwidth;
+    fontheight = pimpl_->saved_fontheight;
+}
+
+#else // TILES
+
+// The fixture is only usable in the tiles test binary.
+struct tile_context_fixture::impl {};
+tile_context_fixture::tile_context_fixture(const bool /*alias_overmap_context*/) {}
+tile_context_fixture::~tile_context_fixture() = default;
+
+#endif // TILES

--- a/tests/tile_helpers.h
+++ b/tests/tile_helpers.h
@@ -1,0 +1,27 @@
+#pragma once
+#ifndef CATA_TESTS_TILE_HELPERS_H
+#    define CATA_TESTS_TILE_HELPERS_H
+
+#    include <memory>
+
+/// RAII fixture: real cata_tiles contexts on a hidden-window software SDL renderer,
+/// with the tiles-mode globals (tilecontext, overmap_tilecontext, use_tiles,
+/// use_tiles_overmap) switched over for the test's scope and restored on destruction.
+/// alias_overmap_context mirrors the stock TILES == OVERMAP_TILES shared-context setup.
+class tile_context_fixture {
+public:
+    explicit tile_context_fixture(bool alias_overmap_context);
+    ~tile_context_fixture();
+    tile_context_fixture(const tile_context_fixture&) = delete;
+    auto operator=(const tile_context_fixture&) -> tile_context_fixture& = delete; // *NOPAD*
+
+    /// false when this environment cannot set up a headless tile context; WARN and bail out
+    auto valid() const -> bool { return valid_; }
+
+private:
+    struct impl;
+    std::unique_ptr<impl> pimpl_;
+    bool valid_ = false;
+};
+
+#endif // CATA_TESTS_TILE_HELPERS_H


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #9688. Switching between the main view and the overmap desynced each view's rendered zoom from its stored zoom: the overmap displayed the default zoom while its zoom keys stepped from the remembered level, and overmap zooming could leak into the main view's scale.

## Describe the solution (The How)

Fix: delete the shim and have each view re-assert its own zoom on takeover:

- `game::reapply_overmap_zoom()` on overmap open applies `overmap_tileset_zoom`, gated on `use_tiles && use_tiles_overmap && overmap_tilecontext` (broken-tileset installs leave contexts with a null `tileset_ptr`; ungated this would null-deref in release builds).
- `game::reapply_zoom()` on close unconditionally runs `rescale_tileset(tileset_zoom)`, bypassing the equality guard same pattern as the #7851 reload fix, gated on `use_tiles && tilecontext`, a superset of the entry gate so an aliased write is always restored.

Intentional behavior change: overmap zoom now persists across opens instead of resetting to default (what `overmap_tileset_zoom` was built for, and what the issue asks for).

Both helpers read `game`-private zoom state, so they are members declared beside the existing zoom family in `game.h`.

Root Cause: Three zoom stores end up driving one draw scale in the stock configuration

- #1101 added a save/restore shim in `overmap_ui.cpp display()`, correct back when the overmap zoom keys shared `game::tileset_zoom`.
- #7168 gave the overmap its own `overmap_tileset_zoom` + `zoom_in/out_overmap()` but left the shim behind, pinning its static at the default forever (its exit capture reads back what its own entry wrote).
- #7322 aliased `overmap_tilecontext = tilecontext` whenever `TILES == OVERMAP_TILES`  the default, since both options default to the same tileset. On the shared object the shim's `set_zoom(16)` stomps the overmap's scale on open, and on close the restore is silently skipped by `set_zoom`'s equality guard whenever the values compare equal, leaving the overmap's scale bleeding into the main view.



## Describe alternatives you've considered

- Dropping the equality guard inside `set_zoom()`: forces rescale/relayout on every other caller and does nothing for the overmap-side reset.
- Un-aliasing the contexts or moving to a per-view draw scale: reverts #7322's tileset-memory dedup and has a much larger blast radius through the window-geometry code.

## Testing

- In-game on the default (aliased) config: both repro directions from the issue plus cross-contamination checks now behave; also verified with "Use tiles to display overmap" disabled.
- New regression tests (tag `[overmap][zoom][tiles]`): `tests/tile_helpers.{h,cpp}` adds an RAII fixture that stands up a hidden-window software SDL renderer and real `cata_tiles` contexts (shipped ASCIITiles tileset), installing the tiles globals for the test's scope. Cases cover the zoom ladder incl. wrap-around at both ends, recovery from off-grid zoom values, `ZOOM_STEP_COUNT` 2, both #9688 directions on an aliased context, and scale independence with separate contexts. Reintroducing the old semantics locally fails exactly the four regression assertions.
- Full `[overmap]` tag passes (11 cases / 1015 assertions). The test cases are appended to the existing `overmap_test.cpp` (no new test-bearing file, keeping CI shard packing stable); the helper files contain no test cases.
- The tileset pipeline (`dynamic_atlas`) uses the `get_sdl_renderer()` global rather than the renderer handed to `cata_tiles`, so a small seam `set_sdl_renderer()` was added in sdltiles for the fixture to install a headless renderer.

## Additional context

This does touch a large header file game.h, however there really isn't any way around this to have the fix work correctly in a clean way.

Open issue #7507 is not addressed in this PR as it only fixes within-session behavior.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [79037ba](https://github.com/cataclysmbn/Cataclysm-BN/commit/79037ba5811a9b76af8f72d0de79645b3a164027) (test: cover zoom bookkeeping against a real headless tile context) on 2026-07-04 11:58:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28703500724/artifacts/8081192355)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28703500724/artifacts/8081454998)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28703500724/artifacts/8081126556)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28703500724/artifacts/8081127619)
<!-- END artifact comment -->