### PR TITLE
feat(balance): Changes "army jacket" into "army blouse", sets layer to normal and gives undershirt to all military professions

### DIFF
--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -410,8 +410,8 @@
     "id": "jacket_army",
     "repairs_like": "trenchcoat",
     "type": "ARMOR",
-    "name": { "str_sp": "army jacket" },
-    "description": "A tough jacket with lots of pockets.  Favored by the military.",
+    "name": { "str_sp": "army blouse" },
+    "description": "A tough blouse with lots of pockets.  Favored by the military.",
     "weight": "780 g",
     "volume": "3 L",
     "price": "35 USD",
@@ -427,7 +427,7 @@
     "warmth": 20,
     "material_thickness": 2,
     "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "ALLOWS_WINGS" ]
+    "flags": [ "VARSIZE", "POCKETS", "ALLOWS_WINGS" ]
   },
   {
     "id": "jacket_chef",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1906,7 +1906,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "helmet_liner",
           "helmet_army",
@@ -1944,7 +1944,7 @@
       "both": {
         "items": [
           "pants",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "helmet_liner",
           "helmet_steel",
@@ -1990,7 +1990,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "helmet_liner",
           "helmet_army",
@@ -2041,7 +2041,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "helmet_liner",
           "helmet_army",
@@ -2090,7 +2090,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "helmet_liner",
           "helmet_army",
@@ -2148,7 +2148,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "helmet_liner",
           "helmet_army",
@@ -2200,7 +2200,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "helmet_liner",
           "helmet_army",
@@ -2256,7 +2256,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "gloves_liner",
           "gloves_tactical",
@@ -2355,7 +2355,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "gloves_liner",
           "gloves_tactical",
@@ -2484,7 +2484,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "gloves_liner",
           "gloves_tactical",
@@ -2534,7 +2534,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "gloves_liner",
           "gloves_tactical",
@@ -4253,7 +4253,8 @@
       "both": {
         "items": [
           "winter_pants_army",
-          "tshirt",
+          "undershirt",
+          "jacket_army",
           "winter_jacket_army",
           "winter_gloves_army",
           "mask_ski",
@@ -4317,7 +4318,8 @@
       "both": {
         "items": [
           "winter_pants_army",
-          "tshirt",
+          "undershirt",
+          "jacket_army",
           "winter_jacket_army",
           "winter_gloves_army",
           "rucksack",
@@ -4376,7 +4378,8 @@
       "both": {
         "items": [
           "winter_pants_army",
-          "tshirt",
+          "undershirt",
+          "jacket_army",
           "winter_jacket_army",
           "gloves_liner",
           "gloves_tactical",
@@ -5499,7 +5502,7 @@
     "skills": [ { "level": 1, "name": "swimming" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "firstaid" } ],
     "items": {
       "both": {
-        "items": [ "shorts", "tshirt", "socks", "smart_phone", "lowtops", "wristwatch" ],
+        "items": [ "shorts", "undershirt", "socks", "smart_phone", "lowtops", "wristwatch" ],
         "entries": [ { "item": "personal_gobag", "custom-flags": [ "FIT" ] } ]
       },
       "male": [ "boxer_shorts" ],
@@ -5765,7 +5768,7 @@
         "items": [
           "socks",
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "boots_combat",
           "gloves_liner",
@@ -7659,7 +7662,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "helmet_liner",
           "helmet_army",
@@ -8227,7 +8230,7 @@
       "both": {
         "items": [
           "pants_army",
-          "tshirt",
+          "undershirt",
           "jacket_army",
           "helmet_liner",
           "helmet_army",
@@ -8593,7 +8596,7 @@
       { "level": 3, "name": "throw" }
     ],
     "items": {
-      "both": { "items": [ "pants_army", "tshirt", "jacket_army", "socks", "boots_combat", "wristwatch", "smart_phone" ] },
+      "both": { "items": [ "pants_army", "undershirt", "jacket_army", "socks", "boots_combat", "wristwatch", "smart_phone" ] },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
     }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Why is army jacket almost always the first thing I throw away after spawning as a military profession? It conflicts with much better stuff on the same OUTER layer. Isn't it a bit strange that you practically only wear 1/2 of the fatigues set unless you are roleplaying on purpose? Why does it have the same warmth as army pants?

This change should fix army uniforms in the game literally not working the way they are intended to in real life.

## Describe the solution (The How)

Renames "army jacket" to "army blouse", the upper half of the uniform.
Sets it to normal layer
Replaces tshirts with undershirts across all military professions
Gives army blouses to professions that start with military winter jacket

## Describe alternatives you've considered

Continuing to never wear the top half of the uniform.

## Testing

<img width="1366" height="768" alt="test" src="https://github.com/user-attachments/assets/4079fdd2-690d-41bc-8ff7-153d6ee40c4d" />


## Additional context

Only JSON changes, no AI.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [07a4b75](https://github.com/cataclysmbn/Cataclysm-BN/commit/07a4b75b82fce0588c884244c325e139ae280463) (mil profession blouses) on 2026-07-03 17:54:49

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28660366652/artifacts/8072357201)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28660366652/artifacts/8067181492)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28660366652/artifacts/8066666721)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28660366652/artifacts/8066698461)
<!-- END artifact comment -->