### PR TITLE
fix: add missing integrated Workshop Toolbox to Vehicle Survivor Workbench and Robobench

### DIFF
--- a/data/json/vehicleparts/crafting.json
+++ b/data/json/vehicleparts/crafting.json
@@ -577,7 +577,9 @@
   {
     "type": "vehicle_part",
     "id": "survivors_workbench",
-	"integrated_tools": [ "toolbox_workshop" ],
+    "integrated_tools": [
+    "toolbox_workshop"
+    ],
     "name": { "str": "survivors workbench" },
     "symbol": "#",
     "looks_like": "veh_table_wood",
@@ -594,7 +596,13 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH", "CRAFTER" ],
+    "flags": [
+    "CARGO",
+    "OBSTACLE",
+    "FLAT_SURF",
+    "WORKBENCH",
+    "CRAFTER"
+    ],
     "breaks_into": [
       { "item": "pipe", "count": [ 4, 6 ] },
       { "item": "sheet_metal", "count": [ 0, 1 ] },
@@ -608,7 +616,9 @@
   {
     "type": "vehicle_part",
     "id": "robobench",
-	"integrated_tools": [ "toolbox_workshop" ],
+	"integrated_tools": [
+    "toolbox_workshop"
+    ],
     "name": { "str": "robobench" },
     "symbol": "#",
     "looks_like": "machinery_heavy",
@@ -625,7 +635,13 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH", "CRAFTER" ],
+    "flags": [
+    "CARGO",
+    "OBSTACLE",
+    "FLAT_SURF",
+    "WORKBENCH",
+    "CRAFTER"
+    ],
     "breaks_into": [
       { "item": "pipe", "count": [ 4, 6 ] },
       { "item": "sheet_metal", "count": [ 0, 1 ] },

--- a/data/json/vehicleparts/crafting.json
+++ b/data/json/vehicleparts/crafting.json
@@ -577,9 +577,7 @@
   {
     "type": "vehicle_part",
     "id": "survivors_workbench",
-    "integrated_tools": [
-    "toolbox_workshop"
-    ],
+    "integrated_tools": [ "toolbox_workshop" ],
     "name": { "str": "survivors workbench" },
     "symbol": "#",
     "looks_like": "veh_table_wood",
@@ -596,13 +594,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
     },
-    "flags": [
-    "CARGO",
-    "OBSTACLE",
-    "FLAT_SURF",
-    "WORKBENCH",
-    "CRAFTER"
-    ],
+    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH", "CRAFTER" ],
     "breaks_into": [
       { "item": "pipe", "count": [ 4, 6 ] },
       { "item": "sheet_metal", "count": [ 0, 1 ] },
@@ -616,9 +608,7 @@
   {
     "type": "vehicle_part",
     "id": "robobench",
-	"integrated_tools": [
-    "toolbox_workshop"
-    ],
+    "integrated_tools": [ "toolbox_workshop" ],
     "name": { "str": "robobench" },
     "symbol": "#",
     "looks_like": "machinery_heavy",
@@ -635,13 +625,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
     },
-    "flags": [
-    "CARGO",
-    "OBSTACLE",
-    "FLAT_SURF",
-    "WORKBENCH",
-    "CRAFTER"
-    ],
+    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH", "CRAFTER" ],
     "breaks_into": [
       { "item": "pipe", "count": [ 4, 6 ] },
       { "item": "sheet_metal", "count": [ 0, 1 ] },

--- a/data/json/vehicleparts/crafting.json
+++ b/data/json/vehicleparts/crafting.json
@@ -577,6 +577,7 @@
   {
     "type": "vehicle_part",
     "id": "survivors_workbench",
+	"integrated_tools": [ "toolbox_workshop" ],
     "name": { "str": "survivors workbench" },
     "symbol": "#",
     "looks_like": "veh_table_wood",
@@ -593,7 +594,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH" ],
+    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH", "CRAFTER" ],
     "breaks_into": [
       { "item": "pipe", "count": [ 4, 6 ] },
       { "item": "sheet_metal", "count": [ 0, 1 ] },
@@ -607,6 +608,7 @@
   {
     "type": "vehicle_part",
     "id": "robobench",
+	"integrated_tools": [ "toolbox_workshop" ],
     "name": { "str": "robobench" },
     "symbol": "#",
     "looks_like": "machinery_heavy",
@@ -623,7 +625,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH" ],
+    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH", "CRAFTER" ],
     "breaks_into": [
       { "item": "pipe", "count": [ 4, 6 ] },
       { "item": "sheet_metal", "count": [ 0, 1 ] },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->
## Purpose of change (The Why)

The furniture of these two items has a built in workshop toolbox, so I figured the vehicle parts not having it is an oversight.

## Describe the solution (The How)

Add a few json lines to fix it.

## Describe alternatives you've considered

Not doing said thing?

## Testing

Launched game locally with changes, no errors. Tested both workbenches, tools showed up as expected.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [70964e6](https://github.com/cataclysmbn/Cataclysm-BN/commit/70964e649d0748edc180aa6425e1825f7a6f9801) (Plap plap get linted!) on 2026-07-21 05:06:01

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29801405135/artifacts/8484025058)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29801405135/artifacts/8484406977)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29801405135/artifacts/8484058824)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29801405135/artifacts/8484085435)
<!-- END artifact comment -->