### PR TITLE
fix: phase immersion suit now has the correct condition

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1087,7 +1087,7 @@
       "passive_effects": [
         {
           "has": "WORN",
-          "condition": "ALWAYS",
+          "condition": "ACTIVE",
           "values": [ { "value": "ARMOR_PSI", "add": -25 }, { "value": "CLIMATE_CONTROL", "add": 1250 } ]
         }
       ]


### PR DESCRIPTION
## Purpose of change (The Why)
In #9812 I moved enchantments from their on variant to off variant
All others used ACTIVE so I assumed phase immersion did too
It did not

## Describe the solution (The How)
Make it use ACTIVE

## Describe alternatives you've considered
None

## Testing
Now is active only

## Additional context
~~Do people do this just to confuse me in a few years~~

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4bbc0e3](https://github.com/cataclysmbn/Cataclysm-BN/commit/4bbc0e3ff1ffb469a10ef3e502757dbd074d56ca) (fix: phase immersion suit now has the correct condition) on 2026-07-06 15:34:19

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28800718793/artifacts/8113017916)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28800718793/artifacts/8113806044)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28800718793/artifacts/8113058515)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28800718793/artifacts/8113206456)
<!-- END artifact comment -->