### PR TITLE
fix: mounts no longer teleport the player back to the bottom of stairs when going up stairs

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -15032,9 +15032,6 @@ auto game::vertical_shift( const int z_before, const int z_after ) -> void
     debug_assert_player_map_origin( "vertical_shift" );
 
     m.spawn_monsters( true );
-    // this may be required after a vertical shift if z-levels are not enabled
-    // the critter is unloaded/loaded, and it needs to reconstruct its rider data after being reloaded.
-    validate_mounted_npcs();
     vertical_notes( z_before, z_after );
     update_overmap_seen();
 }


### PR DESCRIPTION
## Purpose of change (The Why)
Apparently mounts couldn't go up stairs

## Describe the solution (The How)
So you see there was a minor problem.
Mount was *clearly* following player
Player was *clearly* able to normally go up stairs
There was no early return
I was confused

```
    // this may be required after a vertical shift if z-levels are not enabled
    // the critter is unloaded/loaded, and it needs to reconstruct its rider data after being reloaded.
    validate_mounted_npcs();
```
Z levels is no longer an option
Also
`mounted_pl->setpos( m.bub_pos() );`
It teleports the player

Upon deleting it it worked

## Describe alternatives you've considered
Make it make sure the player is not *the player* before it does whatever it does

## Testing
It seems to fix bugs without causing any

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b9c6082](https://github.com/cataclysmbn/Cataclysm-BN/commit/b9c6082b066d683611779f1a0171bedc3a8906dc) (fix: mounts no longer teleport the player back to the bottom of stairs when going up stairs) on 2026-07-07 18:36:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28884404830/artifacts/8147468142)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28884404830/artifacts/8146487468)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28884404830/artifacts/8145867505)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28884404830/artifacts/8145897258)
<!-- END artifact comment -->