### PR TITLE
fix: check assistants for existance before cancelling their activities

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -16446,6 +16446,20 @@ std::vector<npc *> game::get_npcs_if( const std::function<bool( const npc & )> &
     return result;
 }
 
+std::vector<weak_ptr_fast<npc>> game::get_npcs_pointers_if( const std::function<bool( const npc & )>
+                             &pred )
+{
+    std::vector<weak_ptr_fast<npc>> result;
+    for( weak_ptr_fast<npc> guy : *all_npcs().items ) {
+        if( shared_ptr_fast<npc> true_guy = guy.lock() ) {
+            if( pred( *true_guy ) ) {
+                result.push_back( guy );
+            }
+        }
+    }
+    return result;
+}
+
 template<>
 bool game::non_dead_range<monster>::iterator::valid()
 {

--- a/src/game.h
+++ b/src/game.h
@@ -535,6 +535,8 @@ class game : public submap_load_listener
          */
         std::vector<Creature *> get_creatures_if( const std::function<bool( const Creature & )> &pred );
         std::vector<npc *> get_npcs_if( const std::function<bool( const npc & )> &pred );
+        std::vector<weak_ptr_fast<npc>> get_npcs_pointers_if( const std::function<bool( const npc & )>
+                                     &pred );
         /**
          * Returns a creature matching a predicate. Only living (not dead) creatures
          * are checked. Returns `nullptr` if no creature matches the predicate.

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -1,4 +1,5 @@
 #include "player_activity.h"
+#include "memory_fast.h"
 #include "player_activity_ptr.h"
 
 #include <algorithm>
@@ -39,6 +40,7 @@
 #include "string_id.h"
 #include "translations.h"
 #include "type_id.h"
+#include "memory_fast.h"
 
 using metric = std::pair<units::mass, units::volume>;
 
@@ -174,25 +176,28 @@ void player_activity::init_all_moves( Character &who )
     }
 }
 
-std::vector<npc *> &player_activity::assistants()
+std::vector<weak_ptr_fast<npc>> &player_activity::assistants()
 {
     if( !assistants_ids_.empty() && assistants_.empty() ) {
-        for( npc &guy : g->all_npcs() ) {
-            if( assistants_ids_.contains( guy.getID().get_value() ) ) {
-                assistants_.push_back( &guy );
+        for( weak_ptr_fast<npc> guy : * ( g->all_npcs().items ) ) {
+            if( auto true_guy = guy.lock() ) {
+                if( assistants_ids_.contains( true_guy->getID().get_value() ) ) {
+                    assistants_.push_back( guy );
+                }
             }
         }
     }
     return assistants_;
 }
 
-std::vector<npc *> player_activity::get_assistants( const Character &who, unsigned short max )
+std::vector<weak_ptr_fast<npc>> player_activity::get_assistants( const Character &who,
+                             unsigned short max )
 {
     if( max < 1 ) {
         return {};
     }
     int n = 0;
-    return g->get_npcs_if( [&]( const npc & guy ) {
+    return g->get_npcs_pointers_if( [&]( const npc & guy ) {
         if( n >= max ) {
             return false;
         }
@@ -218,10 +223,12 @@ void player_activity::get_assistants( const Character &who )
     }
 
     assistants_ = get_assistants( who, max );
-    for( Character *guy : assistants_ ) {
-        guy->assign_activity( std::make_unique<player_activity>
-                              ( std::make_unique<assist_activity_actor>() ) );
-        assistants_ids_.insert( guy->getID().get_value() );
+    for( weak_ptr_fast<npc> guy : assistants_ ) {
+        if( auto true_guy = guy.lock() ) {
+            true_guy->assign_activity( std::make_unique<player_activity>
+                                       ( std::make_unique<assist_activity_actor>() ) );
+            assistants_ids_.insert( true_guy->getID().get_value() );
+        }
     }
 }
 
@@ -644,9 +651,9 @@ void player_activity::do_turn( player &p )
                 set_to_null();
             }
         }
-        for( Character *npc : assistants() ) {
-            if( npc != nullptr ) {
-                npc->cancel_activity();
+        for( weak_ptr_fast<npc> npc : assistants() ) {
+            if( auto true_npc = npc.lock() ) {
+                true_npc->cancel_activity();
             }
         }
 
@@ -667,9 +674,9 @@ void player_activity::canceled( Character &who )
     if( *this && actor ) {
         actor->canceled( *this, who );
     }
-    for( Character *npc : assistants() ) {
-        if( npc != nullptr ) {
-            npc->cancel_activity();
+    for( weak_ptr_fast<npc> npc : assistants() ) {
+        if( auto true_npc = npc.lock() ) {
+            true_npc->cancel_activity();
         }
     }
 }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -200,7 +200,8 @@ std::vector<npc *> player_activity::get_assistants( const Character &who, unsign
         bool ok = guy.is_npc() && &guy != &who && !guy.in_sleep_state() && guy.is_obeying( who ) &&
                   guy.activity->id() != ACT_ASSIST &&
                   rl_dist( guy.bub_pos(), who.bub_pos() ) < PICKUP_RANGE &&
-                  get_map().clear_path( who.bub_pos(), guy.bub_pos(), PICKUP_RANGE, 1, 100 );
+                  get_map().clear_path( who.bub_pos(), guy.bub_pos(), PICKUP_RANGE, 1, 100 ) &&
+                  !guy.is_hallucination();
         if( ok ) {
             n++;
         }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -644,7 +644,9 @@ void player_activity::do_turn( player &p )
             }
         }
         for( Character *npc : assistants() ) {
-            npc->cancel_activity();
+            if( npc != nullptr ) {
+                npc->cancel_activity();
+            }
         }
 
     }
@@ -665,7 +667,9 @@ void player_activity::canceled( Character &who )
         actor->canceled( *this, who );
     }
     for( Character *npc : assistants() ) {
-        npc->cancel_activity();
+        if( npc != nullptr ) {
+            npc->cancel_activity();
+        }
     }
 }
 

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -43,7 +43,7 @@ class player_activity
         /** Unlocks the activity, or deletes it if it's already gone. */
         void resolve_active();
 
-        std::vector<npc *> assistants_;
+        std::vector<weak_ptr_fast<npc>> assistants_;
         //Cuz game code is borked
         std::set<int> assistants_ids_;
 
@@ -118,7 +118,7 @@ class player_activity
             return moves_left <= 0;
         }
         //Wrapper func to return assistants array properly
