### PR TITLE
fix: Barry Isherwood's rescue mission points to correct z-level

### DIFF
--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -77,7 +77,7 @@
     "destination": "dairy_farm_isherwood_W",
     "start": {
       "effect": [ { "u_add_var": "u_have_barry_escape", "type": "general", "context": "meeting", "value": "yes" } ],
-      "assign_mission_target": { "om_terrain": "dairy_farm_isherwood_W", "reveal_radius": 3 }
+      "assign_mission_target": { "om_terrain": "dairy_farm_isherwood_W", "reveal_radius": 3, "z": 0 }
     },
     "end": {
       "opinion": { "trust": 5, "value": 5 },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Closes https://github.com/cataclysmbn/Cataclysm-BN/issues/9891

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Set correct z-level for `MISSION_ISHERWOOD_BARRY_1` since Barry spawns up in a mi-to tower, and the farm you're taking him back to is on ground level.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Load-tested in compiled test build and started at the Isherwood farms.
2. Did Carlos' missions until I got sent to talk to Chris.
3. Talked to Chris to get the mission to find Barry.
4. Talked to Barry, it correctly starts the mission and points me back to the farm.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [906c560](https://github.com/cataclysmbn/Cataclysm-BN/commit/906c5600966866cb67230393b3bb4fe4cbcb889d) (fix: Barry Isherwood's rescue mission points to correct z-level) on 2026-07-17 23:13:12

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29615823070/artifacts/8421527941)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29615823070/artifacts/8421844917)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29615823070/artifacts/8420622954)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29615823070/artifacts/8420704569)
<!-- END artifact comment -->