### PR TITLE
fix: automated gas station fuel tank

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -65,7 +65,7 @@
     "color": "brown_red",
     "move_cost": 0,
     "coverage": 50,
-    "flags": [ "TRANSPARENT", "FLAMMABLE", "NOITEM", "SEALED", "CONTAINER", "REDUCE_SCENT" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "NOITEM", "SEALED", "CONTAINER", "LIQUIDCONT", "REDUCE_SCENT" ],
     "bash": {
       "str_min": 40,
       "str_max": 100,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Closes: #3868

## Describe the solution (The How)

Add flag to allow 't_gas_tank' to store liquids

## Testing

Created world teleported to nearest AGS station
No gasoline puddle near the fuel tank
Console works as expected
Can't directly add or remove fuel from the tank

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5b1f051](https://github.com/cataclysmbn/Cataclysm-BN/commit/5b1f05137a04ad124738a613213e6833a90d7191) (fix automated gas station) on 2026-07-11 01:34:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29131293376/artifacts/8243153123)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29131293376/artifacts/8242923878)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29131293376/artifacts/8242628874)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29131293376/artifacts/8243071052)
<!-- END artifact comment -->