### PR TITLE
build: Fix bad lua includes in sol.hpp

### DIFF
--- a/src/sol/sol.hpp
+++ b/src/sol/sol.hpp
@@ -2952,16 +2952,16 @@ struct pre_main {
 // beginning of sol/compatibility/lua_version.hpp
 
 #if SOL_IS_ON(SOL_USE_CXX_LUA)
-	#include <lua.h>
-	#include <lualib.h>
-	#include <lauxlib.h>
+	#include "lua/lua.h"
+	#include "lua/lualib.h"
+	#include "lua/lauxlib.h"
 #elif SOL_IS_ON(SOL_USE_LUA_HPP)
 	#include <lua.hpp>
 #else
 	extern "C" {
-		#include <lua.h>
-		#include <lauxlib.h>
-		#include <lualib.h>
+		#include "lua/lua.h"
+		#include "lua/lauxlib.h"
+		#include "lua/lualib.h"
 	}
 #endif // C++ Mangling for Lua vs. Not
 
@@ -3156,9 +3156,9 @@ struct pre_main {
 #if defined(__cplusplus) && !defined(COMPAT53_LUA_CPP)
 extern "C" {
 #endif
-#include <lua.h>
-#include <lauxlib.h>
-#include <lualib.h>
+#include "lua/lua.h"
+#include "lua/lauxlib.h"
+#include "lua/lualib.h"
 #if defined(__cplusplus) && !defined(COMPAT53_LUA_CPP)
 }
 #endif
@@ -4416,9 +4416,9 @@ COMPAT53_API void luaL_requiref(lua_State* L, const char* modname, lua_CFunction
 #if defined(__cplusplus) && !defined(COMPAT53_LUA_CPP)
 extern "C" {
 #endif
-#include <lua.h>
-#include <lauxlib.h>
-#include <lualib.h>
+#include "lua/lua.h"
+#include "lua/lauxlib.h"
+#include "lua/lualib.h"
 #if defined(__cplusplus) && !defined(COMPAT53_LUA_CPP)
 }
 #endif


### PR DESCRIPTION
## Purpose of change (The Why)

Chaos was failing to compile, it was complaining about lua includes in sol.hpp

## Describe the solution (The How)

Change it from evil angle brace includes to wholesome quotation mark includes with the real file path

## Describe alternatives you've considered

Change the compilers themselves

## Testing

<img width="425" height="77" alt="image" src="https://github.com/user-attachments/assets/2b9e41d3-81c1-48e9-8a31-e02d0f3bae92" />

## Additional context

I didn't touch the hpp one, nor any includes in catalua files.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0f74537](https://github.com/cataclysmbn/Cataclysm-BN/commit/0f74537c29f1b74e6f3a61c1c67a48216a71db9a) (Fix bad lua includes in sol.hpp) on 2026-07-03 07:39:32

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28642261114/artifacts/8060230109)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28642261114/artifacts/8060615308)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28642261114/artifacts/8059485722)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28642261114/artifacts/8059444741)
<!-- END artifact comment -->