### PR TITLE
feat(balance): make advanced UPS self-recharging

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -17,6 +17,8 @@
     "ammo": "battery",
     "initial_charges": 5000,
     "max_charges": 5000,
+    "ups_eff_mult": 2,
+    "ups_recharge_rate": 10,
     "looks_like": "battery",
     "//": "Twice the recharge rate, half the size of a heavy plutonium battery.",
     "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "12 m", "rate": 40 } ] },

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -4,7 +4,7 @@
     "type": "TOOL",
     "category": "electronics",
     "name": { "str": "advanced UPS", "str_pl": "advanced UPS's" },
-    "description": "This is an advanced version of the unified power supply, or UPS.  Designed for military use to power advanced weapons, it uses plutonium fuel cells which provide better recharging rates at the cost of capacitor size, and are not modular.  It can power many household electronics as well.",
+    "description": "This is an advanced version of the unified power supply, or UPS.  Designed for military use to power advanced weapons, it uses plutonium fuel cells which provide better efficiency and self-charging capability, in exchange for lacking the ability to swap out batteries for sustained use.  It can power many household electronics as well.",
     "weight": "500 g",
     "volume": "2 L",
     "price": "5600 USD",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -4,7 +4,7 @@
     "type": "TOOL",
     "category": "electronics",
     "name": { "str": "advanced UPS", "str_pl": "advanced UPS's" },
-    "description": "This is an advanced version of the unified power supply, or UPS.  Designed for military use to power advanced weapons, it uses plutonium fuel cells which provide better efficiency, but are not rechargeable.  It can power many household electronics as well.",
+    "description": "This is an advanced version of the unified power supply, or UPS.  Designed for military use to power advanced weapons, it uses plutonium fuel cells which provide better recharging rates at the cost of capacitor size, and are not modular.  It can power many household electronics as well.",
     "weight": "500 g",
     "volume": "2 L",
     "price": "5600 USD",
@@ -14,11 +14,13 @@
     "material": [ "aluminum", "plastic" ],
     "symbol": ";",
     "color": "light_green",
-    "ammo": "plutonium",
-    "max_charges": 2500,
-    "ups_eff_mult": 2,
-    "ups_recharge_rate": 10,
-    "flags": [ "IS_UPS" ]
+    "ammo": "battery",
+    "initial_charges": 5000,
+    "max_charges": 5000,
+    "looks_like": "battery",
+    "//": "Twice the recharge rate, half the size of a heavy plutonium battery.",
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "12 m", "rate": 40 } ] },
+    "flags": [ "IS_UPS", "LEAK_DAM", "RADIOACTIVE" ]
   },
   {
     "id": "camera",

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -649,7 +649,7 @@
     "book_learn": [ [ "recipe_lab_elec", 7 ], [ "textbook_atomic_lab", 8 ] ],
     "using": [ [ "soldering_standard", 24 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "power_supply", 6 ] ], [ [ "amplifier", 5 ] ], [ [ "scrap", 4 ] ], [ [ "cable", 14 ] ], [ [ "plut_cell", 2 ] ] ]
+    "components": [ [ [ "power_supply", 6 ] ], [ [ "amplifier", 5 ] ], [ [ "scrap", 4 ] ], [ [ "cable", 14 ] ], [ [ "plut_cell", 10 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Advanced UPS obsolete in the face of regular one because plutonium sticks are not sustainable.

## Describe the solution (The How)

Advanced UPS now self recharges at 2x the speed of a heavy plutonium battery and has half the max capacity.

## Describe alternatives you've considered

More disassemble pile fodder

## Testing
Images:
<details>
Spawning the item
<img width="1366" height="768" alt="1" src="https://github.com/user-attachments/assets/a8ea49f7-690a-458c-aa53-e56d115ea220" />

Firing off 12 shots with the A7 laser rifle
<img width="1366" height="768" alt="2" src="https://github.com/user-attachments/assets/c9a35a0c-b8dd-4659-9fa0-1d26fae39c4a" />

Waiting an hour, and it does recharge.
<img width="1366" height="768" alt="3" src="https://github.com/user-attachments/assets/91693e1f-a12f-493a-befb-26aa8fcb24a1" />
</details>

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9d55c3c](https://github.com/cataclysmbn/Cataclysm-BN/commit/9d55c3ce59a7ef00bf099a88e6c536fd8e5e1757) (Apply suggestion from @chaosvolt) on 2026-07-11 14:41:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29153210998/artifacts/8249468808)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29153210998)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29153210998)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29153210998/artifacts/8249356088)
<!-- END artifact comment -->