### PR TITLE
feat: add autolearn requirements to recipe unlock notes

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -45,6 +45,7 @@
 #include "recipe.h"
 #include "recipe_dictionary.h"
 #include "requirements.h"
+#include "skill.h"
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "string_utils.h"
@@ -621,8 +622,16 @@ static std::vector<std::string> recipe_info(
         []( const itype_id & type_id ) {
             return colorize( item::nname( type_id ), c_cyan );
         } );
-        oss << _( "book count: " ) << books_with_recipe.size() << "\n";
-        oss << string_format( _( "Written in: %s\n" ), enumerated_books );
+        if( books_with_recipe.size() != 0 ) {
+            oss << _( "book count: " ) << books_with_recipe.size() << "\n";
+            oss << string_format( _( "Written in: %s\n" ), enumerated_books );
+        }
+        if( !recp.autolearn_requirements.empty() ) {
+            oss << _( "Autolearn when all are met:\n" );
+            for( const auto [skill, level] : recp.autolearn_requirements ) {
+                oss << string_format( _( "  Skill %s at level %s\n" ), skill->name(), level );
+            }
+        }
     }
     std::vector<std::string> tmp = foldstring( oss.str(), fold_width );
     result.insert( result.end(), tmp.begin(), tmp.end() );


### PR DESCRIPTION
## Purpose of change (The Why)
Someone was confused

## Describe the solution (The How)
Add a list of that at the end
If no books unlock, dont display book unlock stuff

## Describe alternatives you've considered
Dont do this?

## Testing
On any random testing character
Open crafting menu
Show unknown things
You should now see autolearn reqs at the bottom of the description

## Additional Context
Wording might need to be improved

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5261375](https://github.com/cataclysmbn/Cataclysm-BN/commit/526137547ab14f06e6469e26b1e49c6a157b71ec) (feat: add autolearn requirements to recipe unlock notes) on 2026-07-07 21:32:18

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28895189155/artifacts/8150131114)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28895189155/artifacts/8151820050)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28895189155/artifacts/8150195278)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28895189155/artifacts/8150239036)
<!-- END artifact comment -->