### PR TITLE
fix: make immobile hallucinations disappear

### DIFF
--- a/data/mods/TEST_DATA/monsters.json
+++ b/data/mods/TEST_DATA/monsters.json
@@ -65,13 +65,5 @@
     "copy-from": "mon_test_death_drops_clear",
     "type": "MONSTER",
     "death_drops": ""
-  },
-  {
-    "id": "mon_test_zero_speed_hallucination",
-    "copy-from": "debug_mon",
-    "type": "MONSTER",
-    "name": { "str": "zero-speed hallucination test monster" },
-    "description": "This monster exists only for testing purposes.",
-    "speed": 0
   }
 ]

--- a/data/mods/TEST_DATA/monsters.json
+++ b/data/mods/TEST_DATA/monsters.json
@@ -65,5 +65,13 @@
     "copy-from": "mon_test_death_drops_clear",
     "type": "MONSTER",
     "death_drops": ""
+  },
+  {
+    "id": "mon_test_zero_speed_hallucination",
+    "copy-from": "debug_mon",
+    "type": "MONSTER",
+    "name": { "str": "zero-speed hallucination test monster" },
+    "description": "This monster exists only for testing purposes.",
+    "speed": 0
   }
 ]

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -73,6 +73,7 @@
 #include "crafting.h"
 #include "creature_throw.h"
 #include "creature_tracker.h"
+#include "monster_hallucination.h"
 #include "monster.h"
 #include "monster_action.h"
 #include "monster_plan.h"