-        std::vector<npc *> &assistants();
+        std::vector<weak_ptr_fast<npc>> &assistants();
         /*
         * Members to work with activity_actor.
         */
@@ -184,7 +184,7 @@ class player_activity
 
         //Fills assistant vector with applicable assistants
         void get_assistants( const Character &who );
-        static std::vector<npc *> get_assistants( const Character &who, unsigned short max );
+        static std::vector<weak_ptr_fast<npc>> get_assistants( const Character &who, unsigned short max );
 
         /**
          * Helper that returns an activity specific progress message.


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #9656

NPCs had pointers stored in activities.
If they died or disappeared ( like maybe someone's stupid hallucination NPCs ) they would cause a segfault on completing the activity

Also I hate hallucinations
## Describe the solution (The How)
Store weak pointers like what is passed around in game.cpp to check for validity instead of praying NPCs are still alive

Hallucinations can no longer assist the player butcher

## Describe alternatives you've considered
Let someone else fix bugs

## Testing
Gain mutations:
- Debug Mind Control
- Debug invinsibility

Spawn a dog
Kill the dog

Put a kevlar zombie right by your new mind controlled NPC you spawned by

Begin butchering
You no longer crash after you complete the activity and they are dead

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e8a69f1](https://github.com/cataclysmbn/Cataclysm-BN/commit/e8a69f139791ea9f600a8340767f7479a490c1d5) (pointers evil) on 2026-07-10 03:01:27

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29060009468/artifacts/8216175838)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29060009468/artifacts/8216501162)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29060009468/artifacts/8216232679)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29060009468/artifacts/8216530855)
<!-- END artifact comment -->