### PR TITLE
fix: digging activities now properly apply exertion again

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -556,7 +556,7 @@ void dig_activity_actor::finish( player_activity &act, Character &who )
                       item_group::items_from( item_group_id( byproducts_item_group ),
                               calendar::turn ) );
 
-    const int act_exertion = act.moves_total;
+    const int act_exertion = moves_total;
 
     who.mod_stored_kcal( std::min( -1, -act_exertion / to_moves<int>( 80_seconds ) ) );
     who.mod_thirst( std::max( 1, act_exertion / to_moves<int>( 12_minutes ) ) );
@@ -641,7 +641,7 @@ void dig_channel_activity_actor::finish( player_activity &act, Character &who )
                       item_group::items_from( item_group_id( byproducts_item_group ),
                               calendar::turn ) );
 
-    const int act_exertion = act.moves_total;
+    const int act_exertion = moves_total;
 
     who.mod_stored_kcal( std::min( -1, -act_exertion / to_moves<int>( 80_seconds ) ) );
     who.mod_thirst( std::max( 1, act_exertion / to_moves<int>( 12_minutes ) ) );


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #9778
( I determined that other actors are expectedly uneffected )

## Describe the solution (The How)
Both digging activity actors referenced the player activity to get the number of moves
These actors never pass the number of moves to the player activity, like all other actors, and instead store it in their own object
Thus reference that total_moves instead

## Describe alternatives you've considered
None

## Testing
Debug thingy thing go dig with your digging stick
You get tired

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9fc7d6c](https://github.com/cataclysmbn/Cataclysm-BN/commit/9fc7d6c2fb7939dd1f8dcbd7d3c15cf52b001dc4) (fix: digging activities now properly apply exertion again) on 2026-07-04 04:24:16

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28692838612/artifacts/8077745141)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28692838612/artifacts/8078254111)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28692838612/artifacts/8077779769)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28692838612/artifacts/8077789094)
<!-- END artifact comment -->