### PR TITLE
fix(mods/MagicalNights): Adds missing SHEATH flags to Belt of Weaponry to allow storing axes and the golf club

### DIFF
--- a/data/mods/MagicalNights/items/enchanted/enchanted_belts.json
+++ b/data/mods/MagicalNights/items/enchanted/enchanted_belts.json
@@ -98,7 +98,7 @@
         "gun",
         "unarmed"
       ],
-      "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "BELT_CLIP", "SHEATH_SPEAR" ]
+      "flags": [ "SHEATH_KNIFE", "SHEATH_SWORD", "BELT_CLIP", "SHEATH_SPEAR", "SHEATH_AXE", "SHEATH_GOLF" ]
     }
   },
   {


### PR DESCRIPTION

<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

The Belt of Weaponry from Magical Nights was missing the flag to store axes... and the golf club I guess.

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adding the SHEATH_AXE and SHEATH_GOLF flags to the Belt of Weaponry
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
None
## Testing

1. Added Flags
2. Wore Belt of Weaponry and activated it
3. Can store a Battleaxe and a Golf Club inside

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Not sure why you'd want to store a golf club inside, but since it has its own sheath flag, might as well add it
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [+ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [- ] This PR used AI assistance.
  - [+ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f4341b8](https://github.com/cataclysmbn/Cataclysm-BN/commit/f4341b8b1e1c3f2f668def0a12691e7717e0d2b2) (Update enchanted_belts.json) on 2026-07-19 13:52:20

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29687531176/artifacts/8442642921)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29687531176/artifacts/8443165903)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29687531176/artifacts/8442656960)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29687531176/artifacts/8442700356)
<!-- END artifact comment -->