### PR TITLE
feat: add encumbrance enchantments

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1462,7 +1462,13 @@
     "description": "Most of the flesh in your arms, legs, and upper torso has been replaced with industrial-strength springs and protective padding.  Clenching your fist allows you to fold and unfold this padding; while active, the hydraulic absorbers will prevent damage to your body from severe impacts, at the cost of impaired movement.",
     "occupied_bodyparts": [ [ "torso", 1 ], [ "arm_l", 1 ], [ "arm_r", 1 ], [ "leg_l", 1 ], [ "leg_r", 1 ] ],
     "points": 2,
-    "flags": [ "BIONIC_TOGGLED" ]
+    "flags": [ "BIONIC_TOGGLED" ],
+    "bio_enchantments": [
+      {
+        "condition": "ACTIVE",
+        "values": [ { "value": "ENCUMBRANCE", "add": 3 }, { "value": "ENCUMBRANCE_EYES", "add": -3 } ]
+      }
+    ]
   },
   {
     "id": "bio_taste_blocker",

--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -431,6 +431,46 @@
     "desc": "Affects All Exp Gain"
   },
   {
+    "id": "ENCUMBRANCE",
+    "type": "enchantment_value",
+    "increase_good": false,
+    "suffixes": [
+      [ "TORSO", "Affects Torso Encumbrance" ],
+      [ "HEAD", "Affects Head Encumbrance" ],
+      [ "EYES", "Affects Eyes Encumbrance" ],
+      [ "MOUTH", "Affects Mouth Encumbrance" ],
+      [ "ARM", "Affects Arm Encumbrance" ],
+      [ "HAND", "Affects Hand Encumbrance" ],
+      [ "LEG", "Affects Leg Encumbrance" ],
+      [ "FOOT", "Affects Foot Encumbrance" ]
+    ],
+    "desc": "Affects All Encumbrance Values"
+  },
+  {
+    "id": "ENCUMBRANCE_ARM",
+    "type": "enchantment_value",
+    "copy-from": "ENCUMBRANCE_ARM",
+    "suffixes": [ [ "L", "Affects Left Arm Encumbrance" ], [ "R", "Affects Right Arm Encumbrance" ] ]
+  },
+  {
+    "id": "ENCUMBRANCE_HAND",
+    "type": "enchantment_value",
+    "copy-from": "ENCUMBRANCE_HAND",
+    "suffixes": [ [ "L", "Affects Left Hand Encumbrance" ], [ "R", "Affects Right Hand Encumbrance" ] ]
+  },
+  {
+    "id": "ENCUMBRANCE_LEG",
+    "type": "enchantment_value",
+    "copy-from": "ENCUMBRANCE_LEG",
+    "suffixes": [ [ "L", "Affects Left Leg Encumbrance" ], [ "R", "Affects Right Leg Encumbrance" ] ]
+  },
+  {
+    "id": "ENCUMBRANCE_FOOT",
+    "type": "enchantment_value",
+    "copy-from": "ENCUMBRANCE_FOOT",
+    "suffixes": [ [ "L", "Affects Left Foot Encumbrance" ], [ "R", "Affects Right Foot Encumbrance" ] ]
+  },
+  {
     "id": "ITEM_DAMAGE",
     "type": "enchantment_value",
     "suffixes": [

--- a/docs/en/mod/json/reference/enchantments.md
+++ b/docs/en/mod/json/reference/enchantments.md
@@ -619,6 +619,29 @@ In addition there are the following children of this enchantment
 - `SKILL_EXP_STABBING`
 - `SKILL_EXP_UNARMED`
 
+##### Encumbrance
+
+Character wide encumbrance modifier, children modify certain bodyparts.
+Note: This is the first enchantment with two tiers of parents, left arm inherits arm which inherits overall
+These are the children.
+
+- `ENCUMBRANCE_TORSO`
+- `ENCUMBRANCE_HEAD`
+- `ENCUMBRANCE_EYES`
+- `ENCUMBRANCE_MOUTH`
+- `ENCUMBRANCE_ARM`
+  - `ENCUMBRANCE_ARM_L`
+  - `ENCUMBRANCE_ARM_R`
+- `ENCUMBRANCE_HAND`
+  - `ENCUMBRANCE_HAND_L`
+  - `ENCUMBRANCE_HAND_R`
+- `ENCUMBRANCE_LEG`
+  - `ENCUMBRANCE_LEG_L`
+  - `ENCUMBRANCE_LEG_R`
+- `ENCUMBRANCE_FOOT`
+  - `ENCUMBRANCE_FOOT_L`
+  - `ENCUMBRANCE_FOOT_R`
+
 #### Item values
 
 ##### ITEM_ATTACK_COST

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4493,16 +4493,14 @@ char_encumbrance_data Character::calc_encumbrance( const item &new_item ) const
     mut_cbm_encumb( enc );
 
     // Get swimming skill level
-    if( get_option<bool>( "althletics_encumbrance_buff" ) ) {
-        int swim_skill = get_skill_level( skill_swimming );
+    int swim_skill = get_skill_level( skill_swimming );
+    bool althletics_buff = get_option<bool>( "althletics_encumbrance_buff" );
+    for( auto &iter : enc.elems ) {
+        encumbrance_data &edata = iter.second;
 
-        // Reduce encumbrance for each body part based on swimming skill
-        for( auto &iter : enc.elems ) {
-            encumbrance_data &edata = iter.second;
-
-            // Reduce encumbrance by swim_skill, clamped at 0
-            edata.encumbrance = std::max( 0, edata.encumbrance - swim_skill );
-        }
+        // Reduce encumbrance by swim_skill, clamped at 0
+        // Enchantments can bring encumbrance below 0, so account for that here too
+        edata.encumbrance = std::max( 0, edata.encumbrance - ( althletics_buff ? swim_skill : 0 ) );
     }
 
     return enc;
@@ -4887,17 +4885,18 @@ void Character::mut_cbm_encumb( char_encumbrance_data &vals ) const
         }
     }
 
-    if( has_active_bionic( bio_shock_absorber ) ) {
-        for( auto &val : vals.elems ) {
-            val.second.encumbrance += 3; // Slight encumbrance to all parts except eyes
-        }
-        vals.elems[body_part_eyes].encumbrance -= 3;
-    }
-
     // Lower penalty for bps covered only by XL armor
     const auto oversize = exclusive_flag_coverage( flag_OVERSIZE );
     for( const trait_id &mut : get_mutations() ) {
         apply_mut_encumbrance( vals, mut, oversize );
+    }
+
+    for( const auto &id : get_all_body_parts() ) {
+        const auto ench_id = enchantment_value_id( "ENCUMBRANCE_" + to_upper_case( id.id().str() ) );
+        if( ench_id.is_valid() ) {
+            vals.elems[id.id()].encumbrance += bonus_from_enchantments( vals.elems[id.id()].encumbrance,
+                                               ench_id );
+        }
     }
 }
 
