### PR TITLE
feat(UI): improve spell selection menu

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -43,6 +43,69 @@
   },
   {
     "type": "keybinding",
+    "id": "UP",
+    "category": "SPELL_SELECT",
+    "name": "Select previous spell",
+    "bindings": [ { "input_method": "keyboard", "key": "UP" }, { "input_method": "keyboard", "key": "NUMPAD_8" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "DOWN",
+    "category": "SPELL_SELECT",
+    "name": "Select next spell",
+    "bindings": [ { "input_method": "keyboard", "key": "DOWN" }, { "input_method": "keyboard", "key": "NUMPAD_2" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "LEFT",
+    "category": "SPELL_SELECT",
+    "name": "Previous spell category",
+    "bindings": [ { "input_method": "keyboard", "key": "LEFT" }, { "input_method": "keyboard", "key": "NUMPAD_4" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RIGHT",
+    "category": "SPELL_SELECT",
+    "name": "Next spell category",
+    "bindings": [ { "input_method": "keyboard", "key": "RIGHT" }, { "input_method": "keyboard", "key": "NUMPAD_6" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "FILTER",
+    "category": "SPELL_SELECT",
+    "name": "Filter spells",
+    "bindings": [ { "input_method": "keyboard", "key": "/" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "QUIT",
+    "category": "SPELL_SELECT",
+    "name": "Cancel spell selection",
+    "bindings": [ { "input_method": "keyboard", "key": "ESC" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TOGGLE_FAVORITE",
+    "category": "SPELL_SELECT",
+    "name": "Toggle spell favorite",
+    "bindings": [ { "input_method": "keyboard", "key": "*" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TOGGLE_CASTING_DISTRACTIONS",
+    "category": "SPELL_SELECT",
+    "name": "Toggle casting distractions",
+    "bindings": [ { "input_method": "keyboard", "key": "I" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "ASSIGN_SPELL_HOTKEY",
+    "category": "SPELL_SELECT",
+    "name": "Assign spell hotkey",
+    "bindings": [ { "input_method": "keyboard", "key": "=" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "SHOW_DESCRIPTION",
     "category": "MELEE_STYLE_PICKER",
     "name": "Show description of melee style",

--- a/src/magic/magic.cpp
+++ b/src/magic/magic.cpp
@@ -2005,38 +2005,34 @@ int known_magic::select_spell(Character& guy) {
     spellcasting_callback cb(known_spells, casting_ignore);
     spell_menu.callback = &cb;
     const auto all_category = trait_NONE.str();
-    spell_menu.add_category( all_category, _( "All" ) );
+    spell_menu.add_category(all_category, _("All"));
 
-    const auto is_valid_spell_class = []( const trait_id &spell_class ) -> bool {
+    const auto is_valid_spell_class = [](const trait_id& spell_class) -> bool {
         return spell_class != trait_NONE && spell_class.is_valid();
     };
     auto categories = std::vector<std::pair<std::string, std::string>>{};
-    for( const auto *known_spell : known_spells ) {
+    for (const auto* known_spell : known_spells) {
         const auto spell_class = known_spell->spell_class();
-        if( !is_valid_spell_class( spell_class ) ) {
-            continue;
-        }
-        categories.emplace_back( spell_class.str(), spell_class->name() );
+        if (!is_valid_spell_class(spell_class)) { continue; }
+        categories.emplace_back(spell_class.str(), spell_class->name());
     }
     namespace ranges = std::ranges;
-    ranges::sort( categories, {}, &std::pair<std::string, std::string>::first );
-    const auto unique_end = ranges::unique( categories, {},
-                                           &std::pair<std::string, std::string>::first ).begin();
-    categories.erase( unique_end, categories.end() );
-    ranges::sort( categories, localized_compare,
-                  &std::pair<std::string, std::string>::second );
-    for( const auto &[key, name] : categories ) {
-        spell_menu.add_category( key, name );
-    }
-    spell_menu.set_category_filter( [&known_spells, is_valid_spell_class, all_category](
-    const auto &entry, const auto &category ) -> bool {
-        if( category == all_category ) { return true; }
-        if( entry.retval < 0 || static_cast<size_t>( entry.retval ) >= known_spells.size() ) {
-            return false;
-        }
-        const auto spell_class = known_spells[entry.retval]->spell_class();
-        return is_valid_spell_class( spell_class ) && spell_class.str() == category;
-    } );
+    ranges::sort(categories, {}, &std::pair<std::string, std::string>::first);
+    const auto unique_end =
+        ranges::unique(categories, {}, &std::pair<std::string, std::string>::first).begin();
+    categories.erase(unique_end, categories.end());
+    ranges::sort(categories, localized_compare, &std::pair<std::string, std::string>::second);
+    for (const auto& [key, name] : categories) { spell_menu.add_category(key, name); }
+    spell_menu.set_category_filter(
+        [&known_spells, is_valid_spell_class,
+         all_category](const auto& entry, const auto& category) -> bool {
+            if (category == all_category) { return true; }
+            if (entry.retval < 0 || static_cast<size_t>(entry.retval) >= known_spells.size()) {
+                return false;
+            }
+            const auto spell_class = known_spells[entry.retval]->spell_class();
+            return is_valid_spell_class(spell_class) && spell_class.str() == category;
+        });
 
     std::set<int> used_invlets{cb.reserved_invlets};
 

--- a/src/magic/magic.cpp
+++ b/src/magic/magic.cpp
@@ -1764,13 +1764,11 @@ private:
     spell_selector_categories& categories;
     const spell_selector_category_names& category_names;
     const std::set<int>& reserved_invlets;
-    const std::string favorite_status_hint;
-    const std::string not_favorite_status_hint;
     const std::string ignore_distractions_hint;
     const std::string popup_distractions_hint;
     const std::string assign_hotkey_hint;
     const int assign_hotkey_hint_width;
-    auto draw_spell_info(const spell& sp, bool favorite, const uilist* menu) -> void;
+    auto draw_spell_info(const spell& sp, const uilist* menu) -> void;
     auto update_categories(
         uilist* menu, const spell_selector_category_id& requested_category, bool rebuild_topology)
         -> void;
@@ -1785,7 +1783,6 @@ public:
         spell_selector_categories& categories;
         const spell_selector_category_names& category_names;
         const std::set<int>& reserved_invlets;
-        std::string favorite_action_hint;
         std::string distraction_action_hint;
         std::string assign_hotkey_action_hint;
         bool casting_ignore = false;
@@ -1798,13 +1795,6 @@ public:
           categories(opts.categories),
           category_names(opts.category_names),
           reserved_invlets(opts.reserved_invlets),
-          favorite_status_hint(string_format(
-              pgettext("spell selector favorite status", "%1$s (toggle: %2$s)"),
-              pgettext("spell selector favorite status", "Favorite"), opts.favorite_action_hint)),
-          not_favorite_status_hint(string_format(
-              pgettext("spell selector favorite status", "%1$s (toggle: %2$s)"),
-              pgettext("spell selector favorite status", "Not favorite"),
-              opts.favorite_action_hint)),
           ignore_distractions_hint(
               string_format("[%s] %s", opts.distraction_action_hint, _("Ignore Distractions"))),
           popup_distractions_hint(
@@ -1895,8 +1885,7 @@ public:
         mvwprintz(menu->window, point(assign_hotkey_x, 0), c_yellow, assign_hotkey_hint);
         if (menu->selected >= 0 && static_cast<std::size_t>(menu->selected) < known_spells.size()
             && static_cast<std::size_t>(menu->selected) < categories.spells.size()) {
-            draw_spell_info(
-                *known_spells[menu->selected], categories.spells[menu->selected].favorite, menu);
+            draw_spell_info(*known_spells[menu->selected], menu);
         }
         wnoutrefresh(menu->window);
     }
@@ -2003,8 +1992,7 @@ static std::string enumerate_traits(const std::set<trait_id> st) {
 }
 
 
-auto spellcasting_callback::draw_spell_info(
-    const spell& sp, const bool favorite, const uilist* menu) -> void {
+auto spellcasting_callback::draw_spell_info(const spell& sp, const uilist* menu) -> void {
     const int h_offset = menu->w_width - menu->pad_right + 1;
     // includes spaces on either side for readability
     const int info_width = menu->pad_right - 4;
@@ -2026,10 +2014,6 @@ auto spellcasting_callback::draw_spell_info(
             ? spell_class->name()
             : string_format(pgettext("spell selector", "Unknown class (%s)"), spell_class.str());
     print_colored_text(w_menu, point(h_col1, line++), yellow, yellow, spell_class_name);
-
-    print_colored_text(
-        w_menu, point(h_col1, line++), gray, gray,
-        favorite ? favorite_status_hint : not_favorite_status_hint);
 
     line += fold_and_print(w_menu, point(h_col1, line), info_width, gray, sp.description());
 
@@ -2262,7 +2246,6 @@ int known_magic::select_spell(Character& guy) {
         .categories = categories,
         .category_names = category_names,
         .reserved_invlets = reserved_invlets,
-        .favorite_action_hint = spell_input_context.get_desc(toggle_favorite_action, 1),
         .distraction_action_hint = spell_input_context.get_desc(toggle_distractions_action, 1),
         .assign_hotkey_action_hint = spell_input_context.get_desc(assign_spell_hotkey_action, 1),
         .casting_ignore = casting_ignore,

--- a/src/magic/magic.cpp
+++ b/src/magic/magic.cpp
@@ -51,6 +51,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <memory>
+#include <ranges>
 #include <set>
 #include <tuple>
 #include <utility>
@@ -2003,6 +2004,39 @@ int known_magic::select_spell(Character& guy) {
     spell_menu.hilight_disabled = true;
     spellcasting_callback cb(known_spells, casting_ignore);
     spell_menu.callback = &cb;
+    const auto all_category = trait_NONE.str();
+    spell_menu.add_category( all_category, _( "All" ) );
+
+    const auto is_valid_spell_class = []( const trait_id &spell_class ) -> bool {
+        return spell_class != trait_NONE && spell_class.is_valid();
+    };
+    auto categories = std::vector<std::pair<std::string, std::string>>{};
+    for( const auto *known_spell : known_spells ) {
+        const auto spell_class = known_spell->spell_class();
+        if( !is_valid_spell_class( spell_class ) ) {
+            continue;
+        }
+        categories.emplace_back( spell_class.str(), spell_class->name() );
+    }
+    namespace ranges = std::ranges;
+    ranges::sort( categories, {}, &std::pair<std::string, std::string>::first );
+    const auto unique_end = ranges::unique( categories, {},
+                                           &std::pair<std::string, std::string>::first ).begin();
+    categories.erase( unique_end, categories.end() );
+    ranges::sort( categories, localized_compare,
+                  &std::pair<std::string, std::string>::second );
+    for( const auto &[key, name] : categories ) {
+        spell_menu.add_category( key, name );
+    }
+    spell_menu.set_category_filter( [&known_spells, is_valid_spell_class, all_category](
+    const auto &entry, const auto &category ) -> bool {
+        if( category == all_category ) { return true; }
+        if( entry.retval < 0 || static_cast<size_t>( entry.retval ) >= known_spells.size() ) {
+            return false;
+        }
+        const auto spell_class = known_spells[entry.retval]->spell_class();
+        return is_valid_spell_class( spell_class ) && spell_class.str() == category;
+    } );
 
     std::set<int> used_invlets{cb.reserved_invlets};
 

--- a/src/magic/magic.cpp
+++ b/src/magic/magic.cpp
@@ -1396,11 +1396,45 @@ void known_magic::serialize(JsonOut& json) const {
     json.end_array();
     json.member("invlets", invlets);
 
+    if (!favorite_spells.empty()) {
+        json.member("favorite_spells");
+        json.start_array();
+        for (const auto& favorite_spell : favorite_spells) { json.write(favorite_spell.str()); }
+        json.end_array();
+    }
+
+    const auto saved_category = normalize_spell_selector_category(last_spell_selector_category);
+    auto saved_category_type = std::string{};
+    switch (saved_category.kind) {
+        case spell_selector_category_kind::all:
+            break;
+        case spell_selector_category_kind::favorites:
+            saved_category_type = "favorites";
+            break;
+        case spell_selector_category_kind::spell_class:
+            saved_category_type = "spell_class";
+            break;
+        case spell_selector_category_kind::other:
+            saved_category_type = "other";
+            break;
+    }
+    if (!saved_category_type.empty()) {
+        json.member("last_spell_selector_category");
+        json.start_object();
+        json.member("type", saved_category_type);
+        if (saved_category.kind == spell_selector_category_kind::spell_class) {
+            json.member("spell_class", saved_category.spell_class.str());
+        }
+        json.end_object();
+    }
+
     json.end_object();
 }
 
 void known_magic::deserialize(JsonIn& jsin) {
     auto data = jsin.get_object();
+    favorite_spells.clear();
+    last_spell_selector_category = {};
     data.read("mana", mana);
     last_cast_spell_id.reset();
 
@@ -1408,18 +1442,53 @@ void known_magic::deserialize(JsonIn& jsin) {
     data.read("last_cast_spell", last_cast_spell_str);
 
     for (JsonObject jo : data.get_array("spellbook")) {
-        auto id = jo.get_string("id");
-        auto sp = spell_id(id);
+        const auto id = jo.get_string("id");
+        const auto sp = spell_id(id);
         const auto xp = jo.get_int("xp");
         if (!sp.is_valid()) {
             debugmsg("Skipping spell with invalid id: %s", sp.c_str());
-        } else if (knows_spell(sp)) {
-            spellbook[sp].set_exp(xp);
         } else {
-            spellbook.emplace(sp, spell(sp, xp));
+            if (knows_spell(sp)) {
+                spellbook[sp].set_exp(xp);
+            } else {
+                spellbook.emplace(sp, spell(sp, xp));
+            }
         }
     }
-    data.read("invlets", invlets);
+    invlets.clear();
+    data.read("invlets", invlets, false);
+    sanitize_invlets({});
+
+    if (data.has_array("favorite_spells")) {
+        const auto saved_favorites = data.get_array("favorite_spells");
+        for (const auto favorite_index : std::views::iota(std::size_t{}, saved_favorites.size())) {
+            if (!saved_favorites.has_string(favorite_index)) { continue; }
+            const auto favorite_id = saved_favorites.get_string(favorite_index);
+            if (!favorite_id.empty()) { favorite_spells.insert(spell_id(favorite_id)); }
+        }
+    }
+
+    if (data.has_object("last_spell_selector_category")) {
+        const auto saved_category = data.get_object("last_spell_selector_category");
+        const auto category_type =
+            saved_category.has_string("type") ? saved_category.get_string("type") : std::string{};
+        if (category_type == "favorites") {
+            set_spell_selector_category({
+                .kind = spell_selector_category_kind::favorites,
+                .spell_class = trait_id{},
+            });
+        } else if (category_type == "other") {
+            set_spell_selector_category({
+                .kind = spell_selector_category_kind::other,
+                .spell_class = trait_id{},
+            });
+        } else if (category_type == "spell_class" && saved_category.has_string("spell_class")) {
+            set_spell_selector_category({
+                .kind = spell_selector_category_kind::spell_class,
+                .spell_class = trait_id(saved_category.get_string("spell_class")),
+            });
+        }
+    }
 
     if (!last_cast_spell_str.empty()) {
         const auto spell = spell_id(last_cast_spell_str);
@@ -1530,6 +1599,22 @@ auto known_magic::set_last_cast_spell(const spell_id& sp) -> void {
     if (knows_spell(sp)) { last_cast_spell_id = sp; }
 }
 
+auto known_magic::toggle_favorite_spell(const spell_id& sp) -> bool {
+    if (!knows_spell(sp)) { return false; }
+
+    const auto favorite = favorite_spells.find(sp);
+    if (favorite != favorite_spells.end()) {
+        favorite_spells.erase(favorite);
+        return false;
+    }
+    favorite_spells.insert(sp);
+    return true;
+}
+
+auto known_magic::set_spell_selector_category(spell_selector_category_id category) -> void {
+    last_spell_selector_category = normalize_spell_selector_category(std::move(category));
+}
+
 std::vector<spell*> known_magic::get_spells() {
     std::vector<spell*> spells;
     spells.reserve(spellbook.size());
@@ -1630,73 +1715,211 @@ int known_magic::time_to_learn_spell(const Character& guy, const spell_id& sp) c
             + (guy.get_skill_level(sp->skill) / 10.0));
 }
 
-int known_magic::get_spellname_max_width() {
-    int width = 0;
-    for (const spell* sp : get_spells()) { width = std::max(width, utf8_width(sp->name())); }
-    return width;
+namespace {
+
+constexpr auto spell_selector_input_category = "SPELL_SELECT";
+constexpr auto toggle_favorite_action = "TOGGLE_FAVORITE";
+constexpr auto toggle_distractions_action = "TOGGLE_CASTING_DISTRACTIONS";
+constexpr auto assign_spell_hotkey_action = "ASSIGN_SPELL_HOTKEY";
+
+auto make_spell_selector_input_context() -> input_context {
+    auto ctxt = input_context(spell_selector_input_category);
+    ctxt.register_updown();
+    ctxt.register_leftright();
+    ctxt.register_action("PAGE_UP");
+    ctxt.register_action("PAGE_DOWN");
+    ctxt.register_action("HOME");
+    ctxt.register_action("END");
+    ctxt.register_action("SCROLL_UP");
+    ctxt.register_action("SCROLL_DOWN");
+    ctxt.register_action("QUIT");
+    ctxt.register_action("SELECT");
+    ctxt.register_action("CONFIRM");
+    ctxt.register_action("FILTER");
+    ctxt.register_action("ANY_INPUT");
+    ctxt.register_action("HELP_KEYBINDINGS");
+    ctxt.register_action(toggle_favorite_action);
+    ctxt.register_action(toggle_distractions_action);
+    ctxt.register_action(assign_spell_hotkey_action);
+    return ctxt;
 }
+
+auto spell_selector_reserved_invlets(const input_context& ctxt) -> std::set<int> {
+    auto reserved_invlets = std::set<int>{'*'};
+    for (const auto& action : ctxt.get_registered_actions_copy()) {
+        for (const auto bound_key : ctxt.keys_bound_to(action)) {
+            reserved_invlets.insert(bound_key);
+        }
+    }
+    return reserved_invlets;
+}
+
+} // namespace
 
 class spellcasting_callback: public uilist_callback {
 private:
-    std::vector<spell*> known_spells;
-    void draw_spell_info(const spell& sp, const uilist* menu);
+    known_magic& magic;
+    Character& guy;
+    const std::vector<spell*>& known_spells;
+    spell_selector_categories& categories;
+    const spell_selector_category_names& category_names;
+    const std::set<int>& reserved_invlets;
+    const std::string favorite_status_hint;
+    const std::string not_favorite_status_hint;
+    const std::string ignore_distractions_hint;
+    const std::string popup_distractions_hint;
+    const std::string assign_hotkey_hint;
+    const int assign_hotkey_hint_width;
+    auto draw_spell_info(const spell& sp, bool favorite, const uilist* menu) -> void;
+    auto update_categories(
+        uilist* menu, const spell_selector_category_id& requested_category, bool rebuild_topology)
+        -> void;
 
 public:
-    // invlets reserved for special functions
-    const std::set<int> reserved_invlets{'I', '='};
     bool casting_ignore;
 
-    spellcasting_callback(std::vector<spell*>& spells, bool casting_ignore)
-        : known_spells(spells),
-          casting_ignore(casting_ignore) {}
-    bool key(
-        const input_context&, const input_event& event, int entnum, uilist* /*menu*/) override {
-        if (event.get_first_input() == 'I') {
+    struct options {
+        known_magic& magic;
+        Character& guy;
+        const std::vector<spell*>& known_spells;
+        spell_selector_categories& categories;
+        const spell_selector_category_names& category_names;
+        const std::set<int>& reserved_invlets;
+        std::string favorite_action_hint;
+        std::string distraction_action_hint;
+        std::string assign_hotkey_action_hint;
+        bool casting_ignore = false;
+    };
+
+    explicit spellcasting_callback(options opts)
+        : magic(opts.magic),
+          guy(opts.guy),
+          known_spells(opts.known_spells),
+          categories(opts.categories),
+          category_names(opts.category_names),
+          reserved_invlets(opts.reserved_invlets),
+          favorite_status_hint(string_format(
+              pgettext("spell selector favorite status", "%1$s (toggle: %2$s)"),
+              pgettext("spell selector favorite status", "Favorite"), opts.favorite_action_hint)),
+          not_favorite_status_hint(string_format(
+              pgettext("spell selector favorite status", "%1$s (toggle: %2$s)"),
+              pgettext("spell selector favorite status", "Not favorite"),
+              opts.favorite_action_hint)),
+          ignore_distractions_hint(
+              string_format("[%s] %s", opts.distraction_action_hint, _("Ignore Distractions"))),
+          popup_distractions_hint(
+              string_format("[%s] %s", opts.distraction_action_hint, _("Popup Distractions"))),
+          assign_hotkey_hint(string_format(_("Assign Hotkey [%s]"), opts.assign_hotkey_action_hint)),
+          assign_hotkey_hint_width(utf8_width(assign_hotkey_hint)),
+          casting_ignore(opts.casting_ignore) {}
+    auto key(const input_context& ctxt, const input_event& event, int entnum, uilist* menu)
+        -> bool override {
+        const auto& action = ctxt.input_to_action(event);
+        if (action == toggle_favorite_action) {
+            if (entnum < 0) {
+                popup(_("No spell selected."));
+                return true;
+            }
+            const auto entry_index = static_cast<std::size_t>(entnum);
+            if (entry_index >= known_spells.size() || entry_index >= categories.spells.size()
+                || entry_index >= menu->entries.size()) {
+                popup(_("No spell selected."));
+                return true;
+            }
+
+            const auto current_category =
+                spell_selector_category_at(categories, menu->get_current_category());
+            const auto selected_spell_id = known_spells[entry_index]->id();
+            const auto now_favorite = magic.toggle_favorite_spell(selected_spell_id);
+            menu->entries[entry_index].extratxt.txt = now_favorite ? "*" : "";
+            const auto rebuild_topology =
+                set_spell_selector_favorite(categories, entry_index, now_favorite);
+            update_categories(menu, current_category, rebuild_topology);
+            return true;
+        }
+        if (action == toggle_distractions_action) {
             casting_ignore = !casting_ignore;
             return true;
         }
-        if (event.get_first_input() == '=') {
-            int invlet = 0;
-            invlet = popup_getkey(_("Choose a new hotkey for this spell."));
+        if (action == assign_spell_hotkey_action) {
+            if (entnum < 0) { return true; }
+            const auto entry_index = static_cast<std::size_t>(entnum);
+            if (entry_index >= known_spells.size() || entry_index >= menu->entries.size()) {
+                return true;
+            }
+            const auto invlet = popup_getkey(_("Choose a new hotkey for this spell."));
             if (inv_chars.valid(invlet)) {
-                const bool invlet_set =
-                    g->u.magic->set_invlet(known_spells[entnum]->id(), invlet, reserved_invlets);
-                if (!invlet_set) {
+                auto used_invlets = reserved_invlets;
+                for (const auto other_entry_index :
+                     std::views::iota(std::size_t{}, menu->entries.size())) {
+                    if (other_entry_index != entry_index
+                        && menu->entries[other_entry_index].hotkey > 0) {
+                        used_invlets.insert(menu->entries[other_entry_index].hotkey);
+                    }
+                }
+                const auto previous_hotkey = menu->entries[entry_index].hotkey;
+                if (!menu->set_entry_hotkey(entry_index, invlet)) {
+                    popup(_("Hotkey already used."));
+                } else if (
+                    !magic.set_invlet(known_spells[entry_index]->id(), invlet, used_invlets)) {
+                    menu->set_entry_hotkey(entry_index, previous_hotkey);
                     popup(_("Hotkey already used."));
                 } else {
-                    popup(_("%c set.  Close and reopen spell menu to refresh list with changes."),
-                          invlet);
+                    popup(_("%c set."), invlet);
                 }
             } else {
                 popup(_("Hotkey removed."));
-                g->u.magic->rem_invlet(known_spells[entnum]->id());
+                magic.rem_invlet(known_spells[entry_index]->id());
+                menu->set_entry_hotkey(entry_index, 0);
             }
             return true;
         }
         return false;
     }
 
-    void refresh(uilist* menu) override {
-        mvwputch(menu->window, point(menu->w_width - menu->pad_right, 0), c_magenta, LINE_OXXX);
-        mvwputch(menu->window, point(menu->w_width - menu->pad_right, menu->w_height - 1),
-                 c_magenta, LINE_XXOX);
-        for (int i = 1; i < menu->w_height - 1; i++) {
-            mvwputch(menu->window, point(menu->w_width - menu->pad_right, i), c_magenta, LINE_XOXO);
+    auto refresh(uilist* menu) -> void override {
+        if (menu->pad_right < 8 || menu->pad_right >= menu->w_width) {
+            wnoutrefresh(menu->window);
+            return;
         }
-        std::string ignore_string =
-            casting_ignore ? _("Ignore Distractions") : _("Popup Distractions");
-        mvwprintz(
-            menu->window, point(menu->w_width - menu->pad_right + 2, 0),
-            casting_ignore ? c_red : c_light_green, string_format("%s %s", "[I]", ignore_string));
-        const std::string assign_letter = _("Assign Hotkey [=]");
-        mvwprintz(menu->window, point(menu->w_width - assign_letter.length() - 1, 0), c_yellow,
-                  assign_letter);
-        if (menu->selected >= 0 && static_cast<size_t>(menu->selected) < known_spells.size()) {
-            draw_spell_info(*known_spells[menu->selected], menu);
+
+        const auto divider_x = menu->w_width - menu->pad_right;
+        mvwputch(menu->window, point(divider_x, 0), c_magenta, LINE_OXXX);
+        mvwputch(menu->window, point(divider_x, menu->w_height - 1), c_magenta, LINE_XXOX);
+        for (int i = 1; i < menu->w_height - 1; i++) {
+            mvwputch(menu->window, point(divider_x, i), c_magenta, LINE_XOXO);
+        }
+        mvwprintz(menu->window, point(divider_x + 2, 0), casting_ignore ? c_red : c_light_green,
+                  casting_ignore ? ignore_distractions_hint : popup_distractions_hint);
+        const auto assign_hotkey_x = std::max(0, menu->w_width - assign_hotkey_hint_width - 1);
+        mvwprintz(menu->window, point(assign_hotkey_x, 0), c_yellow, assign_hotkey_hint);
+        if (menu->selected >= 0 && static_cast<std::size_t>(menu->selected) < known_spells.size()
+            && static_cast<std::size_t>(menu->selected) < categories.spells.size()) {
+            draw_spell_info(
+                *known_spells[menu->selected], categories.spells[menu->selected].favorite, menu);
         }
         wnoutrefresh(menu->window);
     }
 };
+
+auto spellcasting_callback::update_categories(
+    uilist* menu, const spell_selector_category_id& requested_category, const bool rebuild_topology)
+    -> void {
+    if (!rebuild_topology) {
+        menu->refresh_category_filter();
+        return;
+    }
+
+    categories = make_spell_selector_categories(std::move(categories.spells), category_names);
+    const auto requested_index = spell_selector_category_index(categories, requested_category);
+    menu->set_categories(
+        spell_selector_category_labels(categories),
+        [category_model = &categories](const auto& entry, const auto category_index) {
+            return spell_matches_spell_selector_category(
+                *category_model, entry.retval, category_index);
+        },
+        requested_index);
+}
 
 static bool casting_time_encumbered(const spell& sp, const Character& guy) {
     int encumb = 0;
@@ -1780,7 +2003,8 @@ static std::string enumerate_traits(const std::set<trait_id> st) {
 }
 
 
-void spellcasting_callback::draw_spell_info(const spell& sp, const uilist* menu) {
+auto spellcasting_callback::draw_spell_info(
+    const spell& sp, const bool favorite, const uilist* menu) -> void {
     const int h_offset = menu->w_width - menu->pad_right + 1;
     // includes spaces on either side for readability
     const int info_width = menu->pad_right - 4;
@@ -1795,9 +2019,17 @@ void spellcasting_callback::draw_spell_info(const spell& sp, const uilist* menu)
     nc_color light_green = c_light_green;
     nc_color yellow = c_yellow;
 
+    const auto spell_class = sp.spell_class();
+    const auto spell_class_name =
+        spell_class == trait_NONE ? _("Classless")
+        : spell_class.is_valid()
+            ? spell_class->name()
+            : string_format(pgettext("spell selector", "Unknown class (%s)"), spell_class.str());
+    print_colored_text(w_menu, point(h_col1, line++), yellow, yellow, spell_class_name);
+
     print_colored_text(
-        w_menu, point(h_col1, line++), yellow, yellow,
-        sp.spell_class() == trait_NONE ? _("Classless") : sp.spell_class()->name());
+        w_menu, point(h_col1, line++), gray, gray,
+        favorite ? favorite_status_hint : not_favorite_status_hint);
 
     line += fold_and_print(w_menu, point(h_col1, line), info_width, gray, sp.description());
 
@@ -1821,7 +2053,7 @@ void spellcasting_callback::draw_spell_info(const spell& sp, const uilist* menu)
         w_menu, point(h_col2, line++), gray, gray,
         string_format("%s: %d", _("Max Level"), sp.get_max_level()));
 
-    print_colored_text(w_menu, point(h_col1, line), gray, gray, sp.colorized_fail_percent(g->u));
+    print_colored_text(w_menu, point(h_col1, line), gray, gray, sp.colorized_fail_percent(guy));
     print_colored_text(
         w_menu, point(h_col2, line++), gray, gray,
         string_format("%s: %d", _("Difficulty"), sp.get_difficulty()));
@@ -1836,26 +2068,26 @@ void spellcasting_callback::draw_spell_info(const spell& sp, const uilist* menu)
 
     if (line <= win_height / 2) { line++; }
 
-    const bool cost_encumb = energy_cost_encumbered(sp, g->u);
+    const bool cost_encumb = energy_cost_encumbered(sp, guy);
     std::string cost_string = cost_encumb ? _("Casting Cost (impeded)") : _("Casting Cost");
     std::string energy_cur =
         sp.energy_source() == hp_energy
             ? ""
-            : string_format(_(" (%s current)"), sp.energy_cur_string(g->u));
-    if (!sp.can_cast(g->u)) {
+            : string_format(_(" (%s current)"), sp.energy_cur_string(guy));
+    if (!sp.can_cast(guy)) {
         cost_string = colorize(_("Not Enough Energy"), c_red);
         energy_cur = "";
     }
     print_colored_text(
         w_menu, point(h_col1, line++), gray, gray,
-        string_format("%s: %s %s%s", cost_string, sp.energy_cost_string(g->u), sp.energy_string(),
+        string_format("%s: %s %s%s", cost_string, sp.energy_cost_string(guy), sp.energy_string(),
                       energy_cur));
-    const bool c_t_encumb = casting_time_encumbered(sp, g->u);
+    const bool c_t_encumb = casting_time_encumbered(sp, guy);
     print_colored_text(
         w_menu, point(h_col1, line++), gray, gray,
         colorize(
             string_format("%s: %s", c_t_encumb ? _("Casting Time (impeded)") : _("Casting Time"),
-                          moves_to_string(sp.casting_time(g->u))),
+                          moves_to_string(sp.casting_time(guy))),
             c_t_encumb ? c_red : c_light_gray));
 
     if (line <= win_height * 3 / 4) { line++; }
@@ -1879,7 +2111,7 @@ void spellcasting_callback::draw_spell_info(const spell& sp, const uilist* menu)
 
     if (line <= win_height * 3 / 4) { line++; }
 
-    const int damage = sp.damage_as_character(g->u);
+    const int damage = sp.damage_as_character(guy);
     std::string damage_string;
     std::string aoe_string;
     // if it's any type of attack spell, the stats are normal.
@@ -1887,11 +2119,11 @@ void spellcasting_callback::draw_spell_info(const spell& sp, const uilist* menu)
         || fx == "line_attack") {
         if (damage > 0) {
             damage_string = string_format(
-                "%s: %s %s", _("Damage"), colorize(sp.damage_string(g->u), sp.damage_type_color()),
+                "%s: %s %s", _("Damage"), colorize(sp.damage_string(guy), sp.damage_type_color()),
                 colorize(sp.damage_type_string(), sp.damage_type_color()));
         } else if (damage < 0) {
-            damage_string = string_format(
-                "%s: %s", _("Healing"), colorize(sp.damage_string(g->u), light_green));
+            damage_string =
+                string_format("%s: %s", _("Healing"), colorize(sp.damage_string(guy), light_green));
         }
         if (sp.aoe() > 0) {
             std::string aoe_string_temp = _("Spell Radius");
@@ -1943,110 +2175,147 @@ void spellcasting_callback::draw_spell_info(const spell& sp, const uilist* menu)
     if (sp.has_components()) {
         if (!sp.components().get_components().empty()) {
             print_vec_string(sp.components().get_folded_components_list(
-                info_width - 2, gray, get_player_character().crafting_inventory(),
-                return_true<item>));
+                info_width - 2, gray, guy.crafting_inventory(), return_true<item>));
         }
         if (!(sp.components().get_tools().empty() && sp.components().get_qualities().empty())) {
             print_vec_string(sp.components().get_folded_tools_list(
-                info_width - 2, gray, get_player_character().crafting_inventory()));
+                info_width - 2, gray, guy.crafting_inventory()));
         }
     }
 }
 
 bool known_magic::set_invlet(const spell_id& sp, int invlet, const std::set<int>& used_invlets) {
-    if (used_invlets.contains(invlet)) { return false; }
+    if (!knows_spell(sp) || !inv_chars.valid(invlet) || used_invlets.contains(invlet)) {
+        return false;
+    }
     invlets[sp] = invlet;
     return true;
 }
 
 void known_magic::rem_invlet(const spell_id& sp) { invlets.erase(sp); }
 
+auto known_magic::sanitize_invlets(const std::set<int>& reserved_invlets) -> std::set<int> {
+    auto used_invlets = reserved_invlets;
+    std::erase_if(invlets, [this, &used_invlets](const auto& entry) {
+        if (!inv_chars.valid(entry.second)) { return true; }
+        if (!knows_spell(entry.first)) { return false; }
+        return !used_invlets.insert(entry.second).second;
+    });
+    return used_invlets;
+}
+
 int known_magic::get_invlet(const spell_id& sp, std::set<int>& used_invlets) {
-    auto found = invlets.find(sp);
+    if (!knows_spell(sp)) { return 0; }
+
+    const auto found = invlets.find(sp);
     if (found != invlets.end()) { return found->second; }
-    for (const std::pair<const spell_id, int>& invlet_pair : invlets) {
-        used_invlets.emplace(invlet_pair.second);
-    }
-    for (int i = 'a'; i <= 'z'; i++) {
-        if (!used_invlets.contains(i)) {
-            used_invlets.emplace(i);
-            return i;
+
+    for (const auto invlet : inv_chars) {
+        if (!used_invlets.contains(invlet)) {
+            used_invlets.insert(invlet);
+            return invlet;
         }
     }
-    for (int i = 'A'; i <= 'Z'; i++) {
-        if (!used_invlets.contains(i)) {
-            used_invlets.emplace(i);
-            return i;
-        }
-    }
-    for (int i = '!'; i <= '-'; i++) {
-        if (!used_invlets.contains(i)) {
-            used_invlets.emplace(i);
-            return i;
+    for (const auto invlet : std::views::iota(static_cast<int>('!'), static_cast<int>('-') + 1)) {
+        if (!used_invlets.contains(invlet)) {
+            used_invlets.insert(invlet);
+            return invlet;
         }
     }
     return 0;
 }
 
 int known_magic::select_spell(Character& guy) {
-    // max width of spell names
-    const int max_spell_name_length = get_spellname_max_width();
-    std::vector<spell*> known_spells = get_spells();
+    const auto known_spells = get_spells();
+    if (known_spells.empty() || !std::in_range<int>(known_spells.size())) { return UILIST_ERROR; }
+
+    using namespace std::views;
+    const auto spell_names =
+        known_spells | transform(&spell::name) | std::ranges::to<std::vector>();
+    const auto max_spell_name_length = std::ranges::max(
+        spell_names | transform([](const auto& name) { return utf8_width(name); }));
+    const auto category_names = spell_selector_category_names{
+        .all = pgettext("spell selector category", "All"),
+        .favorites = pgettext("spell selector category", "Favorites"),
+        .other = pgettext("spell selector category", "Other"),
+    };
+    auto selector_spells =
+        known_spells | transform([this](const auto* known_spell) {
+            return spell_selector_spell{
+                .spell_class = known_spell->spell_class(),
+                .primary_category = std::nullopt,
+                .favorite = favorite_spells.contains(known_spell->id()),
+            };
+        })
+        | std::ranges::to<std::vector>();
+    auto categories = make_spell_selector_categories(std::move(selector_spells), category_names);
+    const auto known_spell_count = static_cast<int>(known_spells.size());
+    const auto calc_width = []() -> int { return std::max(80, TERMX * 3 / 8); };
+    const auto spell_input_context = make_spell_selector_input_context();
+    const auto reserved_invlets = spell_selector_reserved_invlets(spell_input_context);
+    auto used_invlets = sanitize_invlets(reserved_invlets);
+
+    auto cb = spellcasting_callback({
+        .magic = *this,
+        .guy = guy,
+        .known_spells = known_spells,
+        .categories = categories,
+        .category_names = category_names,
+        .reserved_invlets = reserved_invlets,
+        .favorite_action_hint = spell_input_context.get_desc(toggle_favorite_action, 1),
+        .distraction_action_hint = spell_input_context.get_desc(toggle_distractions_action, 1),
+        .assign_hotkey_action_hint = spell_input_context.get_desc(assign_spell_hotkey_action, 1),
+        .casting_ignore = casting_ignore,
+    });
 
     uilist spell_menu;
-    spell_menu.w_height_setup = [&]() -> int {
-        return clamp(static_cast<int>(known_spells.size()), 24, TERMY * 9 / 10);
+    spell_menu.w_height_setup = [known_spell_count]() -> int {
+        return clamp(known_spell_count, 24, TERMY * 9 / 10);
     };
-    const auto calc_width = []() -> int { return std::max(80, TERMX * 3 / 8); };
     spell_menu.w_width_setup = calc_width;
-    spell_menu.pad_right_setup = [&]() -> int { return calc_width() - max_spell_name_length - 5; };
+    spell_menu.pad_right_setup = [calc_width, max_spell_name_length]() -> int {
+        return std::max(0, calc_width() - max_spell_name_length - 5);
+    };
     spell_menu.title = _("Choose a Spell");
     spell_menu.hilight_disabled = true;
-    spellcasting_callback cb(known_spells, casting_ignore);
-    spell_menu.callback = &cb;
-    const auto all_category = trait_NONE.str();
-    spell_menu.add_category(all_category, _("All"));
-
-    const auto is_valid_spell_class = [](const trait_id& spell_class) -> bool {
-        return spell_class != trait_NONE && spell_class.is_valid();
+    spell_menu.input_category = spell_selector_input_category;
+    spell_menu.additional_actions = {
+        {toggle_favorite_action, to_translation("Toggle favorite")},
+        {toggle_distractions_action, to_translation("Toggle casting distractions")},
+        {assign_spell_hotkey_action, to_translation("Assign spell hotkey")},
     };
-    auto categories = std::vector<std::pair<std::string, std::string>>{};
-    for (const auto* known_spell : known_spells) {
-        const auto spell_class = known_spell->spell_class();
-        if (!is_valid_spell_class(spell_class)) { continue; }
-        categories.emplace_back(spell_class.str(), spell_class->name());
-    }
-    namespace ranges = std::ranges;
-    ranges::sort(categories, {}, &std::pair<std::string, std::string>::first);
-    const auto unique_end =
-        ranges::unique(categories, {}, &std::pair<std::string, std::string>::first).begin();
-    categories.erase(unique_end, categories.end());
-    ranges::sort(categories, localized_compare, &std::pair<std::string, std::string>::second);
-    for (const auto& [key, name] : categories) { spell_menu.add_category(key, name); }
-    spell_menu.set_category_filter(
-        [&known_spells, is_valid_spell_class,
-         all_category](const auto& entry, const auto& category) -> bool {
-            if (category == all_category) { return true; }
-            if (entry.retval < 0 || static_cast<size_t>(entry.retval) >= known_spells.size()) {
-                return false;
-            }
-            const auto spell_class = known_spells[entry.retval]->spell_class();
-            return is_valid_spell_class(spell_class) && spell_class.str() == category;
-        });
+    spell_menu.enable_dynamic_categories();
+    spell_menu.callback = &cb;
+    spell_menu.set_categories(
+        spell_selector_category_labels(categories),
+        [&categories](const auto& entry, const auto category_index) {
+            return spell_matches_spell_selector_category(categories, entry.retval, category_index);
+        },
+        spell_selector_category_index(categories, last_spell_selector_category));
 
-    std::set<int> used_invlets{cb.reserved_invlets};
-
-    for (size_t i = 0; i < known_spells.size(); i++) {
+    for (const auto i : iota(std::size_t{}, known_spells.size())) {
         spell_menu.addentry(
             static_cast<int>(i), known_spells[i]->can_cast(guy),
-            get_invlet(known_spells[i]->id(), used_invlets), known_spells[i]->name());
+            get_invlet(known_spells[i]->id(), used_invlets), spell_names[i]);
+        spell_menu.entries.back().extratxt = {
+            .left = 0,
+            .color = c_yellow,
+            .txt = categories.spells[i].favorite ? "*" : "",
+        };
     }
 
     spell_menu.query();
 
-    casting_ignore = static_cast<spellcasting_callback*>(spell_menu.callback)->casting_ignore;
+    casting_ignore = cb.casting_ignore;
 
-    return spell_menu.ret;
+    const auto selected_spell = spell_menu.ret;
+    const auto valid_selection =
+        selected_spell >= 0 && static_cast<std::size_t>(selected_spell) < known_spells.size();
+    if (selected_spell == UILIST_CANCEL || valid_selection) {
+        set_spell_selector_category(
+            spell_selector_category_at(categories, spell_menu.get_current_category()));
+    }
+    return selected_spell == UILIST_CANCEL || valid_selection ? selected_spell : UILIST_ERROR;
 }
 
 void known_magic::on_mutation_gain(const trait_id& mid, Character& guy) {

--- a/src/magic/magic.h
+++ b/src/magic/magic.h
@@ -6,6 +6,7 @@
 #include "damage.h"
 #include "enum_bitset.h"
 #include "event_bus.h"
+#include "magic/spell_selector.h"
 #include "sounds.h"
 #include "translations.h"
 #include "type_id.h"
@@ -523,9 +524,12 @@ private:
     // list of spells known
     std::map<spell_id, spell> spellbook;
     // invlets assigned to spell_id
-    std::map<spell_id, int> invlets;
+    std::map<spell_id, int, spell_id::LexCmp> invlets;
     // the last known spell selected for casting
     std::optional<spell_id> last_cast_spell_id;
+    // per-Character spell selector preferences
+    std::set<spell_id, spell_id::LexCmp> favorite_spells;
+    spell_selector_category_id last_spell_selector_category;
     // the base mana a Character would start with
     int mana_base = 0;
     // current mana
@@ -556,6 +560,7 @@ public:
     spell& get_spell(const spell_id& sp);
     auto last_cast_spell() const -> std::optional<spell_id>;
     auto set_last_cast_spell(const spell_id& sp) -> void;
+    auto toggle_favorite_spell(const spell_id& sp) -> bool;
     // opens up a ui that the Character can choose a spell from
     // returns the index of the spell in the vector of spells
     int select_spell(Character& guy);
@@ -580,14 +585,15 @@ public:
     void serialize(JsonOut& json) const;
     void deserialize(JsonIn& jsin);
 
-    // returns false if invlet is already used
+    // returns false if the spell or invlet is unavailable
     bool set_invlet(const spell_id& sp, int invlet, const std::set<int>& used_invlets);
     void rem_invlet(const spell_id& sp);
 
 private:
-    // gets length of longest spell name
-    int get_spellname_max_width();
-    // gets invlet if assigned, or -1 if not
+    auto set_spell_selector_category(spell_selector_category_id category) -> void;
+    // Drops malformed/conflicting active invlets and returns the keys reserved by active spells.
+    auto sanitize_invlets(const std::set<int>& reserved_invlets) -> std::set<int>;
+    // returns the assigned invlet or selects an unused active invlet
     int get_invlet(const spell_id& sp, std::set<int>& used_invlets);
 };
 

--- a/src/magic/spell_selector.cpp
+++ b/src/magic/spell_selector.cpp
@@ -1,0 +1,217 @@
+#include "magic/spell_selector.h"
+
+#include "mutation.h"
+#include "string_formatter.h"
+#include "translations.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <map>
+#include <ranges>
+#include <utility>
+
+namespace {
+
+const auto trait_none = trait_id("NONE");
+
+struct spell_class_summary {
+    std::string name;
+    std::size_t spell_count = 0;
+    bool displayed = false;
+};
+
+auto class_category_id(const trait_id& spell_class) -> spell_selector_category_id {
+    return {
+        .kind = spell_selector_category_kind::spell_class,
+        .spell_class = spell_class,
+    };
+}
+
+} // namespace
+
+auto normalize_spell_selector_category(spell_selector_category_id category)
+    -> spell_selector_category_id {
+    switch (category.kind) {
+        case spell_selector_category_kind::all:
+        case spell_selector_category_kind::favorites:
+        case spell_selector_category_kind::other:
+            category.spell_class = trait_id{};
+            break;
+        case spell_selector_category_kind::spell_class:
+            if (category.spell_class == trait_none || category.spell_class.str().empty()) {
+                category = {};
+            }
+            break;
+        default:
+            category = {};
+            break;
+    }
+    return category;
+}
+
+auto make_spell_selector_categories(
+    std::vector<spell_selector_spell> spells, const spell_selector_category_names& names)
+    -> spell_selector_categories {
+    auto classes_by_id = std::map<trait_id, spell_class_summary>{};
+    for (const auto& spell : spells) {
+        if (spell.spell_class == trait_none || !spell.spell_class.is_valid()) { continue; }
+
+        const auto [iter, inserted] = classes_by_id.try_emplace(spell.spell_class);
+        auto& summary = iter->second;
+        if (inserted) { summary.name = spell.spell_class->name(); }
+        ++summary.spell_count;
+    }
+
+    using namespace std::views;
+    auto navigable_classes =
+        classes_by_id | filter([spell_count = spells.size()](const auto& entry) {
+            const auto& summary = entry.second;
+            return !summary.name.empty() && summary.spell_count >= 2
+                && summary.spell_count < spell_count;
+        })
+        | transform([](auto& entry) { return &entry; }) | std::ranges::to<std::vector>();
+    std::ranges::sort(navigable_classes, [](const auto* lhs, const auto* rhs) {
+        if (localized_compare(lhs->second.name, rhs->second.name)) { return true; }
+        if (localized_compare(rhs->second.name, lhs->second.name)) { return false; }
+        return lhs->first.str() < rhs->first.str();
+    });
+
+    auto visible_name_counts = std::map<std::string, std::size_t>{};
+    for (const auto* entry : navigable_classes) { ++visible_name_counts[entry->second.name]; }
+
+    auto result = spell_selector_categories{
+        .categories = {{
+            .id =
+                {
+                    .kind = spell_selector_category_kind::all,
+                    .spell_class = trait_id{},
+                },
+            .name = names.all,
+        }},
+        .spells = std::move(spells),
+    };
+    result.favorite_spell_count = static_cast<std::size_t>(
+        std::ranges::count_if(result.spells, &spell_selector_spell::favorite));
+    result.categories.reserve(navigable_classes.size() + 3);
+
+    if (result.favorite_spell_count > 0 && !names.favorites.empty()) {
+        result.categories.push_back({
+            .id =
+                {
+                    .kind = spell_selector_category_kind::favorites,
+                    .spell_class = trait_id{},
+                },
+            .name = names.favorites,
+        });
+    }
+
+    for (auto* const entry : navigable_classes) {
+        entry->second.displayed = true;
+        const auto& raw_id = entry->first.str();
+        const auto conflicts_with_special_category =
+            entry->second.name == names.all || entry->second.name == names.favorites
+            || entry->second.name == names.other;
+        const auto display_name =
+            visible_name_counts[entry->second.name] > 1 || conflicts_with_special_category
+                ? string_format(pgettext("spell selector category", "%1$s (%2$s)"),
+                                entry->second.name, raw_id)
+                : entry->second.name;
+        result.categories.push_back({
+            .id = class_category_id(entry->first),
+            .name = display_name,
+        });
+    }
+
+    for (const auto spell_index : iota(std::size_t{}, result.spells.size())) {
+        auto& spell = result.spells[spell_index];
+        spell.primary_category.reset();
+        const auto found = classes_by_id.find(spell.spell_class);
+        if (found != classes_by_id.end() && found->second.displayed) {
+            spell.primary_category = class_category_id(found->first);
+        }
+    }
+
+    const auto is_uncategorized = [](const auto& spell) { return !spell.primary_category; };
+    const auto other_count = std::ranges::count_if(result.spells, is_uncategorized);
+    if (other_count >= 2 && static_cast<std::size_t>(other_count) < result.spells.size()
+        && !names.other.empty()) {
+        const auto other_id = spell_selector_category_id{
+            .kind = spell_selector_category_kind::other,
+            .spell_class = trait_id{},
+        };
+        result.categories.push_back({
+            .id = other_id,
+            .name = names.other,
+        });
+        for (auto& spell : result.spells) {
+            if (!spell.primary_category) { spell.primary_category = other_id; }
+        }
+    }
+    return result;
+}
+
+auto set_spell_selector_favorite(
+    spell_selector_categories& categories, const std::size_t spell_index, const bool favorite)
+    -> bool {
+    if (spell_index >= categories.spells.size()) { return false; }
+
+    auto& spell = categories.spells[spell_index];
+    if (spell.favorite == favorite) { return false; }
+
+    const auto previously_had_favorites = categories.favorite_spell_count > 0;
+    spell.favorite = favorite;
+    if (favorite) {
+        ++categories.favorite_spell_count;
+    } else if (categories.favorite_spell_count > 0) {
+        --categories.favorite_spell_count;
+    }
+    return previously_had_favorites != (categories.favorite_spell_count > 0);
+}
+
+auto spell_selector_category_labels(const spell_selector_categories& categories)
+    -> std::vector<std::string> {
+    using namespace std::views;
+    return categories.categories | transform(&spell_selector_category::name)
+         | std::ranges::to<std::vector>();
+}
+
+auto spell_selector_category_at(
+    const spell_selector_categories& categories, const std::size_t category_index)
+    -> spell_selector_category_id {
+    return category_index < categories.categories.size()
+             ? normalize_spell_selector_category(categories.categories[category_index].id)
+             : spell_selector_category_id{};
+}
+
+auto spell_selector_category_index(
+    const spell_selector_categories& categories, const spell_selector_category_id& category)
+    -> std::size_t {
+    const auto normalized_category = normalize_spell_selector_category(category);
+    const auto found =
+        std::ranges::find(categories.categories, normalized_category, &spell_selector_category::id);
+    return found == categories.categories.end()
+             ? 0
+             : static_cast<std::size_t>(std::ranges::distance(categories.categories.begin(), found));
+}
+
+auto spell_matches_spell_selector_category(
+    const spell_selector_categories& categories, const int spell_index,
+    const std::size_t category_index) -> bool {
+    if (spell_index < 0 || category_index >= categories.categories.size()) { return false; }
+
+    const auto known_spell_index = static_cast<std::size_t>(spell_index);
+    if (known_spell_index >= categories.spells.size()) { return false; }
+
+    const auto& category = categories.categories[category_index].id;
+    const auto& spell = categories.spells[known_spell_index];
+    switch (category.kind) {
+        case spell_selector_category_kind::all:
+            return true;
+        case spell_selector_category_kind::favorites:
+            return spell.favorite;
+        case spell_selector_category_kind::spell_class:
+        case spell_selector_category_kind::other:
+            return spell.primary_category && *spell.primary_category == category;
+    }
+    return false;
+}

--- a/src/magic/spell_selector.h
+++ b/src/magic/spell_selector.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "type_id.h"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+enum class spell_selector_category_kind {
+    all,
+    favorites,
+    spell_class,
+    other,
+};
+
+struct spell_selector_category_id {
+    spell_selector_category_kind kind = spell_selector_category_kind::all;
+    trait_id spell_class;
+
+    auto operator==(const spell_selector_category_id&) const -> bool = default;
+};
+
+struct spell_selector_category {
+    spell_selector_category_id id;
+    std::string name;
+};
+
+struct spell_selector_spell {
+    trait_id spell_class;
+    std::optional<spell_selector_category_id> primary_category;
+    bool favorite = false;
+};
+
+struct spell_selector_categories {
+    std::vector<spell_selector_category> categories;
+    std::vector<spell_selector_spell> spells;
+    std::size_t favorite_spell_count = 0;
+};
+
+struct spell_selector_category_names {
+    std::string all;
+    std::string favorites;
+    std::string other;
+};
+
+auto normalize_spell_selector_category(spell_selector_category_id category)
+    -> spell_selector_category_id;
+
+auto make_spell_selector_categories(
+    std::vector<spell_selector_spell> spells, const spell_selector_category_names& names)
+    -> spell_selector_categories;
+
+/// Updates favorite membership and reports whether the Favorites category must be added or removed.
+auto set_spell_selector_favorite(
+    spell_selector_categories& categories, std::size_t spell_index, bool favorite) -> bool;
+
+auto spell_selector_category_labels(const spell_selector_categories& categories)
+    -> std::vector<std::string>;
+
+auto spell_selector_category_at(
+    const spell_selector_categories& categories, std::size_t category_index)
+    -> spell_selector_category_id;
+
+auto spell_selector_category_index(
+    const spell_selector_categories& categories, const spell_selector_category_id& category)
+    -> std::size_t;
+
+auto spell_matches_spell_selector_category(
+    const spell_selector_categories& categories, int spell_index, std::size_t category_index)
+    -> bool;

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -212,13 +212,14 @@ void uilist::init()
     categories.clear();
     category_filter = {};
     current_category = 0;
+    dynamic_categories = false;
 }
 
 input_context uilist::create_main_input_context() const
 {
     input_context ctxt( input_category );
     ctxt.register_updown();
-    if( !categories.empty() ) {
+    if( categories.size() > 1 || dynamic_categories ) {
         ctxt.register_action( "LEFT", to_translation( "Previous category" ) );
         ctxt.register_action( "RIGHT", to_translation( "Next category" ) );
     }
@@ -276,6 +277,10 @@ void uilist::filterlist()
 {
     bool filtering = ( this->filtering && !filter.empty() );
 
+    if( categories.empty() || current_category >= categories.size() ) {
+        current_category = 0;
+    }
+
     // TODO: && is_all_lc( filter )
     bool ignore_case = filtering_igncase;
     fentries.clear();
@@ -290,8 +295,7 @@ void uilist::filterlist()
     }
 
     for( int i = 0; i < num_entries; i++ ) {
-        if( !categories.empty() && category_filter &&
-            !category_filter( entries[i], categories[current_category].first ) ) {
+        if( !categories.empty() && !category_filter( entries[i], current_category ) ) {
             continue;
         }
         if( filtering ) {
@@ -369,18 +373,74 @@ void uilist::set_filter( const std::string &fstr )
     filterlist();
 }
 
-auto uilist::add_category( const std::string &key, const std::string &name ) -> void
+auto uilist::set_categories(
+    std::vector<std::string> category_names,
+    std::function < auto( const uilist_entry &, std::size_t ) -> bool > filter,
+    const std::size_t requested_category ) -> void
 {
-    if( key.empty() || name.empty() ) {
-        return;
+    namespace ranges = std::ranges;
+    const auto previously_had_categories = !categories.empty();
+    const auto has_empty_name = ranges::any_of( category_names, &std::string::empty );
+    if( category_names.size() < 2 || has_empty_name || !filter ) {
+        categories.clear();
+        category_filter = {};
+        current_category = 0;
+    } else {
+        categories = std::move( category_names );
+        category_filter = std::move( filter );
+        current_category = requested_category < categories.size() ? requested_category : 0;
     }
-    categories.emplace_back( key, name );
+
+    if( started ) {
+        refresh_category_filter();
+        if( previously_had_categories != !categories.empty() ) {
+            const auto current_ui = ui.lock();
+            if( current_ui ) {
+                current_ui->mark_resize();
+            }
+        }
+    }
 }
 
-auto uilist::set_category_filter( const
-                                  std::function<bool( const uilist_entry &, const std::string & )> &filter ) -> void
+auto uilist::enable_dynamic_categories() -> void
 {
-    category_filter = filter;
+    dynamic_categories = true;
+}
+
+auto uilist::refresh_category_filter() -> void
+{
+    if( !started ) {
+        return;
+    }
+
+    const auto previously_selected = selected;
+    filterlist();
+    if( dynamic_categories && previously_selected >= 0 && !fentries.empty() &&
+        std::ranges::lower_bound( fentries, previously_selected ) == fentries.end() ) {
+        selected = fentries.back();
+        fselected = static_cast<int>( fentries.size() ) - 1;
+    }
+}
+
+auto uilist::get_current_category() const -> std::size_t
+{
+    return current_category;
+}
+
+auto uilist::cycle_category( const bool forward ) -> void
+{
+    if( categories.size() < 2 ) {
+        return;
+    }
+    if( current_category >= categories.size() ) {
+        current_category = 0;
+    }
+    if( forward ) {
+        current_category = current_category == categories.size() - 1 ? 0 : current_category + 1;
+    } else {
+        current_category = current_category == 0 ? categories.size() - 1 : current_category - 1;
+    }
+    filterlist();
 }
 
 void uilist::inputfilter()
@@ -425,6 +485,27 @@ bool uilist::set_selected( int sel )
     }
 
     return false;
+}
+
+auto uilist::set_entry_hotkey( const std::size_t entry_index, const int hotkey ) -> bool
+{
+    if( entry_index >= entries.size() || !std::in_range<int>( entry_index ) ) {
+        return false;
+    }
+
+    const auto entry = static_cast<int>( entry_index );
+    const auto existing = keymap.find( hotkey );
+    if( hotkey > 0 && existing != keymap.end() && existing->second != entry ) {
+        return false;
+    }
+
+    const auto has_entry = [entry]( const auto & mapping ) { return mapping.second == entry; };
+    std::erase_if( keymap, has_entry );
+    entries[entry_index].hotkey = hotkey;
+    if( hotkey > 0 && entries[entry_index].enabled ) {
+        keymap[hotkey] = entry;
+    }
+    return true;
 }
 
 /**
@@ -621,7 +702,7 @@ void uilist::setup()
 
     vmax = entries.size();
     const auto category_lines = categories.empty() ? 0 : 1;
-    int additional_lines = 2 + text_separator_line + category_lines + // borders and category tabs
+    int additional_lines = 2 + text_separator_line + category_lines +
                            static_cast<int>( textformatted.size() );
     if( desc_enabled ) {
         additional_lines += desc_lines + 1; // add one for description separator line
@@ -680,6 +761,9 @@ void uilist::apply_scrollbar()
     } else {
         estart = 1;
     }
+    if( !categories.empty() ) {
+        ++estart;
+    }
 
     scrollbar()
     .offset_x( sbside )
@@ -731,10 +815,13 @@ void uilist::show( ui_adaptor &ui )
     }
 
     if( !categories.empty() ) {
-        const auto &category_text = categories[current_category].second;
-        const auto category_width = std::max( 1, w_width - pad_right - 4 );
-        trim_and_print( window, point( 2, estart++ ), category_width, title_color, _color_error,
-                        "%s", category_text );
+        if( current_category >= categories.size() ) {
+            current_category = 0;
+        }
+        const auto category_label = "<< " + categories[current_category] + " >>";
+        const auto category_width = std::max( 1, w_width - pad_left - pad_right - 4 );
+        trim_and_print( window, point( pad_left + 2, estart++ ), category_width, c_yellow,
+                        _color_error, "%s", category_label );
     }
 
     calcStartPos( vshift, fselected, vmax, fentries.size() );
@@ -877,6 +964,12 @@ bool uilist::scrollby( const int scrollby )
     if( scrollby == 0 ) {
         return false;
     }
+    if( fentries.empty() ) {
+        fselected = -1;
+        selected = -1;
+        vshift = 0;
+        return true;
+    }
 
     bool looparound = ( scrollby == -1 || scrollby == 1 );
     bool backwards = ( scrollby < 0 );
@@ -984,10 +1077,8 @@ void uilist::query( bool loop, int timeout )
             /* nothing */
         } else if( filtering && ret_act == "FILTER" ) {
             inputfilter();
-        } else if( !categories.empty() && ( ret_act == "LEFT" || ret_act == "RIGHT" ) ) {
-            const auto offset = ret_act == "RIGHT" ? 1 : categories.size() - 1;
-            current_category = ( current_category + offset ) % categories.size();
-            filterlist();
+        } else if( categories.size() > 1 && ( ret_act == "LEFT" || ret_act == "RIGHT" ) ) {
+            cycle_category( ret_act == "RIGHT" );
         } else if( ret_act == "ANY_INPUT" && iter != keymap.end() ) {
             // only handle "ANY_INPUT" since "HELP_KEYBINDINGS" is already
             // handled by the input context and the caller might want to handle

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -209,12 +209,19 @@ void uilist::init()
     hotkeys = DEFAULT_HOTKEYS;
     input_category = "UILIST";
     additional_actions.clear();
+    categories.clear();
+    category_filter = {};
+    current_category = 0;
 }
 
 input_context uilist::create_main_input_context() const
 {
     input_context ctxt( input_category );
     ctxt.register_updown();
+    if( !categories.empty() ) {
+        ctxt.register_action( "LEFT", to_translation( "Previous category" ) );
+        ctxt.register_action( "RIGHT", to_translation( "Next category" ) );
+    }
     ctxt.register_action( "PAGE_UP", to_translation( "Fast scroll up" ) );
     ctxt.register_action( "PAGE_DOWN", to_translation( "Fast scroll down" ) );
     ctxt.register_action( "HOME", to_translation( "Go to first entry" ) );
@@ -283,6 +290,10 @@ void uilist::filterlist()
     }
 
     for( int i = 0; i < num_entries; i++ ) {
+        if( !categories.empty() && category_filter &&
+            !category_filter( entries[i], categories[current_category].first ) ) {
+            continue;
+        }
         if( filtering ) {
             if( exact_match_only ) {
                 if( !( entries[i].txt == filter ) ) {
@@ -356,6 +367,20 @@ void uilist::set_filter( const std::string &fstr )
 {
     filter = fstr;
     filterlist();
+}
+
+auto uilist::add_category( const std::string &key, const std::string &name ) -> void
+{
+    if( key.empty() || name.empty() ) {
+        return;
+    }
+    categories.emplace_back( key, name );
+}
+
+auto uilist::set_category_filter( const
+                                  std::function<bool( const uilist_entry &, const std::string & )> &filter ) -> void
+{
+    category_filter = filter;
 }
 
 void uilist::inputfilter()
@@ -595,7 +620,8 @@ void uilist::setup()
     }
 
     vmax = entries.size();
-    int additional_lines = 2 + text_separator_line + // add two for top & bottom borders
+    const auto category_lines = categories.empty() ? 0 : 1;
+    int additional_lines = 2 + text_separator_line + category_lines + // borders and category tabs
                            static_cast<int>( textformatted.size() );
     if( desc_enabled ) {
         additional_lines += desc_lines + 1; // add one for description separator line
@@ -702,6 +728,13 @@ void uilist::show( ui_adaptor &ui )
         }
         mvwputch( window, point( w_width - 1, text_lines + 1 ), border_color, LINE_XOXX );
         estart += text_lines + 1; // +1 for the horizontal line.
+    }
+
+    if( !categories.empty() ) {
+        const auto &category_text = categories[current_category].second;
+        const auto category_width = std::max( 1, w_width - pad_right - 4 );
+        trim_and_print( window, point( 2, estart++ ), category_width, title_color, _color_error,
+                        "%s", category_text );
     }
 
     calcStartPos( vshift, fselected, vmax, fentries.size() );
@@ -951,6 +984,10 @@ void uilist::query( bool loop, int timeout )
             /* nothing */
         } else if( filtering && ret_act == "FILTER" ) {
             inputfilter();
+        } else if( !categories.empty() && ( ret_act == "LEFT" || ret_act == "RIGHT" ) ) {
+            const auto offset = ret_act == "RIGHT" ? 1 : categories.size() - 1;
+            current_category = ( current_category + offset ) % categories.size();
+            filterlist();
         } else if( ret_act == "ANY_INPUT" && iter != keymap.end() ) {
             // only handle "ANY_INPUT" since "HELP_KEYBINDINGS" is already
             // handled by the input context and the caller might want to handle

--- a/src/ui.h
+++ b/src/ui.h
@@ -297,6 +297,10 @@ class uilist // NOLINT(cata-xy)
                            const std::string &desc = "" );
         void settext( const std::string &str );
 
+        auto add_category( const std::string &key, const std::string &name ) -> void;
+        auto set_category_filter( const
+                                  std::function<bool( const uilist_entry &, const std::string & )> &filter ) -> void;
+
         void reset();
 
         // Can be called before `uilist::query` to keep the uilist on UI stack after
@@ -403,6 +407,10 @@ class uilist // NOLINT(cata-xy)
 
         std::unique_ptr<string_input_popup> filter_popup;
         std::string filter;
+
+        std::vector<std::pair<std::string, std::string>> categories;
+        std::function<bool( const uilist_entry &, const std::string & )> category_filter;
+        size_t current_category = 0;
 
         int max_entry_len;
         int max_column_len;

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <initializer_list>
 #include <map>
 #include <memory>
@@ -281,6 +282,8 @@ class uilist // NOLINT(cata-xy)
          * @returns 'false' if entry does not exist / is not available with current filter.
          */
         bool set_selected( int sel );
+        /// Updates an entry's displayed hotkey and active dispatch mapping together.
+        auto set_entry_hotkey( std::size_t entry_index, int hotkey ) -> bool;
 
         void addentry( const std::string &str );
         void addentry( int r, bool e, int k, const std::string &str );
@@ -297,9 +300,13 @@ class uilist // NOLINT(cata-xy)
                            const std::string &desc = "" );
         void settext( const std::string &str );
 
-        auto add_category( const std::string &key, const std::string &name ) -> void;
-        auto set_category_filter( const
-                                  std::function<bool( const uilist_entry &, const std::string & )> &filter ) -> void;
+        auto set_categories(
+            std::vector<std::string> category_names,
+            std::function < auto( const uilist_entry &, std::size_t ) -> bool > filter,
+            std::size_t requested_category = 0 ) -> void;
+        auto enable_dynamic_categories() -> void;
+        auto refresh_category_filter() -> void;
+        auto get_current_category() const -> std::size_t;
 
         void reset();
 
@@ -319,6 +326,7 @@ class uilist // NOLINT(cata-xy)
     private:
         int scroll_amount_from_action( const std::string &action );
         void apply_scrollbar();
+        auto cycle_category( bool forward ) -> void;
         // This function assumes it's being called from `query` and should
         // not be made public.
         void inputfilter();
@@ -408,9 +416,10 @@ class uilist // NOLINT(cata-xy)
         std::unique_ptr<string_input_popup> filter_popup;
         std::string filter;
 
-        std::vector<std::pair<std::string, std::string>> categories;
-        std::function<bool( const uilist_entry &, const std::string & )> category_filter;
-        size_t current_category = 0;
+        std::vector<std::string> categories;
+        std::function < auto( const uilist_entry &, std::size_t ) -> bool > category_filter;
+        std::size_t current_category = 0;
+        bool dynamic_categories = false;
 
         int max_entry_len;
         int max_column_len;
@@ -444,5 +453,3 @@ class pointmenu_cb : public uilist_callback
         ~pointmenu_cb() override;
         void select( uilist *menu ) override;
 };
-
-


### PR DESCRIPTION
Closes https://github.com/cataclysmbn/Cataclysm-BN/issues/9777

## Summary

- Adds spell selector tabs for All, Favorites, Other, and meaningful spell classes.
- Remembers favorites and the last selected tab per character across save/load.
- Keeps search available across tabs and adds configurable favorite and spell-hotkey actions.

To favorite or unfavorite a spell, select it and press `*` (or the configured **Toggle favorite** binding). Favorited spells are marked with `*` and appear in the **Favorites** tab.

## Testing

Tested locally on Android:

- Tested characters from existing saves with Arcana + Magical Nights.
- Favorited and unfavorited spells.
- Saved, closed the game, and loaded the save again. The last selected spell tab remained in memory and the favorites were preserved.
- No bugs observed.

## Screenshots

**All spells**

![All spells tab](https://raw.githubusercontent.com/marojiro/Cataclysm-BN/3de5100b7bfb9ec41abf8347839bd890b17e5abe/screenshots/better-spell-menu/category_all.jpg)

**Favorites**

![Favorites tab](https://raw.githubusercontent.com/marojiro/Cataclysm-BN/3de5100b7bfb9ec41abf8347839bd890b17e5abe/screenshots/better-spell-menu/category_favorites.jpg)

**Other**

![Other spells tab](https://raw.githubusercontent.com/marojiro/Cataclysm-BN/3de5100b7bfb9ec41abf8347839bd890b17e5abe/screenshots/better-spell-menu/category_other.jpg)

**Spell class**

![Stormshaper spell class tab](https://raw.githubusercontent.com/marojiro/Cataclysm-BN/3de5100b7bfb9ec41abf8347839bd890b17e5abe/screenshots/better-spell-menu/category_stormshaper.jpg)

<sub>Note: The “Not favorite” / “Favorite” messages visible in these screenshots were temporary debug text and have been removed from the final code.</sub>

## Checklist

### Mandatory

- [x] I linked any relevant issues using GitHub keyword syntax like `closes #1234` in the purpose of change so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit in the Linux kernel format.
  - Model: OpenAI `gpt-5.6-sol`

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [61d49c9](https://github.com/cataclysmbn/Cataclysm-BN/commit/61d49c9db0e43a4804436225e3c9e1715065d51d) (fix(ui): remove favorite status from spell details) on 2026-07-19 04:40:02

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29671622181/artifacts/8437994425)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29671622181/artifacts/8438107579)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29671622181/artifacts/8437898927)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29671622181/artifacts/8437786317)
<!-- END artifact comment -->