### PR TITLE
fix: restore manual aiming across z-levels

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -481,8 +481,6 @@ class target_ui
         // List of visible hostile targets
         std::vector<Creature *> targets;
 
-        // 'true' if map has z levels and 3D fov is on
-        bool allow_zlevel_shift = false;
         // Snap camera to cursor. Can be permanently toggled in settings
         // or temporarily in this window
         bool snap_to_target = false;
@@ -3235,10 +3233,8 @@ void target_ui::init_window_and_input()
     ctxt.register_action( "zoom_out" );
     ctxt.register_action( "zoom_in" );
     ctxt.register_action( "TOGGLE_MOVE_CURSOR_VIEW" );
-    if( allow_zlevel_shift ) {
-        ctxt.register_action( "LEVEL_UP" );
-        ctxt.register_action( "LEVEL_DOWN" );
-    }
+    ctxt.register_action( "LEVEL_UP" );
+    ctxt.register_action( "LEVEL_DOWN" );
     if( mode == TargetMode::Fire || mode == TargetMode::TurretManual || ( mode == TargetMode::Shape &&
             relevant->is_gun() ) ) {
         ctxt.register_action( "SWITCH_MODE" );
@@ -4262,9 +4258,7 @@ void target_ui::panel_cursor_info( int &text_y )
 
     std::vector<std::string> labels;
     labels.push_back( label_range );
-    if( allow_zlevel_shift ) {
-        labels.push_back( string_format( _( "Elevation: %d" ), dst.z() - src.z() ) );
-    }
+    labels.push_back( string_format( _( "Elevation: %d" ), dst.z() - src.z() ) );
     labels.push_back( string_format( _( "Targets: %d" ), targets.size() ) );
 
     nc_color col = c_light_gray;


### PR DESCRIPTION


<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

The ability to manually aim ranged weapons across z-levels with `>`/`<` disappeared, seemingly unintentionally in #9543 .

## Describe the solution (The How)

Fully remove never-set variable `allow_zlevel_shift` and checks for it that prevented manual z-level aiming. This was previously set based on the z-levels option, but that option was removed in #9543 and the variable remained still checked (and thus could never be true). This seemed unintentional and broke manual aiming across z-levels.

## Describe alternatives you've considered
None

## Testing

Verified ability to aim ranged weapons across z-levels again as it previously worked.

## Additional context

There remains some jank with ranged weapons across z-levels out of the scope of this particular issue, such as being able to poke with reach melee weapons through the roof (made easy with clairvoyance but not required if you poke blindly); or the aiming indicator not making sense when the aim crosses z-levels. Separate issues with separate fixes :)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
***(n/a: Didn't find any)***

### Optional

<!-- please remove checkboxes unrelated to this PR. -->
***n/a***

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [961a6d0](https://github.com/cataclysmbn/Cataclysm-BN/commit/961a6d0e79a48a0e023895021b16567c64616d2f) (Merge remote-tracking branch 'upstream/main' into pr/9788) on 2026-07-03 19:55:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28679374493/artifacts/8073664690)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28679374493/artifacts/8073921003)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28679374493/artifacts/8073658120)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28679374493/artifacts/8073684889)
<!-- END artifact comment -->