### PR TITLE
fix: plastic windows with curtains have same bash stats as without curtains

### DIFF
--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -1455,8 +1455,8 @@
       ]
     },
     "bash": {
-      "str_min": 5,
-      "str_max": 10,
+      "str_min": 10,
+      "str_max": 20,
       "sound": "whump!",
       "sound_fail": "whack!",
       "sound_vol": 90,
@@ -1507,8 +1507,8 @@
       ]
     },
     "bash": {
-      "str_min": 5,
-      "str_max": 10,
+      "str_min": 10,
+      "str_max": 20,
       "sound": "whump!",
       "sound_fail": "whack!",
       "sound_vol": 90,
@@ -1560,8 +1560,8 @@
       ]
     },
     "bash": {
-      "str_min": 5,
-      "str_max": 10,
+      "str_min": 10,
+      "str_max": 20,
       "sound": "whump!",
       "sound_fail": "whack!",
       "sound_vol": 90,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

<img width="658" height="535" alt="image" src="https://github.com/user-attachments/assets/a1d461aa-f33f-4515-9126-8e9ba9a6585c" />

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Numbers go bigger brrrr

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Numbers same as `t_reinforced_plastic_window`

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

We got it right for the ranged bash stats why was the regular bash wrong reee

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c24b376](https://github.com/cataclysmbn/Cataclysm-BN/commit/c24b37627fab5d77df7fc935f3c9c30431a46078) (fix: plastic windows with curtains have same bash stats as without curtain) on 2026-07-02 06:53:11

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28571144002)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28571144002)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28571144002)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28571144002)
<!-- END artifact comment -->