### PR TITLE
fix: add missing bash info to reactors, remove redundant JSON def

### DIFF
--- a/data/json/furniture_and_terrain/terrain-mechanisms.json
+++ b/data/json/furniture_and_terrain/terrain-mechanisms.json
@@ -629,7 +629,7 @@
     "type": "terrain",
     "name": "nuclear reactor core",
     "//": "just a copy of aftershock nuclear reactor",
-    "description": "Naval A1B reactor, used in Gerald R. Ford–class aircraft carriers, and can produce enough steam to generate 125 megawatts of energy.",
+    "description": "The critical infrastructure of a nuclear reactor.  If it was still running, it could produce enough steam to generate 125 megawatts of energy.  It could be salvaged for valuable components, which could be used to juryrig more smaller-scale sources of nuclear power.",
     "symbol": "R",
     "color": "light_green",
     "move_cost": 0,
@@ -639,7 +639,8 @@
       "items": [
         { "item": "compact_reactor_assembly", "count": 2 },
         { "item": "alloy_plate", "count": [ 4, 6 ] },
-        { "item": "plut_cell", "charges": [ 24, 32 ] },
+        { "item": "nuclear_fuel", "charges": [ 8, 16 ] },
+        { "item": "nuclear_waste", "charges": [ 2, 4 ] },
         { "item": "lead", "charges": [ 250, 400 ] },
         { "item": "cable", "charges": [ 60, 90 ] },
         { "item": "power_supply", "count": [ 16, 20 ] },
@@ -653,6 +654,35 @@
         { "item": "steel_lump", "count": [ 20, 35 ] },
         { "item": "steel_chunk", "count": [ 30, 50 ] }
       ]
+    },
+    "bash": {
+      "str_min": 100,
+      "str_max": 500,
+      "explosive": 100,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "ter_set": "t_concrete",
+      "items": [
+        { "item": "compact_reactor_assembly", "prob": 25 },
+        { "item": "alloy_plate", "count": [ 1, 2 ] },
+        { "item": "alloy_sheet", "count": [ 10, 20 ] },
+        { "item": "nuclear_fuel", "charges": [ 2, 8 ] },
+        { "item": "nuclear_waste", "charges": [ 0, 2 ] },
+        { "item": "lead", "charges": [ 100, 200 ] },
+        { "item": "cable", "charges": [ 30, 45 ] },
+        { "item": "power_supply", "count": [ 4, 6 ] },
+        { "item": "circuit", "count": [ 6, 8 ] },
+        { "item": "amplifier", "count": [ 2, 4 ] },
+        { "item": "RAM", "count": [ 0, 2 ] },
+        { "item": "small_lcd_screen", "count": [ 0, 2 ] },
+        { "item": "large_lcd_screen", "prob": 25 },
+        { "item": "e_scrap", "count": [ 15, 30 ] },
+        { "item": "scrap", "count": [ 30, 90 ] },
+        { "item": "steel_lump", "count": [ 15, 40 ] },
+        { "item": "steel_chunk", "count": [ 20, 60 ] }
+      ],
+      "//": "Variable reduction, destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 50, 100 ], "destroy_threshold": 100, "block_unaimed_chance": "75%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -2192,36 +2192,6 @@
     }
   },
   {
-    "id": "t_nuclear_reactor",
-    "type": "terrain",
-    "name": "nuclear reactor core",
-    "description": "",
-    "symbol": "R",
-    "color": "light_green",
-    "move_cost": 0,
-    "flags": [ "TRANSPARENT", "CONTAINER", "REDUCE_SCENT", "PERMEABLE", "PLACE_ITEM", "ADV_DECONSTRUCT" ],
-    "deconstruct": {
-      "ter_set": "t_concrete",
-      "items": [
-        { "item": "compact_reactor_assembly", "count": 2 },
-        { "item": "alloy_plate", "count": [ 4, 6 ] },
-        { "item": "plut_cell", "charges": [ 24, 32 ] },
-        { "item": "lead", "charges": [ 250, 400 ] },
-        { "item": "cable", "charges": [ 60, 90 ] },
-        { "item": "power_supply", "count": [ 16, 20 ] },
-        { "item": "circuit", "count": [ 22, 28 ] },
-        { "item": "amplifier", "count": [ 10, 14 ] },
-        { "item": "RAM", "count": 8 },
-        { "item": "small_lcd_screen", "count": 4 },
-        { "item": "large_lcd_screen", "count": 1 },
-        { "item": "e_scrap", "count": 24 },
-        { "item": "scrap", "count": [ 48, 80 ] },
-        { "item": "steel_lump", "count": [ 20, 35 ] },
-        { "item": "steel_chunk", "count": [ 30, 50 ] }
-      ]
-    }
-  },
-  {
     "type": "terrain",
     "id": "t_fortification_wood",
     "copy-from": "t_wall_wood",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This fixes several flaws with the nuclear reactors mainlined from Aftershock, most notably it being defined in the JSON twice and not having a bash entry. Discovered while working on https://github.com/cataclysmbn/Cataclysm-BN/pull/9087/ and technically needed for it now that one of the core lab chunks is slated to include a reactor area that has a random chance of being bashed out.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added a bash entry for reactors. Breaks down into fewer electronic components than the deconstruct but a wider min and max range for scrap metal and electronic scrap. Also explodes, even more forcefully than plutonium generators.
2. Set it so that reactors yield nuclear fuel and waste when deconstructed/bashed instead of plutonium cells, it's goofy how underused those items are except for crafting cells and as flavor items.
3. Removed a redundant, inexplicably nameless copy of reactor JSON from terrain-walls.json.
4. Misc: tweaked description of nuclear reactors to account for the fact that they can appear in nuclear power plants too, not just aircraft carriers. Also makes it more clear they're not usuable as-is and have to be salvaged.

## Describe alternatives you've considered

Adding the inanimate carbon rod.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Tested bonking a reactor with mjolnir, it do indeed explode. Even 4x the force of plutonim generators isn't enough to damage the mockup I made of the reactor container area, so either I need to at some point sanity-check the scaling of exploding bash results or I'll have to tack on more calls to bash terrain in the central lab overhaul PR.

<img width="342" height="303" alt="image" src="https://github.com/user-attachments/assets/0971eb04-75d5-4bd3-8c3b-8a6e44170601" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5a91a58](https://github.com/cataclysmbn/Cataclysm-BN/commit/5a91a5860c4c28251bc1d6e96fc96df340b18d72) (fix: add missing bash info to reactors, remove redundant JSON def) on 2026-07-09 05:48:27

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28992515822/artifacts/8189746321)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28992515822/artifacts/8190097896)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28992515822/artifacts/8189123665)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/28992515822/artifacts/8189619373)
<!-- END artifact comment -->