### PR TITLE
feat(port): add more bionics, jsonize bio_targeting, general enchantment cleanup

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -595,6 +595,24 @@
     "points": 2
   },
   {
+    "id": "bio_grossfood",
+    "type": "bionic",
+    "name": { "str": "Taste Fouler" },
+    "occupied_bodyparts": [ [ "head", 1 ], [ "mouth", 1 ] ],
+    "description": "A malfunctioning processor haphazardly interfaced with your taste receptors has given everything you consume a horrid bitter taste.  Food and drink will severely harm your morale.",
+    "flags": [ "BIONIC_FAULTY" ],
+    "points": -1,
+    "starting_bionic": true,
+    "bio_enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "FOOD_FUN", "add": -4 }
+        ],
+      }
+    ]
+  },
+  {
     "id": "bio_ground_sonar",
     "type": "bionic",
     "name": { "str": "Terranian Sonar" },
@@ -1106,6 +1124,26 @@
     "points": -1
   },
   {
+    "id": "bio_sleep_shutdown",
+    "type": "bionic",
+    "name": { "str": "Sleep Mode Shutdown" },
+    "description": "For better or worse, this CBM suppresses pain and audio stimuli while asleep, preventing you from waking up from those causes.",
+    "occupied_bodyparts": [ [ "head", 1 ] ],
+    "flags": [ "BIONIC_FAULTY", "BIONIC_SHOCKPROOF" ],
+    "points": -2,
+    "starting_bionic": true,
+    "bio_enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "SLEEP_PAIN_THRESH", "add": 1000, "//": "If you are that in pain props to you" },
+          { "value": "SLEEP_DB_RESIST", "add": 1000, "//": "Sounds can't exceed 191" }
+        ],
+        "flags": [ "NO_THERMAL_WAKE", "NO_DAMAGE_WAKE", "NO_LIGHT_WAKE" ]
+      }
+    ]
+  },
+  {
     "id": "bio_spasm",
     "type": "bionic",
     "name": { "str": "Motor Control Overstimulator" },
@@ -1193,7 +1231,8 @@
     "description": "Your eyes are surgically equipped with range finders, and their movement is synced with that of your arms, to a degree.  Shots you fire will be much more accurate, particularly at long range.",
     "occupied_bodyparts": [ [ "eyes", 1 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "hand_l", 1 ], [ "hand_r", 1 ] ],
     "points": 2,
-    "flags": [ "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_NPC_USABLE" ],
+    "bio_enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "RANGED_DISPERSION", "multiply": -0.25 } ] } ]
   },
   {
     "id": "bio_teleport",

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -603,14 +603,7 @@
     "flags": [ "BIONIC_FAULTY" ],
     "points": -1,
     "starting_bionic": true,
-    "bio_enchantments": [
-      {
-        "condition": "ALWAYS",
-        "values": [
-          { "value": "FOOD_FUN", "add": -4 }
-        ],
-      }
-    ]
+    "bio_enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "FOOD_FUN", "add": -4 } ] } ]
   },
   {
     "id": "bio_ground_sonar",

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1127,7 +1127,7 @@
     "id": "bio_sleep_shutdown",
     "type": "bionic",
     "name": { "str": "Sleep Mode Shutdown" },
-    "description": "For better or worse, this CBM suppresses pain and audio stimuli while asleep, preventing you from waking up from those causes.",
+    "description": "For better or worse, this CBM suppresses most stimuli while asleep, preventing you from waking up from those causes.",
     "occupied_bodyparts": [ [ "head", 1 ] ],
     "flags": [ "BIONIC_FAULTY", "BIONIC_SHOCKPROOF" ],
     "points": -2,

--- a/data/json/enchantment_flags.json
+++ b/data/json/enchantment_flags.json
@@ -36,6 +36,10 @@
     "type": "enchantment_flag"
   },
   {
+    "id": "SILENT",
+    "type": "enchantment_flag"
+  },
+  {
     "id": "EAT_ROTTEN",
     "type": "enchantment_flag"
   },
