### PR TITLE
feat: reintroduce lost content from Expanded Realistic Weapons mod

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -3248,5 +3248,17 @@
         ]
       }
     ]
+  },
+  {
+    "id": "everyday_m6_asw",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "m6_asw", "ammo-group": "on_hand_22", "charges": [ 0, 1 ] },
+      { "group": "on_hand_22" },
+      { "group": "on_hand_410shot" }
+    ]
   }
 ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -708,7 +708,8 @@
       { "group": "nested_longrifle_flintlock", "prob": 90 },
       { "group": "nested_rifle_flintlock", "prob": 90 },
       { "group": "nested_steyr_aug", "prob": 40 },
-      { "group": "nested_m7", "prob": 20 }
+      { "group": "nested_m7", "prob": 20 },
+      { "group": "everyday_m6_asw", "prob": 10 }
     ]
   },
   {
@@ -728,7 +729,8 @@
       { "group": "everyday_longrifle_flintlock", "prob": 90 },
       { "group": "everyday_rifle_flintlock", "prob": 90 },
       { "group": "everyday_steyr_aug", "prob": 40 },
-      { "group": "everyday_m7", "prob": 20 }
+      { "group": "everyday_m7", "prob": 20 },
+      { "group": "everyday_m6_asw", "prob": 10 }
     ]
   },
   {
@@ -1124,6 +1126,7 @@
       { "group": "carried_guns_archery", "prob": 200 },
       { "group": "guns_improvised", "prob": 200 },
       { "group": "carried_guns_rifle_common", "prob": 100 },
+      { "group": "everyday_m6_asw", "prob": 10 },
       { "group": "everyday_carbon_rifle", "prob": 5 },
       { "group": "everyday_carbon_pistol", "prob": 5 },
       { "group": "carried_guns_shotgun_common", "prob": 60 },
@@ -1160,6 +1163,7 @@
       { "group": "nested_savage_111f", "prob": 10 },
       { "group": "nested_marlin_9a", "prob": 20 },
       { "group": "nested_ruger_1022", "prob": 10 },
+      { "group": "everyday_m6_asw", "prob": 5 },
       { "group": "nested_colt_lightning", "prob": 10 },
       { "group": "nested_ar_357sig", "prob": 10 },
       { "group": "nested_hipoint_3895", "prob": 10 },
@@ -1211,7 +1215,8 @@
       { "collection": [ { "item": "garand" }, { "item": "garandclip", "count": [ 1, 2 ] } ], "prob": 20 },
       { "collection": [ { "item": "m1903" }, { "item": "3006_clip", "count": [ 1, 2 ], "prob": 50 } ], "prob": 15 },
       { "collection": [ { "item": "m1918" }, { "group": "display_m1918_mag", "count": [ 1, 2 ] } ], "prob": 15 },
-      { "item": "winchester_1897", "prob": 10 },
+      { "item": "winchester_1897", "prob": 8 },
+      { "item": "m6_asw", "prob": 2 },
       { "collection": [ { "item": "m60" }, { "item": "ammolink308", "count": [ 100, 200 ] } ], "prob": 10 },
       { "collection": [ { "item": "m2browning" }, { "item": "ammolink50", "count": [ 100, 200 ] } ], "prob": 5 },
       { "collection": [ { "item": "m1874_gatling" }, { "item": "gatlingdrum240", "count": [ 1, 2 ] } ], "prob": 5 },

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -968,7 +968,6 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "group": "everyday_m6_asw", "prob": 25 },
       { "item": "flotation_vest", "prob": 25 },
       { "item": "premium_survival_kit", "prob": 25 },
       { "item": "mil_gps_device", "prob": 25 },

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -765,7 +765,8 @@
       { "item": "25mm_hei", "prob": 2 },
       { "item": "belt25mm", "contents-group": "25mm_ammo", "prob": 3 },
       { "item": "105mm_heat", "prob": 1 },
