### PR TITLE
feat: Re-implement Internal Storage CBM

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1434,6 +1434,15 @@
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
   },
   {
+    "id": "bio_storage",
+    "type": "bionic",
+    "name": { "str": "Internal Storage" },
+    "description": "Space inside your chest cavity has been surgically converted into a storage area.  You may carry an extra 2 liters of volume.",
+    "occupied_bodyparts": [ [ "torso", 8 ] ],
+    "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],
+    "bio_enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "CARRY_STORAGE", "add": 2000 } ] } ]
+  },
+  {
     "id": "bio_shock_absorber",
     "type": "bionic",
     "name": { "str": "Kinetic Shock Absorbers" },

--- a/data/json/itemgroups/bionics.json
+++ b/data/json/itemgroups/bionics.json
@@ -90,6 +90,7 @@
       [ "bio_cable_upgrade", 2 ],
       [ "bio_syringe", 10 ],
       [ "bio_weight", 10 ],
+      [ "bio_storage", 10 ],
       [ "bio_shock_absorber", 10 ],
       [ "bio_jointservo", 10 ],
       [ "bio_underwater_propellers", 10 ],
@@ -154,7 +155,8 @@
       [ "bio_sunglasses", 10 ],
       [ "bio_tools", 10 ],
       [ "bio_torsionratchet", 15 ],
-      [ "bio_weight", 5 ]
+      [ "bio_weight", 5 ],
+      [ "bio_storage", 5 ]
     ]
   },
   {
@@ -220,6 +222,7 @@
       [ "bio_cable", 10 ],
       [ "bio_cable_mkII", 3 ],
       [ "bio_weight", 10 ],
+      [ "bio_storage", 10 ],
       [ "bio_jointservo", 10 ],
       [ "bio_underwater_propellers", 5 ],
       [ "bio_shotgun", 10 ],
@@ -394,6 +397,7 @@
       [ "bio_speed", 10 ],
       [ "bio_ups", 10 ],
       [ "bio_weight", 10 ],
+      [ "bio_storage", 10 ],
       [ "bio_atomic_battery", 5 ],
       [ "bio_atomic_battery_upgrade", 5 ],
       [ "bio_reactor", 5 ],
@@ -485,6 +489,7 @@
       [ "bio_adrenaline", 20 ],
       [ "bio_ods", 10 ],
       [ "bio_weight", 15 ],
+      [ "bio_storage", 10 ],
       [ "afs_bio_missiles", 10 ],
       [ "afs_bio_dopamine_stimulators", 15 ],
       [ "bio_cable_mkII", 10 ],
@@ -537,6 +542,7 @@
       [ "bio_targeting", 10 ],
       [ "bio_adrenaline", 10 ],
       [ "bio_weight", 10 ],
+      [ "bio_storage", 10 ],
       [ "bio_eye_enhancer", 10 ],
       [ "bio_int_enhancer", 10 ],
       [ "bio_eye_optic", 10 ],

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -1134,6 +1134,16 @@
     "installation_data": "AID_bio_weight"
   },
   {
+    "id": "bio_storage",
+    "copy-from": "bionic_general_npc_usable",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Internal Storage CBM" },
+    "looks_like": "bio_int_enhancer",
+    "description": "Space inside your chest cavity has been converted into a storage area.  You may carry an extra 2 liters of volume.",
+    "price": "4 kUSD",
+    "difficulty": 7
+  },
+  {
     "id": "bio_shock_absorber",
     "copy-from": "bionic_general",
     "type": "BIONIC_ITEM",

--- a/data/json/obsoletion/items.json
+++ b/data/json/obsoletion/items.json
@@ -210,15 +210,6 @@
     "difficulty": 4
   },
   {
-    "id": "bio_storage",
-    "copy-from": "bionic_general_npc_usable",
-    "type": "BIONIC_ITEM",
-    "name": { "str": "Internal Storage CBM" },
-    "description": "Space inside your chest cavity has been converted into a storage area.  You may carry an extra 2 liters of volume.",
-    "price": "4 kUSD",
-    "difficulty": 7
-  },
-  {
     "id": "v29_cheap",
     "copy-from": "v29",
     "type": "GUN",

--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -8,14 +8,6 @@
     "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ]
   },
   {
-    "id": "bio_storage",
-    "type": "bionic",
-    "name": { "str": "Internal Storage" },
-    "description": "Space inside your chest cavity has been surgically converted into a storage area.  You may carry an extra 2 liters of volume.",
-    "occupied_bodyparts": [ [ "torso", 32 ] ],
-    "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
-  },
-  {
     "type": "effect_type",
     "id": "magnesium",
     "name": [ "Magnesium Supplements" ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1130,6 +1130,7 @@
       "bio_metabolics",
       "bio_power_storage_mkII",
       "bio_tools",
+      "bio_storage",
       "bio_flashlight",
       "bio_lighter",
       "bio_evap",
@@ -3925,7 +3926,7 @@
     "name": "Bionic Thief",
     "description": "You have done many high profile heists, but your gains mean nothing in this world.  All you have left are the tools of your trade and your impeccable style.",
     "points": 4,
-    "CBMs": [ "bio_batteries", "bio_lockpick", "bio_fingerhack", "bio_power_storage_mkII" ],
+    "CBMs": [ "bio_batteries", "bio_storage", "bio_lockpick", "bio_fingerhack", "bio_power_storage_mkII" ],
     "skills": [ { "level": 1, "name": "gun" }, { "level": 1, "name": "smg" } ],
     "items": {
       "both": {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -285,7 +285,6 @@ static const bionic_id bio_ods( "bio_ods" );
 static const bionic_id bio_railgun( "bio_railgun" );
 static const bionic_id bio_recycler( "bio_recycler" );
 static const bionic_id bio_shock_absorber( "bio_shock_absorber" );
-static const bionic_id bio_storage( "bio_storage" );
 static const bionic_id bio_synaptic_regen( "bio_synaptic_regen" );
 static const bionic_id bio_tattoo_led( "bio_tattoo_led" );
 static const bionic_id bio_tools( "bio_tools" );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

I liked the internal storage and I want to bring it back.

## Describe the solution (The How)

I re-added the bionic using `bio_enchantments`, so it actually doesn't need any code support.

I also lowered its slot cost from 32 to 8. I am going to justify it as follows:

* Its effect is not particularly impressive. 2L isn't a lot of storage. It's nice that it's encumbrance-free but it basically comes down to roughly -2 torso encumbrance if using regular storage items.
* 32 is absolutely absurd and would make it the biggest torso bionic in the game. And torso is a body part with a lot of contenders. Combined with the above, it would be completely useless (if you're using slots). A plutonium mini reactor, for comparison, is **10**.
* If we're talking about what's plausible, then this bionic shouldn't exist in the first place. But then neither should a bunch of others, so I assume we're fine with that.
* Thus, I landed on 8 as a number that is somewhere between plausibility and usefulness.

I added it to roughly the same item groups as skeletal bracing. I also added it to Bionic Thief and Bionic Prepper professions. I don't think it changes the balance enough to change their point cost, I just think it makes sense for them.

## Describe alternatives you've considered

## Testing

Debug-installed the bionic and saw that I have 2L of storage. Debug-removed it and saw that it disappeared. Checked that it shows up in the new professions. Started as a bionic thief to check that storage appears properly.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [68c38aa](https://github.com/cataclysmbn/Cataclysm-BN/commit/68c38aad608c1d57388c87154883f216f912c7c8) (Re-implement Internal Storage CBM) on 2026-07-06 00:58:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28759970522/artifacts/8097313736)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28759970522/artifacts/8097587388)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28759970522/artifacts/8097402467)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28759970522/artifacts/8097362007)
<!-- END artifact comment -->