### PR TITLE
fix: NOCOLLIDE parts properly update themselves in the cache

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -942,10 +942,9 @@ void map::add_vehicle_to_cache( vehicle *veh )
         level_cache &ch = get_cache( p.z() );
         ch.veh_in_active_range = true;
 
-        // DANGER: Unlike what you think where you can just use vpr.has_flag( VPFLAG_NOCOLLIDE )
-        // THAT DOES NOT WORK DO NOT TRY AND CHANGE THIS MESS
         if( !ch.veh_cached_parts.contains( p ) ||
-            ( !veh->part_info( vpr.part_index() ).has_flag( VPFLAG_NOCOLLIDE ) ) ) {
+            !veh->part_info( vpr.part_index() ).has_flag( VPFLAG_NOCOLLIDE ) ||
+            ch.veh_cached_parts.at( p ).first == veh ) {
             ch.veh_cached_parts[p] = std::make_pair( veh,  static_cast<int>( vpr.part_index() ) );
         }
         if( inbounds( p ) ) {


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #9674

## Describe the solution (The How)
Remove my confused comment due to previous scrungles with part flags
Add check that allows NOCOLLIDE parts to write over old cache entries from the same vehicle, as it is impossible for two of the same tile to exist at once

## Describe alternatives you've considered
None

## Testing
Could replicate before, cannot after

## Additional context
~~Why do all these bugs keep on being 1 line changes~~

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c2a3cc0](https://github.com/cataclysmbn/Cataclysm-BN/commit/c2a3cc0956847399a7c72bf0a6efc981ad4e3437) (fix: NOCOLLIDE parts properly update themselves in the cache) on 2026-07-05 05:02:12

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28727532335/artifacts/8088447641)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28727532335/artifacts/8087970202)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28727532335/artifacts/8087828769)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28727532335/artifacts/8087815836)
<!-- END artifact comment -->