### PR TITLE
fix: fix error about not finding valid location for light retrieval mission

### DIFF
--- a/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
+++ b/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
@@ -159,7 +159,6 @@
         "om_terrain": "office_tower_collapse_b_a0",
         "om_special": "office_tower_collapsed",
         "reveal_radius": 1,
-        "random": false,
         "search_range": 500,
         "z": -1
       },

--- a/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
+++ b/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
@@ -159,8 +159,8 @@
         "om_terrain": "office_tower_collapse_b_a0",
         "om_special": "office_tower_collapsed",
         "reveal_radius": 1,
-        "random": true,
-        "search_range": 180,
+        "random": false,
+        "search_range": 500,
         "z": -1
       },
       "update_mapgen": [ { "place_nested": [ { "chunks": [ "robofac_mi3_photonics_chunk" ], "x": 10, "y": 22 } ] } ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The search radius for the collapsed tower for the hub01 mission light retrieval is comically small, so there are commonly errors about not being able to find one.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Increases the search radius greatly and makes the game always choose the closest one to compensate.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Errors
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5fc8d68](https://github.com/cataclysmbn/Cataclysm-BN/commit/5fc8d68eb96ae3b5efcc86c32582d17ea6241933) (Apply suggestion from @chaosvolt) on 2026-07-02 02:50:03

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28561529001)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28561529001)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28561529001)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28561529001)
<!-- END artifact comment -->