@@ -6147,6 +6148,12 @@ void game::monmove( const monster_activity_ai_mode mode, activity_monmove_cache 
 
             if( !critter.is_dead() ) {
                 critter.process_turn();
+            }
+
+            if( monster_hallucination::needs_lifecycle_expiry( critter ) &&
+                one_in( monster_hallucination::expiry_one_in ) ) {
+                critter.die( nullptr );
+                continue;
             }
 
             m.creature_in_field( critter );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -46,6 +46,7 @@
 #include "mattack_common.h"
 #include "messages.h"
 #include "monfaction.h"
+#include "monster_hallucination.h"
 #include "monster_oracle.h"
 #include "mtype.h"
 #include "npc.h"
@@ -1112,7 +1113,7 @@ monster_action_t monster::decide_action() const
     const auto wandering = goal == pos;
 
     // (1) Hallucination: chance to vanish each tick.
-    if( hallucination && one_in( 25 ) ) {
+    if( hallucination && one_in( monster_hallucination::expiry_one_in ) ) {
         action.kind = monster_action_kind::die;
         return action;
     }

--- a/src/monster_hallucination.cpp
+++ b/src/monster_hallucination.cpp
@@ -1,0 +1,14 @@
+#include "monster_hallucination.h"
+
+#include "monster.h"
+
+namespace monster_hallucination
+{
+
+auto needs_lifecycle_expiry( const monster &critter ) -> bool
+{
+    return !critter.is_dead() && critter.is_hallucination() && critter.get_moves() <= 0 &&
+           critter.get_speed() <= 0;
+}
+
+} // namespace monster_hallucination

--- a/src/monster_hallucination.h
+++ b/src/monster_hallucination.h
@@ -7,7 +7,7 @@ namespace monster_hallucination
 
 inline constexpr auto expiry_one_in = 25;
 
-/// Whether a hallucination cannot reach the action loop and needs lifecycle expiry.
+/// Whether a stalled zero-speed hallucination needs the lifecycle expiry fallback.
 auto needs_lifecycle_expiry( const monster &critter ) -> bool;
 
 } // namespace monster_hallucination

--- a/src/monster_hallucination.h
+++ b/src/monster_hallucination.h
@@ -1,0 +1,13 @@
+#pragma once
+
+class monster;
+
+namespace monster_hallucination
+{
+
+inline constexpr auto expiry_one_in = 25;
+
+/// Whether a hallucination cannot reach the action loop and needs lifecycle expiry.
+auto needs_lifecycle_expiry( const monster &critter ) -> bool;
+
+} // namespace monster_hallucination

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -1,6 +1,5 @@
 #include "action_time_scale.h"
 #include "avatar.h"
-#include "cata_utility.h"
 #include "catch/catch.hpp"
 #include "coordinates.h"
 #include "field_type.h"
@@ -127,14 +126,8 @@ TEST_CASE("hallucination_electric_field_does_not_ignite_items", "[monster][hallu
 TEST_CASE(
     "only stalled hallucinations qualify for lifecycle expiry fallback",
     "[monster][hallucination]") {
-    clear_all_state();
-    const auto cleanup = on_out_of_scope([]() { clear_all_state(); });
-    move_player_out_of_the_way();
-    build_test_map(ter_id("t_floor"));
-
-    const auto monster_pos = tripoint_bub_ms(60, 60, 0);
-    auto& test_monster = spawn_test_monster("mon_test_zero_speed_hallucination", monster_pos);
-    REQUIRE(test_monster.has_flag(MF_NOT_HALLU));
+    auto test_monster = monster(mtype_id("debug_mon"));
+    test_monster.set_speed_base(0);
     test_monster.hallucination = true;
     test_monster.set_moves(0);
 

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -1,5 +1,6 @@
 #include "action_time_scale.h"
 #include "avatar.h"
+#include "cata_utility.h"
 #include "catch/catch.hpp"
 #include "coordinates.h"
 #include "field_type.h"
@@ -13,6 +14,7 @@
 #include "monattack.h"
 #include "monster.h"
 #include "monster_action.h"
+#include "monster_hallucination.h"
 #include "options.h"
 #include "options_helpers.h"
 #include "player.h"
@@ -120,6 +122,54 @@ TEST_CASE("hallucination_electric_field_does_not_ignite_items", "[monster][hallu
     hallucination.process_turn();
 
     CHECK(here.get_field(fuel_pos, fd_fire) == nullptr);
+}
+
+TEST_CASE(
+    "only stalled hallucinations qualify for lifecycle expiry fallback",
+    "[monster][hallucination]") {
+    clear_all_state();
+    const auto cleanup = on_out_of_scope([]() { clear_all_state(); });
+    move_player_out_of_the_way();
+    build_test_map(ter_id("t_floor"));
+
+    const auto monster_pos = tripoint_bub_ms(60, 60, 0);
+    auto& test_monster = spawn_test_monster("mon_test_zero_speed_hallucination", monster_pos);
+    REQUIRE(test_monster.has_flag(MF_NOT_HALLU));
+    test_monster.hallucination = true;
+    test_monster.set_moves(0);
+
+    REQUIRE(test_monster.get_speed() == 0);
+    REQUIRE(test_monster.get_moves() == 0);
+
+    SECTION("a stalled hallucination needs lifecycle expiry") {
+        CHECK(monster_hallucination::needs_lifecycle_expiry(test_monster));
+    }
+
+    SECTION("real zero-speed monsters do not use hallucination expiry") {
+        test_monster.hallucination = false;
+
+        CHECK_FALSE(monster_hallucination::needs_lifecycle_expiry(test_monster));
+    }
+
+    SECTION("positive-speed hallucinations keep their action-path expiry") {
+        test_monster.set_speed_base(100);
+
+        REQUIRE(test_monster.get_speed() > 0);
+        CHECK_FALSE(monster_hallucination::needs_lifecycle_expiry(test_monster));
+    }
+
+    SECTION("zero-speed hallucinations with banked moves keep their action-path expiry") {
+        test_monster.set_moves(1);
+
+        CHECK_FALSE(monster_hallucination::needs_lifecycle_expiry(test_monster));
+    }
+
+    SECTION("dead hallucinations do not need lifecycle expiry") {
+        test_monster.set_hp(0);
+
+        REQUIRE(test_monster.is_dead());
+        CHECK_FALSE(monster_hallucination::needs_lifecycle_expiry(test_monster));
+    }
 }
 
 TEST_CASE("MONSTER_SPEED scales monster move credit", "[monster][speed]") {


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #9794

Zero-speed hallucinations such as wasp larvae never reach the monster action loop, so their existing expiry roll never runs.

## Describe the solution (The How)

- Check stalled hallucinations during per-turn monster lifecycle processing.
- Keep functional hallucinations on the existing action-path expiry behavior.
- Add deterministic coverage for zero-speed, positive-speed, banked-move, real, and dead monsters.

## Describe alternatives you've considered

- Moving all hallucination expiry into per-turn lifecycle processing was not used, because it would change functional hallucinations from action-based rolls to turn-based rolls.
- Giving wasp larvae or pupae movement speed was not used, because they are intentionally immobile, and changing their data would not fix other zero-speed hallucinations.


## Testing

- Manually confirmed the affected hallucination now disappears in the Windows tiles build.
- Rebuilt `cataclysm-bn-tiles` and `cata_test-tiles` with MSVC RelWithDebInfo.
- Passed the focused regression (27 assertions) and hallucination suite (40 assertions across 4 cases).
- Passed the complete non-slow suite (2,608,291 assertions across 896 cases).
- Easiest way for reviewer to test is to spawn hallucinatory wasp larvae using the debug menu, they should disappear after several seconds worth of turns.

## Checklist

### Mandatory

- [x] I linked the relevant issue using GitHub keyword syntax.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.


Assisted-by: OpenAI Codex:gpt-5.6 Sol

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3c02a12](https://github.com/cataclysmbn/Cataclysm-BN/commit/3c02a129fad62cd199bdd5672348c71339214e1c) (test: simplify hallucination expiry coverage) on 2026-07-11 19:50:47

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29163304203/artifacts/8251807107)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29163304203/artifacts/8252019256)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29163304203/artifacts/8251850105)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29163304203/artifacts/8252123912)
<!-- END artifact comment -->