### PR TITLE
fix: abort loading on null lockpick result with lockpick iexamine

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1484,6 +1484,12 @@ void ter_t::check() const
     check_decon_items( deconstruct, id.str(), true );
     check_pry_items( pry, id.str(), true );
 
+    if( examine == iexamine_function_from_string( "locked_object_pickable" ) &&
+        lockpick_result.is_null() ) {
+        throw JsonError(
+            string_format( "Terrain %s has iexamine `locked_object_pickable`, without a non-null `lockpick_result`",
+                           id.str(), lockpick_result.str() ) );
+    }
     if( !transforms_into.is_valid() ) {
         debugmsg( "invalid transforms_into %s for %s", transforms_into.c_str(), id.c_str() );
     }


### PR DESCRIPTION
## Purpose of change (The Why)
Once again we got a false report
Mod: https://github.com/OpsCoretango/Nuclear_Power_Plant_BN causes segfaults due to specifying lockpick iexamines on a door without lockpicking results.
I'm done with these errors

## Describe the solution (The How)
Throw a JsonError when you give null lockpick result and `locked_object_pickable`

## Describe alternatives you've considered
Make this a measly debugmessage which we all know *every player* skips
Make this incompatible with basegame due to #9807 porting the original dda version ( which it ports ) to basegame

## Testing
The mod no longer loads after it checks that

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9bf1cf9](https://github.com/cataclysmbn/Cataclysm-BN/commit/9bf1cf9731d8c1b266971b5a02a7b01c043b4b83) (fix: abort loading on null lockpick result with lockpick iexamine) on 2026-07-15 19:57:25

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29441541553/artifacts/8354785813)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29441541553/artifacts/8355327243)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29441541553/artifacts/8354681430)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29441541553/artifacts/8355576173)
<!-- END artifact comment -->