### PR TITLE
feat: fix misplaced nested mapgen caused by the "Cut 200 planks" mission

### DIFF
--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -117,7 +117,7 @@
           "place_nested": [ { "chunks": [ "tacoma_commune_west_wall_door" ], "x": 22, "y": 0 } ]
         },
         {
-          "om_terrain": "ranch_camp_66",
+          "om_terrain": "ranch_camp_75",
           "translate_ter": [ { "from": "t_underbrush", "to": "t_dirt", "x": 0, "y": 0 } ],
           "place_nested": [
             { "chunks": [ "tacoma_commune_east_wall_door" ], "x": 0, "y": 0 },


### PR DESCRIPTION
## Purpose of change (The Why)
Because some nested mapgen placed when completing the "Cut 200 planks" mission for the Tacoma commune are placed in the wrong location.
## Describe the solution (The How)
Look at the one line that was changed.
## Describe alternatives you've considered
none
## Testing
Loaded a new game; no errors.
Completed the "Cut 200 planks" mission and saw with my own eyes that the nested mapgen placed by this mission upon completion are in the right place.
## Additional context
none
## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e6ad090](https://github.com/cataclysmbn/Cataclysm-BN/commit/e6ad090fe418a019a43214c72a8a5e225e588c57) (Update NPC_ranch_foreman.json) on 2026-07-06 20:39:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28817749934/artifacts/8120351068)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28817749934/artifacts/8120350720)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28817749934/artifacts/8119852358)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28817749934/artifacts/8119846758)
<!-- END artifact comment -->