### PR TITLE
feat: fix the misplaced car near the refugee center

### DIFF
--- a/data/json/mapgen/refugee_center/refugee_center.json
+++ b/data/json/mapgen/refugee_center/refugee_center.json
@@ -42,7 +42,7 @@
       "palettes": [ "evac_center" ],
       "place_vehicles": [
         { "vehicle": "schoolbus", "x": 32, "y": 18, "chance": 75, "rotation": 0 },
-        { "vehicle": "car", "x": 48, "y": 23, "chance": 75, "rotation": 270 }
+        { "vehicle": "car", "x": 55, "y": 8, "chance": 75, "rotation": 180 }
       ]
     }
   },


### PR DESCRIPTION
## Purpose of change (The Why)
Because this car near the refugee center is partially embedded in brick walls.
## Describe the solution (The How)
Put the car somewhere else.
## Describe alternatives you've considered
none
## Testing
I started a new game; no errors.
## Additional context

<details>
<summary>Screenshot (Before):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/efe9b7a5-ad3f-49a6-92b4-787a4f16ac1c"></a>
</details>

<details>
<summary>Screenshot (After):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/ce2bf44c-79c8-4ab7-b433-a21ddac8daff"></a>
</details>

## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0093c45](https://github.com/cataclysmbn/Cataclysm-BN/commit/0093c45591c276fce2f6361e800875de9def245e) (Update refugee_center.json) on 2026-07-16 18:04:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29518504506/artifacts/8383960730)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29518504506/artifacts/8384953518)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29518504506/artifacts/8385223576)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29518504506/artifacts/8384190623)
<!-- END artifact comment -->