@@ -9018,6 +9017,9 @@ void Character::recalculate_enchantment_cache()
 
     // Enchantments can give HP now, so recalc it
     recalc_hp();
+
+    // Enchantments can also give encumbrance
+    reset_encumbrance();
 }
 
 void Character::rebuild_mutation_cache()


### PR DESCRIPTION
## Purpose of change (The Why)
More jsonization

## Describe the solution (The How)
Jsonize kinetic shock absorber's encumbrance gains via encumbrance enchantments.
Adds per bodypart encumbrance modifiers

## Describe alternatives you've considered
None

## Testing
Shock absorbers encumbrance modifiers work right

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.

<!-- BEGIN docs comment -->

## Translations

| post                               | changed | stale | missing |
| ---------------------------------- | ------- | ----- | ------- |
| mod/json/reference/enchantments.md | en      |       | ja, ko  |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [653f50b](https://github.com/cataclysmbn/Cataclysm-BN/commit/653f50b47d33b838c4184a808992dd9f07fa5ff8) (feat: add encumbrance enchantments) on 2026-07-15 03:54:16

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29383443602/artifacts/8331396008)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29383443602/artifacts/8331636732)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29383443602/artifacts/8331348191)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29383443602/artifacts/8331974591)
<!-- END artifact comment -->