### PR TITLE
feat(UI): add enchantment info

### DIFF
--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -181,7 +181,10 @@
   {
     "id": "CLIMATE_CONTROL",
     "type": "enchantment_value",
-    "suffixes": [ [ "COOLING", "Keeps you comfortable against hot temperatures" ], [ "HEATING", "Keeps you comfortable against cold temperatures" ] ],
+    "suffixes": [
+      [ "COOLING", "Keeps you comfortable against hot temperatures" ],
+      [ "HEATING", "Keeps you comfortable against cold temperatures" ]
+    ],
     "desc": "Grants climate control, which keeps you at a comfortable temperature"
   },
   {

--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -247,7 +247,7 @@
     "can_add": false,
     "can_mult": false,
     "can_max": true,
-    "desc": "Determines Luminosity"
+    "desc": "Grants Lighting"
   },
   {
     "id": "NIGHT_VISION",
@@ -255,7 +255,7 @@
     "can_add": false,
     "can_mult": false,
     "can_max": true,
-    "desc": "Affects Night Vision"
+    "desc": "Grants Night Vision"
   },
   {
     "id": "CLAIRVOYANCE",
@@ -263,7 +263,7 @@
     "can_add": false,
     "can_mult": false,
     "can_max": true,
-    "desc": "Affects Clarivoyance"
+    "desc": "Grants Clarivoyance"
   },
   {
     "id": "ARMOR",

--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -181,7 +181,7 @@
   {
     "id": "CLIMATE_CONTROL",
     "type": "enchantment_value",
-    "suffixes": [ [ "COOLING", "Cools towards ideal temperature" ], [ "HEATING", "Heats towards ideal temperature" ] ],
+    "suffixes": [ [ "COOLING", "Keeps you comfortable against hot temperatures" ], [ "HEATING", "Keeps you comfortable against cold temperatures" ] ],
     "desc": "Moves temperature towards ideal temperature"
   },
   {

--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -182,7 +182,7 @@
     "id": "CLIMATE_CONTROL",
     "type": "enchantment_value",
     "suffixes": [ [ "COOLING", "Keeps you comfortable against hot temperatures" ], [ "HEATING", "Keeps you comfortable against cold temperatures" ] ],
-    "desc": "Moves temperature towards ideal temperature"
+    "desc": "Grants climate control, which keeps you at a comfortable temperature"
   },
   {
     "id": "LIE",

--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -247,7 +247,7 @@
     "can_add": false,
     "can_mult": false,
     "can_max": true,
-    "desc": "Grants Lighting"
+    "desc": "Grants Light Source"
   },
   {
     "id": "NIGHT_VISION",

--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -74,10 +74,7 @@
     "id": "CONSTRUCTION_SPEED",
     "type": "enchantment_value",
     "desc": "Affects Construction Speed ( Construction and Vehicle )",
-    "suffixes": [
-      [ "CON", "Affects Construction Speed ( Construction )" ],
-      [ "VEH", "Affects Construction Speed ( Vehicle )" ]
-    ]
+    "suffixes": [ [ "CON", "Affects Construction Speed ( Construction )" ], [ "VEH", "Affects Construction Speed ( Vehicle )" ] ]
   },
   {
     "id": "METABOLISM",
@@ -184,10 +181,7 @@
   {
     "id": "CLIMATE_CONTROL",
     "type": "enchantment_value",
-    "suffixes": [
-      [ "COOLING", "Cools towards ideal temperature" ],
-      [ "HEATING", "Heats towards ideal temperature" ]
-    ],
+    "suffixes": [ [ "COOLING", "Cools towards ideal temperature" ], [ "HEATING", "Heats towards ideal temperature" ] ],
     "desc": "Moves temperature towards ideal temperature"
   },
   {
@@ -313,8 +307,8 @@
       [ "COLD", "Affects Outgoing Ranged Cold Damage" ],
       [ "ELECTRIC", "Affects Outgoing Ranged Electric Damage" ],
       [ "ACID", "Affects Outgoing Ranged Acid Damage" ],
-      [ "BIOLOGICAL", "Affects Outgoing Ranged Biological Damage"  ],
-      [ "TRUE", "Affects Outgoing Ranged True Damage"  ],
+      [ "BIOLOGICAL", "Affects Outgoing Ranged Biological Damage" ],
+      [ "TRUE", "Affects Outgoing Ranged True Damage" ]
     ],
     "desc": "Affects Outgoing Ranged Damage"
   },
@@ -392,7 +386,7 @@
       [ "CUTTING", "Affects Cutting Skill Level" ],
       [ "DODGE", "Affects Dodging Skill Level" ],
       [ "STABBING", "Affects Stabbing Skill Level" ],
-      [ "UNARMED", "Affects Unarmed Skill Level" ],
+      [ "UNARMED", "Affects Unarmed Skill Level" ]
     ],
     "desc": "Affects All Skill Levels"
   },
@@ -429,7 +423,7 @@
       [ "CUTTING", "Affects Cutting Skill Exp Gain" ],
       [ "DODGE", "Affects Dodging Skill Exp Gain" ],
       [ "STABBING", "Affects Stabbing Skill Exp Gain" ],
-      [ "UNARMED", "Affects Unarmed Skill Exp Gain" ],
+      [ "UNARMED", "Affects Unarmed Skill Exp Gain" ]
     ],
     "desc": "Affects All Exp Gain"
   },