@@ -86,6 +90,18 @@
   },
   {
     "id": "FIRE_FIELD_IMMUNE",
+    "type": "enchantment_flag"
+  },
+  {
+    "id": "NO_THERMAL_WAKE",
+    "type": "enchantment_flag"
+  },
+  {
+    "id": "NO_DAMAGE_WAKE",
+    "type": "enchantment_flag"
+  },
+  {
+    "id": "NO_LIGHT_WAKE",
     "type": "enchantment_flag"
   }
 ]

--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -234,6 +234,11 @@
     "desc": "Affects Focus"
   },
   {
+    "id": "FOOD_FUN",
+    "type": "enchantment_value",
+    "desc": "Affects Food Taste"
+  },
+  {
     "id": "BONUS_DODGE",
     "type": "enchantment_value",
     "desc": "Affects Dodging Ability"

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -1353,6 +1353,24 @@
     "difficulty": 5
   },
   {
+    "id": "bio_grossfood",
+    "copy-from": "bionic_general_faulty",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Taste Fouler" },
+    "description": "A broken and mis-wired module that would cause food and drink to taste terrible.",
+    "weight": "100 g",
+    "difficulty": 7
+  },
+  {
+    "id": "bio_sleep_shutdown",
+    "copy-from": "bionic_general_faulty",
+    "type": "BIONIC_ITEM",
+    "name": { "str_sp": "Sleep Mode Shutdown CBM" },
+    "description": "This CBM completely shuts down all communication between the user's brain and the rest of their body when they fall asleep, preventing them from waking up under any circumstance until their natural sleep cycle completes.  An inability to trigger its effects manually makes it useless as an anesthesia substitute.",
+    "weight": "100 g",
+    "difficulty": 10
+  },
+  {
     "id": "bn_bio_solar",
     "copy-from": "bionic_general_npc_usable",
     "type": "BIONIC_ITEM",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6877,7 +6877,7 @@
     "valid": false,
     "description": "Be vewwy vewwy quiet.  We're hunting bugs.",
     "debug": true,
-    "mut_enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "NOISE", "multiply": 0 } ] } ]
+    "mut_enchantments": [ { "condition": "ALWAYS", "flags": [ "SILENT" ] } ]
   },
   {
     "type": "mutation",

--- a/docs/en/mod/json/reference/enchantments.md
+++ b/docs/en/mod/json/reference/enchantments.md
@@ -771,3 +771,7 @@ Gives the ability to see the precise time
 ##### FIRE_FIELD_IMMUNE
 
 Provides immunity to fire fields.
+
+##### SILENT
+
+Prevents player sound from movement

--- a/docs/en/mod/json/reference/enchantments.md
+++ b/docs/en/mod/json/reference/enchantments.md
@@ -502,6 +502,11 @@ Maximum is 3
 Modifier to focus. `base_value` is current focus
 There is no limit
 
+##### FOOD_FUN
+
+Modifier to food morale. `base_value` is current food morale
+There is no limit.
+
 ##### BONUS_DODGE
 
 Additional dodges per turn before dodge penalty kicks in. `base_value` here is character's base
@@ -775,3 +780,15 @@ Provides immunity to fire fields.
 ##### SILENT
 
 Prevents player sound from movement
+
+##### NO_THERMAL_WAKE
+
+Extreme temperatures will not wake up the player
+
+##### NO_DAMAGE_WAKE
+
+Taking damage will not wake up the player
+
+##### NO_LIGHT_WAKE
+
+Lights will not wake up the player

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -377,6 +377,19 @@ static const trait_flag_str_id flag_NON_THRESH( "NON_THRESH" );
 
 static const activity_id ACT_ASSIST( "ACT_ASSIST" );
 
+static const enchantment_flag_id ench_flag_NO_THERMAL_WAKE( "NO_THERMAL_WAKE" );
+static const enchantment_flag_id ench_flag_NO_DAMAGE_WAKE( "NO_DAMAGE_WAKE" );
+static const enchantment_flag_id ench_flag_FIRE_FIELD_IMMUNE( "FIRE_FIELD_IMMUNE" );
+static const enchantment_flag_id ench_flag_BLIND( "BLIND" );
+static const enchantment_flag_id ench_flag_ELECTROSENSE( "ELECTROSENSE" );
+static const enchantment_flag_id ench_flag_VIEW_DRONE_CAM( "VIEW_DRONE_CAM" );
+static const enchantment_flag_id ench_flag_UNDERWATER_SIGHT( "UNDERWATER_SIGHT" );
+static const enchantment_flag_id ench_flag_NEARSIGHTED( "NEARSIGHTED" );
+static const enchantment_flag_id ench_flag_ALARMCLOCK( "ALARMCLOCK" );
+static const enchantment_flag_id ench_flag_WATCH( "WATCH" );
+static const enchantment_flag_id ench_flag_SLEEP_SIGHT( "SLEEP_SIGHT" );
+static const enchantment_flag_id ench_flag_INFRARED_VISION( "INFRARED_VISION" );
+
 namespace io
 {
 
@@ -973,8 +986,8 @@ bool Character::sight_impaired() const
     return ( ( ( has_effect( effect_boomered ) || has_effect( effect_no_sight ) ||
                  has_effect( effect_darkness ) ) && !has_trait( trait_PER_SLIME_OK ) ) ||
              ( is_underwater() && !worn_with_flag( flag_SWIM_GOGGLES ) &&
-               !has_enchantment_flag( enchantment_flag_id( "UNDERWATER_SIGHT" ) ) ) ||
-             ( has_enchantment_flag( enchantment_flag_id( "NEARSIGHTED" ) ) &&
+               !has_enchantment_flag( ench_flag_UNDERWATER_SIGHT ) ) ||
+             ( has_enchantment_flag( ench_flag_NEARSIGHTED ) &&
                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) ) ||
              has_trait( trait_PER_SLIME ) );
 }
