### PR TITLE
fix: resolve Android SDL3 regressions for fullscreen and keyboard sca…

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2270,7 +2270,6 @@ void options_manager::add_options_graphics()
          display_list.front().first, COPT_CURSES_HIDE );
 #endif
 
-#if !defined(__ANDROID__) // Android is always fullscreen
     add( "FULLSCREEN", graphics, translate_marker( "Fullscreen" ),
          translate_marker( "Starts Cataclysm in one of the fullscreen modes.  Requires restart." ),
     { { "no", translate_marker( "No" ) }, { "maximized", translate_marker( "Maximized" ) }, { "fullscreen", translate_marker( "Fullscreen" ) }, { "windowedbl", translate_marker( "Windowed borderless" ) } },
@@ -2280,7 +2279,6 @@ void options_manager::add_options_graphics()
     add( "MINIMIZE_ON_FOCUS_LOSS", graphics,
          translate_marker( "Minimize on focus loss" ),
          translate_marker( "Minimize fullscreen window when it loses focus.  Requires restart." ), false );
-#endif
 
 #if !defined(__ANDROID__)
 #   if !defined(TILES)

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -215,7 +215,6 @@ static void WinCreate()
     WindowHeight = TERMINAL_HEIGHT * fontheight * scaling_factor;
     window_flags |= SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
 
-#if !defined(__ANDROID__)
     const auto screen_mode = get_option<std::string>( "FULLSCREEN" );
     const auto minimize = get_option<bool>( "MINIMIZE_ON_FOCUS_LOSS" );
 
@@ -230,7 +229,6 @@ static void WinCreate()
     } else if( screen_mode == "maximized" ) {
         window_flags |= SDL_WINDOW_MAXIMIZED;
     }
-#endif
 
     int display = std::stoi( get_option<std::string>( "DISPLAY" ) );
     {
@@ -266,17 +264,12 @@ static void WinCreate()
                            SDL_WINDOWPOS_CENTERED_DISPLAY( display ) );
     SDL_StartTextInput( ::window.get() );
 
-#if !defined(__ANDROID__)
-    // On Android SDL seems janky in windowed mode so we're fullscreen all the time.
-    // Fullscreen mode is now modified so it obeys terminal width/height, rather than
-    // overwriting it with this calculation.
     if( fullscreen || ( window_flags & SDL_WINDOW_MAXIMIZED ) ) {
         SDL_GetWindowSize( ::window.get(), &WindowWidth, &WindowHeight );
         // Ignore previous values, use the whole window, but nothing more.
         TERMINAL_WIDTH = WindowWidth / fontwidth / scaling_factor;
         TERMINAL_HEIGHT = WindowHeight / fontheight / scaling_factor;
     }
-#endif
     // Initialize framebuffer caches
     terminal_framebuffer.resize( TERMINAL_HEIGHT );
     for( int i = 0; i < TERMINAL_HEIGHT; i++ ) {
@@ -348,11 +341,6 @@ static void WinCreate()
                               fontheight * FULL_SCREEN_HEIGHT * scaling_factor );
 
 #if defined(__ANDROID__)
-    // TODO: Not too sure why this works to make fullscreen on Android behave. :/
-    if( fullscreen || ( window_flags & SDL_WINDOW_MAXIMIZED ) ) {
-        SDL_GetWindowSize( ::window.get(), &WindowWidth, &WindowHeight );
-    }
-
     // Load virtual joystick texture
     touch_joystick = CreateTextureFromSurface( renderer, load_image( "android/joystick.png" ) );
 #endif
@@ -3232,14 +3220,9 @@ static void CheckMessages()
                     g->quicksave();
                 }
                 break;
-            // SDL sends a pixel size changed event whenever the screen rotates orientation
+            // SDL sends pixel size changed event on screen rotation or keyboard open/close
             case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
-                WindowWidth = ev.window.data1;
-                WindowHeight = ev.window.data2;
-                SDL_Delay( 500 );
-                SDL_GetWindowSurface( window.get() );
-                refresh_display();
-                needupdate = true;
+                handle_resize( ev.window.data1, ev.window.data2 );
                 break;
 #endif
             case SDL_EVENT_WINDOW_SHOWN:


### PR DESCRIPTION
…ling

Remove #if !defined(__ANDROID__) guards blocking FULLSCREEN option, window flags, and size calc. Fix SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED handler to call handle_resize() instead of broken SDL2-ism (SDL_GetWindowSurface + delay). Remove duplicate Android fullscreen block.

<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [81e6ed4](https://github.com/cataclysmbn/Cataclysm-BN/commit/81e6ed44367b926cffbbb1f099785896ce83947d) (fix: resolve Android SDL3 regressions for fullscreen and keyboard scaling) on 2026-07-05 18:21:48

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28748289582/artifacts/8094307967)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28748289582/artifacts/8094478340)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28748289582/artifacts/8094254558)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28748289582/artifacts/8094178708)
<!-- END artifact comment -->