-      { "item": "105mm_ap", "prob": 1 }
+      { "item": "105mm_ap", "prob": 1 },
+      { "item": "m6_asw", "prob": 5 }
     ]
   },
   {
@@ -967,6 +968,7 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
+      { "group": "everyday_m6_asw", "prob": 25 },
       { "item": "flotation_vest", "prob": 25 },
       { "item": "premium_survival_kit", "prob": 25 },
       { "item": "mil_gps_device", "prob": 25 },

--- a/data/json/items/gun/combination.json
+++ b/data/json/items/gun/combination.json
@@ -52,6 +52,7 @@
   {
     "id": "m6_asw",
     "copy-from": "rifle_1shot",
+    "looks_like": "combination_gun",
     "type": "GUN",
     "name": { "str": "M6 Aircrew Survival Weapon" },
     "description": "A lightweight combination rifle, combining a .22 rimfire barrel with .410 shotgun barrel, and designed to fold for compact storage.  Produced for military aircraft pilots who might be stranded after a crash, later produced commercially by various companies.",

--- a/data/json/items/gun/combination.json
+++ b/data/json/items/gun/combination.json
@@ -48,5 +48,37 @@
     "barrel_volume": "500 ml",
     "built_in_mods": [ "combination_gun_shotgun_pipe" ],
     "extend": { "flags": "NEVER_JAMS" }
+  },
+  {
+    "id": "m6_asw",
+    "copy-from": "rifle_1shot",
+    "type": "GUN",
+    "name": { "str": "M6 Aircrew Survival Weapon" },
+    "description": "A lightweight combination rifle, combining a .22 rimfire barrel with .410 shotgun barrel, and designed to fold for compact storage.  Produced for military aircraft pilots who might be stranded after a crash, later produced commercially by various companies.",
+    "weight": "2 kg",
+    "volume": "1750 ml",
+    "price": "595 USD",
+    "price_postapoc": "1250 cent",
+    "bashing": 6,
+    "material": "steel",
+    "ammo": "22",
+    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
+    "durability": 7,
+    "clip_size": 1,
+    "barrel_volume": "500 ml",
+    "built_in_mods": [ "folding_stock", "M6_shotgun" ],
+    "valid_mod_locations": [
+      [ "accessories", 4 ],
+      [ "barrel", 1 ],
+      [ "bore", 1 ],
+      [ "grip", 1 ],
+      [ "mechanism", 4 ],
+      [ "magazine", 1 ],
+      [ "rail", 2 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "underbarrel", 1 ]
+    ],
+    "flags": [ "NEEDS_UNFOLD" ]
   }
 ]