@@ -985,7 +998,7 @@ bool Character::has_alarm_clock() const
     return ( has_item_with_flag( flag_ALARMCLOCK, true ) ||
              ( here.veh_at( bub_pos() ) &&
                !here.veh_at( bub_pos() )->vehicle().get_avail_parts( "ALARMCLOCK" ).empty() ) ||
-             has_enchantment_flag( enchantment_flag_id( "ALARMCLOCK" ) ) );
+             has_enchantment_flag( ench_flag_ALARMCLOCK ) );
 }
 
 bool Character::has_watch() const
@@ -994,7 +1007,7 @@ bool Character::has_watch() const
     return ( has_item_with_flag( flag_WATCH, true ) ||
              ( here.veh_at( bub_pos() ) &&
                !here.veh_at( bub_pos() )->vehicle().get_avail_parts( "WATCH" ).empty() ) ||
-             has_enchantment_flag( enchantment_flag_id( "WATCH" ) ) );
+             has_enchantment_flag( ench_flag_WATCH ) );
 }
 
 void Character::react_to_felt_pain( int intensity )
@@ -2014,7 +2027,7 @@ void Character::recalc_sight_limits()
 
     // Set sight_max.
     if( is_blind() || ( in_sleep_state() &&
-                        !has_enchantment_flag( enchantment_flag_id( "SLEEP_SIGHT" ) ) ) ||
+                        !has_enchantment_flag( ench_flag_SLEEP_SIGHT ) ) ||
         has_effect( effect_narcosis ) ) {
         sight_max = 0;
     } else if( has_effect( effect_boomered ) && ( !( has_trait( trait_PER_SLIME_OK ) ) ) ) {
@@ -2022,12 +2035,12 @@ void Character::recalc_sight_limits()
         vision_mode_cache.set( BOOMERED );
     } else if( has_effect( effect_in_pit ) || has_effect( effect_no_sight ) ||
                ( is_underwater() && !worn_with_flag( flag_SWIM_GOGGLES ) &&
-                 !has_enchantment_flag( enchantment_flag_id( "UNDERWATER_SIGHT" ) ) ) ) {
+                 !has_enchantment_flag( ench_flag_UNDERWATER_SIGHT ) ) ) {
         sight_max = 1;
     } else if( has_active_mutation( trait_SHELL2 ) ) {
         // You can kinda see out a bit.
         sight_max = 2;
-    } else if( has_enchantment_flag( enchantment_flag_id( "NEARSIGHTED" ) ) &&
+    } else if( has_enchantment_flag( ench_flag_NEARSIGHTED ) &&
                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) ) {
         sight_max = 4;
     } else if( has_trait( trait_PER_SLIME ) ) {
@@ -2069,7 +2082,7 @@ void Character::recalc_sight_limits()
     }
 
     // Not exactly a sight limit thing, but related enough
