### PR TITLE
fix(mods/Arcana): Remove `need_wielding` from refined blood offering

### DIFF
--- a/data/mods/Arcana_BN/items/comestibles.json
+++ b/data/mods/Arcana_BN/items/comestibles.json
@@ -214,13 +214,7 @@
     "color": "red",
     "healthy": -6,
     "fun": -4,
-    "use_action": {
-      "type": "cast_spell",
-      "spell_id": "arcana_item_sacramental_heart",
-      "no_fail": true,
-      "need_wielding": true,
-      "level": 0
-    },
+    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_sacramental_heart", "no_fail": true, "level": 0 },
     "flags": [ "NO_INGEST", "NPC_SAFE", "NUTRIENT_OVERRIDE" ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

@ChrisLR found a smol mistake I made, seems comestibles don't play nice with `needs_wielding` and it wasn't really needed on refined blood offering anyway.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Removed from the item's spellcasting action.

## Describe alternatives you've considered

explode

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

<img width="404" height="32" alt="image" src="https://github.com/user-attachments/assets/94da3a67-98ec-492e-ab76-f845b663736e" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [314677e](https://github.com/cataclysmbn/Cataclysm-BN/commit/314677e60c73883339d21855a0669109384bdc22) (fix(mods/Arcana): Remove `need_wielding` from refined blood offering) on 2026-07-19 20:12:36

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29699278541/artifacts/8446355938)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29699278541/artifacts/8446729089)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29699278541/artifacts/8446448006)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29699278541/artifacts/8446300952)
<!-- END artifact comment -->