### PR TITLE
fix: skills through kills arcana compat

### DIFF
--- a/data/mods/skills_through_kills/main.lua
+++ b/data/mods/skills_through_kills/main.lua
@@ -37,6 +37,7 @@ local SKILL_DEFS = {
   { id = "driving", name = gettext("Driving") },
   { id = "fabrication", name = gettext("Fabrication") },
   { id = "spellcraft", name = gettext("Spellcraft") },
+  { id = "magic", name = gettext("Arcana") },
 }
 
 ---@class SkillsThroughKillsSkill


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #9851

## Describe the solution (The How)
Add it to scarfs list of things

## Describe alternatives you've considered
Expose getting all skill ids, and then using that in lua to dynamically generate the list to ensure all mod compat

## Testing
Eyes

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c0a46b8](https://github.com/cataclysmbn/Cataclysm-BN/commit/c0a46b8ffc7179f81a90d6f79fa858c18315d7de) (fix: skills through kills arcana compat) on 2026-07-10 19:49:43

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29114607186/artifacts/8237102389)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29114607186/artifacts/8237686970)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29114607186/artifacts/8237159213)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29114607186/artifacts/8237794146)
<!-- END artifact comment -->