--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -1,241 +1,364 @@
 [
   {
     "id": "STRENGTH",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Strength"
   },
   {
     "id": "DEXTERITY",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Dexterity"
   },
   {
     "id": "PERCEPTION",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Perception"
   },
   {
     "id": "INTELLIGENCE",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Intellegence"
   },
   {
     "id": "HEALTH_POINTS",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects HP"
   },
   {
     "id": "SPEED",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Speed"
   },
   {
     "id": "ATTACK_COST",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Attack Speed",
+    "increase_good": false
   },
   {
     "id": "MOVE_COST",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Movement Speed",
+    "increase_good": false
   },
   {
     "id": "FLAT_MOVE_COST",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Movement Speed on flat ground",
+    "increase_good": false
   },
   {
     "id": "OBSTACLE_MOVE_COST",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Movement Speed on Obstacles",
+    "increase_good": false
   },
   {
     "id": "SWIM_MOVE_COST",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Swimming Movement Speed",
+    "increase_good": false
   },
   {
     "id": "READING_SPEED",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Reading Speed",
+    "increase_good": false
   },
   {
     "id": "CRAFTING_SPEED",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Crafting Speed"
   },
   {
     "id": "CONSTRUCTION_SPEED",
     "type": "enchantment_value",
-    "suffixes": [ "CON", "VEH" ]
+    "desc": "Affects Construction Speed ( Construction and Vehicle )",
+    "suffixes": [
+      [ "CON", "Affects Construction Speed ( Construction )" ],
+      [ "VEH", "Affects Construction Speed ( Vehicle )" ]
+    ]
   },
   {
     "id": "METABOLISM",
     "type": "enchantment_value",
-    "can_add": false
+    "can_add": false,
+    "desc": "Affects Metabolism",
+    "increase_good": false
   },
   {
     "id": "MANA_CAP",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Maximum Mana"
   },
   {
     "id": "MANA_REGEN",
     "type": "enchantment_value",
-    "can_add": false
+    "can_add": false,
+    "desc": "Affects Mana Regen"
   },
   {
     "id": "STAMINA_CAP",
     "type": "enchantment_value",
-    "can_add": false
+    "can_add": false,
+    "desc": "Affects Maximum Stamina"
   },
   {
     "id": "STAMINA_REGEN",
     "type": "enchantment_value",
-    "can_add": false
+    "can_add": false,
+    "desc": "Affects Stamina Regen"
   },
   {
     "id": "THIRST",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Thirst Rates",
+    "increase_good": false
   },
   {
     "id": "FATIGUE",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Fatigue Rates",
+    "increase_good": false
   },
   {
     "id": "MENDING_MULT",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Broken Bone Healing Rates"
   },
   {
     "id": "HEARING",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Hearing Ability"
   },
   {
     "id": "NOISE",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Created Noise",
+    "increase_good": false
   },
   {
     "id": "SCENT",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Created Scent",
+    "increase_good": false
   },
   {
     "id": "STEALTH",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Visibility"
   },
   {
     "id": "BODYTEMP_MIN",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Minimum Survivable Temperatures",
+    "increase_good": false
   },
   {
     "id": "BODYTEMP_MAX",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Maximum Survivable Temperatures"
   },
   {
     "id": "BODYTEMP_SLEEP",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Sleeping Bodytemp"
   },
   {
     "id": "BODYTEMP_SPEED",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Cold Blooded Speed"
   },
   {
     "id": "SLEEP_PAIN_THRESH",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Pain To Wake Up",
+    "increase_good": false
   },
   {
     "id": "SLEEP_DB_RESIST",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Noise To Wake Up",
+    "increase_good": false
   },
   {
     "id": "CLIMATE_CONTROL",
     "type": "enchantment_value",
-    "suffixes": [ "COOLING", "HEATING" ]
+    "suffixes": [
+      [ "COOLING", "Cools towards ideal temperature" ],
+      [ "HEATING", "Heats towards ideal temperature" ]
+    ],
+    "desc": "Moves temperature towards ideal temperature"
   },
   {
     "id": "LIE",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects lying ability"
   },
   {
     "id": "PERSUADE",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects persuasion ability"
   },
   {
     "id": "INTIMIDATE",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects intimidation ability"
   },
   {
     "id": "HEALTHY_MULT",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Health Gain"
   },
   {
     "id": "FALL_DAMAGE_MULT",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Fall Damage",
+    "increase_good": false
   },
   {
     "id": "CARRY_STORAGE",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Carrying Capacity ( Storage )"
   },
   {
     "id": "CARRY_WEIGHT",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Carrying Capacity ( Weight )"
   },
   {
     "id": "OVERMAP_SIGHT",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Long Range Vision"
   },
   {
     "id": "EFFECTIVE_FOCUS",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Focus"
   },
   {
     "id": "BONUS_DODGE",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Dodging Ability"
   },
   {
     "id": "BLISTER_COUNT",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Fire Resistance",
+    "increase_good": false
   },
   {
     "id": "LUMINATION",
     "type": "enchantment_value",
     "can_add": false,
     "can_mult": false,
-    "can_max": true
+    "can_max": true,
+    "desc": "Determines Luminosity"
   },
   {
     "id": "NIGHT_VISION",
     "type": "enchantment_value",
     "can_add": false,
     "can_mult": false,
-    "can_max": true
+    "can_max": true,
+    "desc": "Affects Night Vision"
   },
   {
     "id": "CLAIRVOYANCE",
     "type": "enchantment_value",
     "can_add": false,
     "can_mult": false,
-    "can_max": true
+    "can_max": true,
+    "desc": "Affects Clarivoyance"
   },
   {
     "id": "ARMOR",
     "type": "enchantment_value",
-    "suffixes": [ "BASH", "CUT", "DARK", "LIGHT", "PSI", "STAB", "BULLET", "HEAT", "COLD", "ELECTRIC", "ACID", "BIOLOGICAL", "TRUE" ]
+    "suffixes": [
+      [ "BASH", "Affects Incoming Bash Damage" ],
+      [ "CUT", "Affects Incoming Cut Damage" ],
+      [ "DARK", "Affects Incoming Dark Damage" ],
+      [ "LIGHT", "Affects Incoming Light Damage" ],
+      [ "PSI", "Affects Incoming Psi Damage" ],
+      [ "STAB", "Affects Incoming Stab Damage" ],
+      [ "BULLET", "Affects Incoming Ballistic Damage" ],
+      [ "HEAT", "Affects Incoming Heat Damage" ],
+      [ "COLD", "Affects Incoming Cold Damage" ],
+      [ "ELECTRIC", "Affects Incoming Electric Damage" ],
+      [ "ACID", "Affects Incoming Acidic Damage" ],
+      [ "BIOLOGICAL", "Affects Incoming Biological Damage" ],
+      [ "TRUE", "Affects Incoming True Damage" ]
+    ],
+    "desc": "Affects Against All Damage",
+    "increase_good": false
   },
   {
     "id": "RANGED_DISPERSION",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Ranged Dispersion",
+    "increase_good": false
   },
   {
     "id": "RANGED_DAMAGE",
     "type": "enchantment_value",
-    "suffixes": [ "BASH", "CUT", "DARK", "LIGHT", "PSI", "STAB", "BULLET", "HEAT", "COLD", "ELECTRIC", "ACID", "BIOLOGICAL", "TRUE" ]
+    "suffixes": [
+      [ "BASH", "Affects Outgoing Ranged Bash Damage" ],
+      [ "CUT", "Affects Outgoing Ranged Cut Damage" ],
+      [ "DARK", "Affects Outgoing Ranged Dark Damage" ],
+      [ "LIGHT", "Affects Outgoing Ranged Light Damage" ],
+      [ "PSI", "Affects Outgoing Ranged Psi Damage" ],
+      [ "STAB", "Affects Outgoing Ranged Stab Damage" ],
+      [ "BULLET", "Affects Outgoing Ranged Ballistic Damage" ],
+      [ "HEAT", "Affects Outgoing Ranged Heat Damage" ],
+      [ "COLD", "Affects Outgoing Ranged Cold Damage" ],
+      [ "ELECTRIC", "Affects Outgoing Ranged Electric Damage" ],
+      [ "ACID", "Affects Outgoing Ranged Acid Damage" ],
+      [ "BIOLOGICAL", "Affects Outgoing Ranged Biological Damage"  ],
+      [ "TRUE", "Affects Outgoing Ranged True Damage"  ],
+    ],
+    "desc": "Affects Outgoing Ranged Damage"
   },
   {
     "id": "RANGED_ARMOR_PENETRATION",
     "type": "enchantment_value",
-    "suffixes": [ "BASH", "CUT", "DARK", "LIGHT", "PSI", "STAB", "BULLET", "HEAT", "COLD", "ELECTRIC", "ACID", "BIOLOGICAL", "TRUE" ]
+    "suffixes": [
+      [ "BASH", "Affects Outgoing Ranged Bash Armor Penetration" ],
+      [ "CUT", "Affects Outgoing Ranged Cut Armor Penetration" ],
+      [ "DARK", "Affects Outgoing Ranged Dark Armor Penetration" ],
+      [ "LIGHT", "Affects Outgoing Ranged Light Armor Penetration" ],
+      [ "PSI", "Affects Outgoing Ranged Psi Armor Penetration" ],
+      [ "STAB", "Affects Outgoing Ranged Stab Armor Penetration" ],
+      [ "BULLET", "Affects Outgoing Ranged Bullet Armor Penetration" ],
+      [ "HEAT", "Affects Outgoing Ranged Heat Armor Penetration" ],
+      [ "COLD", "Affects Outgoing Ranged Cold Armor Penetration" ],
+      [ "ELECTRIC", "Affects Outgoing Ranged Electric Armor Penetration" ],
+      [ "ACID", "Affects Outgoing Ranged Acid Armor Penetration" ],
+      [ "BIOLOGICAL", "Affects Outgoing Ranged Biological Armor Penetration" ],
+      [ "TRUE", "Affects Outgoing Ranged True Armor Penetration" ]
+    ],
+    "desc": "Affects Outgoing Ranged Armor Penetration"
   },
   {
     "id": "RANGED_RANGE",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Ranged Attack Range"
   },
   {
     "id": "RANGED_RECOIL",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Recoil",
+    "increase_good": false
   },
   {
     "id": "RANGED_RELOAD_TIME",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Ranged Weapon Reload Time"
   },
   {
     "id": "RANGED_AIM_SPEED",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Ranged Weapon Aim Speed",
+    "increase_good": false
   },
   {
     "id": "SKILL_LEVEL",
@@ -243,34 +366,35 @@
     "can_add": true,
     "can_mult": true,
     "suffixes": [
-      "BARTER",
-      "SPEECH",
-      "COMPUTER",
-      "FIRSTAID",
-      "MECHANICS",
-      "TRAPS",
-      "DRIVING",
-      "SWIMMING",
-      "FABRICATION",
-      "COOKING",
-      "TAILOR",
-      "SURVIVAL",
-      "ELECTRONICS",
-      "ARCHERY",
-      "GUN",
-      "LAUNCHER",
-      "PISTOL",
-      "RIFLE",
-      "SHOTGUN",
-      "SMG",
-      "THROW",
-      "MELEE",
-      "BASHING",
-      "CUTTING",
-      "DODGE",
-      "STABBING",
-      "UNARMED"
-    ]
+      [ "BARTER", "Affects Barter Skill Level" ],
+      [ "SPEECH", "Affects Speech Skill Level" ],
+      [ "COMPUTER", "Affects Computer Skill Level" ],
+      [ "FIRSTAID", "Affects First Aid Skill Level" ],
+      [ "MECHANICS", "Affects Mechanics Skill Level" ],
+      [ "TRAPS", "Affects Traps Skill Level" ],
+      [ "DRIVING", "Affects Driving Skill Level" ],
+      [ "SWIMMING", "Affects Swimming Skill Level" ],
+      [ "FABRICATION", "Affects Fabrication Skill Level" ],
+      [ "COOKING", "Affects Cooking Skill Level" ],
+      [ "TAILOR", "Affects Tailor Skill Level" ],
+      [ "SURVIVAL", "Affects Survival Skill Level" ],
+      [ "ELECTRONICS", "Affects Electronics Skill Level" ],
+      [ "ARCHERY", "Affects Archery Skill Level" ],
+      [ "GUN", "Affects Gun Skill Level" ],
+      [ "LAUNCHER", "Affects Launcher Skill Level" ],
+      [ "PISTOL", "Affects Pistol Skill Level" ],
+      [ "RIFLE", "Affects Rifle Skill Level" ],
+      [ "SHOTGUN", "Affects Shotgun Skill Level" ],
+      [ "SMG", "Affects Sub Machine Gun Skill Level" ],
+      [ "THROW", "Affects Throwing Skill Level" ],
+      [ "MELEE", "Affects Melee Skill Level" ],
+      [ "BASHING", "Affects Bashing Skill Level" ],
+      [ "CUTTING", "Affects Cutting Skill Level" ],
+      [ "DODGE", "Affects Dodging Skill Level" ],
+      [ "STABBING", "Affects Stabbing Skill Level" ],
+      [ "UNARMED", "Affects Unarmed Skill Level" ],
+    ],
+    "desc": "Affects All Skill Levels"
   },
   {
     "id": "SKILL_EXP",
@@ -279,47 +403,80 @@
     "can_add": false,
     "can_mult": true,
     "suffixes": [
-      "BARTER",
-      "SPEECH",
-      "COMPUTER",
-      "FIRSTAID",
-      "MECHANICS",
-      "TRAPS",
-      "DRIVING",
-      "SWIMMING",
-      "FABRICATION",
-      "COOKING",
-      "TAILOR",
-      "SURVIVAL",
-      "ELECTRONICS",
-      "ARCHERY",
-      "GUN",
-      "LAUNCHER",
-      "PISTOL",
-      "RIFLE",
-      "SHOTGUN",
-      "SMG",
-      "THROW",
-      "MELEE",
-      "BASHING",
-      "CUTTING",
-      "DODGE",
-      "STABBING",
-      "UNARMED"
-    ]
+      [ "BARTER", "Affects Barter Skill Exp Gain" ],
+      [ "SPEECH", "Affects Speech Skill Exp Gain" ],
+      [ "COMPUTER", "Affects Computer Skill Exp Gain" ],
+      [ "FIRSTAID", "Affects First Aid Skill Exp Gain" ],
+      [ "MECHANICS", "Affects Mechanics Skill Exp Gain" ],
+      [ "TRAPS", "Affects Traps Skill Exp Gain" ],
+      [ "DRIVING", "Affects Driving Skill Exp Gain" ],
+      [ "SWIMMING", "Affects Swimming Skill Exp Gain" ],
+      [ "FABRICATION", "Affects Fabrication Skill Exp Gain" ],
+      [ "COOKING", "Affects Cooking Skill Exp Gain" ],
+      [ "TAILOR", "Affects Tailor Skill Exp Gain" ],
+      [ "SURVIVAL", "Affects Survival Skill Exp Gain" ],
+      [ "ELECTRONICS", "Affects Electronics Skill Exp Gain" ],
+      [ "ARCHERY", "Affects Archery Skill Exp Gain" ],
+      [ "GUN", "Affects Gun Skill Exp Gain" ],
+      [ "LAUNCHER", "Affects Launcher Skill Exp Gain" ],
+      [ "PISTOL", "Affects Pistol Skill Exp Gain" ],
+      [ "RIFLE", "Affects Rifle Skill Exp Gain" ],
+      [ "SHOTGUN", "Affects Shotgun Skill Exp Gain" ],
+      [ "SMG", "Affects Sub Machine Gun Skill Exp Gain" ],
+      [ "THROW", "Affects Throwing Skill Exp Gain" ],
+      [ "MELEE", "Affects Melee Skill Exp Gain" ],
+      [ "BASHING", "Affects Bashing Skill Exp Gain" ],
+      [ "CUTTING", "Affects Cutting Skill Exp Gain" ],
+      [ "DODGE", "Affects Dodging Skill Exp Gain" ],
+      [ "STABBING", "Affects Stabbing Skill Exp Gain" ],
+      [ "UNARMED", "Affects Unarmed Skill Exp Gain" ],
+    ],
+    "desc": "Affects All Exp Gain"
   },
   {
     "id": "ITEM_DAMAGE",
     "type": "enchantment_value",
-    "suffixes": [ "BASH", "CUT", "DARK", "LIGHT", "PSI", "STAB", "BULLET", "HEAT", "COLD", "ELECTRIC", "ACID", "BIOLOGICAL", "TRUE" ]
+    "suffixes": [
+      [ "BASH", "Affects Outgoing Bash Damage ( This Item Only )" ],
+      [ "CUT", "Affects Outgoing Cut Damage ( This Item Only )" ],
+      [ "DARK", "Affects Outgoing Dark Damage ( This Item Only )" ],
+      [ "LIGHT", "Affects Outgoing Light Damage ( This Item Only )" ],
+      [ "PSI", "Affects Outgoing Psi Damage ( This Item Only )" ],
+      [ "STAB", "Affects Outgoing Stab Damage ( This Item Only )" ],
+      [ "BULLET", "Affects Outgoing Ballistic Damage ( This Item Only )" ],
+      [ "HEAT", "Affects Outgoing Heat Damage ( This Item Only )" ],
+      [ "COLD", "Affects Outgoing Cold Damage ( This Item Only )" ],
+      [ "ELECTRIC", "Affects Outgoing Electric Damage ( This Item Only )" ],
+      [ "ACID", "Affects Outgoing Acidic Damage ( This Item Only )" ],
+      [ "BIOLOGICAL", "Affects Outgoing Biological Damage ( This Item Only )" ],
+      [ "TRUE", "Affects Outgoing True Damage ( This Item Only )" ]
+    ],
+    "desc": "Affects All Outgoing Damage ( This Item Only )"
   },
   {
     "id": "ITEM_ARMOR",
     "type": "enchantment_value",
-    "suffixes": [ "BASH", "CUT", "DARK", "LIGHT", "PSI", "STAB", "BULLET", "HEAT", "COLD", "ELECTRIC", "ACID", "BIOLOGICAL", "TRUE" ]
+    "suffixes": [
+      [ "BASH", "Affects Incoming Bash Damage ( This Item Only )" ],
+      [ "CUT", "Affects Incoming Cut Damage ( This Item Only )" ],
+      [ "DARK", "Affects Incoming Dark Damage ( This Item Only )" ],
+      [ "LIGHT", "Affects Incoming Light Damage ( This Item Only )" ],
+      [ "PSI", "Affects Incoming Psi Damage ( This Item Only )" ],
+      [ "STAB", "Affects Incoming Stab Damage ( This Item Only )" ],
+      [ "BULLET", "Affects Incoming Ballistic Damage ( This Item Only )" ],
+      [ "HEAT", "Affects Incoming Heat Damage ( This Item Only )" ],
+      [ "COLD", "Affects Incoming Cold Damage ( This Item Only )" ],
+      [ "ELECTRIC", "Affects Incoming Electric Damage ( This Item Only )" ],
+      [ "ACID", "Affects Incoming Acidic Damage ( This Item Only )" ],
+      [ "BIOLOGICAL", "Affects Incoming Biological Damage ( This Item Only )" ],
+      [ "TRUE", "Affects Incoming True Damage ( This Item Only )" ]
+    ],
+    "desc": "Affects All Incoming Damage ( This Item Only )",
+    "increase_good": false
   },
   {
     "id": "ITEM_ATTACK_COST",
-    "type": "enchantment_value"
+    "type": "enchantment_value",
+    "desc": "Affects Attack Cost ( This Item Only )"
   }
 ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1157,6 +1157,12 @@
     "info": "This item contains a nanofabricator recipe."
   },
   {
+    "id": "SECRET_ENCHANTMENTS",
+    "type": "json_flag",
+    "context": [ "generic" ],
+    "//": "Hides enchantments from info menu"
+  },
+  {
     "id": "BIONIC_FAULTY",
     "type": "json_flag",
     "context": [ "BIONIC" ],

--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -571,7 +571,7 @@
     "covers": [ "head" ],
     "coverage": 90,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_PSI", "add": -10 } ] } ] },
-    "flags": [ "OVERSIZE", "PSYSHIELD_PARTIAL", "SKINTIGHT", "TRADER_AVOID", "POWERARMOR_COMPATIBLE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "PSYSHIELD_PARTIAL", "SKINTIGHT", "TRADER_AVOID", "POWERARMOR_COMPATIBLE", "ALLOWS_NATURAL_ATTACKS", "SECRET_ENCHANTMENTS" ]
   },
   {
     "id": "tophat",

--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -571,7 +571,15 @@
     "covers": [ "head" ],
     "coverage": 90,
     "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "ARMOR_PSI", "add": -10 } ] } ] },
-    "flags": [ "OVERSIZE", "PSYSHIELD_PARTIAL", "SKINTIGHT", "TRADER_AVOID", "POWERARMOR_COMPATIBLE", "ALLOWS_NATURAL_ATTACKS", "SECRET_ENCHANTMENTS" ]
+    "flags": [
+      "OVERSIZE",
+      "PSYSHIELD_PARTIAL",
+      "SKINTIGHT",
+      "TRADER_AVOID",
+      "POWERARMOR_COMPATIBLE",
+      "ALLOWS_NATURAL_ATTACKS",
+      "SECRET_ENCHANTMENTS"
+    ]
   },
   {
     "id": "tophat",

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -89,7 +89,16 @@
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
     "resistance": { "bullet": 90 },
-    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "COMBAT_NPC_USE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "COMBAT_NPC_USE" ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
+        }
+      ]
+    },
   },
   {
     "id": "power_armor_basic_on",
@@ -102,15 +111,6 @@
     "extend": { "flags": [ "HEAVY_WEAPON_SUPPORT", "TRADER_AVOID", "COMBAT_NPC_ON" ] },
     "power_draw": 1500000,
     "revert_to": "power_armor_basic",
-    "relic_data": {
-      "passive_effects": [
-        {
-          "has": "WORN",
-          "condition": "ACTIVE",
-          "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
-        }
-      ]
-    },
     "use_action": {
       "type": "set_transform",
       "turn_off": true,
@@ -159,7 +159,16 @@
       "set_charges": 2,
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
-    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "COMBAT_NPC_USE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "COMBAT_NPC_USE" ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "values": [ { "value": "STRENGTH", "add": 6 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
+        }
+      ]
+    },
   },
   {
     "id": "power_armor_heavy_on",
@@ -172,15 +181,6 @@
     "extend": { "flags": [ "HEAVY_WEAPON_SUPPORT", "TRADER_AVOID", "COMBAT_NPC_ON" ] },
     "power_draw": 2250000,
     "revert_to": "power_armor_heavy",
-    "relic_data": {
-      "passive_effects": [
-        {
-          "has": "WORN",
-          "condition": "ACTIVE",
-          "values": [ { "value": "STRENGTH", "add": 6 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
-        }
-      ]
-    },
     "use_action": {
       "type": "set_transform",
       "turn_off": true,
@@ -229,7 +229,16 @@
       "set_charges_msg": "You need a UPS or a bionic armor interface to power this."
     },
     "resistance": { "bullet": 70 },
-    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "COMBAT_NPC_USE" ]
+    "flags": [ "USE_UPS", "NAT_UPS", "POWERARMOR_EXO", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "COMBAT_NPC_USE" ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
+        }
+      ]
+    },
   },
   {
     "id": "power_armor_light_on",
@@ -242,15 +251,6 @@
     "extend": { "flags": [ "HEAVY_WEAPON_SUPPORT", "TRADER_AVOID", "COMBAT_NPC_ON" ] },
     "power_draw": 750000,
     "revert_to": "power_armor_light",
-    "relic_data": {
-      "passive_effects": [
-        {
-          "has": "WORN",
-          "condition": "ACTIVE",
-          "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
-        }
-      ]
-    },
     "use_action": {
       "type": "set_transform",
       "turn_off": true,

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -98,7 +98,7 @@
           "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
         }
       ]
