### PR TITLE
fix: remove artifact data from in repo mods

### DIFF
--- a/data/mods/Aftershock/items/armor.json
+++ b/data/mods/Aftershock/items/armor.json
@@ -53,7 +53,7 @@
     "initial_charges": 15,
     "charges_per_use": 1,
     "use_action": "DIRECTIONAL_HOLOGRAM",
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ] },
     "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "STURDY", "OUTER", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {

--- a/data/mods/Aftershock/items/cast_spell_items.json
+++ b/data/mods/Aftershock/items/cast_spell_items.json
@@ -25,7 +25,7 @@
     "max_charges": 15,
     "initial_charges": 15,
     "charges_per_use": 1,
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ] },
     "use_action": { "type": "cast_spell", "spell_id": "afs_holo_transposition", "no_fail": true, "level": 1 }
   },
   {
@@ -37,7 +37,7 @@
     "max_charges": 15,
     "initial_charges": 15,
     "charges_per_use": 1,
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ] },
     "use_action": { "type": "cast_spell", "spell_id": "afs_holo_flare", "no_fail": true, "level": 1 }
   },
   {
@@ -49,7 +49,7 @@
     "max_charges": 2,
     "initial_charges": 2,
     "charges_per_use": 1,
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ] },
     "use_action": { "type": "cast_spell", "spell_id": "afs_holo_decoy", "no_fail": true, "level": 1 }
   },
   {
@@ -61,7 +61,7 @@
     "max_charges": 1,
     "initial_charges": 1,
     "charges_per_use": 1,
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ] },
     "use_action": { "type": "cast_spell", "spell_id": "afs_holo_field", "no_fail": true, "level": 1 }
   }
 ]

--- a/data/mods/MagicalNights/items/enchanted/enchanted_boots.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_boots.json
@@ -45,7 +45,7 @@
     "max_charges": 24,
     "charges_per_use": 24,
     "material": [ "leather", "steel" ],
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ] },
     "use_action": { "type": "cast_spell", "spell_id": "magus_escape", "no_fail": true, "level": 10, "need_worn": true },
     "encumbrance": 8,
     "warmth": 30,

--- a/data/mods/MagicalNights/items/enchanted/enchanted_bracers.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_bracers.json
@@ -71,9 +71,11 @@
     "initial_charges": 72,
     "max_charges": 72,
     "charges_per_use": 24,
-    "artifact_data": { "charge_type": "ARTC_TIME" },
     "flags": [ "BELTED", "STURDY", "BLOCK_WHILE_WORN" ],
-    "relic_data": { "passive_effects": [ { "conditions": [ "WORN" ], "values": [ { "value": "ARMOR_ELECTRIC", "add": -5 } ] } ] },
+    "relic_data": {
+      "passive_effects": [ { "conditions": [ "WORN" ], "values": [ { "value": "ARMOR_ELECTRIC", "add": -5 } ] } ],
+      "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ]
+    },
     "use_action": { "type": "cast_spell", "spell_id": "jolt", "no_fail": true, "level": 15, "need_worn": true }
   },
   {
@@ -85,9 +87,11 @@
     "initial_charges": 72,
     "max_charges": 72,
     "charges_per_use": 24,
-    "artifact_data": { "charge_type": "ARTC_TIME" },
     "flags": [ "BELTED", "STURDY", "BLOCK_WHILE_WORN" ],
-    "relic_data": { "passive_effects": [ { "conditions": [ "WORN" ], "values": [ { "value": "ARMOR_ELECTRIC", "add": -10 } ] } ] },
+    "relic_data": {
+      "passive_effects": [ { "conditions": [ "WORN" ], "values": [ { "value": "ARMOR_ELECTRIC", "add": -10 } ] } ],
+      "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ]
+    },
     "use_action": { "type": "cast_spell", "spell_id": "lightning_bolt", "no_fail": true, "level": 15, "need_worn": true }
   }
 ]

--- a/data/mods/MagicalNights/items/enchanted/enchanted_masks.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_masks.json
@@ -30,7 +30,7 @@
     "max_charges": 12,
     "charges_per_use": 12,
     "use_action": { "type": "cast_spell", "spell_id": "invisibility", "no_fail": true, "level": 15, "need_worn": true },
-    "artifact_data": { "charge_type": "ARTC_TIME" }
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ] }
   },
   {
     "type": "TOOL_ARMOR",

--- a/data/mods/MagicalNights/items/enchanted/enchanted_misc.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_misc.json
@@ -19,7 +19,7 @@
     "max_charges": 60,
     "charges_per_use": 1,
     "sub": "hotplate",
-    "artifact_data": { "charge_type": "ARTC_TIME" },
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ] },
     "use_action": [
       "HOTPLATE",
       "HEAT_FOOD",

--- a/data/mods/MagicalNights/items/enchanted/enchanted_rings.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_rings.json
@@ -109,7 +109,7 @@
     "initial_charges": 5,
     "max_charges": 5,
     "charges_per_use": 1,
-    "artifact_data": { "charge_type": "ARTC_TIME" }
+    "relic_data": { "recharge_scheme": [ { "type": "time", "interval": "1 h", "rate": 1 } ] }
   },
   {
     "copy-from": "mring_silver",


### PR DESCRIPTION
## Purpose of change (The Why)
With thoughts of moving to relicgen from artifactgen coming up
It's time to start thinking about eliminating artifact data

## Describe the solution (The How)
Replace `ARTC_TIME` with the equivalent recharge data
That was all that was left

## Describe alternatives you've considered
Never delete artifacts

## Testing
Heat cube lose charge
Heat cube gain charge

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9a76d44](https://github.com/cataclysmbn/Cataclysm-BN/commit/9a76d44fae0dd750cc598f6cc3ebf17ba6321685) (fix: remove artifact data from in repo mods) on 2026-07-19 03:39:34

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29669675326/artifacts/8437365382)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29669675326/artifacts/8437576998)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29669675326/artifacts/8437212155)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29669675326/artifacts/8437008329)
<!-- END artifact comment -->