### PR TITLE
fix: blindness memorizes terrain tiles they bump into again

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -747,19 +747,23 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
             you.moves -= 100;
         }
         // Add to map memory if blind
+        // TODO: make this not ugly by having the rotation and connections without
+        // Also revealing the nearby tiles to the player
         if( you.is_blind() ) {
-            std::string obstacle;
             if( m.veh_at( dest_loc ) ) {
                 char part_mod = 0;
                 const vpart_id &vp_id = m.veh_at( dest_loc )->vehicle().part_id_string( m.veh_at(
                                             dest_loc )->part_index(), false, part_mod );
-                obstacle = "vp_" + vp_id.str();
+                you.memorize_tile( bub_to_abs( dest_loc ), "vp_" + vp_id.str(), 0, 0 );
             } else {
-                obstacle = m.has_furn( dest_loc ) ? m.furn( dest_loc ).id().str() : m.ter(
-                               dest_loc ).id().str();
+                if( m.has_furn( dest_loc ) ) {
+                    you.memorize_tile( bub_to_abs( dest_loc ), m.furn( dest_loc ).id().str(), 0, 0 );
+                } else {
+                    std::string ter = m.ter( dest_loc ).id().str();
+                    you.memorize_tile( bub_to_abs( dest_loc ), ter, 0, 0 );
+                    you.memorize_terrain_tile( bub_to_abs( dest_loc ), ter, 0, 0 );
+                }
             }
-            // TODO: Figure out how to make subtile and rotation work right here
-            you.memorize_tile( bub_to_abs( dest_loc ), obstacle, 0, 0 );
         }
     } else if( m.ter( dest_loc ) == t_door_locked || m.ter( dest_loc ) == t_door_locked_peep ||
                m.ter( dest_loc ) == t_door_locked_alarm || m.ter( dest_loc ) == t_door_locked_interior ) {


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #9827

## Describe the solution (The How)
Memorize terrain using `memorize_terrain_tile`

## Describe alternatives you've considered
None

## Testing
Furniture already worked
Terrain works too

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ac89f8f](https://github.com/cataclysmbn/Cataclysm-BN/commit/ac89f8fc2fc6f8d5cc1042d399a302c570e83b72) (fix: blindness memorizes terrain tiles they bump into again) on 2026-07-07 19:53:48

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28890265027/artifacts/8148158017)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28890265027/artifacts/8148830425)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28890265027/artifacts/8148383974)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28890265027/artifacts/8148325965)
<!-- END artifact comment -->