### PR TITLE
fix: don't embed washing machines in urban bar windows

### DIFF
--- a/data/json/mapgen/city_blocks/urban_38_bar_hardware_house.json
+++ b/data/json/mapgen/city_blocks/urban_38_bar_hardware_house.json
@@ -114,7 +114,7 @@
         "i2h222222hth2tti22222222",
         "ihth222222h22tti22222ccc",
         "i2h2222222222hhiiiJiivvv",
-        "iiWiWii++iiWiWii;;;;;;;;",
+        "iiwiwii++iiwiwii;;;;;;;;",
         ";;;;;'''''';;;;;;;;;;;;;",
         ";;;;;;;;;;;;;;;;;;;;;;^;",
         ";;;;;;;;;;;;;;;;;;;;;;;;"
@@ -122,7 +122,7 @@
       "palettes": [ "acidia_residential_commercial_palette" ],
       "terrain": {
         "R": "t_linoleum_white",
-        "W": "t_window_stained_green",
+        "w": "t_window_stained_green",
         "c": "t_linoleum_white",
         "h": "t_linoleum_white",
         "r": "t_linoleum_white",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Closes https://github.com/cataclysmbn/Cataclysm-BN/issues/9888

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Set `urban_38_3` to use `w` instead of `W` for its stained glass windows, so it doesn't place washers embedded in them.

## Describe alternatives you've considered

I tried just adding `"W": "f_null"` to the furniture entry but that didn't work for some reason.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

<img width="611" height="277" alt="image" src="https://github.com/user-attachments/assets/a8ab608a-07b1-4397-b876-010cab8481ca" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4ee92b6](https://github.com/cataclysmbn/Cataclysm-BN/commit/4ee92b619f0d0633b159f3f0e8c060d971376a5d) (fix: don't embed washing machines in urban bar windows) on 2026-07-18 03:19:38

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29614404150/artifacts/8421083183)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29614404150)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29614404150/artifacts/8420174978)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29614404150/artifacts/8420259869)
<!-- END artifact comment -->