### PR TITLE
feat(balance): nerf RM11B suppressor, fix Mp5sd spawn

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -689,7 +689,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "entries": [
-      { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
+      { "item": "hk_mp5sd", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag", "charges-min": 0, "prob": 80 },
       { "group": "nested_mp5_mag", "charges-min": 0, "prob": 50 },
       { "group": "on_hand_9mm", "prob": 25, "charges": [ 10, 20 ], "count": [ 1, 2 ] }

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -954,7 +954,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
+      { "item": "hk_mp5sd", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 },
       { "group": "on_hand_9mm" }

--- a/data/json/items/gunmod/muzzle.json
+++ b/data/json/items/gunmod/muzzle.json
@@ -136,8 +136,7 @@
     "material": [ "superalloy", "ceramic" ],
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ] ],
     "handling_modifier": 5,
-    "loudness_modifier": -80,
-    "speed": -660,
+    "loudness_modifier": -75,
     "flags": [ "IRREMOVABLE" ]
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

My second stab at #9760 (but much simplified and less ambitious), also a follow up to #9765.
The mp5 used to spawn where the mp5sd should spawn.

## Describe the solution (The How)

Remove the bullet slowdown effect from rivtech suppressor, and slightly lower its effectiveness. It's still by far the best suppressor in the game. 
Make the mp5sd actually spawn where it should

## Describe alternatives you've considered

Nerfing the rivtech suppressor more

## Testing

Before this tweak, the RM11B produces 74 decibels when shooting a round that is almost going at mach 3 (!). 
After this nerf, it is still insanely quiet at 79db. 

For reference, the DeLisle carbine, one of the quietest guns ever made, makes 85db, using a subsonic round (45 acp). Think of it, it might be a good addition to the game as an obscure / historical gun. 

## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1cd1b29](https://github.com/cataclysmbn/Cataclysm-BN/commit/1cd1b299fb9093bcd04d6c9b33d41b0d4fd7d402) (nerf RM11B suppressor, fix Mp5sd spawn) on 2026-07-04 18:09:34

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28622933916/artifacts/8053705917)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28622933916/artifacts/8053456255)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28622933916/artifacts/8053080056)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28622933916/artifacts/8052964404)
<!-- END artifact comment -->