-    },
+    }
   },
   {
     "id": "power_armor_basic_on",
@@ -168,7 +168,7 @@
           "values": [ { "value": "STRENGTH", "add": 6 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
         }
       ]
-    },
+    }
   },
   {
     "id": "power_armor_heavy_on",
@@ -238,7 +238,7 @@
           "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "CLIMATE_CONTROL", "add": 2000 } ]
         }
       ]
-    },
+    }
   },
   {
     "id": "power_armor_light_on",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -631,6 +631,9 @@
     "description": "This a bodysuit with a number of heatsinks and heating coils tied to a liquid coolant system, and a built-in thermometer.  Use it to turn it on, helping to keep the entire body at an ideal temperature",
     "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID", "ONLY_ONE", "THERMOMETER" ],
     "weight": "1652 g",
+    "relic_data": {
+      "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "CLIMATE_CONTROL", "add": 1250 } ] } ]
+    },
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
@@ -647,9 +650,6 @@
     "copy-from": "thermal_cooling_suit",
     "name": { "str": "liquid cooling suit (on)", "str_pl": "liquid cooling suits (on)" },
     "description": "This a bodysuit with a number of heatsinks and heating coils tied to a liquid coolant system, and a built-in thermometer.  It is currently working to keep the entire body at an ideal temperature, use it to turn it off.",
