### PR TITLE
fix: remove hallucination NPCs

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7351,26 +7351,6 @@ void game::clear_zombies()
  */
 bool game::spawn_hallucination( const tripoint_bub_ms &p )
 {
-    if( one_in( 100 ) ) {
-        shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
-        tmp->randomize( NC_HALLU );
-        const auto proj = project_remain<coords::sm>( bub_to_abs( p ) );
-        tmp->spawn_at_precise( proj.quotient, proj.remainder_tripoint );
-        cata::run_hooks( "on_creature_spawn", [&]( sol::table & params ) {
-            params["creature"] = tmp.get();
-        } );
-        cata::run_hooks( "on_npc_spawn", [&]( sol::table & params ) {
-            params["npc"] = tmp.get();
-        } );
-        if( !critter_at( p, true ) ) {
-            get_overmapbuffer( current_dimension_id_ ).insert_npc( tmp );
-            load_npcs();
-            return true;
-        } else {
-            return false;
-        }
-    }
-
     const mtype_id &mt = MonsterGenerator::generator().get_valid_hallucination();
     const shared_ptr_fast<monster> phantasm = make_shared_fast<monster>( mt );
     phantasm->hallucination = true;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -125,7 +125,6 @@ static const bionic_id bio_memory( "bio_memory" );
 static const trait_id trait_BEE( "BEE" );
 static const trait_id trait_CANNIBAL( "CANNIBAL" );
 static const trait_id trait_DEBUG_MIND_CONTROL( "DEBUG_MIND_CONTROL" );
-static const trait_id trait_HALLUCINATION( "HALLUCINATION" );
 static const trait_id trait_HYPEROPIC( "HYPEROPIC" );
 static const trait_id trait_ILLITERATE( "ILLITERATE" );
 static const trait_id trait_KILLER( "KILLER" );
@@ -170,7 +169,6 @@ npc::npc()
     death_drops = true;
     dead = false;
     hit_by_player = false;
-    hallucination = false;
     moves = 100;
     mission = NPC_MISSION_NULL;
     myclass = npc_class_id::NULL_ID();
@@ -505,7 +503,7 @@ void npc::set_fac( const faction_id &id )
     }
     my_fac = g->faction_manager_ptr->get( id );
     if( my_fac ) {
-        if( !is_fake() && !is_hallucination() ) {
+        if( !is_fake() ) {
             my_fac->add_to_membership( getID(), disp_name(), known_to_u );
         }
         fac_id = my_fac->id;
@@ -1659,9 +1657,6 @@ void npc::make_angry()
 
 void npc::on_attacked( const Creature &attacker )
 {
-    if( is_hallucination() ) {
-        die( nullptr );
-    }
     if( attacker.is_player() && !is_enemy() ) {
         const auto attacked_faction = get_monster_faction();
         make_angry();
@@ -1777,11 +1772,6 @@ void npc::say( const std::string &line, const sounds::sound_t spriority ) const
     std::string sound = string_format( _( "%1$s saying \"%2$s\"" ), name, formatted_line );
     if( g->u.sees( *this ) && g->u.is_deaf() ) {
         add_msg( m_warning, _( "%1$s says something but you can't hear it!" ), name );
-    }
-    // Hallucinations don't make noise when they speak
-    if( is_hallucination() ) {
-        add_msg( _( "%1$s saying \"%2$s\"" ), name, formatted_line );
-        return;
     }
     // Sound happens even if we can't hear it
     if( spriority == sounds::sound_t::order || spriority == sounds::sound_t::alert ) {
@@ -2434,7 +2424,7 @@ void npc::npc_dismount()
 
 int npc::smash_ability() const
 {
-    if( !is_hallucination() && ( !is_player_ally() || rules.has_flag( ally_rule::allow_bash ) ) ) {
+    if( !is_player_ally() || rules.has_flag( ally_rule::allow_bash ) ) {
         ///\EFFECT_STR_NPC increases smash ability
         return str_cur + primary_weapon().damage_melee( DT_BASH );
     }
@@ -2788,7 +2778,7 @@ void npc::die( Creature *nkiller )
     }
     // if this NPC was the only member of a micro-faction, clean it up.
     if( my_fac ) {
-        if( !is_fake() && !is_hallucination() ) {
+        if( !is_fake() ) {
             if( my_fac->members.size() == 1 ) {
                 for( auto elem : inv_dump() ) {
                     elem->remove_owner();
@@ -2800,13 +2790,6 @@ void npc::die( Creature *nkiller )
     }
     dead = true;
     Character::die( nkiller );
-
-    if( is_hallucination() ) {
-        if( g->u.sees( *this ) ) {
-            add_msg( _( "%s disappears." ), name.c_str() );
-        }
-        return;
-    }
 
     if( g->u.sees( *this ) ) {
         add_msg( _( "%s dies!" ), name );
@@ -2865,7 +2848,7 @@ void npc::erase()
         critter->mounted_player_id = character_id();
     }
     if( my_fac ) {
-        if( !is_fake() && !is_hallucination() ) {
+        if( !is_fake() ) {
             if( my_fac->members.size() == 1 ) {
                 for( auto elem : inv_dump() ) {
                     elem->remove_owner();
@@ -3098,10 +3081,6 @@ void npc::on_load()
                      disp_name() );
         }
     }
-    if( has_trait( trait_HALLUCINATION ) ) {
-        hallucination = true;
-    }
-
     cata::run_hooks( "on_creature_loaded", [this]( sol::table & params ) {
         params["creature"] = this;
     } );
@@ -3367,10 +3346,6 @@ std::ostream &operator<< ( std::ostream &os, const npc_need &need )
 
 bool npc::will_accept_from_player( const item &it ) const
 {
-    if( is_hallucination() ) {
-        return false;
-    }
-
     if( is_minion() || g->u.has_trait( trait_DEBUG_MIND_CONTROL ) ||
         it.has_flag( flag_NPC_SAFE ) ) {
         return true;
@@ -3799,11 +3774,6 @@ void npc_follower_rules::toggle_specific_override_state( ally_rule rule, bool st
     } else {
         set_specific_override_state( rule, state );
     }
-}
-
-bool npc::is_hallucination() const
-{
-    return hallucination;
 }
 
 bool npc_follower_rules::has_override_enable( ally_rule test ) const

--- a/src/npc.h
+++ b/src/npc.h
@@ -823,7 +823,6 @@ class npc : public player
         std::string pick_talk_topic( const Character &u );
         float character_danger( const Character &u ) const;
         float vehicle_danger( int radius ) const;
-        void pretend_fire( npc *source, int shots, item &gun ); // fake ranged attack for hallucination
         // True if our anger is at least equal to...
         bool turned_hostile() const;
         // ... this value!
@@ -853,7 +852,8 @@ class npc : public player
         bool is_following() const;
         bool is_obeying( const Character &p ) const;
 
-        bool is_hallucination() const override; // true if the NPC isn't actually real
+        // NPCs cannot be hallucinations
+        bool is_hallucination() const override { return false; }
 
         // Ally of or traveling with p
         bool is_friendly( const Character &p ) const;
@@ -1175,7 +1175,6 @@ class npc : public player
         bool alt_attack();
         void heal_player( Character &patient );
         void heal_self();
-        void pretend_heal( Character &patient, item &used ); // healing action of hallucinations
         void mug_player( Character &mark );
         void look_for_player( const Character &sought );
         // Do we have an idea of where u are?
@@ -1324,7 +1323,6 @@ class npc : public player
         npc_follower_rules rules;
         bool marked_for_death = false; // If true, we die as soon as we respawn!
         bool hit_by_player = false;
-        bool hallucination = false; // If true, NPC is an hallucination
         std::vector<npc_need> needs;
         std::optional<int> confident_range_cache;
         // Dummy point that indicates that the goal is invalid.

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -489,7 +489,7 @@ void npc::assess_danger()
     // True if this NPC has traits/effects that cause monster::attitude() to return a
     // result different from what a generic NPC would get.  When false, we can use each
     // monster's per-npcmove-pass cached attitude instead of recomputing it.
-    const auto has_special_attitude_traits = guaranteed_hostile() || is_hallucination() ||
+    const auto has_special_attitude_traits = guaranteed_hostile() ||
             has_mutation_attitude_rules ||
             has_trait( trait_ANIMALEMPATH ) || has_trait( trait_ANIMALEMPATH2 ) ||
             has_trait( trait_ANIMALDISCORD ) || has_trait( trait_ANIMALDISCORD2 ) ||
@@ -1411,15 +1411,11 @@ void npc::execute_action( npc_action action )
             }
 
             aim();
-            if( is_hallucination() ) {
-                pretend_fire( this, mode.qty, *mode );
-            } else {
-                add_msg( m_debug, "%s recoil on firing: %s", name, recoil );
-                ranged::fire_gun( *this, tar, mode.qty, *mode, nullptr );
-                // Clear the ranged cbm entry and item so next turn a new comparison is made.
-                if( !cbm_active.is_null() ) {
-                    discharge_cbm_weapon();
-                }
+            add_msg( m_debug, "%s recoil on firing: %s", name, recoil );
+            ranged::fire_gun( *this, tar, mode.qty, *mode, nullptr );
+            // Clear the ranged cbm entry and item so next turn a new comparison is made.
+            if( !cbm_active.is_null() ) {
+                discharge_cbm_weapon();
             }
             // Important, once they've fired their gun, wield calculations have to be redone
             // else they'll fail to realize when they run out of ammo.
@@ -2214,12 +2210,6 @@ npc_action npc::address_needs( float danger )
             return npc_noop;
         }
     }
-    //Does the hallucination needs to disappear ?
-    if( is_hallucination() && player_character.sees( *this ) ) {
-        if( !player_character.has_effect( effect_hallu ) ) {
-            die( nullptr );
-        }
-    }
 
     if( danger > NPC_DANGER_VERY_LOW ) {
         return npc_undecided;
@@ -2650,8 +2640,7 @@ bool npc::can_move_to( const tripoint_bub_ms &p, bool no_bashing ) const
     // Allow moving into any bashable spots, but penalize them during pathing
     // Doors are not passable for hallucinations
     return( rl_dist( bub_pos(), p ) <= 1 && here.has_floor( p ) && !g->is_dangerous_tile( p ) &&
-            ( here.passable( p ) || ( can_open_door( p, !here.is_outside( bub_pos() ) ) &&
-                                      !is_hallucination() ) ||
+            ( here.passable( p ) || can_open_door( p, !here.is_outside( bub_pos() ) ) ||
               ( !no_bashing && here.bash_rating( smash_ability(), p ) > 0 ) )
           );
 }
@@ -2776,7 +2765,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         // Let NPCs push each other when non-hostile
         // TODO: Have them attack each other when hostile
         npc *np = dynamic_cast<npc *>( critter );
-        if( !is_hallucination() && np != nullptr && !np->in_sleep_state() ) {
+        if( np != nullptr && !np->in_sleep_state() ) {
             std::unique_ptr<std::set<tripoint_bub_ms>> newnomove;
             std::set<tripoint_bub_ms> *realnomove;
             if( nomove != nullptr ) {
@@ -2852,13 +2841,8 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         }
         moved = true;
     } else if( here.can_open_door( this, p, !here.is_outside( bub_pos() ) ) ) {
-        if( !is_hallucination() ) { // hallucinations don't open doors
-            here.open_door( this, p, !here.is_outside( bub_pos() ) );
-            moves -= 100;
-        } else { // hallucinations teleport through doors
-            moves -= 100;
-            moved = true;
-        }
+        here.open_door( this, p, !here.is_outside( bub_pos() ) );
+        moves -= 100;
     } else if( get_dex() > 1 && here.has_flag_ter_or_furn( "CLIMBABLE", p ) &&
                !ceiling_blocking_climb ) {
         ///\EFFECT_DEX_NPC increases chance to climb CLIMBABLE furniture or terrain
@@ -2895,9 +2879,6 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         } else {
             facing = FD_LEFT;
         }
-        if( is_hallucination() ) {
-            return;
-        }
         if( is_mounted() ) {
             if( mounted_creature->bub_pos() != bub_pos() ) {
                 mounted_creature->setpos( bub_pos() );
@@ -2924,8 +2905,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         }
 
         // Close doors behind self (if you can)
-        if( ( rules.has_flag( ally_rule::close_doors ) &&
-              is_player_ally() ) && !is_hallucination() ) {
+        if( rules.has_flag( ally_rule::close_doors ) && is_player_ally() ) {
             doors::close_door( here, *this, old_pos );
         }
 
@@ -3179,12 +3159,6 @@ void npc::see_item_say_smth( const itype_id &object, const std::string &smth )
 
 void npc::find_item()
 {
-    if( is_hallucination() ) {
-        see_item_say_smth( itype_thorazine, "<no_to_thorazine>" );
-        see_item_say_smth( itype_lsd, "<yes_to_lsd>" );
-        return;
-    }
-
     if( is_player_ally() && !rules.has_flag( ally_rule::allow_pick_up ) ) {
         // Grabbing stuff not allowed by our "owner"
         return;
@@ -3367,10 +3341,6 @@ void npc::find_item()
 
 void npc::pick_up_item()
 {
-    if( is_hallucination() ) {
-        return;
-    }
-
     if( !rules.has_flag( ally_rule::allow_pick_up ) && is_player_ally() ) {
         add_msg( m_debug, "%s::pick_up_item(); Canceling on player's request", name );
         fetching_item = false;
@@ -3624,9 +3594,7 @@ void npc::drop_items( units::mass drop_weight, units::volume drop_volume, int mi
         } else if( num_items_dropped == 2 ) {
             item_name += _( " and " ) + dropped->tname();
         }
-        if( !is_hallucination() ) { // hallucinations can't drop real items
-            here.add_item_or_charges( bub_pos(), std::move( dropped ) );
-        }
+        here.add_item_or_charges( bub_pos(), std::move( dropped ) );
     }
     // Finally, describe the action if u can see it
     if( get_player_character().sees( *this ) ) {
@@ -3644,8 +3612,7 @@ bool npc::find_corpse_to_pulp()
 {
     Character &player_character = get_player_character();
     if( ( is_player_ally() && ( !rules.has_flag( ally_rule::allow_pulp ) ||
-                                player_character.in_vehicle ) ) ||
-        is_hallucination() ) {
+                                player_character.in_vehicle ) ) ) {
         return false;
     }
 
@@ -3962,15 +3929,13 @@ static void npc_throw( npc &np, item &it, const tripoint_bub_ms &pos )
 
     detached_ptr<item> det = it.count_by_charges() ? it.split( 1 ) : it.detach();
 
-    if( !np.is_hallucination() ) { // hallucinations only pretend to throw
-        ranged::throw_item( np, pos, std::move( det ), std::nullopt );
-    }
+    ranged::throw_item( np, pos, std::move( det ), std::nullopt );
     np.clear_npc_ai_info_cache( npc_ai_info::range );
 }
 
 bool npc::alt_attack()
 {
-    if( ( is_player_ally() && !rules.has_flag( ally_rule::use_grenades ) ) || is_hallucination() ) {
+    if( is_player_ally() && !rules.has_flag( ally_rule::use_grenades ) ) {
         return false;
     }
 
@@ -4111,10 +4076,6 @@ bool npc::alt_attack()
 
 void npc::activate_item( int item_index )
 {
-    if( is_hallucination() ) {
-        move_pause();
-        return;
-    }
     const int oldmoves = moves;
     item &it = i_at( item_index );
     if( it.is_tool() || it.is_food() ) {
@@ -4151,31 +4112,13 @@ void npc::heal_player( Character &patient )
         debugmsg( "%s tried to heal you but has no healing item", disp_name() );
         return;
     }
-    if( !is_hallucination() ) {
-        int charges_used = used.type->invoke( *this, used, patient.bub_pos(), "heal" );
-        consume_charges( used, charges_used );
-    } else {
-        pretend_heal( patient, used );
-    }
+    int charges_used = used.type->invoke( *this, used, patient.bub_pos(), "heal" );
+    consume_charges( used, charges_used );
 
-}
-
-void npc:: pretend_heal( Character &patient, item &used )
-{
-    if( get_player_character().sees( *this ) ) {
-        add_msg( _( "%1$s heals %2$s." ), disp_name(),
-                 patient.disp_name() ); // you can tell that it's not real by looking at your HP though
-    }
-    consume_charges( used, 1 ); // empty hallucination's inventory to avoid spammming
-    moves -= 100; // consumes moves to avoid infinite loop
 }
 
 void npc::heal_self()
 {
-    if( is_hallucination() ) {
-        move_pause();
-        return;
-    }
     if( has_effect( effect_asthma ) ) {
         item *treatment = &null_item_reference();
         std::string iusage = "OXYGEN_BOTTLE";
@@ -4213,10 +4156,6 @@ void npc::heal_self()
 
 void npc::use_painkiller()
 {
-    if( is_hallucination() ) {
-        move_pause();
-        return;
-    }
     // First, find the best painkiller for our pain level
     item *it = inv.most_appropriate_painkiller( get_pain() );
 
@@ -4321,10 +4260,6 @@ static float rate_food( const item &it, int want_nutr, int want_quench )
 
 bool npc::consume_food()
 {
-    if( is_hallucination() ) {
-        move_pause();
-        return false;
-    }
     float best_weight = 0.0f;
     int index = -1;
     int want_hunger = std::max<int>( 0, ( max_stored_kcal() - get_stored_kcal() ) / 10 );
@@ -4379,10 +4314,8 @@ void npc::mug_player( Character &mark )
     Character &player_character = get_player_character();
     const bool u_see = player_character.sees( *this ) || player_character.sees( mark );
     if( mark.cash > 0 ) {
-        if( !is_hallucination() ) { // hallucinations can't take items
-            cash += mark.cash;
-            mark.cash = 0;
-        }
+        cash += mark.cash;
+        mark.cash = 0;
         moves = 0;
         // Describe the action
         if( mark.is_npc() ) {
@@ -4425,15 +4358,13 @@ void npc::mug_player( Character &mark )
         moves -= 100;
         return;
     }
-    if( !is_hallucination() ) {
-        i_add( to_steal->detach( ) );
-        if( mark.is_npc() ) {
-            if( u_see ) {
-                add_msg( _( "%1$s takes %2$s's %3$s." ), name, mark.name, to_steal->tname() );
-            }
-        } else {
-            add_msg( m_bad, _( "%1$s takes your %2$s." ), name, to_steal->tname() );
+    i_add( to_steal->detach( ) );
+    if( mark.is_npc() ) {
+        if( u_see ) {
+            add_msg( _( "%1$s takes %2$s's %3$s." ), name, mark.name, to_steal->tname() );
         }
+    } else {
+        add_msg( m_bad, _( "%1$s takes your %2$s." ), name, to_steal->tname() );
     }
     moves -= 100;
     if( !mark.is_npc() ) {
@@ -5020,10 +4951,6 @@ bool npc::complain()
 
 void npc::do_reload( item &it )
 {
-    if( is_hallucination() ) {
-        move_pause();
-        return;
-    }
     item_reload_option reload_opt = character_funcs::select_ammo( *this, it );
 
     if( !reload_opt ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1052,31 +1052,6 @@ bool ranged::handle_gun_damage( Character &shooter, item &it )
     return true;
 }
 
-void npc::pretend_fire( npc *source, int shots, item &gun )
-{
-    int curshot = 0;
-    avatar &you = get_avatar();
-    if( you.sees( *source ) && one_in( 50 ) ) {
-        add_msg( m_info, _( "%s shoots something." ), source->disp_name() );
-    }
-    while( curshot != shots ) {
-        if( gun.ammo_consume( gun.ammo_required(), bub_pos() ) != gun.ammo_required() ) {
-            debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname().c_str() );
-            break;
-        }
-
-        item *weapon = &gun;
-        const auto data = weapon->gun_noise( shots > 1 );
-
-        if( you.sees( *source ) ) {
-            add_msg( m_warning, _( "You hear %s." ), data.sound );
-        }
-        curshot++;
-        moves -= 100;
-    }
-}
-
-
 namespace ranged
 {
 


### PR DESCRIPTION
## Purpose of change (The Why)
Today even more issues with hallucination NPCs showed up
Specifically that they
- Leave blood on the ground
- Help with crafting

It is getting a little ridiculous
Related:
#9615
#9625

## Describe the solution (The How)
It doesn't really make sense to have full on hallucinated NPCs
They currently have entirely separate healing, activation, gun firing and more paths
And the bugs just keep coming with them due to the number of things that can be done

## Describe alternatives you've considered
Keep on playing wack a mole with these bugs

## Testing
Compiled and load tested
I dont splode when making hallucinations
The make NPC hallucinations path is gone

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [8c88aae](https://github.com/cataclysmbn/Cataclysm-BN/commit/8c88aae47739c1df08775c75927a03d53d27d089) (fix: remove hallucination NPCs) on 2026-07-09 18:51:42

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29036387236)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29036387236)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29036387236)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29036387236)
<!-- END artifact comment -->