### PR TITLE
feat(UI): improve item enchantment info

### DIFF
--- a/data/json/artifact/premade_artifacts.json
+++ b/data/json/artifact/premade_artifacts.json
@@ -11,7 +11,10 @@
     "color": "light_gray",
     "flags": [ "TRADER_AVOID" ],
     "relic_data": {
-      "passive_effects": [ { "conditions": [ "HELD" ], "ench_effects": [ { "effect": "debug_clairvoyance", "intensity": 1 } ] } ]
+      "passive_effects": [
+        { "conditions": [ "HELD" ], "ench_effects": [ { "effect": "debug_clairvoyance", "intensity": 1 } ] },
+        { "ench_effects": [ { "effect": "blind", "intensity": 1 } ], "immune_effects": [ "blind" ] }
+      ]
     }
   },
   {

--- a/data/json/enchantment_flags.json
+++ b/data/json/enchantment_flags.json
@@ -1,107 +1,132 @@
 [
   {
     "id": "UNDERWATER_SIGHT",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Permits underwater sight</good>"
   },
   {
     "id": "SLEEP_SIGHT",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Permits sight while sleeping</good>"
   },
   {
     "id": "NEARSIGHTED",
     "type": "enchantment_flag",
-    "conflicts": [ "FIX_NEARSIGHTED" ]
+    "conflicts": [ "FIX_NEARSIGHTED" ],
+    "info": "<bad>Causes nearsightedness</bad>"
   },
   {
     "id": "FIX_NEARSIGHTED",
     "type": "enchantment_flag",
-    "conflicts": [ "NEARSIGHTED" ]
+    "conflicts": [ "NEARSIGHTED" ],
+    "info": "<good>Prevents nearsightedness</good>"
   },
   {
     "id": "BLIND",
     "type": "enchantment_flag",
-    "conflicts": [ "FIX_BLIND" ]
+    "conflicts": [ "FIX_BLIND" ],
+    "info": "<bad>Causes blindness</bad>"
   },
   {
     "id": "FIX_BLIND",
     "type": "enchantment_flag",
-    "conflicts": [ "BLIND" ]
+    "conflicts": [ "BLIND" ],
+    "info": "<good>Prevents blindness</good>"
   },
   {
     "id": "INFRARED_VISION",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Allows seeing infrared light<bad>"
   },
   {
     "id": "ELECTROSENSE",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Allows seeing electrical signals</good>"
   },
   {
     "id": "SILENT",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Prevents sounds from movement</good>"
   },
   {
     "id": "EAT_ROTTEN",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Permits eating rotten food</good>"
   },
   {
     "id": "ONLY_EAT_ROTTEN",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<bad>Prevents eating fresh food</bad>"
   },
   {
     "id": "EAT_ROTTEN_MORALE",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Eating rotten food no longer has negative morale impacts</good>"
   },
   {
     "id": "CONSUME_UNCLEAN",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Can drink and eat dirty foods</good>"
   },
   {
     "id": "FOOD_PARASITE_IMMUNE",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Immune to food parasites</good>"
   },
   {
     "id": "FOOD_POISON_IMMUNE",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Immune to food poison</good>"
   },
   {
     "id": "ALARMCLOCK",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Gives an alarmclock</good>"
   },
   {
     "id": "INTERNAL_ALARMCLOCK",
     "type": "enchantment_flag",
-    "parents": [ "ALARMCLOCK" ]
+    "parents": [ "ALARMCLOCK" ],
+    "info": "<good>Gives a silent internal alarmclock</good>"
   },
   {
     "id": "VIEW_DRONE_CAM",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Allows viewing the position of enemies marked by friendly drones</good>"
   },
   {
     "id": "RADIO",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Provides a method of communication over radio waves</good>"
   },
   {
     "id": "THERMOMETER",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Provides the temperature</good>"
   },
   {
     "id": "WATCH",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Provides the time</good>"
   },
   {
     "id": "FIRE_FIELD_IMMUNE",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<good>Prevents damage from open fires</good>"
   },
   {
     "id": "NO_THERMAL_WAKE",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<bad>Prevents waking up from overheating</bad>"
   },
   {
     "id": "NO_DAMAGE_WAKE",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<bad>Prevents waking up from overheating</bad>"
   },
   {
     "id": "NO_LIGHT_WAKE",
-    "type": "enchantment_flag"
+    "type": "enchantment_flag",
+    "info": "<bad>Prevents waking up from seeing light</bad>"
   }
 ]

--- a/docs/en/mod/json/reference/enchantments.md
+++ b/docs/en/mod/json/reference/enchantments.md
@@ -655,7 +655,9 @@ value, in addition to the global `ITEM_ARMOR`:
 {
   "id": "NEARSIGHTED",               // Id of the enchantment flag
   "type": "enchantment_flag",        // Needed type
+  "parents": [ "BLIND" ],            // Array of other enchantment_flags it also gives
   "conflicts": [ "FIX_NEARSIGHTED" ] // Array of other enchantment_flags of which it cancels
+  "info": "<bad>Causes nearsightedness</bad>" // Info string showed in enchantment info
 },
 ```
 

--- a/src/enchantments/enchantment.cpp
+++ b/src/enchantments/enchantment.cpp
@@ -111,22 +111,6 @@ std::vector<std::string> enchantment::get_effect_string(bool is_item) const {
             string_format(_("  <color_%s>Gives mutation %s</color>"), color, trait_id->name()));
         describe = true;
     }
-    for (const auto eff_id : immune_effects) {
-        if (!eff_id->is_show_in_info()) { continue; }
-        effect_rating rating = eff_id->get_rating();
-        const std::string color =
-            rating == effect_rating::e_bad ? "green"
-            : rating == effect_rating::e_good
-                ? "red"
-                : "magenta";
-        const std::string name =
-            effect(&*eff_id, 1_turns, bodypart_str_id::NULL_ID(), 1, calendar::turn).disp_name();
-        if (name != "") {
-            result.push_back(
-                string_format(_("  <color_%s>Provides Immunity To %s</color>"), color, name));
-            describe = true;
-        }
-    }
     for (const auto [flag, _] : flags) { result.push_back(string_format("  %s", flag->info)); }
     if (describe) {
         return result;

--- a/src/enchantments/enchantment.cpp
+++ b/src/enchantments/enchantment.cpp
@@ -5,6 +5,7 @@
 #include "character.h"
 #include "creature.h"
 #include "debug.h"
+#include "effect.h"
 #include "enchantment_condition.h"
 #include "enchantment_flag.h"
 #include "enchantment_value.h"
@@ -38,7 +39,7 @@ std::vector<std::string> enchantment::get_effect_string(bool is_item) const {
     if (conditions.empty()) { cond_string = _("At all times"); }
     for (const enchantment_condition_id cond_id : conditions) {
         if (!cond_string.empty()) { cond_string += _(" and "); }
-        cond_string += cond_id->condition_info;
+        cond_string += cond_id->condition_info.translated();
     }
 
     std::map<enchantment_value_id, int> value_effects;
@@ -61,18 +62,77 @@ std::vector<std::string> enchantment::get_effect_string(bool is_item) const {
         value_effects[ench_id] += 1;
     }
     std::vector<std::string> result;
-    if (value_effects.empty()) { return result; }
+    bool describe = false;
     result.push_back(cond_string);
     for (const auto [ench_id, goodbad] : value_effects) {
-        if (goodbad > 0) {
-            result.push_back(string_format("  <color_green>%s</color>", ench_id->desc));
-        } else if (goodbad < 0) {
-            result.push_back(string_format("  <color_red>%s</color>", ench_id->desc));
-        } else {
-            result.push_back(string_format("  <color_magenta>%s</color>", ench_id->desc));
+        const std::string color = goodbad > 0 ? "green" : goodbad < 0 ? "red" : "magenta";
+        result.push_back(string_format("  <color_%s>%s</color>", color, ench_id->desc));
+        describe = true;
+    }
+    for (const auto [eff_id, intense] : ench_effects) {
+        if (!eff_id->is_show_in_info()) { continue; }
+        effect_rating rating = eff_id->get_rating();
+        const std::string color =
+            rating == effect_rating::e_good ? "green"
+            : rating == effect_rating::e_bad
+                ? "red"
+                : "magenta";
+        const std::string name =
+            effect(&*eff_id, 1_turns, bodypart_str_id::NULL_ID(), intense, calendar::turn)
+                .disp_name();
+        if (name != "") {
+            result.push_back(string_format(_("  <color_%s>Gives effect %s</color>"), color, name));
+            describe = true;
         }
     }
-    return result;
+    for (const auto eff_id : immune_effects) {
+        if (!eff_id->is_show_in_info()) { continue; }
+        effect_rating rating = eff_id->get_rating();
+        const std::string color =
+            rating == effect_rating::e_bad ? "green"
+            : rating == effect_rating::e_good
+                ? "red"
+                : "magenta";
+        const std::string name =
+            effect(&*eff_id, 1_turns, bodypart_str_id::NULL_ID(), 1, calendar::turn).disp_name();
+        if (name != "") {
+            result.push_back(
+                string_format(_("  <color_%s>Provides Immunity To %s</color>"), color, name));
+            describe = true;
+        }
+    }
+    for (const auto trait_id : mutations) {
+        const std::string color =
+            trait_id->points > 0 ? "green"
+            : trait_id->points < 0
+                ? "red"
+                : "magenta";
+        result.push_back(
+            string_format(_("  <color_%s>Gives mutation %s</color>"), color, trait_id->name()));
+        describe = true;
+    }
+    for (const auto eff_id : immune_effects) {
+        if (!eff_id->is_show_in_info()) { continue; }
+        effect_rating rating = eff_id->get_rating();
+        const std::string color =
+            rating == effect_rating::e_bad ? "green"
+            : rating == effect_rating::e_good
+                ? "red"
+                : "magenta";
+        const std::string name =
+            effect(&*eff_id, 1_turns, bodypart_str_id::NULL_ID(), 1, calendar::turn).disp_name();
+        if (name != "") {
+            result.push_back(
+                string_format(_("  <color_%s>Provides Immunity To %s</color>"), color, name));
+            describe = true;
+        }
+    }
+    for (const auto [flag, _] : flags) { result.push_back(string_format("  %s", flag->info)); }
+    if (describe) {
+        return result;
+    } else {
+        return std::vector<std::string>();
+    }
 }
 
 void enchantment::load_enchantment(const JsonObject& jo, const std::string& src) {

--- a/src/enchantments/enchantment_condition.h
+++ b/src/enchantments/enchantment_condition.h
@@ -89,7 +89,7 @@ public:
     std::string condition_function;
 
     // String used for display of enchantment conditions in item info
-    std::string condition_info;
+    translation condition_info;
     // First: String id of the condition function
     // Second: The condition, called via check_item_condition for item conditions
     // Or check_generic_condition for everything else

--- a/src/enchantments/enchantment_flag.cpp
+++ b/src/enchantments/enchantment_flag.cpp
@@ -19,6 +19,7 @@ void enchantment_flag::load_enchantment_flags(const JsonObject& jo, const std::s
 }
 
 void enchantment_flag::load(const JsonObject& jo, const std::string& src) {
+    mandatory(jo, was_loaded, "info", info);
     optional(jo, was_loaded, "conflicts", conflicts);
     optional(jo, was_loaded, "parents", parents);
 }

--- a/src/enchantments/enchantment_flag.h
+++ b/src/enchantments/enchantment_flag.h
@@ -2,6 +2,7 @@
 
 #include "json.h"
 #include "string_id.h"
+#include "translations.h"
 #include "type_id.h"
 
 /**
@@ -26,6 +27,8 @@ public:
     std::set<enchantment_flag_id> get_parents() const;
 
     enchantment_flag_id id;
+
+    translation info;
 
     bool was_loaded = false;
 

--- a/src/enchantments/enchantment_value.cpp
+++ b/src/enchantments/enchantment_value.cpp
@@ -33,7 +33,7 @@ void enchantment_value::load(const JsonObject& jo, const std::string& src) {
             enchantment_value suffixed = enchantment_value(*this);
             suffixed.id = enchantment_value_id(suffixed.id.str() + "_" + suffix.next_string());
             suffixed.parent_id = id;
-            suffixed.desc = suffix.next_string();
+            suffixed.desc = to_translation(suffix.next_string());
             all_enchantment_values.insert(suffixed);
         }
     }

--- a/src/enchantments/enchantment_value.h
+++ b/src/enchantments/enchantment_value.h
@@ -39,7 +39,7 @@ public:
     bool can_mult = true;
     bool can_max = false;
 
-    std::string desc = "How did you get here?";
+    translation desc;
     bool increase_good = true;
 
     bool has_parent() const;


### PR DESCRIPTION
## Purpose of change (The Why)
#9904 and #9896 are making it much more pressing that we are able to properly describe effects of things to the player.
As enchantments become more and more important and are less and less constant

## Describe the solution (The How)
Add info to enchantment flags
Show what effects enchantments give  ( if they are displayed in the effects the player has menu )
Show what effects enchantments prevent ( same requirement )
Show what mutations are given
Show what flags are given

## Describe alternatives you've considered
None

## Testing
Rm13 armor shows flags
Cube of Shame shows mutations
Architect's cube shows off both effect things

## Additional context
Also fixed some translation issues

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.<!-- BEGIN docs comment -->

## Translations

| post                               | changed | stale | missing |
| ---------------------------------- | ------- | ----- | ------- |
| mod/json/reference/enchantments.md | en      |       | ja, ko  |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bf592fd](https://github.com/cataclysmbn/Cataclysm-BN/commit/bf592fdb62cd9f3d262d4386e669c1aaee9706f1) (docs and provide example) on 2026-07-19 03:01:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29669100453/artifacts/8437100042)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29669100453/artifacts/8437288703)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29669100453/artifacts/8436965407)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29669100453/artifacts/8436957178)
<!-- END artifact comment -->