### PR TITLE
fix: prevent queued explosions from using destroyed creatures

### DIFF
--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "debug.h"
+#include "explosion_queue.h"
 #include "map.h"
 #include "mongroup.h"
 #include "monster.h"
@@ -311,10 +312,13 @@ bool Creature_tracker::kill_marked_for_death()
 
 void Creature_tracker::remove_dead()
 {
+    // Queued explosions must not keep raw source pointers to destroyed monsters.
+    auto &explosions = explosion_handler::get_explosion_queue();
     // Can't use game::all_monsters() as it would not contain *dead* monsters.
     for( auto iter = monsters_list.begin(); iter != monsters_list.end(); ) {
         const monster &critter = **iter;
         if( critter.is_dead() ) {
+            explosions.invalidate_source( &critter );
             remove_from_location_map( critter );
             iter = monsters_list.erase( iter );
         } else {
@@ -322,5 +326,8 @@ void Creature_tracker::remove_dead()
         }
     }
 
+    for( const auto &mon_ptr : removed_ ) {
+        explosions.invalidate_source( mon_ptr.get() );
+    }
     removed_.clear();
 }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -2146,8 +2146,11 @@ void explosion_queue::execute()
     // bomb's blast killing a searchlight) would re-detonate it forever. Defer to
     // the turn-loop drain, which runs after processing (same turn).
     if( drains_deferred() ) {
+        deferred_drain_requested = true;
         return;
     }
+    // Any real drain satisfies a pending suppressed request.
+    deferred_drain_requested = false;
 
     // Per-drain backstop (not the #9696 fix): cap one runaway drain that re-feeds
     // its own queue. Per drain, not per turn, so it never drops a later,

--- a/src/explosion_queue.h
+++ b/src/explosion_queue.h
@@ -3,8 +3,10 @@
 #include "explosion.h"
 #include "coordinates.h"
 
+#include <algorithm>
 #include <string>
 #include <deque>
+#include <utility>
 
 namespace explosion_handler
 {
@@ -34,7 +36,7 @@ struct queued_explosion {
     /** Whether it affects player */
     bool affects_player = false;
     /** Who's responsible of the explosion */
-    Creature *source;
+    Creature *source = nullptr;
 };
 
 namespace explosion_funcs
@@ -54,6 +56,8 @@ class explosion_queue
         int explosion_count = 0;
         /// > 0 while execute() drains are deferred to the turn loop (issue #9696).
         int drain_deferral_depth = 0;
+        /// A drain was requested but suppressed by the deferral.
+        bool deferred_drain_requested = false;
 
     public:
         /// OOM/hang backstop (not the #9696 fix): bounds one runaway execute()
@@ -69,16 +73,38 @@ class explosion_queue
 
         void execute();
 
-        void clear() { elems.clear(); }
+        void clear() {
+            elems.clear();
+            deferred_drain_requested = false;
+        }
 
         auto empty() const -> bool { return elems.empty(); }
 
         auto get_count() const -> int { return explosion_count; }
 
+        /// Null queued sources naming a creature that is about to be destroyed.
+        auto invalidate_source( const Creature *source ) -> void {
+            for( queued_explosion &exp : elems ) {
+                if( exp.source == source ) {
+                    exp.source = nullptr;
+                }
+            }
+        }
+
+        /// Whether any queued explosion still names this source.
+        auto references_source( const Creature *source ) const -> bool {
+            return std::ranges::contains( elems, source, &queued_explosion::source );
+        }
+
         /// Drain deferral -- see scoped_drain_deferral (issue #9696).
         void push_drain_deferral() { drain_deferral_depth++; }
         void pop_drain_deferral() { drain_deferral_depth--; }
         auto drains_deferred() const -> bool { return drain_deferral_depth > 0; }
+
+        /// Consume the pending suppressed-drain request, if any.
+        auto take_deferred_drain_request() -> bool {
+            return std::exchange( deferred_drain_requested, false );
+        }
 };
 
 explosion_queue &get_explosion_queue();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2242,6 +2242,14 @@ bool game::do_turn()
         m.process_items();
     }
     {
+        // Deferred drains must run before monmove()'s cleanup_dead() frees their sources.
+        ZoneScopedN( "do_turn_explosions_after_items" );
+        auto &explosions = explosion_handler::get_explosion_queue();
+        if( explosions.take_deferred_drain_request() ) {
+            explosions.execute();
+        }
+    }
+    {
         ZoneScopedN( "do_turn_creature_in_field" );
         m.creature_in_field( u );
     }
