### PR TITLE
fix: fix serializing flags enchantment array

### DIFF
--- a/src/enchantments/enchantment.cpp
+++ b/src/enchantments/enchantment.cpp
@@ -326,6 +326,7 @@ void enchantment::serialize(JsonOut& jsout) const {
     }
     jsout.end_array();
 
+    jsout.member("flags");
     jsout.start_array();
     for (const auto& [ench_flag_id, cnt] : flags) { jsout.write(ench_flag_id.str()); }
     jsout.end_array();


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #9843 

## Describe the solution (The How)
Remember member

## Describe alternatives you've considered
Further bapping incoming

## Testing
Load, rm13 spawn, save, load, no crash

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a564e9f](https://github.com/cataclysmbn/Cataclysm-BN/commit/a564e9fe4a5bec0e06f44668d64219cf39e8bc78) (fix: fix serializing flags enchantment array) on 2026-07-10 00:47:37

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29042079716/artifacts/8210620068)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29042079716)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29042079716/artifacts/8209483408)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29042079716/artifacts/8210346860)
<!-- END artifact comment -->