### PR TITLE
fix: typo in MF_POLICE_EYEBOT sound event description

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -3556,7 +3556,7 @@ bool mattack::photograph( monster *z )
             se.origin = z->bub_pos();
             se.volume = 80;
             se.category = sounds::sound_t::alert;
-            se.description = string_format( _( "a robotic boice boom, \"Citizen %s!\"" ), cname );
+            se.description = string_format( _( "a robotic voice boom, \"Citizen %s!\"" ), cname );
             se.movement_noise = false;
             se.from_monster = true;
             se.monfaction = z->faction.id();


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

🅱️oice

## Describe the solution (The How)

✌️oice

## Describe alternatives you've considered

Sleep

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [cb4449c](https://github.com/cataclysmbn/Cataclysm-BN/commit/cb4449c31f74aa27ec7c202d30471ed09d92c0ec) (Fix typo in sound event description) on 2026-07-08 20:06:47

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28948950785/artifacts/8171465878)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28948950785/artifacts/8172054470)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28948950785/artifacts/8171254482)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28948950785/artifacts/8171343605)
<!-- END artifact comment -->