### PR TITLE
fix: add sprite data for mounted gatling laser in UnDeadPeople tileset

### DIFF
--- a/gfx/MSX++UnDeadPeopleEdition/tile_config.json
+++ b/gfx/MSX++UnDeadPeopleEdition/tile_config.json
@@ -18750,6 +18750,13 @@
           "additional_tiles": [ { "id": "broken", "fg": 9861 } ]
         },
         {
+          "id": "vp_mounted_gatling_mech_laser_rebuilt",
+          "fg": 9860,
+          "rotates": true,
+          "multitile": true,
+          "additional_tiles": [ { "id": "broken", "fg": 9861 } ]
+        },
+        {
           "id": "vp_mounted_launcher_simple",
           "fg": 9862,
           "rotates": true,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Mounted gatling laser is currently displayed with letter "t" (default letter of base turret) instead of proper sprite, becuase it didn't have any sprite data.
external request: [https://gall.dcinside.com/board/view/?id=rlike&no=521160](https://gall.dcinside.com/board/view/?id=rlike&no=521160)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Add sprite data in UnDeadPeople tileset's tile_config.json.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Wait until someone draw and add proper and unique sprite?

## Testing
(Before)
<img width="533" height="400" alt="스크린샷 2026-07-23 131544" src="https://github.com/user-attachments/assets/e2c80149-25c9-476c-90e8-2db30041d1a6" />
(After)
<img width="532" height="386" alt="스크린샷 2026-07-23 131437" src="https://github.com/user-attachments/assets/6a1428fd-892f-4fe1-be4b-e67fe7bc5a57" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1f21bd5](https://github.com/cataclysmbn/Cataclysm-BN/commit/1f21bd5248472af5d91bd3723f1d1d9b8527ed86) (Add vp_mounted_gatling_mech_laser_rebuilt tile config) on 2026-07-23 05:46:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29979319775/artifacts/8553523522)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29979319775/artifacts/8553891617)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29979319775/artifacts/8552765852)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/29979319775/artifacts/8552839833)
<!-- END artifact comment -->