### PR TITLE
fix: Various cable charger CBM fixes

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -59,7 +59,7 @@
     "id": "sunlight",
     "symbol": "?",
     "color": "white",
-    "name": { "str_sp": "sun light" },
+    "name": { "str_sp": "sunlight" },
     "description": "seeing this is a bug",
     "stackable": true,
     "price": "0 cent",

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -676,6 +676,9 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
 
         bio.powered = bio.info().has_flag( flag_BIONIC_TOGGLED ) || bio.info().charge_time > 0;
 
+        if( bio.info().is_remote_fueled ) {
+            find_remote_fuel();
+        }
         if( bio.info().charge_time > 0 ) {
             bio.charge_timer = bio.info().charge_time;
         }
@@ -1440,22 +1443,15 @@ bool Character::burn_fuel( bionic &bio, bool start )
                             mod_power_level( units::from_kilojoule( fuel_energy ) * effective_efficiency );
                         }
                     } else if( is_cable_powered ) {
-                        auto to_consume = bio.info().remote_fuel_draw;
-                        if( get_power_level() >= get_max_power_level() ) {
-                            to_consume = 0_J;
-                        }
-                        const auto unconsumed = consume_remote_fuel( to_consume );
-                        // we don't check if to_consume != unconsumed cuz we wouldn't get there otherwise
+                        const units::energy power_needed = ( get_max_power_level() - get_power_level() ) /
+                                                           effective_efficiency;
+                        const units::energy to_consume = std::min( bio.info().remote_fuel_draw, power_needed );
                         if( to_consume > 0_J ) {
-                            if( unconsumed == 0_J ) {
-                                mod_power_level( bio.info().remote_fuel_draw * effective_efficiency );
-                                current_fuel_stock -= units::to_kilojoule( to_consume );
-                            } else {
-                                mod_power_level( ( to_consume - unconsumed ) * effective_efficiency );
-                                current_fuel_stock = 0;
-                            }
+                            const auto unconsumed = consume_remote_fuel( to_consume );
+                            mod_power_level( ( to_consume - unconsumed ) * effective_efficiency );
+                            current_fuel_stock -= units::to_kilojoule( to_consume - unconsumed );
+                            set_value( "rem_" + fuel.str(), std::to_string( current_fuel_stock ) );
                         }
-                        set_value( "rem_" + fuel.str(), std::to_string( current_fuel_stock ) );
                     } else {
                         current_fuel_stock -= 1;
                         set_value( fuel.str(), std::to_string( current_fuel_stock ) );
@@ -1682,6 +1678,10 @@ units::energy Character::consume_remote_fuel( units::energy amount )
         }
     }
 
+    // We truncate anything less than 1 kJ, so we may have left some unfulfilled
+    if( amount > units::from_kilojoule( amount_kj ) ) {
+        unconsumed_amount += ( amount - units::from_kilojoule( amount_kj ) );
+    }
     return unconsumed_amount;
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10960,14 +10960,14 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
             qty -= std::min( qty, power_drain );
             return res;
         }
-        if( has_power() && has_active_bionic( bio_ups ) ) {
+        if( has_power() && has_active_bionic( bio_ups ) && filter( null_item_reference() ) ) {
             int bio = std::min( units::to_kilojoule( get_power_level() ), qty );
             mod_power_level( units::from_kilojoule( -bio ) );
             qty -= std::min( qty, bio );
         }
 
         remove_items_with( [ & ]( detached_ptr<item> &&e ) {
-            if( e->has_flag( flag_IS_UPS ) && e->ammo_remaining() > 0 ) {
+            if( e->has_flag( flag_IS_UPS ) && e->ammo_remaining() > 0 && filter( *e ) ) {
                 int ups_eff_mult = e->type->tool->ups_eff_mult;
                 detached_ptr<item> split = item::spawn( *e );
                 split->ammo_set( e->ammo_current(), e->ammo_remaining() );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Cable chargers, when active, can only take either their full power draw or nothing from whatever they're connected to. That means if you have a Leukocyte Breeder running (5 J/turn) and you're connected to your car with a cable charger mk2, it will draw 10 battery charges, which is 10kJ = 10000J every turn, while voiding 9995 of them. In the process of investigating it I also found some minor issues that I fixed.
(Yes, you can turn on fuel saving and auto start, but 1) you need to know to do that and it's not intuitive to have the power go into nothing and 2) it spams you with messages.)

## Describe the solution (The How)

* Not related to cable charger, but I renamed "sun light" to "sunlight" because fuel types are separated by spaces, so it was confusing to read. I don't know why it's spelled like that in the first place.
* Cable charger wouldn't update available power immediately when turned on (it would just display "battery:").
* Cable chargers now draw as much power as they need, anywhere from 1 kJ (1 battery charge) to their max draw.
* If you had multiple UPSes and connected the cable to one of them, the game would draw from the first one you have, not the one you were actually connected to (filter wasn't respected).
* Fixes #9117 (the game always prioritised drawing from bionic power - now it only does that if the filter isn't set).

## Describe alternatives you've considered

* I hate how `Character::find_remote_fuel` works and would like to change it, but it's consistent with other fuelled bionics.
* Additionally, cable charger now won't charge you *to full*, e.g. if you have 199.5/200 kJ, it won't charge you to 200. It's not possible to draw half of a charge from batteries, so the options here are 1) don't charge to full 2) charge the last kJ for free 3) charge it for 1 battery charge, which is the current behaviour that causes problems.
* I'm not a huge fan of the `filter( null_item_reference() )` check, but the only other option I could think of is to add a new parameter to `use_charges`, which I *really* don't want to do just for this incredibly specific interaction.

There are some issues that I found and didn't fix:

* Cable charger wouldn't charge on the first turn after it was activated. It's something that seems to affect all bionics that activate every X turns, and I quickly realised it's beyond my ability to test.
* Bionics UI doesn't always show an accurate number of available power when cable charger that's connected to an UPS. Minor issue that isn't easy to fix.
* Bionics UI doesn't properly update number of charges available when connected to something and the amount of power in that something changes externally (e.g. a car with power generation/use). Also minor and not easy to fix.

## Testing

Did some testing by connecting to vehicle/solar backpack/UPS to make sure it works. Also that regular UPS charging works.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [376f5f7](https://github.com/cataclysmbn/Cataclysm-BN/commit/376f5f72c5f8f8887ebe434c0ac38ef61fdda3a4) (Various cable CBM fixes) on 2026-07-03 18:14:04

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28675319003/artifacts/8072301549)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28675319003/artifacts/8072695545)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28675319003/artifacts/8072327545)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28675319003/artifacts/8072390958)
<!-- END artifact comment -->