### PR TITLE
feat(UI): add relative decible and tile distance sound display options

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1641,6 +1641,11 @@ void options_manager::add_options_interface()
          translate_marker( "Metric or Imperial" ),
     { { "metric", translate_marker( "Metric" ) }, { "imperial", translate_marker( "Imperial" ) } },
     "metric" );
+    add( "SOUND_DISPLAY_TYPE", interface, translate_marker( "Sound Display Type" ),
+         translate_marker( "Switch between decibles, relative decibels, and rough tile distance." ),
+    {  { "decibels", translate_marker( "Decibels" ) }, { "relative_decibels", translate_marker( "Relative Decibels" ) }, { "tiles", translate_marker( "Rough Tiles" ) } },
+    "decibels"
+       );
 
     add(
         "OVERMAP_COORDINATE_FORMAT",

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1144,6 +1144,42 @@ static std::string move_mode_string( avatar &u )
     }
 }
 
+static std::string get_sound( const avatar &u )
+{
+    std::string snd;
+    const std::string sound_option = get_option<std::string>( "SOUND_DISPLAY_TYPE" );
+    if( sound_option == "decibels" ) {
+        snd = std::to_string( u.volume );
+    } else if( sound_option == "relative_decibels" ) {
+        // Stolen from sounds::process_sounds
+        const weather_manager &weather = get_weather();
+        // Weather sound attenuation * 2, which we add to ambient noise. sound_attn ranges from 0-8
+        const short weather_vol = ( weather.weather_id->sound_attn );
+        const short wind_volume = ( std::min( 150, weather.windspeed ) );
+        const short INDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
+                                           2 * weather_vol ) ) / 100;
+        // We also use this as the base ambient to measure horde signals against.
+        const short OUTDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
+                                            wind_volume + weather_vol ) ) / 100;
+        snd = std::to_string( u.volume - ( !get_map().is_outside( u.bub_pos() ) ? INDOOR_AMBIENT :
+                                           OUTDOOR_AMBIENT ) );
+    } else if( sound_option == "tiles" ) {
+        // Stolen from sounds::process_sounds
+        const weather_manager &weather = get_weather();
+        // Weather sound attenuation * 2, which we add to ambient noise. sound_attn ranges from 0-8
+        const int weather_vol = ( weather.weather_id->sound_attn );
+        const int wind_volume = ( std::min( 150, weather.windspeed ) );
+        const int INDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
+                                         2 * weather_vol ) ) / 1000;
+        // We also use this as the base ambient to measure horde signals against.
+        const int OUTDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
+                                          wind_volume + weather_vol ) ) / 1000;
+        snd = std::to_string( average_minvol_distance( -3,
+                              u.volume - ( !get_map().is_outside( u.bub_pos() ) ? INDOOR_AMBIENT : OUTDOOR_AMBIENT ) ) );
+
+    }
+    return snd;
+}
 static void draw_stealth( avatar &u, const catacurses::window &w )
 {
     werase( w );
@@ -1156,7 +1192,7 @@ static void draw_stealth( avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 22, 0 ), c_red, _( "DEAF" ) );
     } else {
         mvwprintz( w, point( 20, 0 ), c_light_gray, _( "Sound:" ) );
-        const std::string snd = std::to_string( u.volume );
+        std::string snd = get_sound( u );
         mvwprintz( w, point( 30 - utf8_width( snd ), 0 ), u.volume != 0 ? c_yellow : c_light_gray, snd );
     }
 
@@ -1402,7 +1438,7 @@ static void draw_char_narrow( avatar &u, const catacurses::window &w )
     std::string movecost = std::to_string( u.movecounter ) + "(" + move_char + ")";
     bool m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
     std::string smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
