### PR TITLE
fix: fix lights not spawning on wooden floor tiles in labs

### DIFF
--- a/data/json/lua/mapgen/lab.lua
+++ b/data/json/lua/mapgen/lab.lua
@@ -9,6 +9,7 @@ local east_edge = 23
 local see = 12
 
 local t_floor = TerId.new("t_floor"):int_id()
+local t_floor_olight = TerId.new("t_floor_olight"):int_id()
 local t_thconc_floor = TerId.new("t_thconc_floor"):int_id()
 local t_thconc_floor_olight = TerId.new("t_thconc_floor_olight"):int_id()
 local t_strconc_floor = TerId.new("t_strconc_floor"):int_id()
@@ -178,6 +179,8 @@ draw_lights = function(data, map)
           if map:get_ter_at( PointOmtMs.new(i, j)) == t_thconc_floor or
              map:get_ter_at( PointOmtMs.new(i, j)) == t_strconc_floor then
             map:set_ter_at( PointOmtMs.new(i, j), t_thconc_floor_olight)
+          elseif map:get_ter_at( PointOmtMs.new(i, j)) == t_floor then
+            map:set_ter_at( PointOmtMs.new(i, j), t_floor_olight)
           end
         end
       end


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
With the addition of several rooms in labs with wooden floors, the randomly placed lights that are supposed to sometimes spawn in these rooms don't spawn correctly because they don't work with wooden floors.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Fixes the problem so that wooden floors can also now spawn overhead lights.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
No lights?
## Testing
Debug teleported to central lab, wood floors have lights
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/f6e8a51c-0b9a-446b-9806-ac015fb3b89f" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Thanks to N4 for the bug report
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [04d500b](https://github.com/cataclysmbn/Cataclysm-BN/commit/04d500b7def09d6a271722ebf9b91cd2f829a7d6) (Update lab.lua) on 2026-07-20 05:50:16

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29716788706/artifacts/8451005490)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29716788706/artifacts/8451986455)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29716788706/artifacts/8451054756)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29716788706/artifacts/8451064074)
<!-- END artifact comment -->