@@ -5593,6 +5601,7 @@ void game::cleanup_dead()
     if( npc_is_dead ) {
         for( auto it = active_npc.begin(); it != active_npc.end(); ) {
             if( ( *it )->is_dead() ) {
+                explosion_handler::get_explosion_queue().invalidate_source( it->get() );
                 if( !( *it )->is_manually_erased() ) {
                     // Normal death path — npc::erase() was not called, so do cleanup here.
                     remove_npc_follower( ( *it )->getID() );
@@ -7323,6 +7332,7 @@ void game::erase_npc( character_id id )
         debugmsg( "game::erase_npc: NPC (%d) not found in active_npc.", id.get_value() );
         return;
     }
+    explosion_handler::get_explosion_queue().invalidate_source( it->get() );
     ( *it )->get_mapbuffer().remove_active_npc( **it );
     active_npc.erase( it );
 }

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -293,9 +293,23 @@ TEST_CASE("explosion queue defers drains during item processing", "[explosion][e
         CHECK_FALSE(queue.empty());
     }
 
+    // The suppressed drain is remembered so the turn loop can run it before cleanup_dead().
+    CHECK(queue.take_deferred_drain_request());
+    CHECK_FALSE(queue.take_deferred_drain_request()); // consumed by the take
+
     // The turn-loop drain (outside the window) empties the queue.
     queue.execute();
     CHECK(queue.empty());
+
+    {
+        // A suppressed request satisfied by any real drain must not linger.
+        explosion_handler::scoped_drain_deferral defer;
+        explosion_handler::explosion(origin, ex, nullptr);
+        queue.execute(); // suppressed: sets the request
+    }
+    queue.execute(); // real drain satisfies it
+    CHECK(queue.empty());
+    CHECK_FALSE(queue.take_deferred_drain_request()); // no stale flag
 }
 
 TEST_CASE("EMP bomb processed next to a searchlight does not run away", "[explosion][emp]") {
@@ -332,4 +346,28 @@ TEST_CASE("EMP bomb processed next to a searchlight does not run away", "[explos
 
     REQUIRE(searchlight.is_dead()); // scenario actually triggered
     CHECK(queue.empty());           // ...and terminated with no runaway
+}
+
+TEST_CASE("queued explosions drop their source when the creature is removed", "[explosion]") {
+    clear_all_state();
+
+    const auto source_pos = tripoint_bub_ms{61, 60, 0};
+    auto& source = spawn_test_monster("mon_zombie", source_pos);
+    const Creature* source_ptr = &source;
+
+    auto& queue = explosion_handler::get_explosion_queue();
+    queue.clear();
+    const auto ex = explosion_data{.damage = 10, .radius = 2.0f};
+    explosion_handler::explosion(source_pos, ex, &source);
+    REQUIRE(queue.references_source(source_ptr));
+
+    // The source dies and is destroyed while its blast is still queued (e.g. a
+    // drain deferred during map::process_items() outliving cleanup_dead()).
+    source.set_hp(0);
+    g->cleanup_dead();
+
+    // The source object is gone from here on; only the saved address may be used.
+    CHECK_FALSE(queue.references_source(source_ptr));
+    queue.execute(); // the drain must not touch the destroyed source
+    CHECK(queue.empty());
 }


### PR DESCRIPTION
## Purpose of change

Follow-up to #9716. The drain deferral it added lets a queued explosion outlive its source causing loss of kill attribution due to explosions using destroyed creatures.

## Describe the solution

Two layers:

- **Ordering.** `execute()` now records when a drain was requested but suppressed by the deferral (`deferred_drain_requested`). `do_turn` consumes that flag right after `m.process_items()` and runs the drain there ,before `monmove()`'s `cleanup_dead()` invalidates creature pointers, matching the activity path, which already drains immediately after `process_items()`. The flag keeps the change scoped: turns where nothing requested a drain during item processing (grenade timers, traps, spells) keep draining at the late turn-loop point exactly as before.
- **Invariant guard.** `explosion_queue::invalidate_source()` nulls queued sources naming a creature at every point one is destroyed mid-game: `Creature_tracker::remove_dead()` (dead monsters plus the `removed_` list) and the dead-NPC erase in `game::cleanup_dead()`. Null-source explosions are already a supported state, so any future path that leaves a blast queued across a cleanup degrades to an uncredited kill instead of UB.

## Describe alternatives you've considered

- Draining unconditionally after `process_items()`: simpler, but it also accelerates explosions queued in the player phase (traps, consoles, spells, vehicle crashes) past monmove/npcmove, where both pre- and post-#9716 builds resolved them causing a balance-visible timing change. The request flag confines the shift to exactly the explosions #9716's deferral delayed.
- Storing a `weak_ptr`/id instead of the raw `Creature *`: sources can be the avatar, NPCs, or monsters, each with a different ownership model; resolving at drain time would touch every consumer. The invalidation hook is smaller and sits at the point where the invariant actually breaks.

## Testing

- New regression test: queue a blast with a live monster source, kill and `cleanup_dead()` it, assert the queue no longer references the monster and drains clean. Fails without the guard.
- Extended the #9716 deferral mechanism test to pin the suppressed-drain flag contract.
- `cata_test-tiles "[explosion]"`: 710 assertions in 10 test cases, all pass.
- In-game (Windows tiles build): EMP bomb next to a searchlight the searchlight dies, death beam lands the same turn, no debugmsg, no hang, no crashing, no OOM issues. Landmine and grenade controls confirm unchanged blast timing: monsters still act before a queued blast resolves, as on main.

## Additional context

Tests were appended to `explosion_balance_test.cpp` rather than a new file to keep CI shard packing unchanged.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0cd2342](https://github.com/cataclysmbn/Cataclysm-BN/commit/0cd23429386a44b8207c95293148471ef6154af3) (fix: prevent queued explosions from using destroyed creatures) on 2026-07-02 14:42:38

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28587666140/artifacts/8042101146)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28587666140/artifacts/8040464034)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28587666140/artifacts/8041229694)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28587666140/artifacts/8041351228)
<!-- END artifact comment -->