-    mvwprintz( w, point( 8, 0 ), c_light_gray, std::to_string( u.volume ) );
+    mvwprintz( w, point( 8, 0 ), c_light_gray, get_sound( u ) );
 
     // print stamina
     auto needs_pair = std::make_pair( get_hp_bar( u.get_stamina(), u.get_stamina_max() ).second,
@@ -1447,7 +1483,7 @@ static void draw_char_wide( avatar &u, const catacurses::window &w )
     bool m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
     std::string smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
 
-    mvwprintz( w, point( 8, 0 ), c_light_gray, std::to_string( u.volume ) );
+    mvwprintz( w, point( 8, 0 ), c_light_gray, get_sound( u ) );
     mvwprintz( w, point( 23, 0 ), morale_pair.first, "%s", smiley );
     mvwprintz( w, point( 38, 0 ), focus_color( u.focus_pool ), "%s", u.focus_pool );
 
@@ -1711,7 +1747,7 @@ static void draw_sound_labels( const avatar &u, const catacurses::window &w )
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Sound:" ) );
     if( !u.is_deaf() ) {
-        mvwprintz( w, point( 8, 0 ), c_yellow, std::to_string( u.volume ) );
+        mvwprintz( w, point( 8, 0 ), c_yellow, get_sound( u ) );
     } else {
         mvwprintz( w, point( 8, 0 ), c_red, _( "Deaf!" ) );
     }
@@ -1724,7 +1760,7 @@ static void draw_sound_narrow( const avatar &u, const catacurses::window &w )
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Sound:" ) );
     if( !u.is_deaf() ) {
-        mvwprintz( w, point( 8, 0 ), c_yellow, std::to_string( u.volume ) );
+        mvwprintz( w, point( 8, 0 ), c_yellow, get_sound( u ) );
     } else {
         mvwprintz( w, point( 8, 0 ), c_red, _( "Deaf!" ) );
     }
@@ -2226,7 +2262,7 @@ static void draw_lighting_classic( const avatar &u, const catacurses::window &w 
 
     if( !u.is_deaf() ) {
         mvwprintz( w, point( 31, 0 ), c_light_gray, _( "Sound:" ) );
-        mvwprintz( w, point( 38, 0 ), c_yellow, std::to_string( u.volume ) );
+        mvwprintz( w, point( 38, 0 ), c_yellow, get_sound( u ) );
     } else {
         mvwprintz( w, point( 31, 0 ), c_red, _( "Deaf!" ) );
     }

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -55,6 +55,7 @@
 #include "player.h"
 #include "pldata.h"
 #include "point.h"
+#include "sounds.h"
 #include "string_formatter.h"
 #include "string_id.h"
 #include "tileray.h"
@@ -1170,13 +1171,15 @@ static std::string get_sound( const avatar &u )
         const int weather_vol = ( weather.weather_id->sound_attn );
         const int wind_volume = ( std::min( 150, weather.windspeed ) );
         const int INDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
-                                         2 * weather_vol ) ) / 1000;
+                                         2 * weather_vol ) );
         // We also use this as the base ambient to measure horde signals against.
         const int OUTDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
-                                          wind_volume + weather_vol ) ) / 1000;
-        snd = std::to_string( average_minvol_distance( -3,
-                              u.volume - ( !get_map().is_outside( u.bub_pos() ) ? INDOOR_AMBIENT : OUTDOOR_AMBIENT ) ) );
-
+                                          wind_volume + weather_vol ) );
+        const int AMBIENT = ( get_map().is_outside( u.bub_pos() ) ?
+                              OUTDOOR_AMBIENT :
+                              INDOOR_AMBIENT ) / 100;
+        const int dist_to_ambient = std::pow( 10, ( u.volume - AMBIENT ) / 20 );
+        snd = std::to_string( dist_to_ambient );
     }
     return snd;
 }


### PR DESCRIPTION
## Purpose of change (The Why)
Instead of arguing for 10 minutes just make a PR

## Describe the solution (The How)
Add the interface option

## Describe alternatives you've considered
None

## Testing
Seems right

## Additional context
Yes the sound values are low, that is because walking is currently ~= to ambient

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ebb195c](https://github.com/cataclysmbn/Cataclysm-BN/commit/ebb195c00abf821ecdeaf4f3e900d424d641c5a9) (this is the best I got) on 2026-07-22 22:35:33

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29938097283/artifacts/8537312327)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29938097283/artifacts/8538183180)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29938097283/artifacts/8538182738)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29938097283/artifacts/8537449872)
<!-- END artifact comment -->