### PR TITLE
feat(UI): Clean up throwing crafting nested categories

### DIFF
--- a/data/json/recipes/nested_categories.json
+++ b/data/json/recipes/nested_categories.json
@@ -140,11 +140,41 @@
   {
     "type": "nested_category",
     "id": "nested_throwing",
-    "nested_name": "primitive throwers",
+    "nested_name": "throwables",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_NESTED",
-    "description": "Simple slings and throwing tools.",
-    "nested_category_data": [ "throwing_stick", "bolas", "net", "sling", "slingshot", "bullwhip" ]
+    "description": "Weapons that can be thrown effectively.",
+    "nested_category_data": [
+      "bolas",
+      "net",
+      "lawn_dart",
+      "throwing_axe",
+      "throwing_knife",
+      "shuriken",
+      "throwing_stick",
+      "atlatl_dart_wood",
+      "atlatl_dart_iron",
+      "atlatl_dart_stone",
+      "atlatl_dart_copper",
+      "pointy_stick",
+      "pointy_stick_long",
+      "javelin",
+      "javelin_iron",
+      "javelin_stone",
+      "javelin_copper",
+      "knife_combat",
+      "tomahawk_primitive",
+      "tomahawk_copper"
+    ]
+  },
+  {
+    "type": "nested_category",
+    "id": "nested_throwers",
+    "nested_name": "throwers",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_NESTED",
+    "description": "Throwing tools.",
+    "nested_category_data": [ "sling", "sling_cord", "slingshot", "atlatl", "staff_sling" ]
   },
   {
     "type": "nested_category",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Currently, "primitive throwers" is a nonsense category that contains three thowables, two throwers, and for some reason bullwhip, which is a melee long reach weapon.

## Describe the solution (The How)

Made two categories, one containing items you throw, and the other containing launchers that use throwing skill.

## Describe alternatives you've considered

At first I wanted to make a separate crafting category under weapons, but there's a lot of overlap with items like spears or the combat knife, which are also melee weapons.

## Testing

Looked at the crafting menu and saw that the new categories don't show up. Experimented some more with category Ids. Opened issue #9901 about it.

## Additional context

So because of #9901, the new throwers category (that's the one with the new Id) won't be visible on existing characters. So that probably needs to be fixed first.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [cbf029b](https://github.com/cataclysmbn/Cataclysm-BN/commit/cbf029b45df50975460605f2ba9363b0c09f5a99) (Clean up throwing crafting nested categories) on 2026-07-18 22:19:17

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29658190514/artifacts/8434797845)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29658190514/artifacts/8434675041)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29658190514/artifacts/8434462954)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29658190514/artifacts/8434468070)
<!-- END artifact comment -->