-    if( has_enchantment_flag( enchantment_flag_id( "INFRARED_VISION" ) ) ||
+    if( has_enchantment_flag( ench_flag_INFRARED_VISION ) ||
         worn_with_flag( flag_IR_EFFECT ) ||
         ( is_mounted() && mounted_creature->has_flag( MF_MECH_RECON_VISION ) ) ) {
         vision_mode_cache.set( IR_VISION );
@@ -6549,11 +6562,12 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
         // AND you have frostbite, then that also prevents you from sleeping
         if( in_sleep_state() ) {
             int curr_temperature = bp_stats.get_temp_cur();
-            if( bp == body_part_torso && curr_temperature <= BODYTEMP_COLD ) {
+            if( bp == body_part_torso && curr_temperature <= BODYTEMP_COLD &&
+                !has_enchantment_flag( ench_flag_NO_THERMAL_WAKE ) ) {
                 add_msg( m_warning, _( "Your shivering prevents you from sleeping." ) );
                 wake_up();
             } else if( bp != body_part_torso && curr_temperature <= BODYTEMP_VERY_COLD &&
-                       has_effect( effect_frostbite ) ) {
+                       has_effect( effect_frostbite ) && !has_enchantment_flag( ench_flag_NO_THERMAL_WAKE ) ) {
                 add_msg( m_warning, _( "You are too cold.  Your frostbite prevents you from sleeping." ) );
                 wake_up();
             }
@@ -7082,7 +7096,7 @@ bool Character::is_immune_field( const field_type_id &fid ) const
         return is_elec_immune();
     }
     if( ft.has_fire ) {
-        return has_enchantment_flag( enchantment_flag_id( "FIRE_FIELD_IMMUNE" ) );
+        return has_enchantment_flag( ench_flag_FIRE_FIELD_IMMUNE );
     }
     if( ft.has_acid ) {
         return !is_on_ground() && get_env_resist( bodypart_id( "foot_l" ) ) >= 15 &&
@@ -7260,7 +7274,7 @@ tripoint_abs_omt Character::abs_omt_pos() const
 bool Character::is_blind() const
 {
     return worn_with_flag( flag_BLIND ) || has_effect( effect_blind ) ||
-           has_enchantment_flag( enchantment_flag_id( "BLIND" ) );
+           has_enchantment_flag( ench_flag_BLIND );
 }
 
 bool Character::is_invisible() const
@@ -7366,7 +7380,7 @@ bool Character::sees_with_specials( const Creature &critter ) const
     }
 
     // electroreceptors grants vision of robots and electric monsters through walls
-    if( has_enchantment_flag( enchantment_flag_id( "ELECTROSENSE" ) ) &&
+    if( has_enchantment_flag( ench_flag_ELECTROSENSE ) &&
         ( critter.in_species( ROBOT ) || critter.has_flag( MF_ELECTRIC ) ) ) {
         return true;
     }
@@ -7380,7 +7394,7 @@ bool Character::sees_with_specials( const Creature &critter ) const
     }
     // Friendly eyebots can designate targets for the player
     if( critter.has_effect( effect_drone_marker ) && ( has_item_with_flag( flag_DRONE_CAM ) ||
-            has_enchantment_flag( enchantment_flag_id( "VIEW_DRONE_CAM" ) ) ) ) {
+            has_enchantment_flag( ench_flag_VIEW_DRONE_CAM ) ) ) {
         return true;
     }
 
@@ -9864,7 +9878,8 @@ void Character::on_hurt( Creature *source, bool disturb /*= true*/ )
     }
 
     if( disturb ) {
-        if( has_effect( effect_sleep ) && !has_effect( effect_narcosis ) ) {
+        if( has_effect( effect_sleep ) && !has_effect( effect_narcosis ) &&
+            !has_enchantment_flag( ench_flag_NO_DAMAGE_WAKE ) ) {
             wake_up();
         }
         if( !is_npc() && !has_effect( effect_narcosis ) ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -135,6 +135,15 @@ static const vitamin_id vitamin_wheat_allergen( "wheat_allergen" );
 
 static const trait_flag_str_id trait_flag_CANNIBAL( "CANNIBAL" );
 
+static const enchantment_value_id ench_val_FOOD_FUN( "FOOD_FUN" );
+static const enchantment_value_id ench_val_METABOLISM( "METABOLISM" );
+
+static const enchantment_flag_id ench_flag_EAT_ROTTEN( "EAT_ROTTEN" );
+static const enchantment_flag_id ench_flag_ONLY_EAT_ROTTEN( "ONLY_EAT_ROTTEN" );
+static const enchantment_flag_id ench_flag_EAT_ROTTEN_MORALE( "EAT_ROTTEN_MORALE" );
+static const enchantment_flag_id ench_flag_FOOD_POISON_IMMUNE( "FOOD_POISON_IMMUNE" );
+static const enchantment_flag_id ench_flag_FOOD_PARASITE_IMMUNE( "FOOD_PARASITE_IMMUNE" );
+
 // note: cannot use constants from flag.h (e.g. flag_ALLERGEN_VEGGY) here, as they
 // might be uninitialized at the time these const arrays are created
 static const std::array<vitamin_id, 4> carnivore_blacklist {{
@@ -488,7 +497,7 @@ std::pair<int, int> Character::fun_for( const item &comest ) const
 
     const float relative_rot = comest.get_relative_rot();
 
-    if( relative_rot > 1.0f && !has_enchantment_flag( enchantment_flag_id( "EAT_ROTTEN_MORALE" ) ) ) {
+    if( relative_rot > 1.0f && !has_enchantment_flag( ench_flag_EAT_ROTTEN_MORALE ) ) {
         // Rotten food should be pretty disgusting.
         // Baseline minumum is the same as eating raw meat as a normal human being.
         fun = std::min( fun - 5, -10.0f );
@@ -603,7 +612,7 @@ float Character::metabolic_rate_base() const
     const float hunger_rate = get_option< float >( hunger_rate_string );
     const float mut_bonus = 1.0f + mutation_value( metabolism_modifier );
     const float with_mut = hunger_rate * mut_bonus;
-    const float ench_bonus = bonus_from_enchantments( with_mut, enchantment_value_id( "METABOLISM" ) );
+    const float ench_bonus = bonus_from_enchantments( with_mut, ench_val_METABOLISM );
 
     return std::max( 0.0f, with_mut + ench_bonus );
 }
@@ -743,7 +752,7 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
 
     const auto &comest = food.get_comestible();
 
-    if( food.rotten() && !has_enchantment_flag( enchantment_flag_id( "EAT_ROTTEN" ) ) ) {
+    if( food.rotten() && !has_enchantment_flag( ench_flag_EAT_ROTTEN ) ) {
         add_consequence( _( "This is rotten and smells awful!" ), edible_rating::rotten );
     }
 
@@ -772,7 +781,7 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
         add_consequence( _( "Your stomach won't be happy (allergy)." ), edible_rating::allergy );
     }
 
-    if( has_enchantment_flag( enchantment_flag_id( "ONLY_EAT_ROTTEN" ) ) && edible && food.rotten() ) {
+    if( has_enchantment_flag( ench_flag_ONLY_EAT_ROTTEN ) && edible && food.rotten() ) {
         // Note: We're allowing all non-solid "food". This includes drugs
         //~ No, we don't eat "rotten" food. We eat properly aged food, like a normal person.
         //~ Semantic difference, but greatly facilitates people being proud of their character.
@@ -858,13 +867,13 @@ bool Character::eat( item &food, bool force )
     // If neither of the above is true then it's a drug and shouldn't get mealtime penalty/bonus
 
     if( spoiled ) {
-        if( !has_enchantment_flag( enchantment_flag_id( "EAT_ROTTEN_MORALE" ) ) ) {
+        if( !has_enchantment_flag( ench_flag_EAT_ROTTEN_MORALE ) ) {
             add_msg_if_player( m_bad, _( "Ick, this %s doesn't taste so good…" ), food.tname() );
         } else {
             add_msg_if_player( m_good, _( "Mmm, this %s tastes delicious…" ), food.tname() );
         }
-        if( !has_enchantment_flag( enchantment_flag_id( "EAT_ROTTEN" ) ) &&
-            !has_enchantment_flag( enchantment_flag_id( "FOOD_POISON_IMMUNE" ) ) ) {
+        if( !has_enchantment_flag( ench_flag_EAT_ROTTEN ) &&
+            !has_enchantment_flag( ench_flag_FOOD_POISON_IMMUNE ) ) {
             add_effect( effect_foodpoison, rng( 6_minutes, ( nutr + 1 ) * 6_minutes ) );
         }
     }
@@ -940,7 +949,7 @@ bool Character::eat( item &food, bool force )
     }
 
     // Chance to become parasitised
-    if( !has_enchantment_flag( enchantment_flag_id( "FOOD_PARASITE_IMMUNE" ) ) ) {
+    if( !has_enchantment_flag( ench_flag_FOOD_PARASITE_IMMUNE ) ) {
         if( food.get_comestible()->parasites > 0 && !food.has_flag( flag_NO_PARASITES ) &&
             one_in( food.get_comestible()->parasites ) ) {
             switch( rng( 0, 3 ) ) {
@@ -1086,6 +1095,9 @@ void Character::modify_morale( item &food, int nutr )
 
 
     std::pair<int, int> fun = fun_for( food );
+
+    fun.first += bonus_from_enchantments( fun.first, ench_val_FOOD_FUN );
+
     if( fun.first < 0 ) {
         if( has_active_bionic( bio_taste_blocker ) &&
             get_power_level() > units::from_kilojoule( -fun.first ) ) {
@@ -1152,7 +1164,7 @@ void Character::modify_morale( item &food, int nutr )
     }
     const bool chew = food.get_comestible()->comesttype == comesttype_FOOD ||
                       food.has_flag( flag_USE_EAT_VERB );
-    if( !food.rotten() && chew && has_enchantment_flag( enchantment_flag_id( "ONLY_EAT_ROTTEN" ) ) ) {
+    if( !food.rotten() && chew && has_enchantment_flag( ench_flag_ONLY_EAT_ROTTEN ) ) {
         // It's OK to *drink* things that haven't rotted.  Alternative is to ban water.  D:
         add_msg_if_player( m_bad, _( "Your stomach begins gurgling and you feel bloated and ill." ) );
         add_morale( MORALE_NO_DIGEST, -75, -400, 30_minutes, 24_minutes );
@@ -1194,7 +1206,7 @@ bool Character::consume_effects( item &food )
 
     // Rotten food causes health loss
     const float relative_rot = food.get_relative_rot();
-    if( relative_rot > 1.0f && !has_enchantment_flag( enchantment_flag_id( "EAT_ROTTEN" ) ) ) {
+    if( relative_rot > 1.0f && !has_enchantment_flag( ench_flag_EAT_ROTTEN ) ) {
         const float rottedness = clamp( 2 * relative_rot - 2.0f, 0.1f, 1.0f );
         // ~-1 health per 1 nutrition at halfway-rotten-away, ~0 at "just got rotten"
         // But always round down
@@ -1707,7 +1719,7 @@ void consume_poison( Character &consumer, item &food )
     // If it's poisonous... poison us.
     // TODO: Move this to a flag
     if( food.poison > 0 &&
-        !consumer.has_enchantment_flag( enchantment_flag_id( "FOOD_POISON_IMMUNE" ) ) ) {
+        !consumer.has_enchantment_flag( ench_flag_FOOD_POISON_IMMUNE ) ) {
         if( food.poison >= rng( 2, 4 ) ) {
             consumer.add_effect( effect_poison, food.poison * 1_minutes );
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12719,7 +12719,8 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
             u.mod_fatigue( 1 );
         }
     }
-    if( !u.has_artifact_with( AEP_STEALTH ) ) {
+    if( !u.has_artifact_with( AEP_STEALTH ) &&
+        !u.has_enchantment_flag( enchantment_flag_id( "SILENT" ) ) ) {
         int volume = u.is_stealthy() ? 30 : 50;
         volume *= u.mutation_value( "noise_modifier" );
         volume += u.bonus_from_enchantments( volume, enchantment_value_id( "NOISE" ) );

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -107,10 +107,13 @@ static const trait_id trait_INFRESIST( "INFRESIST" );
 static const trait_id trait_M_IMMUNE( "M_IMMUNE" );
 static const trait_id trait_M_SKIN3( "M_SKIN3" );
 static const trait_id trait_NOPAIN( "NOPAIN" );
-static const trait_id trait_SEESLEEP( "SEESLEEP" );
 static const trait_id trait_SCHIZOPHRENIC( "SCHIZOPHRENIC" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
 static const trait_id trait_WATERSLEEP( "WATERSLEEP" );
+
+static const enchantment_flag_id ench_flag_INTERNAL_ALARMCLOCK( "INTERNAL_ALARMCLOCK" );
+static const enchantment_flag_id ench_flag_SLEEP_SIGHT( "SLEEP_SIGHT" );
+static const enchantment_flag_id ench_flag_NO_LIGHT_WAKE( "NO_LIGHT_WAKE" );
 
 static void eff_fun_onfire( player &u, effect &it )
 {
@@ -1167,8 +1170,9 @@ void Character::hardcoded_effects( effect &it )
         bool woke_up = false;
         int tirednessVal = rng( 5, 200 ) + rng( 0, std::abs( get_fatigue() * 2 * 5 ) );
         if( !is_blind() && !has_effect( effect_narcosis ) ) {
-            if( !has_enchantment_flag(
-                    enchantment_flag_id( "SLEEP_SIGHT" ) ) ) { // People who can see while sleeping are acclimated to the light.
+            // If you can see while sleeping light probably doesn't bother you
+            if( !has_enchantment_flag( ench_flag_SLEEP_SIGHT ) &&
+                !has_enchantment_flag( ench_flag_NO_LIGHT_WAKE ) ) {
                 if( has_trait( trait_HEAVYSLEEPER2 ) && !has_trait( trait_HIBERNATE ) ) {
                     // So you can too sleep through noon
                     if( ( tirednessVal * 1.25 ) < g->m.ambient_light_at( bub_pos() ) && ( get_fatigue() < 10 ||
@@ -1194,7 +1198,7 @@ void Character::hardcoded_effects( effect &it )
                     it.set_duration( 0_turns );
                     woke_up = true;
                 }
-            } else if( !has_enchantment_flag( enchantment_flag_id( "SLEEP_SIGHT" ) ) ) {
+            } else if( has_enchantment_flag( ench_flag_SLEEP_SIGHT ) ) {
                 Creature *hostile_critter = g->is_hostile_very_close();
                 if( hostile_critter != nullptr ) {
                     add_msg_if_player( _( "You see %s approaching!" ),
@@ -1270,7 +1274,7 @@ void Character::hardcoded_effects( effect &it )
     } else if( id == effect_alarm_clock ) {
         if( in_sleep_state() ) {
             const bool asleep = has_effect( effect_sleep );
-            if( has_enchantment_flag( enchantment_flag_id( "INTERNAL_ALARMCLOCK" ) ) ) {
+            if( has_enchantment_flag( ench_flag_INTERNAL_ALARMCLOCK ) ) {
                 if( dur == 1_turns ) {
                     if( !asleep ) {
                         add_msg_if_player( _( "Your internal chronometer went off and you haven't slept a wink." ) );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2682,9 +2682,6 @@ dispersion_sources ranged::get_weapon_dispersion( const Character &who, const it
 
     dispersion.add_range( dispersion_from_skill( avgSkill, weapon_dispersion ) );
 
-    if( who.has_bionic( bio_targeting ) ) {
-        dispersion.add_multiplier( 0.75 );
-    }
     // If we're crouched, it's easier to steady our aim.
     if( who.movement_mode_is( CMM_CROUCH ) ) {
         dispersion.add_multiplier( 0.75 );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -98,6 +98,8 @@ static const itype_id fuel_type_battery( "battery" );
 
 static const itype_id itype_weapon_fire_suppressed( "weapon_fire_suppressed" );
 
+static const enchantment_value_id ench_val_SLEEP_DB_RESIST( "SLEEP_DB_RESIST" );
+
 // For use with the floodfill logic.
 static constexpr auto tile_structure_sound_absorption_tier = std::array<short, 4>
 {
@@ -2732,8 +2734,7 @@ void sounds::process_sound_markers( Character *who )
             if( who->has_effect( effect_sleep ) ) {
                 const int diff_db_vol = mdBspl_to_dBspl( tile_vol - passive_sound_dampening - tile_vol );
                 int wake_up_vol = 10;
-                wake_up_vol += who->bonus_from_enchantments( wake_up_vol,
-                               enchantment_value_id( "SLEEP_DB_RESIST" ) );
+                wake_up_vol += who->bonus_from_enchantments( wake_up_vol, ench_val_SLEEP_DB_RESIST );
 
                 if( rng( wake_up_vol / 2, wake_up_vol ) <= db_vol && !who->has_effect( effect_narcosis ) ) {
                     who->wake_up();


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #2836 by porting Taste Fouler and Sleep Shutdown from https://github.com/CleverRaven/Cataclysm-DDA/pull/55909
Closes: #2812

## Describe the solution (The How)
Start of using static const enchantment_xxx_id instead of making the ids on the spot

Add `SILENT` `NO_THERMAL_WAKE` `NO_DAMAGE_WAKE` and `NO_LIGHT_WAKE`

Also add `FOOD_FUN`

## Describe alternatives you've considered
Split into more PRs, got a little carried away

## Testing
With bionic: tested sleeping conditions including
- Slept through the sunrise
- Sleeping near migo heat emitter
- Sleeping through c4 explosion

Also tested the new food flag
Otherwise it's mainly format changes

## Additional context
I probably should have split this more

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [x] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [x] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [x] I have linked the URL of original PR(s) in the description.
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f1e6873](https://github.com/cataclysmbn/Cataclysm-BN/commit/f1e68735864f211c3afbdee83da7719638545fb8) (style(autofix.ci): automated formatting) on 2026-07-10 05:28:36

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29067552150/artifacts/8218638730)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29067552150/artifacts/8218984174)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29067552150/artifacts/8218701752)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29067552150/artifacts/8218909216)
<!-- END artifact comment -->

<!-- BEGIN docs comment -->

## Translations

| post                               | changed | stale | missing |
| ---------------------------------- | ------- | ----- | ------- |
| mod/json/reference/enchantments.md | en      |       | ja, ko  |

<!-- END docs comment -->