### PR TITLE
feat: Make cargo carriers disassembleable

### DIFF
--- a/data/json/uncraft/vehicle/other.json
+++ b/data/json/uncraft/vehicle/other.json
@@ -16,5 +16,25 @@
     "time": "15 m",
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "hard_steel_armor", 8 ] ], [ [ "ceramic_armor", 8 ] ] ]
+  },
+  {
+    "result": "cargo_rack",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "mechanics", 1 ],
+    "difficulty": 1,
+    "time": "15 m",
+    "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
+    "components": [ [ [ "steel_lump", 80 ] ], [ [ "rope_6", 20 ] ] ]
+  },
+  {
+    "result": "cargo_rack_carbon",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "skills_required": [ "mechanics", 1 ],
+    "time": "15 m",
+    "qualities": [ { "id": "SAW_M_FINE", "level": 1 } ],
+    "components": [ [ [ "frame_carbon", 6 ] ], [ [ "rope_6", 20 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

I was looking to make some carbon cargo carriers and realised that I can't just take the ropes from regular cargo carriers to do that, which doesn't make a lot of sense. Based on their description there's no reason why you shouldn't be able to do this.

## Describe the solution (The How)

I added disassembly to both types of cargo carriers:

* Regular ones are made from heavy duty frame (which is made from 100 steel lumps) and leave 20 lumps as byproduct, so they disassemble into 80 lumps + 20 short ropes.
* Carbon ones disassemble into 6 carbon fiber frames + 20 short ropes.

## Describe alternatives you've considered

## Testing

Looked at cargo carriers in the crafting menu to see they have disassembly set properly.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [fb914f5](https://github.com/cataclysmbn/Cataclysm-BN/commit/fb914f5d91123bf82aba28a4b3112f725d3a5c3c) (Make cargo racks disassembleable) on 2026-07-20 15:58:12

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29746629556/artifacts/8462972483)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29746629556/artifacts/8467314947)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29746629556/artifacts/8463317076)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29746629556/artifacts/8463289497)
<!-- END artifact comment -->