### PR TITLE
feat(balance): rework power armor soldier profession to use advanced UPS and A7 laser rifle

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2409,7 +2409,7 @@
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "knife_combat", "container-item": "power_armor_leg_hardpoint" },
           { "item": "power_armor_grenadebandolier", "contents-item": [ "grenade", "grenade" ] },
-          { "item": "laser_rifle", "contents-item": [ "acog_scope" ], "custom-flags": [ "auto_wield" ] }
+          { "item": "laser_rifle", "contents-item": [ "hybrid_sight" ], "custom-flags": [ "auto_wield" ] }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2409,11 +2409,7 @@
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "knife_combat", "container-item": "power_armor_leg_hardpoint" },
           { "item": "power_armor_grenadebandolier", "contents-item": [ "grenade", "grenade" ] },
-          {
-            "item": "laser_rifle",
-            "contents-item": [ "acog_scope" ],
-            "custom-flags": [ "auto_wield" ]
-          }
+          { "item": "laser_rifle", "contents-item": [ "acog_scope" ], "custom-flags": [ "auto_wield" ] }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -479,15 +479,6 @@
   {
     "type": "item_group",
     "subtype": "collection",
-    "id": "army_mags_power_armor",
-    "entries": [
-      { "item": "stanag100", "ammo-item": "556_incendiary", "charges": 100 },
-      { "item": "heavy_plus_battery_cell", "ammo-item": "battery", "charges": 1500 }
-    ]
-  },
-  {
-    "type": "item_group",
-    "subtype": "collection",
     "id": "army_mags_rm51",
     "entries": [
       { "item": "8x40_50_mag", "ammo-item": "8mm_caseless", "charges": 50 },
@@ -2388,7 +2379,7 @@
     "type": "profession",
     "id": "power_armor_soldier",
     "name": "Power Armor Soldier",
-    "description": "Those new plutonium power banks they were rolling out never arrived, nevermind the experimental new weapons, but at least your unit received the latest generation of powered armor.  The rest of your squad has fallen, but your gear might see you through.",
+    "description": "Your unit received the latest generation of powered armor, running off those new plutonium power banks they were rolling out and equipped with experimental energy weapons.  The rest of your squad has fallen, but your gear might see you through.",
     "age": { "min": 20, "max": 40 },
     "points": 8,
     "traits": [ "PROF_MILITARY" ],
@@ -2414,15 +2405,13 @@
           "power_armor_canteen"
         ],
         "entries": [
-          { "item": "heavy_plus_battery_cell", "charges": 1500, "container-item": "UPS_off" },
+          { "item": "adv_UPS_off", "charges": 5000 },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
-          { "item": "power_armor_chest_rig", "contents-group": "army_mags_power_armor" },
           { "item": "knife_combat", "container-item": "power_armor_leg_hardpoint" },
+          { "item": "power_armor_grenadebandolier", "contents-item": [ "grenade", "grenade" ] },
           {
-            "item": "stanag100",
-            "ammo-item": "556_incendiary",
-            "charges": 100,
-            "container-item": "m27iar",
+            "item": "laser_rifle",
+            "contents-item": [ "acog_scope" ],
             "custom-flags": [ "auto_wield" ]
           }
         ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Lil followup to https://github.com/cataclysmbn/Cataclysm-BN/pull/9860 to tinker with the power armor profession.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Swapped out the standard UPS on power armor soldier profession for an advanced UPS. Main reason they lacked it previously was plutonium cells were a rare and disposable resource, but making the advanced UPS self-charge like plutonium batteries makes it more sustainable. Total time they can run their power armor continuously now goes from 50 minutes to a bit over 2 hours and 45 minutes, not counting the relic recharge potentially triggering vs usage of their weapon (see below).
2. With their main power source now lasting much longer, swapped out their M27 being used as a bootleg LMG for an A7 laser rifle, and removed the mag carrier now that it's no longer needed.
3. Added a power armor hand grenade pouch with two grenades since most soldier professions get grenades, making their starting gear have an equivalent to basically everything a normal rifleman gets except the entrenching tool (which I could add another leg mount for but eh, they're already in full armor and probably in-lore are mostly being deployed from vehicles like the advanced infantry carrier so I doubt they'd be planning to dig in that often).
3. Adjusted profession description accordingly now that they're no longer explicitly stuck with an outdated UPS model and not allowed to play with the cutting-edge energy weapons that I headcanon as likely being most favored by power armor units, vs more mundane spec-ops units likely siding with Rivtech in the future-gun bidding wars instead.

## Describe alternatives you've considered

1. Keeping the idea of them using a mundane MG and just upgrading them to an M249 or M240, possibly with a V29 as a sidearm.
2. Adding a proper laser LMG, though this would trend on the toes of Cataclysm++ and the Omnitech weapons a bit, plus lore-wise the A7 was the bleeding edge as far as handheld laser weapons in vanilla, with Cata++'s Omnitech thing being kinda a divergence from that.
3. Saying "fuck it" and giving them a minigun. I kinda still want to keep the starting weight low enough for a standard 8-strength character to not be overburdened when the armor's inactive.
4. Giving them an entrenching tool so they can get their armor all covered in dirt like all other military professions are allowed to do.
5. Giving power armor helmets the `TWO_WAY_RADIO` flag and removing their radio.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Before:
<img width="887" height="324" alt="before" src="https://github.com/user-attachments/assets/7c3b5987-3542-4be9-b3a0-36d4f8e232c8" />

After:
<img width="908" height="324" alt="after" src="https://github.com/user-attachments/assets/c843e5a5-c5fa-45cc-896e-5b05b0c2ebfe" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6adac18](https://github.com/cataclysmbn/Cataclysm-BN/commit/6adac18c6d32841f90f98ed06ca15e32f37a665a) (Update data/json/professions.json) on 2026-07-11 18:09:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29159454167/artifacts/8251147872)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29159454167/artifacts/8251324959)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29159454167/artifacts/8250767115)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29159454167/artifacts/8251090905)
<!-- END artifact comment -->