### PR TITLE
fix: mounts maintain position when crossing submaps

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12976,12 +12976,13 @@ auto game::place_player( const tripoint_bub_ms &dest_loc ) -> point_rel_sm
         u.stop_hauling();
     }
     const auto origin_before_setpos = m.get_abs_sub();
+    const tripoint_abs_ms abs_dest_loc = bub_to_abs( dest_loc );
     u.setpos( dest_loc );
     m.invalidate_visibility_caches();
     mon_info_cache_dirty = true;
     if( u.is_mounted() ) {
         monster *mon = u.mounted_creature.get();
-        mon->setpos( dest_loc );
+        mon->setpos( abs_dest_loc );
         mon->process_triggers();
         m.creature_in_field( *mon );
     }


### PR DESCRIPTION
## Purpose of change (The Why)
Closes #9623

## Describe the solution (The How)
Previous logic:
- Player crosses submap
- Reality bubble shifts
- Mount set using previous bubble coords

New logic:
- Save abs pos
- Player crosses submap
- Reality bubble shifts
- Mount set using abs pos

## Describe alternatives you've considered
Wait for all the tripoint stuff

## Testing
Mount goes over line

## Additional Context
I was tired of the complaints

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [36a3329](https://github.com/cataclysmbn/Cataclysm-BN/commit/36a332908bf1fbd5f975a687d45c69f5d06db331) (fix: mounts maintain position when crossing submaps) on 2026-07-07 01:33:51

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28833761577/artifacts/8125500171)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28833761577/artifacts/8125856637)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28833761577/artifacts/8125508620)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28833761577/artifacts/8125579328)
<!-- END artifact comment -->