### PR TITLE
fix: make merchants restock again

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1912,7 +1912,7 @@ void npc::shop_restock()
         return;
     }
 
-    restock = calendar::turn + 3_days * get_option<float>( "RESTOCK_DELAY_MULT" );;
+    restock = calendar::turn + 3_days * get_option<float>( "RESTOCK_DELAY_MULT" );
     if( is_player_ally() ) {
         return;
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1908,12 +1908,11 @@ int npc::max_willing_to_owe() const
 
 void npc::shop_restock()
 {
-    if( ( restock != calendar::turn_zero ) &&
-        ( ( calendar::turn - restock ) < 3_days * get_option<float>( "RESTOCK_DELAY_MULT" ) ) ) {
+    if( ( restock != calendar::turn_zero ) && ( calendar::turn < restock ) ) {
         return;
     }
 
-    restock = calendar::turn + 3_days * get_option<float>( "RESTOCK_DELAY_MULT" );
+    restock = calendar::turn + 3_days * get_option<float>( "RESTOCK_DELAY_MULT" );;
     if( is_player_ally() ) {
         return;
     }


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves https://github.com/cataclysmbn/Cataclysm-BN/issues/9302

## Describe the solution (The How)

Turns actually increase and we set the restock to now + delay, so we can just check if the current turn is greater.

## Describe alternatives you've considered

## Testing

Created world with 0.1 merchant scaling, waiting 1h, did not restock.
Applied fix, waited 1h, stock did change, waited an additional time, restock.


## Additional context

<img width="632" height="127" alt="image" src="https://github.com/user-attachments/assets/0808efe0-813a-4342-a8cd-6d8b0e3360e0" />

<img width="643" height="257" alt="image" src="https://github.com/user-attachments/assets/90560a97-9632-42aa-9fce-4c4fcaea2786" />

<img width="167" height="37" alt="image" src="https://github.com/user-attachments/assets/c49a0332-6c05-4150-9c7c-b731b5d6df8d" />

<img width="637" height="254" alt="image" src="https://github.com/user-attachments/assets/43938861-2693-44f3-81c0-b361d6eab48c" />



## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1739c7f](https://github.com/cataclysmbn/Cataclysm-BN/commit/1739c7f468069551746f1ba97a92886c633eeda7) (Oops) on 2026-07-12 12:52:07

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29190775210/artifacts/8259838347)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29190775210/artifacts/8260082827)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29190775210/artifacts/8259858534)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29190775210/artifacts/8260181695)
<!-- END artifact comment -->