### PR TITLE
feat(balance): Nerfs autolearn from some high tier tailoring items to make the grind harder

### DIFF
--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1599,7 +1599,7 @@
     "skill_used": "tailor",
     "difficulty": 4,
     "time": "30 m",
-    "autolearn": true,
+    "book_learn": [ [ "textbook_tailor", 2 ] ],
     "using": [ [ "sewing_standard", 3 ] ],
     "components": [ [ [ "rag", 4 ] ] ]
   },

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1404,7 +1404,6 @@
     "skill_used": "tailor",
     "difficulty": 5,
     "time": "2 h 30 m",
-    "autolearn": true,
     "book_learn": [ [ "textbook_tailor", 3 ] ],
     "using": [ [ "sewing_standard", 32 ] ],
     "components": [ [ [ "rag", 16 ] ] ]
@@ -1417,7 +1416,6 @@
     "skill_used": "tailor",
     "difficulty": 7,
     "time": "5 h",
-    "autolearn": true,
     "book_learn": [ [ "textbook_tailor", 4 ] ],
     "using": [ [ "sewing_standard", 48 ] ],
     "components": [ [ [ "rag", 25 ] ] ]
@@ -1430,7 +1428,6 @@
     "skill_used": "tailor",
     "difficulty": 5,
     "time": "2 h 30 m",
-    "autolearn": true,
     "book_learn": [ [ "textbook_tailor", 4 ] ],
     "using": [ [ "sewing_standard", 60 ] ],
     "components": [ [ [ "rag", 12 ] ] ]
@@ -1456,7 +1453,6 @@
     "skill_used": "tailor",
     "difficulty": 5,
     "time": "2 h 30 m",
-    "autolearn": true,
     "book_learn": [ [ "textbook_tailor", 3 ] ],
     "using": [ [ "sewing_standard", 32 ] ],
     "components": [ [ [ "rag", 16 ] ] ]
@@ -1469,7 +1465,6 @@
     "skill_used": "tailor",
     "difficulty": 7,
     "time": "5 h",
-    "autolearn": true,
     "book_learn": [ [ "textbook_tailor", 4 ] ],
     "using": [ [ "sewing_standard", 48 ] ],
     "components": [ [ [ "rag", 20 ] ] ]
@@ -1482,7 +1477,6 @@
     "skill_used": "tailor",
     "difficulty": 6,
     "time": "4 h",
-    "autolearn": true,
     "book_learn": [ [ "textbook_tailor", 4 ] ],
     "using": [ [ "sewing_standard", 48 ] ],
     "components": [ [ [ "rag", 20 ] ] ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Tailoring is no doubt the easiest craft skill to get to high levels in a crazy short period of time.

## Describe the solution (The How)

Removes autolearn from recipes that:
- require skill equal or more than 5
- only use rag & thread

Thus it removes autolearn from: gown, maid dress, waistcoat, suit, tuxedo, wedding dress
(Also adds the maid hat to textbook_tailor just to keep it in line with the dress, although it does not strictly concern the PR)

This PR does not touch items that need more than rag and thread to make, because gathering tailoring materials is kinda annoying in the first place and it seems in line with grinding out the rest of the crafting skills when you go out there to get them.

## Describe alternatives you've considered

Grind tailoring to 8 in three days every single time

## Testing

Just some autolearn flags deleted from certain items nothing crazy

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5b8db90](https://github.com/cataclysmbn/Cataclysm-BN/commit/5b8db906f2a511ba504993cbeb229b9794b33ba4) (maid hat book recipe) on 2026-07-06 09:58:25

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28779332614/artifacts/8105439386)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28779332614/artifacts/8105006034)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28779332614/artifacts/8104551649)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28779332614/artifacts/8104434485)
<!-- END artifact comment -->