### PR TITLE
feat: add `NO_ROOF_ABOVE` overmap terrain flag

### DIFF
--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -1386,6 +1386,7 @@ These branches are also the valid entries for the categories of `dreams` in `dre
 - `GENERIC_LOOT` This is a place that may contain any of the above, but at a lower frequency -
   usually a house.
 - `IS_BRIDGE` Will be expanded to a bridge in mapgen, terrains with the id of this object followed by _under, _road, head_ground and head_ramp must be defined, and _center_under may also be defined.
+- `NO_ROOF_ABOVE` Prohibits automatic roof generation above this tile.
 
 ## Recipes
 

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -48,8 +48,10 @@
 #include "mongroup.h"
 #include "mtype.h"
 #include "options.h"
+#include "overmap.h"
 #include "overmapbuffer.h"
 #include "output.h"
+#include "overmapbuffer_registry.h"
 #include "popup.h"
 #include "profile.h"
 #include "rng.h"
@@ -61,6 +63,7 @@
 #include "thread_pool.h"
 #include "translations.h"
 #include "trap.h"
+#include "type_id.h"
 #include "ui_manager.h"
 #include "units_mass.h"
 #include "veh_type.h"
@@ -4201,6 +4204,9 @@ auto mapbuffer::run_omt_pillar_post_pass( const point_abs_omt &omt_pos ) -> void
             auto *const sub_below = zlev > -OVERMAP_DEPTH ?
                                     lookup_submap_in_memory( sm_pos + tripoint_below ) : nullptr;
 
+            auto const &omt_below = zlev > -OVERMAP_DEPTH ?
+                                    get_overmapbuffer( g->get_current_dimension_id() ).ter( omt_addr + tripoint_below ) : oter_id(
+                                        -100 );
             auto changed = false;
             for( const auto local : submap_tiles() ) {
                 const auto terrain_here = sub_here->get_ter( local );
@@ -4232,6 +4238,9 @@ auto mapbuffer::run_omt_pillar_post_pass( const point_abs_omt &omt_pos ) -> void
                     continue;
                 }
                 if( sub_below == nullptr ) {
+                    continue;
+                }
+                if( omt_below->has_flag( oter_flags::no_roof_above ) ) {
                     continue;
                 }
 

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -153,6 +153,7 @@ enum class oter_flags : int {
     source_vehicles,
     source_weapon,
     is_bridge,
+    no_roof_above,
     num_oter_flags
 };
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -153,7 +153,8 @@ static const std::map<std::string, oter_flags> oter_flags_map = {
     { "SOURCE_TAILORING", oter_flags::source_tailoring },
     { "SOURCE_VEHICLES", oter_flags::source_vehicles },
     { "SOURCE_WEAPON", oter_flags::source_weapon },
-    { "IS_BRIDGE", oter_flags::is_bridge }
+    { "IS_BRIDGE", oter_flags::is_bridge },
+    { "NO_ROOF_ABOVE", oter_flags::no_roof_above }
 };
 
 /*


### PR DESCRIPTION
## Purpose of change (The Why)
Request from @N0-4 for his lab

## Describe the solution (The How)
Add: `NO_ROOF_ABOVE` which prevents generating roofs above that mapgen

## Describe alternatives you've considered
None

## Testing
Patch json with [demo.patch](https://github.com/user-attachments/files/30028061/demo.patch)
Behold the outlet mall has no roof
Dont do patch and it has roof

## Additional Context
Ignore the branch name
Just ignore it

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.<!-- BEGIN docs comment -->

## Translations

| post                             | changed | stale  | missing |
| -------------------------------- | ------- | ------ | ------- |
| mod/json/reference/json_flags.md | en      | ja, ko |         |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [06fcb50](https://github.com/cataclysmbn/Cataclysm-BN/commit/06fcb5020155e289e38848d8d1aa51be0f0722e7) (feat: add `NO_ROOF_ABOVE` overmap terrain flag) on 2026-07-15 01:31:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29377524797/artifacts/8329441369)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29377524797/artifacts/8329810112)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29377524797/artifacts/8329378639)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29377524797/artifacts/8329953517)
<!-- END artifact comment -->