### PR TITLE
feat: add ability to prevent starting traits from being randomly picked

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -852,6 +852,7 @@
     "points": -6,
     "description": "You never learned to read!  Books and computers are off-limits to you.",
     "starting_trait": true,
+    "random_starting_trait": false,
     "valid": false,
     "purifiable": false,
     "cancels": [ "FASTREADER", "SLOWREADER", "PROF_DICEMASTER", "LOVES_BOOKS" ]
@@ -6982,6 +6983,7 @@
     "points": -8,
     "description": "Whether from personal choice or childhood trauma, using ranged weapons is off-limits to you, even if your life depended on it.",
     "starting_trait": true,
+    "random_starting_trait": false,
     "cancels": [ "GUNSHY", "CARRY_PERMIT" ],
     "valid": false
   },
@@ -6992,6 +6994,7 @@
     "points": -4,
     "description": "Whether from personal choice or childhood trauma, using firearms is completely off-limits to you, even if your life depended on it.  Other ranged weapons, however, are totally fine.",
     "starting_trait": true,
+    "random_starting_trait": false,
     "cancels": [ "BRAWLER", "CARRY_PERMIT" ],
     "valid": false
   },
@@ -7012,6 +7015,7 @@
     "points": -8,
     "description": "Whether from personal choice or childhood trauma, traveling with vehicles is off-limits to you, even if your life depended on it.",
     "starting_trait": true,
+    "random_starting_trait": false,
     "valid": false,
     "purifiable": false
   },

--- a/docs/en/mod/json/reference/creatures/mutations.md
+++ b/docs/en/mod/json/reference/creatures/mutations.md
@@ -6,7 +6,7 @@
 
 ### Traits/Mutations fields
 
-```json
+```jsonc
 "id": "LIGHTEATER",  // Unique ID
 "name": "Optimist",  // In-game name displayed
 "points": 2,         // Point cost of the trait. Positive values cost points and negative values give points
@@ -25,6 +25,7 @@
 "description": "Nothing gets you down!" // In-game description
 "apperance_description": "mowhawk" //only used for describing apperance mutations (i.e hair_color, hair_style, eye_color, skin_tone) in photos and extended descriptions 
 "starting_trait": true, // Can be selected at character creation (default: false)
+"random_starting_trait": true, // Will be randomly selected at character creation (default: starting_trait)
 "valid": false,      // Can be mutated ingame (default: true)
 "purifiable": false, //Sets if the mutation be purified (default: true)
 "profession": true, //Trait is a starting profession special trait. (default: false)

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -92,6 +92,7 @@ struct mutation_branch {
         // Whether it has positive as well as negative effects.
         bool mixed_effect  = false;
         bool startingtrait = false;
+        bool randomstartingtrait = true;
         bool activated     = false;
         // Should it activate as soon as it is gained?
         bool starts_active = false;

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -293,6 +293,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "visibility", visibility, 0 );
     optional( jo, was_loaded, "ugliness", ugliness, 0 );
     optional( jo, was_loaded, "starting_trait", startingtrait, false );
+    optional( jo, was_loaded, "random_starting_trait", randomstartingtrait, startingtrait );
     optional( jo, was_loaded, "mixed_effect", mixed_effect, false );
     optional( jo, was_loaded, "active", activated, false );
     optional( jo, was_loaded, "starts_active", starts_active, false );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4067,7 +4067,8 @@ trait_id newcharacter::random_good_trait()
     std::vector<trait_id> vTraitsGood;
 
     for( auto &traits_iter : mutation_branch::get_all() ) {
-        if( traits_iter.points > 0 && g->scen->traitquery( traits_iter.id ) ) {
+        if( traits_iter.points > 0 && g->scen->traitquery( traits_iter.id ) &&
+            traits_iter.randomstartingtrait ) {
             vTraitsGood.push_back( traits_iter.id );
         }
     }
@@ -4080,7 +4081,8 @@ trait_id newcharacter::random_bad_trait()
     std::vector<trait_id> vTraitsBad;
 
     for( auto &traits_iter : mutation_branch::get_all() ) {
-        if( traits_iter.points < 0 && g->scen->traitquery( traits_iter.id ) ) {
+        if( traits_iter.points < 0 && g->scen->traitquery( traits_iter.id ) &&
+            traits_iter.randomstartingtrait ) {
             vTraitsBad.push_back( traits_iter.id );
         }
     }


### PR DESCRIPTION
## Purpose of change (The Why)
#9829 has blind
That greatly changes gameplay and maybe shouldn't be randomly given
Similarly: `GUNSHY` `ILLITERATE` `BRAWLER` `WAYFARER`

## Describe the solution (The How)
Add `random_starting_trait` which chooses weather it can be gained randomly

## Describe alternatives you've considered
None

## Testing
Swapped it to default false, gave only a few traits it, they were the only ones to pop up in random char creation

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.

<!-- BEGIN docs comment -->

## Translations

| post                                      | changed | stale  | missing |
| ----------------------------------------- | ------- | ------ | ------- |
| mod/json/reference/creatures/mutations.md | en      | ja, ko |         |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d282b57](https://github.com/cataclysmbn/Cataclysm-BN/commit/d282b5753a3b61f1cf7cb921cf25d1733a081a7f) (feat: add random_starting_trait as a field for mutations) on 2026-07-08 01:09:45

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28891810792/artifacts/8149670376)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28891810792/artifacts/8150334692)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28891810792/artifacts/8149424114)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28891810792/artifacts/8149416822)
<!-- END artifact comment -->