### PR TITLE
fix: readd portal spawns for military corpse map extra, fix acid juggernaut harvest, fix spelling error

### DIFF
--- a/data/json/enchantment_values.json
+++ b/data/json/enchantment_values.json
@@ -17,7 +17,7 @@
   {
     "id": "INTELLIGENCE",
     "type": "enchantment_value",
-    "desc": "Affects Intellegence"
+    "desc": "Affects Intelligence"
   },
   {
     "id": "HEALTH_POINTS",

--- a/data/json/mapgen/map_extras/corpses.json
+++ b/data/json/mapgen/map_extras/corpses.json
@@ -103,7 +103,7 @@
       "place_nested": [
         { "chunks": [ [ "lost_squad_chunk_bodies", 100 ] ], "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 2, 6 ] },
         {
-          "chunks": [ [ "lost_squad_chunk_zombies", 50 ], [ "lost_squad_chunk_robot", 50 ] ],
+          "chunks": [ [ "lost_squad_chunk_zombies", 40 ], [ "lost_squad_chunk_robot", 40 ], [ "lost_squad_chunk_portal", 20 ] ],
           "x": [ 1, 22 ],
           "y": [ 1, 22 ]
         }
@@ -145,7 +145,6 @@
     "object": { "mapgensize": [ 1, 1 ], "place_monster": [ { "group": "GROUP_ROBOT_MX_MILITARY", "chance": 100, "x": 0, "y": 0 } ] }
   },
   {
-    "//": "unused until traps are correctly visible again",
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "lost_squad_chunk_portal",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1165,6 +1165,7 @@
     "armor_stab": 1000000,
     "armor_bullet": 1000000,
     "armor_electric": 1000000,
+    "armor_fire": 1000000,
     "dodge": 20,
     "harvest": "exempt",
     "vision_day": 150,

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1165,7 +1165,6 @@
     "armor_stab": 1000000,
     "armor_bullet": 1000000,
     "armor_electric": 1000000,
-    "armor_fire": 1000000,
     "dodge": 20,
     "harvest": "exempt",
     "vision_day": 150,

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -190,7 +190,7 @@
     "looks_like": "mon_zombie_soldier",
     "diff": 30,
     "attack_cost": 100,
-    "harvest": "CBM_OP2",
+    "harvest": "zombie_maybe_mil_bionics_acid",
     "relative": { "hp": 160, "speed": -20, "melee_skill": 8, "armor_bash": 15, "armor_cut": 10, "armor_bullet": 10 },
     "delete": { "flags": [ "BLEED" ], "categories": [ "CLASSIC" ] },
     "upgrades": { "half_life": 42, "into_group": "GROUP_NULL", "into": "mon_zombie_soldier_acid_3" },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
some small glitches and stuff to fix:
there was a portal version of the military corpse map extra that was planned, but was not implemented originally because trap visibility was broken at the time. now that trap visibility is fixed it should be implemented
the acid juggernaut has the same harvest definiton as the elite bio-operator instead of the standard military acid zombie harvest definition
the int enchantment says "intellegence" instead of "intelligence"
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Fixes the above issues:
adds the portal version
changes acid juggernaut harvest to match other military acid zombies
fixes typo
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Bugs
## Testing
Loaded in, no explode
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2729a51](https://github.com/cataclysmbn/Cataclysm-BN/commit/2729a51cc782eb656bfc810de75e1692fb419ea4) (Update data/json/monsters/nether.json) on 2026-07-16 01:40:30

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29462926153/artifacts/8362014347)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29462926153/artifacts/8362464000)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29462926153/artifacts/8362040740)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29462926153/artifacts/8362079432)
<!-- END artifact comment -->