-    "relic_data": {
-      "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "CLIMATE_CONTROL", "add": 1250 } ] } ]
-    },
     "power_draw": 125000,
     "revert_to": "thermal_cooling_suit",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "thermal_cooling_suit" }
@@ -932,7 +932,20 @@
     "coverage": 100,
     "material_thickness": 4,
     "resistance": { "bullet": 50 },
-    "hearing_protection": 12
+    "hearing_protection": 12,
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ACTIVE",
+          "values": [
+            { "value": "STRENGTH", "add": 2 },
+            { "value": "CLIMATE_CONTROL", "add": 1250 },
+            { "value": "BLISTER_COUNT", "add": -20 }
+          ]
+        }
+      ]
+    }
   },
   {
     "id": "rm13_armor_on",
@@ -961,19 +974,6 @@
     ],
     "turns_per_charge": 18,
     "revert_to": "rm13_armor",
-    "relic_data": {
-      "passive_effects": [
-        {
-          "has": "WORN",
-          "condition": "ACTIVE",
-          "values": [
-            { "value": "STRENGTH", "add": 2 },
-            { "value": "CLIMATE_CONTROL", "add": 1250 },
-            { "value": "BLISTER_COUNT", "add": -20 }
-          ]
-        }
-      ]
-    },
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your RM13 combat armor turns off.", "target": "rm13_armor" },
     "environmental_protection": 40,
     "encumbrance": 10,
