### PR TITLE
fix: Swap time-related zeroing from Hammer Space to Hammer Time

### DIFF
--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -28,6 +28,7 @@
 
 static const trait_id trait_CHLOROMORPH( "CHLOROMORPH" );
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
+static const trait_id trait_DEBUG_HT( "DEBUG_HT" );
 static const trait_id trait_M_SKIN3( "M_SKIN3" );
 static const trait_id trait_SHELL2( "SHELL2" );
 static const trait_id trait_THRESH_SPIDER( "THRESH_SPIDER" );
@@ -451,7 +452,7 @@ void gunmod_add( avatar &you, item &gun, item &mod )
         actions[ prompt.ret ]();
     } while( requery );
 
-    const int moves = !you.has_trait( trait_DEBUG_HS ) ? mod.type->gunmod->install_time : 0;
+    const int moves = !you.has_trait( trait_DEBUG_HT ) ? mod.type->gunmod->install_time : 0;
 
     you.assign_activity( activity_id( "ACT_GUNMOD_ADD" ), moves, -1, 0, tool );
     you.activity->targets.emplace_back( &gun );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -82,6 +82,7 @@ static const quality_id qual_LIFT( "LIFT" );
 static const quality_id qual_SELF_JACK( "SELF_JACK" );
 
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
+static const trait_id trait_DEBUG_HT( "DEBUG_HT" );
 
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 
@@ -158,7 +159,7 @@ std::unique_ptr<player_activity> veh_interact::serialize_activity()
         default:
             break;
     }
-    if( you.has_trait( trait_DEBUG_HS ) ) {
+    if( you.has_trait( trait_DEBUG_HT ) ) {
         time = 1;
     }
     std::unique_ptr<player_activity> res = std::make_unique<player_activity>( ACT_VEHICLE, time,


### PR DESCRIPTION
## Purpose of change (The Why)

It would make no sense for hammerspace to affect the time it takes to do something, only the requirements

## Describe the solution (The How)

Swaps the two examples of hammerspace affecting time over to hammertime

## Describe alternatives you've considered

Make someone else do it

## Testing

None, but this is an incredibly simple change and clangd doesn't yell at me for it so the C++ side is fine lol

## Additional context

There's probably other areas this same logic could be applied to.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b760344](https://github.com/cataclysmbn/Cataclysm-BN/commit/b760344a3ba02ffd70a101b600b091ac7184c067) (Swap time-related zeroing from HS to HT) on 2026-07-11 00:22:42

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29128306076/artifacts/8242316012)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29128306076/artifacts/8242113892)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29128306076/artifacts/8241867263)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29128306076/artifacts/8242272696)
<!-- END artifact comment -->