### PR TITLE
feat(balance): buff ballistic mask and remove from survivor mask recipes

### DIFF
--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -153,7 +153,7 @@
     "repairs_like": "kevlar",
     "type": "ARMOR",
     "name": { "str": "ballistic mask" },
-    "description": "A protective reinforced Kevlar mask that covers the face.  Provides excellent protection from ballistic threats.",
+    "description": "A protective reinforced Kevlar mask that covers the face.  Provides protection from ballistic threats up to 9x19mm.",
     "weight": "512 g",
     "volume": "750 ml",
     "price": "200 USD",
@@ -169,6 +169,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
+    "resistance": { "bullet": 36 },
     "flags": [ "WATER_FRIENDLY", "STURDY" ]
   },
   {

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -67,7 +67,7 @@
     "id": "shield_ballistic",
     "type": "ARMOR",
     "name": { "str": "ballistic shield" },
-    "description": "A heavy composite shield used by SWAT teams and other armed forces.  It can handle the occasional pistol bullet, but its heavy-duty nature means it's quite encumbering and doesn't cover the legs very well.",
+    "description": "A heavy composite shield used by SWAT teams and other armed forces.  It can handle pistol bullets up to .40 S&W, but its heavy-duty nature means it's quite encumbering and doesn't cover the legs very well.",
     "weight": "8 kg",
     "volume": "4 L",
     "price": "1000 USD",
@@ -92,7 +92,7 @@
     "looks_like": "shield_riot",
     "type": "ARMOR",
     "name": { "str": "large ballistic shield" },
-    "description": "A tall composite shield used by SWAT teams and other armed forces, rated for pistol bullets.  Covers the body and legs quite well, but is much heavier and more encumbering than lighter models.",
+    "description": "A tall composite shield used by SWAT teams and other armed forces, rated for pistol bullets up to .40 S&W.  Covers the body and legs quite well, but is much heavier and more encumbering than lighter models.",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.5, "price_postapoc": 1.5 },
     "relative": { "to_hit": -1, "encumbrance": 10, "bashing": 4 },
     "techniques": [ "WBLOCK_3" ]

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -970,7 +970,7 @@
     "book_learn": [ [ "textbook_fireman", 7 ], [ "atomic_survival", 8 ], [ "textbook_gaswarfare", 9 ] ],
     "using": [ [ "adhesive", 2 ], [ "sewing_standard", 20 ] ],
     "tools": [ [ [ "soldering_standard", 80, "LIST" ], [ "surface_heat", 80, "LIST" ] ] ],
-    "components": [ [ [ "mask_bunker", 1 ] ], [ [ "nomex", 4 ] ], [ [ "mask_bal", 1 ], [ "kevlar_plate", 4 ] ] ]
+    "components": [ [ [ "mask_bunker", 1 ] ], [ [ "nomex", 4 ] ], [ [ "kevlar_plate", 4 ] ] ]
   },
   {
     "result": "mask_gas",
@@ -1054,12 +1054,7 @@
     "autolearn": true,
     "using": [ [ "adhesive", 2 ], [ "sewing_standard", 20 ] ],
     "tools": [ [ [ "soldering_standard", 80, "LIST" ], [ "surface_heat", 80, "LIST" ] ] ],
-    "components": [
-      [ [ "rebreather", 1 ] ],
-      [ [ "goggles_swim", 1 ] ],
-      [ [ "plastic_chunk", 4 ] ],
-      [ [ "mask_bal", 1 ], [ "kevlar_plate", 4 ] ]
-    ]
+    "components": [ [ [ "rebreather", 1 ] ], [ [ "goggles_swim", 1 ] ], [ [ "plastic_chunk", 4 ] ], [ [ "kevlar_plate", 4 ] ] ]
   },
   {
     "result": "mask_hsurvivor",
@@ -1078,7 +1073,7 @@
       [ [ "mask_filter", 2 ], [ "mask_gas", 1 ], [ "mask_bunker", 1 ] ],
       [ [ "glasses_safety", 2 ], [ "glasses_bal", 1 ] ],
       [ [ "steel_standard", 2, "LIST" ] ],
-      [ [ "mask_bal", 1 ], [ "kevlar_plate", 4 ] ]
+      [ [ "kevlar_plate", 4 ] ]
     ]
   },
   {
@@ -1098,7 +1093,7 @@
       [ [ "mask_filter", 2 ], [ "mask_gas", 1 ], [ "mask_bunker", 1 ] ],
       [ [ "glasses_safety", 2 ], [ "glasses_bal", 1 ] ],
       [ [ "alloy_sheet", 2 ] ],
-      [ [ "mask_bal", 1 ], [ "kevlar_plate", 4 ] ]
+      [ [ "kevlar_plate", 4 ] ]
     ]
   },
   {
@@ -1117,7 +1112,7 @@
       [ [ "mask_filter", 2 ], [ "mask_gas", 1 ], [ "mask_bunker", 1 ] ],
       [ [ "glasses_safety", 2 ], [ "glasses_bal", 1 ] ],
       [ [ "fabric_standard", 3, "LIST" ] ],
-      [ [ "mask_bal", 1 ], [ "kevlar_plate", 4 ] ]
+      [ [ "kevlar_plate", 4 ] ]
     ]
   },
   {
@@ -1161,7 +1156,7 @@
       [ [ "mask_filter", 2 ], [ "mask_gas", 1 ], [ "mask_bunker", 1 ] ],
       [ [ "glasses_safety", 2 ], [ "glasses_bal", 1 ] ],
       [ [ "fabric_hides_proper", 3, "LIST" ] ],
-      [ [ "mask_bal", 1 ], [ "kevlar_plate", 4 ] ]
+      [ [ "kevlar_plate", 4 ] ]
     ]
   },
   {
@@ -1179,7 +1174,7 @@
     "components": [
       [ [ "mask_filter", 2 ], [ "mask_gas", 1 ], [ "mask_bunker", 1 ] ],
       [ [ "glasses_safety", 2 ], [ "glasses_bal", 1 ] ],
-      [ [ "mask_bal", 1 ], [ "kevlar_plate", 4 ] ],
+      [ [ "kevlar_plate", 4 ] ],
       [ [ "fur", 6 ] ]
     ]
   },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Minor lil update, ballistic masks claim to be more protective than they actually are. At 20 ballistic armor even .22 FMJ would go through it.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Granted ballistic mask explicit ballistic resistance of 36 and updated description to specify it protects against up to 9mm.
2. Removed use of ballistic mask from survivor mask recipes so they don't have to implicitly have the same or better protection to make sense.
3. Misc: Updated description of ballistic shields to specify what ammo they can handle.

## Describe alternatives you've considered

1. Also tweaking ballistic stats of survivor gear while I'm at it, they're kinda all over the place. Meh, that can be a separate PR I guess.
2. Buffing ballistic shields and/or adding a rifle-rated version.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Used basic math skills to confirm that 36 is a higher number than 20.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [57ac0e5](https://github.com/cataclysmbn/Cataclysm-BN/commit/57ac0e522cb692c9188bc166e92d2070171a8231) (feat(balance): buff ballistic mask and remove from survivor mask recipes) on 2026-07-04 20:37:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28714312033/artifacts/8084391535)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28714312033/artifacts/8084509702)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28714312033/artifacts/8084349710)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28714312033/artifacts/8084220220)
<!-- END artifact comment -->