### PR TITLE
fix(mods/aftershock): add missing tools to ForgeBuddy/KitchenBuddy

### DIFF
--- a/data/mods/Aftershock/furniture_and_terrain/furniture-appliances.json
+++ b/data/mods/Aftershock/furniture_and_terrain/furniture-appliances.json
@@ -50,7 +50,7 @@
     "move_cost_mod": -1,
     "coverage": 60,
     "required_str": -1,
-    "crafting_pseudo_item": [ "fake_oven", "fake_chemistry_set", "fake_gridelectrolysis_kit", "pot", "pan" ],
+    "crafting_pseudo_item": [ "fake_oven", "fake_chemistry_set", "fake_gridelectrolysis_kit", "fake_gridfood_processor", "fake_griddehydrator", "fake_gridvac_sealer", "fake_gridwater_purifier", "press", "pot", "pan" ],
     "flags": [ "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT", "TRANSPARENT" ],
     "deconstruct": {
       "items": [
@@ -95,7 +95,7 @@
     "move_cost_mod": -1,
     "coverage": 60,
     "required_str": -1,
-    "crafting_pseudo_item": [ "fake_gridforge", "fake_gridkiln" ],
+    "crafting_pseudo_item": [ "fake_gridforge", "fake_gridkiln", "fake_gridwelder", "fake_gridsolderingiron" ],
     "flags": [ "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT", "TRANSPARENT" ],
     "deconstruct": {
       "items": [

--- a/data/mods/Aftershock/furniture_and_terrain/furniture-appliances.json
+++ b/data/mods/Aftershock/furniture_and_terrain/furniture-appliances.json
@@ -50,7 +50,18 @@
     "move_cost_mod": -1,
     "coverage": 60,
     "required_str": -1,
-    "crafting_pseudo_item": [ "fake_oven", "fake_chemistry_set", "fake_gridelectrolysis_kit", "fake_gridfood_processor", "fake_griddehydrator", "fake_gridvac_sealer", "fake_gridwater_purifier", "press", "pot", "pan" ],
+    "crafting_pseudo_item": [
+      "fake_oven",
+      "fake_chemistry_set",
+      "fake_gridelectrolysis_kit",
+      "fake_gridfood_processor",
+      "fake_griddehydrator",
+      "fake_gridvac_sealer",
+      "fake_gridwater_purifier",
+      "press",
+      "pot",
+      "pan"
+    ],
     "flags": [ "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT", "TRANSPARENT" ],
     "deconstruct": {
       "items": [

--- a/data/mods/Aftershock/vehicles/vehicle_parts.json
+++ b/data/mods/Aftershock/vehicles/vehicle_parts.json
@@ -190,15 +190,19 @@
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
     "flags": [ "CARGO", "OBSTACLE", "HOTPLATE", "FAUCET", "WATER_PURIFIER", "COVERED", "CRAFTER", "CONVERTER" ],
-    "integrated_tools": [ "chemistry_set", "electrolysis_kit", "pot", "pan", "hotplate", "dehydrator", "vac_sealer", "water_purifier", "food_processor", "press" ],
-	"converter": {
-    "input": "water",
-    "input_step": 8,
-    "output": "water_clean",
-    "output_step": 8,
-    "max_steps": 6,
-    "charge_cost": 1 
-	},
+    "integrated_tools": [
+      "chemistry_set",
+      "electrolysis_kit",
+      "pot",
+      "pan",
+      "hotplate",
+      "dehydrator",
+      "vac_sealer",
+      "water_purifier",
+      "food_processor",
+      "press"
+    ],
+    "converter": { "input": "water", "input_step": 8, "output": "water_clean", "output_step": 8, "max_steps": 6, "charge_cost": 1 },
     "breaks_into": [
       { "item": "steel_lump", "count": [ 9, 18 ] },
       { "item": "steel_chunk", "count": [ 9, 18 ] },

--- a/data/mods/Aftershock/vehicles/vehicle_parts.json
+++ b/data/mods/Aftershock/vehicles/vehicle_parts.json
@@ -189,8 +189,16 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE", "HOTPLATE", "FAUCET", "WATER_PURIFIER", "COVERED", "CRAFTER" ],
-    "integrated_tools": [ "chemistry_set", "electrolysis_kit", "pot", "pan", "hotplate", "dehydrator", "vac_sealer", "food_processor", "press" ],
+    "flags": [ "CARGO", "OBSTACLE", "HOTPLATE", "FAUCET", "WATER_PURIFIER", "COVERED", "CRAFTER", "CONVERTER" ],
+    "integrated_tools": [ "chemistry_set", "electrolysis_kit", "pot", "pan", "hotplate", "dehydrator", "vac_sealer", "water_purifier", "food_processor", "press" ],
+	"converter": {
+    "input": "water",
+    "input_step": 8,
+    "output": "water_clean",
+    "output_step": 8,
+    "max_steps": 6,
+    "charge_cost": 1 
+	},
     "breaks_into": [
       { "item": "steel_lump", "count": [ 9, 18 ] },
       { "item": "steel_chunk", "count": [ 9, 18 ] },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Adds missing tools for furniture of both the Forgebuddy and KitchenBuddy, along with fixing the KitchenBuddy vehicle part to have the correct flag and ability to purify water.

## Describe the solution (The How)

Add a few lines of JSON to fix the missing parts. 

## Describe alternatives you've considered

Not making the changes.

## Testing

Loaded the game, didn't get any errors.

## Additional context

I haven't used Github and such in a while, sorry if I made any mistakes. 

 ## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory


- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [87bc51c](https://github.com/cataclysmbn/Cataclysm-BN/commit/87bc51c17f61e61ba413ad4655ea70db615723e2) (Lint 2: Lint Harder) on 2026-07-21 09:07:23

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29797733719/artifacts/8482824074)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29797733719)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29797733719/artifacts/8482811564)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29797733719/artifacts/8482861282)
<!-- END artifact comment -->