### PR TITLE
feat(UI): Don't show "faulty" on bionics in scanned corpses

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3455,7 +3455,7 @@ void item::component_info( std::vector<iteminfo> &info, const iteminfo_query *pa
         // TODO: Extract into a more proper place (function in namespace)
         std::string bionics_string = enumerate_as_string( components.begin(), components.end(),
         []( const item * const & entry ) -> std::string {
-            return entry->is_bionic() ? entry->display_name() : "";
+            return entry->is_bionic() ? entry->type_name() : "";
         }, enumeration_conjunction::none );
         info.emplace_back( "DESCRIPTION", string_format( _( "Contains: %s" ),
                            bionics_string ) );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

When you scan a corpse that has bionics, they show up as "faulty [name]". There's no point saying they're faulty because they're always non-sterile, so it just clutters up the description, especially when there's a lot.

THE BIONIC IS FAULTY

IT WAS ALWAYS FAULTY

IT WILL ALWAYS BE FAULTY

## Describe the solution (The How)

Replace `display_name()` with `type_name()`.

## Testing

Looked at a corpse and checked that it displays bionics accurately.

## Additional context

<img width="584" height="305" src="https://github.com/user-attachments/assets/8d2853ac-229f-45b3-92fa-180de3469eab" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4750ff3](https://github.com/cataclysmbn/Cataclysm-BN/commit/4750ff372e8bdce3e915b522fd862ad9664fe056) (Don't show "faulty" on bionics in scanned corpses) on 2026-07-18 12:24:46

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29643062701/artifacts/8429289785)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29643062701/artifacts/8429526234)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29643062701/artifacts/8429307795)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29643062701/artifacts/8429339478)
<!-- END artifact comment -->