@@ -1082,7 +1082,16 @@
       "SWIM_GOGGLES",
       "SUN_GLASSES",
       "COMBAT_NPC_USE"
-    ]
+    ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "WORN",
+          "condition": "ALWAYS",
+          "values": [ { "value": "ARMOR_PSI", "add": -25 }, { "value": "CLIMATE_CONTROL", "add": 1250 } ]
+        }
+      ]
+    },
   },
   {
     "id": "phase_immersion_suit_on",
@@ -1098,15 +1107,6 @@
     "qualities": [ [ "HV_INSULATION", 1 ] ],
     "covers": [ "head", "mouth", "eyes", "torso", "arms", "hands", "legs", "feet" ],
     "environmental_protection": 80,
-    "relic_data": {
-      "passive_effects": [
-        {
-          "has": "WORN",
-          "condition": "ALWAYS",
-          "values": [ { "value": "ARMOR_PSI", "add": -25 }, { "value": "CLIMATE_CONTROL", "add": 1250 } ]
-        }
-      ]
-    },
     "flags": [
       "RAD_PROOF",
       "STURDY",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1091,7 +1091,7 @@
           "values": [ { "value": "ARMOR_PSI", "add": -25 }, { "value": "CLIMATE_CONTROL", "add": 1250 } ]
         }
       ]
