### PR TITLE
feat(UI): Make qualities comparable

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3556,13 +3556,13 @@ void item::qualities_info( std::vector<iteminfo> &info, const iteminfo_query *pa
     auto name_quality = [&info]( const std::pair<quality_id, int> &q ) {
         std::string str;
         if( q.first == qual_JACK || q.first == qual_LIFT ) {
-            str = string_format( _( "Has level <info><num> %1$s</info> quality and "
-                                    "is rated at <info>%2$d</info> %3$s" ),
+            str = string_format( _( "Has level <num> <info>%1$s</info> quality and "
+                                    "is rated at <info>%2$d</info> %3$s." ),
                                  q.first.obj().name,
                                  static_cast<int>( convert_weight( q.second * TOOL_LIFT_FACTOR ) ),
                                  weight_units() );
         } else {
-            str = string_format( _( "Has level <info><num> %1$s</info> quality." ),
+            str = string_format( _( "Has level <num> <info>%1$s</info> quality." ),
                                  q.first.obj().name );
         }
         info.emplace_back( "QUALITIES", string_format( "%s", q.first.obj().name ), str,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3556,16 +3556,17 @@ void item::qualities_info( std::vector<iteminfo> &info, const iteminfo_query *pa
     auto name_quality = [&info]( const std::pair<quality_id, int> &q ) {
         std::string str;
         if( q.first == qual_JACK || q.first == qual_LIFT ) {
-            str = string_format( _( "Has level <info>%1$d %2$s</info> quality and "
-                                    "is rated at <info>%3$d</info> %4$s" ),
-                                 q.second, q.first.obj().name,
+            str = string_format( _( "Has level <info><num> %1$s</info> quality and "
+                                    "is rated at <info>%2$d</info> %3$s" ),
+                                 q.first.obj().name,
                                  static_cast<int>( convert_weight( q.second * TOOL_LIFT_FACTOR ) ),
                                  weight_units() );
         } else {
-            str = string_format( _( "Has level <info>%1$d %2$s</info> quality." ),
-                                 q.second, q.first.obj().name );
+            str = string_format( _( "Has level <info><num> %1$s</info> quality." ),
+                                 q.first.obj().name );
         }
-        info.emplace_back( "QUALITIES", "", str );
+        info.emplace_back( "QUALITIES", string_format( "%s", q.first.obj().name ), str,
+                           iteminfo::flags::no_name, q.second );
     };
 
     if( parts->test( iteminfo_parts::QUALITIES ) ) {

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -904,9 +904,9 @@ TEST_CASE("list of item qualities", "[item][iteminfo][quality]") {
         test_info_equals(
             "test_halligan", q,
             "--\n"
-            "Has level <color_c_cyan>1 digging</color> quality.\n"
-            "Has level <color_c_cyan>2 hammering</color> quality.\n"
-            "Has level <color_c_cyan>4 prying</color> quality.\n");
+            "Has level <color_c_yellow>1</color> <color_c_cyan>digging</color> quality.\n"
+            "Has level <color_c_yellow>2</color> <color_c_cyan>hammering</color> quality.\n"
+            "Has level <color_c_yellow>4</color> <color_c_cyan>prying</color> quality.\n");
     }
 
     SECTION("bottle jack") {
@@ -914,19 +914,19 @@ TEST_CASE("list of item qualities", "[item][iteminfo][quality]") {
         test_info_equals(
             "test_jack_small", q,
             "--\n"
-            "Has level <color_c_cyan>4 jacking</color> quality and is rated at "
-            "<color_c_cyan>4409</color> lbs\n");
+            "Has level <color_c_yellow>4</color> <color_c_cyan>jacking</color> quality and is rated at "
+            "<color_c_cyan>4409</color> lbs.\n");
     }
 
     SECTION("sonic screwdriver") {
         test_info_equals(
             "test_sonic_screwdriver", q,
             "--\n"
-            "Has level <color_c_cyan>30 lockpicking</color> quality.\n"
-            "Has level <color_c_cyan>2 prying</color> quality.\n"
-            "Has level <color_c_cyan>2 screw driving</color> quality.\n"
-            "Has level <color_c_cyan>1 fine screw driving</color> quality.\n"
-            "Has level <color_c_cyan>1 bolt turning</color> quality.\n");
+            "Has level <color_c_yellow>30</color> <color_c_cyan>lockpicking</color> quality.\n"
+            "Has level <color_c_yellow>2</color> <color_c_cyan>prying</color> quality.\n"
+            "Has level <color_c_yellow>2</color> <color_c_cyan>screw driving</color> quality.\n"
+            "Has level <color_c_yellow>1</color> <color_c_cyan>fine screw driving</color> quality.\n"
+            "Has level <color_c_yellow>1</color> <color_c_cyan>bolt turning</color> quality.\n");
     }
 }
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Makes it easier to compare long quality lists at a glance.

## Describe the solution (The How)

See screenshots.

## Testing

Compared some items to obtain the screenshots.

## Additional context

Toolbox in the regular view. Those numbers are now yellow.
<img width="376" height="310" alt="image" src="https://github.com/user-attachments/assets/ccc98bcb-c456-43a2-83b1-916cc101132b" />

Comparing jacks:
<img width="423" height="102" alt="image" src="https://github.com/user-attachments/assets/50a6369c-64e1-47d5-9b72-d7d0eadbbb75" />

Comparing a butchering kit to a survivor belt with a bunch of items:
<img width="322" height="199" alt="image" src="https://github.com/user-attachments/assets/3bbfd8b1-61aa-4799-8554-3996395be9c9" />

Comparing toolbox and workshop toolbox you can immediately see the difference:
<img width="378" height="359" alt="image" src="https://github.com/user-attachments/assets/c9c8c070-eec6-4faa-9502-1a74fd7fed69" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1a4af86](https://github.com/cataclysmbn/Cataclysm-BN/commit/1a4af86a89d867685701bddf54e15515b57d6aeb) (Fix quality formatting and tests) on 2026-07-06 14:05:46

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28794730806/artifacts/8110516024)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28794730806/artifacts/8111324087)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28794730806/artifacts/8110598083)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28794730806/artifacts/8110663838)
<!-- END artifact comment -->