### PR TITLE
feat: reference itype relic data instead of item relic data by default

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -104,6 +104,7 @@
 #include "scores_ui.h"
 #include "cloning_utils.h"
 #include "skill.h"
+#include "sol/sol.hpp"
 #include "stomach.h"
 #include "string_formatter.h"
 #include "string_id_utils.h"
@@ -371,11 +372,6 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ),
         snip_id = SNIPPET.random_id_from_category( type->snippet_category );
     }
 
-    // item always has any relic properties from itype.
-    if( type->relic_data ) {
-        relic_data = type->relic_data;
-    }
-
     for( const auto &func : type->use_methods | std::views::values ) {
         const auto actor = func.get_actor_ptr();
         if( actor != nullptr ) {
@@ -605,7 +601,6 @@ detached_ptr<item> item::make_corpse( const mtype_id &mt, time_point turn, const
 void item::convert( const itype_id &new_type )
 {
     type = &*new_type;
-    relic_data = type->relic_data;
     invalidate_processing_cache_upwards();
 }
 
@@ -1144,7 +1139,7 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
     if( !skip_type_check && type != rhs.type ) {
         return false;
     }
-    if( is_relic() && rhs.is_relic() && !( *relic_data == *rhs.relic_data ) ) {
+    if( is_relic( true ) && rhs.is_relic( true ) && !( *relic_data == *rhs.relic_data ) ) {
         return false;
     }
     if( is_money() && charges != 0 && rhs.charges != 0 ) {
@@ -8051,9 +8046,9 @@ bool item::is_artifact() const
     return !!type->artifact;
 }
 
-bool item::is_relic() const
+bool item::is_relic( bool not_itype ) const
 {
-    return !!relic_data;
+    return !!relic_data || ( !not_itype && type->relic_data );
 }
 
 const std::vector<enchantment> &item::get_enchantments() const
@@ -8062,7 +8057,11 @@ const std::vector<enchantment> &item::get_enchantments() const
         static const std::vector<enchantment> fallback;
         return fallback;
     }
-    return relic_data->get_enchantments();
+    if( is_relic( true ) ) {
+        return relic_data->get_enchantments();
+    } else {
+        return type->relic_data->get_enchantments();
+    }
 }
 
 double item::bonus_from_enchantments( const Character &owner, double base,
@@ -8105,7 +8104,11 @@ double item::bonus_from_enchantments_wielded( double base, enchantment_value_id 
 
 const std::vector<relic_recharge> &item::get_relic_recharge_scheme() const
 {
-    return relic_data->get_recharge_scheme();
+    if( is_relic( true ) ) {
+        return relic_data->get_recharge_scheme();
+    } else {
+        return type->relic_data->get_recharge_scheme();
+    }
 }
 
 bool item::can_contain( const item &it ) const
@@ -10480,10 +10483,13 @@ std::vector<trait_id> item::mutations_from_wearing( const Character &guy ) const
     }
     std::vector<trait_id> muts;
 
-    for( const enchantment &ench : relic_data->get_enchantments() ) {
-        for( const trait_id &mut : ench.get_mutations() ) {
-            // this may not be perfectly accurate due to conditions
-            muts.push_back( mut );
+    const auto rel_data = is_relic( true ) ? relic_data : type->relic_data;
+    for( const enchantment &ench : rel_data->get_enchantments() ) {
+        if( ench.is_active( guy, is_active() ) ) {
+            for( const trait_id &mut : ench.get_mutations() ) {
+                // this may not be perfectly accurate due to conditions
+                muts.push_back( mut );
+            }
         }
     }
 

--- a/src/item.h
+++ b/src/item.h
@@ -1363,7 +1363,7 @@ class item : public location_visitable<item>, public game_object<item>
         bool is_tool() const;
         bool is_transformable() const;
         bool is_artifact() const;
-        bool is_relic() const;
+        bool is_relic( bool not_itype = false ) const;
         bool is_pocket_dimension_key() const;
         bool is_bucket() const;
         bool is_bucket_nonempty() const;


### PR DESCRIPTION
## Purpose of change (The Why)
Relevant: #9846
Relic data is unlike any other type of item data, as it is not updated when json is updated, rather set on spawn

## Describe the solution (The How)
Stop setting relic data on items
If there is relic data set ( I.E. via future artifact methods or past items ) use it otherwise
Fall back on itype relic data

## Describe alternatives you've considered
Use both at once
But this at the moment would cause double set relic data

## Testing
This build still has bad saveload, so see that everything (mutations, stats) still work
And that saveload works because relic data remains unset

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [379afa3](https://github.com/cataclysmbn/Cataclysm-BN/commit/379afa3bf1dfe9605e12a4f09b06759cadb79928) (feat: reference itype relic data instead of item relic data by default) on 2026-07-09 21:47:43

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29045515018/artifacts/8211769828)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29045515018/artifacts/8212319147)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29045515018/artifacts/8211319167)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29045515018/artifacts/8212023551)
<!-- END artifact comment -->