### PR TITLE
fix: .40 kriss spawn load correct ammo into magazines

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -750,8 +750,8 @@
     "subtype": "collection",
     "entries": [
       { "item": "kriss_vector", "ammo-group": "on_hand_40", "charges": [ 0, 30 ] },
-      { "group": "nested_kriss_vector_mag", "charges-min": 0, "prob": 80 },
-      { "group": "nested_kriss_vector_mag", "charges-min": 0, "prob": 50 },
+      { "group": "nested_kriss_vector_mag", "ammo-group": "on_hand_40", "charges-min": 0, "prob": 80 },
+      { "group": "nested_kriss_vector_mag", "ammo-group": "on_hand_40", "charges-min": 0, "prob": 50 },
       { "group": "on_hand_40", "prob": 25, "charges": [ 10, 20 ], "count": [ 1, 2 ] }
     ]
   },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -1019,8 +1019,8 @@
     "subtype": "collection",
     "entries": [
       { "item": "kriss_vector", "ammo-group": "on_hand_40", "charges": [ 0, 30 ] },
-      { "group": "nested_kriss_vector_mag", "charges-min": 0 },
-      { "group": "nested_kriss_vector_mag", "charges-min": 0, "prob": 50 },
+      { "group": "nested_kriss_vector_mag", "ammo-group": "on_hand_40", "charges-min": 0 },
+      { "group": "nested_kriss_vector_mag", "ammo-group": "on_hand_40", "charges-min": 0, "prob": 50 },
       { "group": "on_hand_40" }
     ]
   },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

<img width="505" height="117" alt="image" src="https://github.com/user-attachments/assets/f20a82ce-f6ff-4059-87e8-1a9af9f39e65" />

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Added `"ammo-group": "on_hand_40"` where relevant.

## Describe alternatives you've considered

explode

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

<img width="550" height="486" alt="image" src="https://github.com/user-attachments/assets/d864546b-311a-45e9-b84e-2c7db7847213" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1389c98](https://github.com/cataclysmbn/Cataclysm-BN/commit/1389c988ecc039e4dbba71b1fc6a0e893c1ea048) (fix: .40 kriss spawn load correct ammo into magazines) on 2026-07-19 06:36:32

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29674445666/artifacts/8438876624)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29674445666/artifacts/8439121064)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29674445666/artifacts/8438475868)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29674445666/artifacts/8438496546)
<!-- END artifact comment -->