-    },
+    }
   },
   {
     "id": "phase_immersion_suit_on",

--- a/docs/en/mod/json/reference/enchantments.md
+++ b/docs/en/mod/json/reference/enchantments.md
@@ -645,4 +645,3 @@ value, in addition to the global `ITEM_ARMOR`:
 - `ITEM_ARMOR_HEAT`
 - `ITEM_ARMOR_STAB`
 - `ITEM_ARMOR_TRUE`
-

--- a/docs/en/mod/json/reference/enchantments.md
+++ b/docs/en/mod/json/reference/enchantments.md
@@ -237,6 +237,7 @@ For all basegame values see [here](#Basegame-Enchantment-Value-ID-List)
     "can_mult": true, // Weather multiplying to the enchantment value will do anything; Default true
     "can_max": false, // Weather getting the maximum value of this type will do anything; Default false
     "desc": "Affects Outgoing Ranged Damage", // Description of the enchantment used in some menus
+    "increase_good": true, // Color for enchantment descriptions, if true > 0 or > 1 == green else == red
     "suffixes": [ // All the suffixes. These appear as `RANGED_DAMAGE_XXX` in this case
       [ "BASH", "Affects Outgoing Ranged Bash Damage" ], // Suffixes reference the value of the parent in calculations automatically
       [ "CUT", "Affects Outgoing Ranged Cut Damage" ], // The second value here is the description of the enchantment

--- a/docs/en/mod/json/reference/enchantments.md
+++ b/docs/en/mod/json/reference/enchantments.md
@@ -182,9 +182,81 @@ being applied to the base value.
 Since there's no limit on number of enchantments the character can have at a time, the final
 calculated values have hardcoded bounds to prevent unintended behavior.
 
-#### IDs of modifiable values
+For all basegame values see [here](#Basegame-Enchantment-Value-ID-List)
 
-Note: mods can add more values to this list
+## Examples
+
+```json
+[
+  {
+    "//": "On-hit effect for ink glands mutation, implemented via enchantment.",
+    "type": "enchantment",
+    "id": "MEP_INK_GLAND_SPRAY",
+    "hit_me_effect": [
+      {
+        "id": "generic_blinding_spray_1",
+        "hit_self": false,
+        "once_in": 15,
+        "message": "Your ink glands spray some ink into %2$s's eyes.",
+        "npc_message": "%1$s's ink glands spay some ink into %2$s's eyes."
+      }
+    ]
+  },
+  {
+    "//": "This one would look good on a katana for an anime mod.",
+    "type": "enchantment",
+    "id": "ENCH_ULTIMATE_ASSKICK",
+    "has": "WIELD",
+    "condition": "ALWAYS",
+    "ench_effects": [{ "effect": "invisibility", "intensity": 1 }],
+    "hit_you_effect": [{ "id": "AEA_FIREBALL" }],
+    "hit_me_effect": [{ "id": "AEA_HEAL" }],
+    "mutations": ["KILLER", "PARKOUR"],
+    "values": [{ "value": "STRENGTH", "multiply": 1.1, "add": -5 }],
+    "intermittent_activation": {
+      "effects": [
+        {
+          "frequency": "1 hour",
+          "spell_effects": [
+            { "id": "AEA_ADRENALINE" }
+          ]
+        }
+      ]
+    }
+  }
+]
+```
+
+# Enchantment Values
+
+```jsonc
+  {
+    "id": "RANGED_DAMAGE", // Id of enchantment
+    "type": "enchantment_value", // Needed type
+    "can_add": true, // Weather adding to the enchantment value will do anything; Default true
+    "can_mult": true, // Weather multiplying to the enchantment value will do anything; Default true
+    "can_max": false, // Weather getting the maximum value of this type will do anything; Default false
+    "desc": "Affects Outgoing Ranged Damage", // Description of the enchantment used in some menus
+    "suffixes": [ // All the suffixes. These appear as `RANGED_DAMAGE_XXX` in this case
+      [ "BASH", "Affects Outgoing Ranged Bash Damage" ], // Suffixes reference the value of the parent in calculations automatically
+      [ "CUT", "Affects Outgoing Ranged Cut Damage" ], // The second value here is the description of the enchantment
+      [ "DARK", "Affects Outgoing Ranged Dark Damage" ],
+      [ "LIGHT", "Affects Outgoing Ranged Light Damage" ],
+      [ "PSI", "Affects Outgoing Ranged Psi Damage" ],
+      [ "STAB", "Affects Outgoing Ranged Stab Damage" ],
+      [ "BULLET", "Affects Outgoing Ranged Ballistic Damage" ],
+      [ "HEAT", "Affects Outgoing Ranged Heat Damage" ],
+      [ "COLD", "Affects Outgoing Ranged Cold Damage" ],
+      [ "ELECTRIC", "Affects Outgoing Ranged Electric Damage" ],
+      [ "ACID", "Affects Outgoing Ranged Acid Damage" ],
+      [ "BIOLOGICAL", "Affects Outgoing Ranged Biological Damage"  ],
+      [ "TRUE", "Affects Outgoing Ranged True Damage"  ],
+    ],
+  }
+}
+```
+
+## Basegame Enchantment Value ID List
 
 #### Character values
 
@@ -573,71 +645,3 @@ value, in addition to the global `ITEM_ARMOR`:
 - `ITEM_ARMOR_STAB`
 - `ITEM_ARMOR_TRUE`
 
-## Examples
-
-```json
-[
-  {
-    "//": "On-hit effect for ink glands mutation, implemented via enchantment.",
-    "type": "enchantment",
-    "id": "MEP_INK_GLAND_SPRAY",
-    "hit_me_effect": [
-      {
-        "id": "generic_blinding_spray_1",
-        "hit_self": false,
-        "once_in": 15,
-        "message": "Your ink glands spray some ink into %2$s's eyes.",
-        "npc_message": "%1$s's ink glands spay some ink into %2$s's eyes."
-      }
-    ]
-  },
-  {
-    "//": "This one would look good on a katana for an anime mod.",
-    "type": "enchantment",
-    "id": "ENCH_ULTIMATE_ASSKICK",
-    "has": "WIELD",
-    "condition": "ALWAYS",
-    "ench_effects": [{ "effect": "invisibility", "intensity": 1 }],
-    "hit_you_effect": [{ "id": "AEA_FIREBALL" }],
-    "hit_me_effect": [{ "id": "AEA_HEAL" }],
-    "mutations": ["KILLER", "PARKOUR"],
-    "values": [{ "value": "STRENGTH", "multiply": 1.1, "add": -5 }],
-    "intermittent_activation": {
-      "effects": [
-        {
-          "frequency": "1 hour",
-          "spell_effects": [
-            { "id": "AEA_ADRENALINE" }
-          ]
-        }
-      ]
-    }
-  }
-]
-```
-
-# Enchantment Values
-
-```jsonc
-{
-  "id": "RANGED_DAMAGE", // Id of the enchantment
-  "type": "enchantment_value", // Needed Type
-  "can_add": true, // Weather adding to the enchantment value will do anything; Default true
-  "can_mult": true, // Weather multiplying to the enchantment value will do anything; Default true
-  "can_max": false, // Weather getting the maximum value of this type will do anything; Default false
-  "suffixes": [ // All the suffixes. These appear as in this case RANGED_DAMAGE_XXX
-    "BASH",     // In addition suffixes will also reference the parent type when in use
-    "CUT",
-    "DARK",
-    "LIGHT",
-    "PSI",
-    "STAB",
-    "BULLET",
-    "HEAT",
-    "COLD",
-    "ELECTRIC",
-    "ACID",
-    "BIOLOGICAL"
-  ]
-},
-```

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -740,6 +740,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `SLEEP_IGNORE` ... This item is not shown as before-sleep warning.
 - `SLOW_WIELD` ... Has an additional time penalty upon wielding. For melee weapons and guns this is
   offset by the relevant skill. Stacks with "NEEDS_UNFOLD".
+- `SECRET_ENCHANTMENTS` ... Enchantments on this item aren't shown in item info.
 - `TACK` ... Item can be used as tack for a mount.
 - `TIE_UP` ... Item can be used to tie up a creature.
 - `TINDER` ... This item can be used as tinder for lighting a fire with a REQUIRES_TINDER flagged

--- a/src/enchantments/enchantment.cpp
+++ b/src/enchantments/enchantment.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <memory>
 #include <set>
+#include <vector>
 
 template <typename E> struct enum_traits;
 
@@ -89,6 +90,67 @@ generic_factory<enchantment> enchant_factory("enchantment");
 } // namespace
 
 IMPLEMENT_STRING_AND_INT_IDS(enchantment, enchant_factory);
+
+std::vector<std::string> enchantment::get_effect_string(bool is_item) const {
+    std::string cond_string;
+    if (is_item) {
+        if (active_conditions.first == has::WIELD) {}
+        const auto itemCond = active_conditions.first;
+        cond_string =
+            itemCond == has::WIELD  ? _("While wielded and ")
+            : itemCond == has::WORN ? _("While worn and ")
+            : itemCond == has::HELD
+                ? _("While held and ")
+                : "You shouldn't see this";
+    }
+    const auto genCond = active_conditions.second;
+    cond_string +=
+        genCond == condition::ALWAYS        ? _("At all times:")
+        : genCond == condition::ACTIVE      ? _("While active:")
+        : genCond == condition::INACTIVE    ? _("While inactive:")
+        : genCond == condition::UNDERGROUND ? _("While underground:")
+        : genCond == condition::ABOVEGROUND ? _("While aboveground:")
+        : genCond == condition::UNDERWATER  ? _("While underwater:")
+        : genCond == condition::NIGHT       ? _("During the night:")
+        : genCond == condition::DAY         ? _("During the day:")
+        : genCond == condition::DUSK        ? _("At dusk:")
+        : genCond == condition::DAWN
+            ? _("At dawn:")
+            : "You shouldn't see this";
+
+    std::map<enchantment_value_id, int> value_effects;
+    for (const auto [ench_id, effect] : values_add) {
+        if (effect > 0) {
+            value_effects[ench_id] += (ench_id->increase_good) ? 1 : -1;
+        } else if (effect < 0) {
+            value_effects[ench_id] += (ench_id->increase_good) ? -1 : 1;
+        }
+    }
+    for (const auto [ench_id, effect] : values_multiply) {
+        if (effect > 1) {
+            value_effects[ench_id] += (ench_id->increase_good) ? 1 : -1;
+        } else if (effect < 1) {
+            value_effects[ench_id] += (ench_id->increase_good) ? -1 : 1;
+        }
+    }
+    for (const auto [ench_id, effect] : values_max) {
+        // Value max fundamentally cant be bad
+        value_effects[ench_id] += 1;
+    }
+    std::vector<std::string> result;
+    if (value_effects.empty()) { return result; }
+    result.push_back(cond_string);
+    for (const auto [ench_id, goodbad] : value_effects) {
+        if (goodbad > 0) {
+            result.push_back(string_format("  <color_green>%s</color>", ench_id->desc));
+        } else if (goodbad < 0) {
+            result.push_back(string_format("  <color_red>%s</color>", ench_id->desc));
+        } else {
+            result.push_back(string_format("  <color_magenta>%s</color>", ench_id->desc));
+        }
+    }
+    return result;
+}
 
 void enchantment::load_enchantment(const JsonObject& jo, const std::string& src) {
     enchant_factory.load(jo, src);

--- a/src/enchantments/enchantment.h
+++ b/src/enchantments/enchantment.h
@@ -102,6 +102,8 @@ public:
     static void finalize_all();
     void finalize();
 
+    std::vector<std::string> get_effect_string(bool is_item) const;
+
 private:
     std::set<trait_id> mutations;
     std::optional<emit_id> emitter;

--- a/src/enchantments/enchantment_value.cpp
+++ b/src/enchantments/enchantment_value.cpp
@@ -21,11 +21,15 @@ void enchantment_value::load(const JsonObject& jo, const std::string& src) {
     optional(jo, was_loaded, "can_add", can_add, true);
     optional(jo, was_loaded, "can_mult", can_mult, true);
     optional(jo, was_loaded, "can_max", can_max, false);
+    optional(jo, was_loaded, "increase_good", increase_good, true);
+    mandatory(jo, was_loaded, "desc", desc);
     if (jo.has_array("suffixes")) {
-        for (std::string& suffix : jo.get_string_array("suffixes")) {
+        for (JsonValue val : jo.get_array("suffixes")) {
+            JsonArray suffix = val.get_array();
             enchantment_value suffixed = enchantment_value(*this);
-            suffixed.id = enchantment_value_id(suffixed.id.str() + "_" + suffix);
+            suffixed.id = enchantment_value_id(suffixed.id.str() + "_" + suffix.next_string());
             suffixed.parent_id = id;
+            suffixed.desc = suffix.next_string();
             all_enchantment_values.insert(suffixed);
         }
     }

--- a/src/enchantments/enchantment_value.h
+++ b/src/enchantments/enchantment_value.h
@@ -41,6 +41,9 @@ public:
     bool can_mult = true;
     bool can_max = false;
 
+    std::string desc = "How did you get here?";
+    bool increase_good = true;
+
     bool has_parent() const;
     enchantment_value_id get_parent() const;
 

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -305,6 +305,7 @@ const flag_id flag_ROLLER_ONE( "ROLLER_ONE" );
 const flag_id flag_ROLLER_QUAD( "ROLLER_QUAD" );
 const flag_id flag_SAFECRACK( "SAFECRACK" );
 const flag_id flag_SEMITANGIBLE( "SEMITANGIBLE" );
+const flag_id flag_SECRET_ENCHANTMENTS( "SECRET_ENCHANTMENTS" );
 const flag_id flag_SHATTERS( "SHATTERS" );
 const flag_id flag_SHOCKING( "SHOCKING" );
 const flag_id flag_ACIDIC( "ACIDIC" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -306,6 +306,7 @@ extern const flag_id flag_ROLLER_ONE;
 extern const flag_id flag_ROLLER_QUAD;
 extern const flag_id flag_SAFECRACK;
 extern const flag_id flag_SEMITANGIBLE;
+extern const flag_id flag_SECRET_ENCHANTMENTS;
 extern const flag_id flag_SHATTERS;
 extern const flag_id flag_SHOCKING;
 extern const flag_id flag_ACIDIC;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4506,6 +4506,22 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
     }
 }
 
+void item::enchantment_info( std::vector<iteminfo> &info, const iteminfo_query &parts_ref,
+                             int batch,
+                             bool debug ) const
+{
+    const std::vector<enchantment> &enchs = get_enchantments();
+    if( is_null() || enchs.empty() || has_flag( flag_SECRET_ENCHANTMENTS ) ) {
+        return;
+    }
+    insert_separation_line( info );
+    for( const enchantment &ench : get_enchantments() ) {
+        for( std::string str : ench.get_effect_string( true ) ) {
+            info.emplace_back( "DESCRIPTION", str );
+        }
+    }
+    insert_separation_line( info );
+}
 std::vector<iteminfo> item::info() const
 {
     return info( iteminfo_query::no_conditions, 1, temperature_flag::TEMP_NORMAL );
@@ -4592,6 +4608,8 @@ std::vector<iteminfo> item::info( const iteminfo_query &parts_ref, int batch,
 
     repair_info( info, parts, batch, debug );
     disassembly_info( info, parts, batch, debug );
+
+    enchantment_info( info, parts_ref, batch, debug );
 
     final_info( info, parts_ref, batch, debug );
 

--- a/src/item.h
+++ b/src/item.h
@@ -590,6 +590,8 @@ class item : public location_visitable<item>, public game_object<item>
                             bool debug ) const;
         void final_info( std::vector<iteminfo> &info, const iteminfo_query &parts, int batch,
                          bool debug ) const;
+        void enchantment_info( std::vector<iteminfo> &info, const iteminfo_query &parts, int batch,
+                               bool debug ) const;
 
         /**
          * Calculate all burning calculations, but don't actually apply them to item.


### PR DESCRIPTION
## Purpose of change (The Why)
Closes #9699
Let people see what their items do in enchantment land

## Describe the solution (The How)
Add `desc` field to all enchantment values, this is their description
Add `SECRET_ENCHANTMENT` flag, this is currently used by the Tinfoil Hat as I assume we didn't want people to know about it's silly effects
Move power armor and such relic data that is enabled on `ACTIVE` to the base version so it actually displays before starting it
Add a new set of item info `enchantment_info` with all enchantment information

## Describe alternatives you've considered
Adding 5000 more json lines for good bad and neutral effects

## Testing
SECRET_ENCHANTMENT works ( see tinfoil hat )
Ignoring non-value enchantments work ( see triffid dagger )
Negative works ( demo is rm13 armor's BLISTER_COUNT )
Child enchantments descriptions work, ( see "Debugging Hammer" for example )

## Additional context
The magenta color is a required part of the PR.

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.<!-- BEGIN docs comment -->

## Translations

| post                               | changed | stale  | missing |
| ---------------------------------- | ------- | ------ | ------- |
| mod/json/reference/enchantments.md | en      |        | ja, ko  |
| mod/json/reference/json_flags.md   | en      | ja, ko |         |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7f1be14](https://github.com/cataclysmbn/Cataclysm-BN/commit/7f1be1499829b8549e6648d1ac8f194d0c2afa07) (style(autofix.ci): automated formatting) on 2026-07-06 06:21:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28760059526/artifacts/8097810861)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28760059526/artifacts/8097987465)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28760059526/artifacts/8097712815)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28760059526/artifacts/8097582127)
<!-- END artifact comment -->