### PR TITLE
fix: Make vehicle-screen siphon radius consistent with tool use

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2113,7 +2113,7 @@ void veh_interact::do_siphon()
         hide_ui( true );
         const item &base = pt.get_base();
         const int idx = veh->find_part( base );//TODO!: Wtf is this way of finding the part number?
-        liquid_handler::handle_liquid( veh, idx, 0 );
+        liquid_handler::handle_liquid( veh, idx, 1 );
     };
 
     overview( sel, act );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Siphoning from the vehicle screen (`veh_interact.cpp`, `veh_interact::do_siphon()`) searched for on-map target containers within radius 0 (the current tile only). However, siphoning by using a siphon (or siphon-capable tool, `act_vehicle_siphon(...)`) searched in radius 1, allowing targeting a container on the ground adjacent to the player.

This means, for example, a drum on the ground adjacent to the player can be siphoned into when (`a`) using a hose/siphoning tool from the player's inventory, but *not* when selecting (`s`) siphon from the source vehicle screen ("You don't have a suitable container for carrying `foo`").

## Describe the solution (The How)

Change siphoning from the vehicle screen to also use radius 1 (in argument to `liquid_handler::handle_liquid`) for consistency (and convenience).

## Describe alternatives you've considered

It might be more 'realistic' for the player to also need to be near/adjacent to the source tank tile (or a faucet?) as well, but simply being adjacent to the vehicle is an acceptable abstraction that players are used to anyway.

## Testing

Verified that I can select a container on the floor adjacent to the character when siphoning from a vehicle in *both* the vehicle screen and when using a siphon tool directly.

## Additional context

The camera centers in a weird spot relative to the vehicle when in the process of choosing a siphon target this way, I thought this was related but it seems to be its own issue.

edit: Pretty sure camera thing is unrelated, see issue #9873

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->
n/a

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5ba00ab](https://github.com/cataclysmbn/Cataclysm-BN/commit/5ba00abbaaf6fe87523ee1530d7879c9d4193fc1) (fix: Make vehicle-screen siphon radius consistent with tool use) on 2026-07-14 08:33:25

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29312305013/artifacts/8304664681)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29312305013/artifacts/8304102961)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29312305013/artifacts/8303506466)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29312305013/artifacts/8304373904)
<!-- END artifact comment -->