### PR TITLE
feat(UI): Don't show "faulty" on bionics when scanning corpses, too

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2035,7 +2035,7 @@ void Character::process_bionic( bionic &bio )
             if( !cbms.empty() ) {
                 corpse->set_flag( flag_CBM_SCANNED );
                 auto bionics_string = enumerate_as_string( cbms.begin(), cbms.end(),
-                []( const auto entry ) { return entry->display_name(); }, enumeration_conjunction::none );
+                []( const auto entry ) { return entry->type_name(); }, enumeration_conjunction::none );
                 //~ %1 is corpse name, %2 is direction, %3 is bionic name
                 add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s." ),
                                    corpse->display_name().c_str(),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2288,7 +2288,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint_bub_ms &pos 
         if( !cbms.empty() ) {
             corpse->set_flag( flag_CBM_SCANNED );
             auto bionics_string = enumerate_as_string( cbms.begin(), cbms.end(),
-            []( const auto entry ) { return entry->display_name(); }, enumeration_conjunction::none );
+            []( const auto entry ) { return entry->type_name(); }, enumeration_conjunction::none );
             //~ %1 is corpse name, %2 is direction, %3 is bionic name
             p->add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s." ),
                                   corpse->display_name().c_str(),


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Continuation of #9898.

## Describe the solution (The How)

Applies the same solution to the message that appears when you scan a corpse.

## Testing

Scanned some corpses and looked at the message.

## Additional context

<img width="351" height="361" src="https://github.com/user-attachments/assets/49b2e398-5567-4187-86cb-30e753c17d8d" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3f481b6](https://github.com/cataclysmbn/Cataclysm-BN/commit/3f481b6fad47ef02e5f58fc349b2a74e8c4f5a41) (Don't show "faulty" on bionics when scanning corpses, too) on 2026-07-18 21:48:36

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29659568617/artifacts/8434347494)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29659568617/artifacts/8434657810)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29659568617/artifacts/8434013287)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29659568617/artifacts/8434050470)
<!-- END artifact comment -->