### PR TITLE
feat: hover repulsors no longer affected by traps

### DIFF
--- a/data/json/vehicleparts/jets.json
+++ b/data/json/vehicleparts/jets.json
@@ -75,7 +75,7 @@
     "description": "This is a lightweight hover repulsor module mounted on the underside of a vehicle.  It offers unparalleled maneuverability, allowing the vehicle to glide and fly effortlessly over rough terrain and obstacles.  Though originally intended to be frictionless, unknown antigrav phenomena nonetheless causes vehicles to experience a force similar to friction.",
     "damage_modifier": 50,
     "breaks_into": [ { "item": "scrap", "count": [ 15, 30 ] }, { "item": "steel_chunk", "count": [ 8, 16 ] } ],
-    "flags": [ "BALLOON", "WHEEL", "FLOATS", "ROTOR", "STABLE", "SELF_JACK", "VARIABLE_SIZE", "TRACKED" ],
+    "flags": [ "BALLOON", "WHEEL", "FLOATS", "ROTOR", "STABLE", "SELF_JACK", "VARIABLE_SIZE", "TRACKED", "TRAP_PROOF" ],
     "damage_reduction": { "all": 40 }
   }
 ]

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -188,6 +188,12 @@
     "info": "If the center of balance of your vehicle is between all the wheels, the vehicle will be able to move, provided it has an active engine or motor with enough power to move the vehicle."
   },
   {
+    "id": "TRAP_PROOF",
+    "type": "json_flag",
+    "context": [ "vehicle_part" ],
+    "info": "This wheel <info>hovers</info> and will <good>not set off traps</good> such as deep pits or landmines."
+  },
+  {
     "id": "FLAT_SURF",
     "type": "json_flag",
     "context": [ "vehicle_part" ],

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -134,7 +134,8 @@ static const std::unordered_map<std::string, vpart_bitflags> vpart_bitflag_map =
     { "NOSMASH", VPFLAG_NOSMASH },
     { "NOFIELDS", VPFLAG_NOFIELDS },
     { "DROPPER", VPFLAG_DROPPER },
-    { "LADDER", VPFLAG_LADDER }
+    { "LADDER", VPFLAG_LADDER },
+    { "TRAP_PROOF", VPFLAG_TRAP_PROOF }
 };
 
 auto vpart_rotating_light::arc_width() const -> units::angle

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -87,6 +87,7 @@ enum vpart_bitflags : int {
     VPFLAG_DROPPER,
     VPFLAG_LADDER,
     VPFLAG_POWERED_BY_ENGINE,
+    VPFLAG_TRAP_PROOF,
 
     NUM_VPFLAGS
 };

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1021,6 +1021,7 @@ void vehicle::handle_trap( const tripoint_bub_ms &p, int part )
 {
     int pwh = part_with_feature( part, VPFLAG_WHEEL, true );
     if( pwh < 0 ) {
+        return;
     }
     if( part_with_feature( part, VPFLAG_TRAP_PROOF, true ) >= 0 ) {
         return;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1021,6 +1021,8 @@ void vehicle::handle_trap( const tripoint_bub_ms &p, int part )
 {
     int pwh = part_with_feature( part, VPFLAG_WHEEL, true );
     if( pwh < 0 ) {
+    }
+    if( part_with_feature( part, VPFLAG_TRAP_PROOF, true ) >= 0 ) {
         return;
     }
     map &here = get_map();


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

A while back I was reminded that hover vehicles still get their repulsors wrecked by turrets, something that makes no sense given how they work.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. Defined new vehiclepart flag `TRAP_PROOF` in veh_type.cpp and veh_type.h.
2. In vehicle_move.cpp, `vehicle::handle_trap` returns early if the relevant tile has the new flag for the part being checked.

JSON changes:
1. Defined vehiclepart flag JSON.
2. Added new flag to hover repulsors.

## Describe alternatives you've considered

Continue to forget about implementing this until someone else does it for me.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned a hover tank, drove it over lava without it taking any damage.
4. Retested with a regular RV, wheels melted off as expected.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ce06bd1](https://github.com/cataclysmbn/Cataclysm-BN/commit/ce06bd169f7ad053c6ac276872cae72cf4c16ad9) (fix the mistake) on 2026-07-06 15:57:30

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28801438434/artifacts/8113633892)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28801438434/artifacts/8114405686)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28801438434/artifacts/8113735063)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28801438434/artifacts/8113698242)
<!-- END artifact comment -->