--- a/data/json/items/gun/pipe_gun.json
+++ b/data/json/items/gun/pipe_gun.json
@@ -119,6 +119,7 @@
     "barrel_volume": "500 ml",
     "valid_mod_locations": [
       [ "accessories", 2 ],
+      [ "bore", 1 ],
       [ "sling", 1 ],
       [ "stock", 1 ],
       [ "barrel", 1 ],
@@ -143,6 +144,7 @@
     "barrel_volume": "750 ml",
     "valid_mod_locations": [
       [ "accessories", 2 ],
+      [ "bore", 1 ],
       [ "sling", 1 ],
       [ "stock", 1 ],
       [ "barrel", 1 ],

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -24,6 +24,7 @@
     "loudness": 2,
     "valid_mod_locations": [
       [ "accessories", 1 ],
+      [ "bore", 1 ],
       [ "grip", 1 ],
       [ "stock", 1 ],
       [ "mechanism", 4 ],

--- a/data/json/items/gunmod/conversions.json
+++ b/data/json/items/gunmod/conversions.json
@@ -437,7 +437,7 @@
     "location": "bore",
     "mod_targets": [ "ashot", "pipe_shotgun", "pipe_double_shotgun" ],
     "install_time": "5 m",
-    "ammo_modifier": "410",
+    "ammo_modifier": "410shot",
     "min_skills": [ [ "weapon", 1 ], [ "mechanics", 1 ] ]
   }
 ]

--- a/data/json/items/gunmod/conversions.json
+++ b/data/json/items/gunmod/conversions.json
@@ -419,5 +419,25 @@
     "magazine_adaptor": [ [ "9mm", [ "9mm_speedloader6" ] ] ],
     "min_skills": [ [ "weapon", 2 ], [ "mechanics", 2 ] ],
     "flags": [ "INSTALL_DIFFICULT" ]
+  },
+  {
+    "id": "retool_pipe_410",
+    "type": "GUNMOD",
+    "name": { "str": ".410 pipe shotgun conversion kit" },
+    "description": "A replacement barrel and chamber assembly for a pipe shotgun, bored out to fire .410 shells.",
+    "weight": "250 g",
+    "volume": "125 ml",
+    "integral_volume": "0 ml",
+    "integral_weight": "0 g",
+    "price": "100 USD",
+    "price_postapoc": "5 USD",
+    "material": "steel",
+    "symbol": ":",
+    "color": "green",
+    "location": "bore",
+    "mod_targets": [ "ashot", "pipe_shotgun", "pipe_double_shotgun" ],
+    "install_time": "5 m",
+    "ammo_modifier": "410",
+    "min_skills": [ [ "weapon", 1 ], [ "mechanics", 1 ] ]
   }
 ]

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -441,8 +441,8 @@
   {
     "id": "M6_shotgun",
     "type": "GUNMOD",
-    "name": { "str": "M6 Survival Gun shotgun" },
-    "description": "The integrated 12 gauge shotgun barrel of the Chiappa M6 Survival Gun.  It's irremovable.",
+    "name": { "str": "M6 Aircrew Survival Weapon shotgun" },
+    "description": "The integrated .410 shotgun barrel of the M6 Aircrew Survival Weapon.  It's irremovable.",
     "volume": "0 ml",
     "price": "0 cent",
     "price_postapoc": "0 cent",
@@ -452,7 +452,7 @@
     "location": "underbarrel",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ] ],
     "gun_data": {
-      "ammo": "shot",
+      "ammo": "410",
       "skill": "shotgun",
       "range": 1,
       "dispersion": 320,

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -452,7 +452,7 @@
     "location": "underbarrel",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ] ],
     "gun_data": {
-      "ammo": "410",
+      "ammo": "410shot",
       "skill": "shotgun",
       "range": 1,
       "dispersion": 320,

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -1440,6 +1440,19 @@
   },
   {
     "type": "recipe",
+    "result": "retool_pipe_410",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "fabrication",
+    "skills_required": [ "mechanics", 1 ],
+    "difficulty": 2,
+    "time": "10 m",
+    "autolearn": true,
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "pipe", 1 ] ], [ [ "scrap", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
     "result": "carbon_grip",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_MODS",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

While poking around in the JSON, I noticed that there was an underbarrel mod for an M6 survival gun but no sign of the weapon it goes with. After some digging I found it USED to be part of DN's old gun mod, and for some dumb reason the accessory for it was mainlined but not the gun that actually USES it. They also forgot .410 pipe shotguns, but now that modular pipe guns are a thing I opted to bring that back as a gunmod instead.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Reimplemented the M6 ASW as of when it was deleted in https://github.com/CleverRaven/Cataclysm-DDA/pull/38888, then modernized the shit out of its ancient JSON.
2. Set the M6 gunmod to use .410 like the original was designed to, since it was originally meant to showcase .410 which is underused compared to 12 gauge I feel.
3. Added to M6 to itemgroups `helicopter`, `guns_rifle_obscure`, `carried_guns_rifle_obscure`, `guns_survival`, `guns_hunting`, `guns_surplus`, and `pilot_bail_kit` just for fun (realistically the go-to bailout gun seems to instead be a takedown AR but this is more interesting).
4. Reimplemented the .410 pipe shotgun as a conversion kit gunmod for the 12 gauge pistol, pipe shotgun, and double pipe shotgun.
5. Added associated recipe.
6. Added bore slot to 12 gauge pistol and pipe shotguns so they can accept the .410 conversion.

## Describe alternatives you've considered

1. Not spawning a gun that hasn't been in service since the 70s in F-35 lightnings. It's neat though, plus the bailout kit already gives you a lot of useful shit so a .22/.410 gun is probably better balance-wise than a takedown AR.
2. Reflavoring the M6 as the Chiappa or Springfield versions, the former would entail keeping the underbarrel in 12 gauge.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b17bf10](https://github.com/cataclysmbn/Cataclysm-BN/commit/b17bf10f9f5a4a79c3913badf51ebd4a4a9f15e3) (looks like) on 2026-07-21 07:33:22

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29808514215/artifacts/8486705372)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29808514215/artifacts/8487324166)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29808514215/artifacts/8486858639)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29808514215/artifacts/8486820892)
<!-- END artifact comment -->