### PR TITLE
feat(balance): add wrenches to mechanics and common tools itemgroups

### DIFF
--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -98,6 +98,7 @@
       [ "scissors", 80 ],
       [ "screwdriver", 70 ],
       [ "hammer", 60 ],
+      [ "wrench", 50 ],
       [ "pliers", 60 ],
       [ "thermometer", 50 ],
       [ "magnifying_glass", 50 ],
@@ -276,6 +277,7 @@
       { "group": "charged_UPS", "prob": 5 },
       [ "jack", 80 ],
       [ "jack_small", 80 ],
+      [ "wrench", 80 ],
       {
         "collection": [
           { "item": "oxy_torch", "prob": 100 },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Wrenches, despite being used for like half of vehicle related tasks, are strangely absent from the "tools_mechanic" itemgroup. This leads to hilarious situations like entire garages not having a single wrench while simultaneously having several cutting torches.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds wrenches to the "tools_mechanic" itemgroup, as well as to the tools_drawer itemgroup, cause wrenches aren't that rare and most people who have some tools have one.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
No wrenches?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [02ce54d](https://github.com/cataclysmbn/Cataclysm-BN/commit/02ce54d7a58c94ef44a7e97f406f9e0f2fceeda0) (Update tools.json) on 2026-07-16 21:09:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29510044936/artifacts/8380556122)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29510044936)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29510044936/artifacts/8380643428)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29510044936/artifacts/8380759290)
<!-- END artifact comment -->