### PR TITLE
fix(UI): fix black void and game hang with isometric tilesets

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -190,7 +190,7 @@ auto render_light_tint_from_packed( const uint32_t packed ) -> render_light_tint
     const auto rank_fraction = static_cast<double>( rank ) / 255.0;
     const auto alpha_value = alpha_base + alpha_span * std::sqrt( rank_fraction );
     const auto alpha = static_cast<uint8_t>( std::clamp<int>(
-                           static_cast<int>( std::lround( alpha_value ) ), 40, 176 ) );
+            static_cast<int>( std::lround( alpha_value ) ), 40, 176 ) );
     return render_light_tint{
         .color = SDL_Color{
             .r = static_cast<uint8_t>( color_rgb >> 16 ),
@@ -420,9 +420,9 @@ tileset::find_tile_type_by_season( const std::string &id, season_type season ) c
     }
     auto &res = iter->second;
     if( res.season_tile ) {
-        return *res.season_tile;
-    } else if( res.default_tile ) { // can skip this check, but just in case
-        return tile_lookup_res( iter->first, *res.default_tile );
+    return *res.season_tile;
+} else if( res.default_tile ) { // can skip this check, but just in case
+    return tile_lookup_res( iter->first, *res.default_tile );
     }
     debugmsg( "empty record found in `tile_ids_by_season` for key: %s", id );
     return std::nullopt;
@@ -449,7 +449,7 @@ tile_type &tileset::create_tile_type( const std::string &id, tile_type &&new_til
             has_season_suffix = true;
             // key is id without _season suffix
             season_tile_value &value = tile_ids_by_season[i][id.substr( 0,
-                                       id.size() - strlen( season_suffix[i] ) )];
+                id.size() - strlen( season_suffix[i] ) )];
             // value stores reference to string id with _season suffix
             value.season_tile = tile_lookup_res( inserted_id, inserted_tile );
             break;
@@ -491,6 +491,7 @@ void cata_tiles::load_tileset(
     loader.load( tileset_id, precheck, /*pump_events=*/pump_events );
     tileset_ptr = std::move( new_tileset_ptr );
     tileset_mod_list_stamp = mod_list;
+    tile_iso = tileset_ptr->get_tile_iso();
 
     set_draw_scale( 16 );
 
@@ -1116,17 +1117,17 @@ bool tileset_loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf, const
 {
     assert( surf );
     const rect_range<SDL_Rect> input_range(
-        sprite_width, sprite_height,
-        point( surf->w / sprite_width, surf->h / sprite_height ) );
+    sprite_width, sprite_height,
+    point( surf->w / sprite_width, surf->h / sprite_height ) );
 
     const std::shared_ptr<SDL_Texture> texture_ptr =
         CreateTextureFromSurface( renderer, surf );
     if( !texture_ptr ) {
-        return false;
-    }
+    return false;
+}
 
-    for( const SDL_Rect rect : input_range ) {
-        assert( offset.x % sprite_width == 0 );
+for( const SDL_Rect rect : input_range ) {
+    assert( offset.x % sprite_width == 0 );
         assert( offset.y % sprite_height == 0 );
         const point pos( offset + point( rect.x, rect.y ) );
         assert( pos.x % sprite_width == 0 );
@@ -1173,7 +1174,7 @@ bool tileset_loader::copy_surface_to_dynamic_atlas(
             ( pos.y / sprite_height ) * ( tile_atlas_width / sprite_width );
 
         SDL_FillSurfaceRect( st_surf, nullptr, SDL_MapRGBA( SDL_GetPixelFormatDetails( st_surf->format ),
-                             nullptr, 255, 255, 255, 0 ) );
+                nullptr, 255, 255, 255, 0 ) );
         SDL_BlitSurface( surf.get(), &src_rect, st_surf, &st_sub_rect );
 
         const auto surf_hash = get_surface_hash( st_surf, nullptr );
@@ -1316,9 +1317,9 @@ static void apply_surf_blend_effect(
             case tint_blend_mode::hardlight: {
                 auto hardlight_channel = []( const uint8_t base, const uint8_t blend ) -> uint8_t {
                     if( blend > 127 )
-                    {
-                        return static_cast<uint8_t>( std::clamp<int>( 255 - ( 255 - blend ) * ( ( std::max( 255 - base,
-                                                     1 ) ) * 255 / 127 ) / 255, 0, 255 ) );
+                {
+                    return static_cast<uint8_t>( std::clamp<int>( 255 - ( 255 - blend ) * ( ( std::max( 255 - base,
+                        1 ) ) * 255 / 127 ) / 255, 0, 255 ) );
                     } else
                     {
                         return static_cast<uint8_t>( std::clamp<int>( blend * ( base * 255 / 127 ) / 255, 0, 255 ) );
@@ -1335,9 +1336,9 @@ static void apply_surf_blend_effect(
             case tint_blend_mode::overlay: {
                 auto overlay_channel = []( const uint8_t base, const uint8_t blend ) -> uint8_t {
                     if( base > 127 )
-                    {
-                        return static_cast<uint8_t>( std::clamp<int>( 255 - ( std::max( 255 - blend,
-                                                     1 ) ) * ( ( 255 - base ) * 255 / 127 ) / 255, 0, 255 ) );
+                {
+                    return static_cast<uint8_t>( std::clamp<int>( 255 - ( std::max( 255 - blend,
+                        1 ) ) * ( ( 255 - base ) * 255 / 127 ) / 255, 0, 255 ) );
                     } else
                     {
                         return static_cast<uint8_t>( std::clamp<int>( blend * ( base * 255 / 127 ) / 255, 0, 255 ) );
@@ -1358,9 +1359,9 @@ static void apply_surf_blend_effect(
 
                 constexpr auto overlay = []( const uint8_t base, const uint8_t blend ) -> uint8_t {
                     if( base > 127 )
-                    {
-                        return static_cast<uint8_t>( std::clamp<int>( 255 - ( std::max( 255 - blend,
-                                                     1 ) ) * ( ( 255 - base ) * 255 / 127 ) / 255, 0, 255 ) );
+                {
+                    return static_cast<uint8_t>( std::clamp<int>( 255 - ( std::max( 255 - blend,
+                        1 ) ) * ( ( 255 - base ) * 255 / 127 ) / 255, 0, 255 ) );
                     } else
                     {
                         return static_cast<uint8_t>( std::clamp<int>( blend * ( base * 255 / 127 ) / 255, 0, 255 ) );
@@ -1750,7 +1751,7 @@ std::tuple<bool, SDL_Surface *, SDL_Rect> tileset::get_sprite_surface( int sprit
 void tileset::ensure_readback_loaded() const
 {
     if( tileset_atlas ) {
-        tileset_atlas->readback_load();
+    tileset_atlas->readback_load();
     }
 }
 
@@ -1813,7 +1814,7 @@ bool tileset_loader::create_textures_from_tile_atlas( const SDL_Surface_Ptr &til
     for( tiles_pixel_color_entry &entry : tile_values_data ) {
         std::vector<texture> *tile_values = std::get<0>( entry );
         color_pixel_function_pointer color_pixel_function = get_color_pixel_function( std::get<1>
-                ( entry ) );
+            ( entry ) );
         bool success;
         if( !color_pixel_function ) {
             // TODO: Move it inside apply_color_filter.
@@ -1881,7 +1882,7 @@ void tileset_loader::load_tileset( const std::string &img_path, const bool pump_
     if( max_texture_width == 0 ) {
         max_texture_width = sprite_width * min_tile_xcount;
         dbg( DL::Info ) <<
-                        "max_texture_width was set to 0.  Changing it to " <<
+        "max_texture_width was set to 0.  Changing it to " <<
                         max_texture_width;
     } else {
         throwErrorIf( max_texture_width < sprite_width,
@@ -1891,7 +1892,7 @@ void tileset_loader::load_tileset( const std::string &img_path, const bool pump_
     if( max_texture_height == 0 ) {
         max_texture_height = sprite_height * min_tile_ycount;
         dbg( DL::Info ) <<
-                        "max_texture_height was set to 0.  Changing it to "
+        "max_texture_height was set to 0.  Changing it to "
                         << max_texture_height;
     } else {
         throwErrorIf( max_texture_height < sprite_height,
@@ -2220,13 +2221,11 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck,
         ts.tile_height = curr_info.get_int( "height" );
         ts.tile_width = curr_info.get_int( "width" );
         ts.zlevel_height = curr_info.get_int( "zlevel_height", 0 );
-        ts.zlevel_height = 0;
         tile_iso = curr_info.get_bool( "iso", false );
+        ts.is_iso = tile_iso;
         ts.tile_pixelscale = curr_info.get_float( "pixelscale", 1.0f );
         ts.prevent_occlusion_min_dist = curr_info.get_float( "retract_dist_min", -1.0f );
-        ts.prevent_occlusion_min_dist = -1.0f;
         ts.prevent_occlusion_max_dist = curr_info.get_float( "retract_dist_max", 0.0f );
-        ts.prevent_occlusion_max_dist = 0.0f;
     }
 
     if( precheck ) {
@@ -2431,12 +2430,12 @@ void tileset_loader::load_internal( const JsonObject &config, const std::string 
         //     This is intentionally NOT rgba to allow brightness > 1.0
         auto parse_color = [&colors]( const std::string & color_str ) -> color_parse_result {
             if( color_str.empty() )
-            {
-                return { std::nullopt, std::nullopt };
-            }
-            if( color_str.starts_with( '#' ) )
-            {
-                const std::string hex_part = color_str.substr( 1 );
+        {
+            return { std::nullopt, std::nullopt };
+        }
+        if( color_str.starts_with( '#' ) )
+        {
+            const std::string hex_part = color_str.substr( 1 );
                 for( const char c : hex_part ) {
                     if( !std::isxdigit( c ) ) {
                         return { std::nullopt, std::nullopt };
@@ -2460,10 +2459,10 @@ void tileset_loader::load_internal( const JsonObject &config, const std::string 
             }
             const nc_color curse_color = colors.name_to_color( color_str );
             if( curse_color == c_unset )
-            {
-                return { std::nullopt, std::nullopt };
-            }
-            return { static_cast<SDL_Color>( curses_color_to_RGB( curse_color ) ), std::nullopt };
+        {
+            return { std::nullopt, std::nullopt };
+        }
+        return { static_cast<SDL_Color>( curses_color_to_RGB( curse_color ) ), std::nullopt };
         };
 
         auto parse_blend_mode = []( const std::string & str ) -> tint_blend_mode {
@@ -2473,9 +2472,9 @@ void tileset_loader::load_internal( const JsonObject &config, const std::string 
         // Parse a tint_config from either a string or an object
         // When has_top_level is true, fg_color/bg_color must be strings (simple mode)
         auto parse_tint_config = [&parse_color, &parse_blend_mode]( const JsonObject & obj,
-                                 const std::string & key,
-                                 bool has_top_level, tint_blend_mode top_blend_mode,
-                                 std::optional<float> top_contrast, std::optional<float> top_saturation,
+            const std::string & key,
+            bool has_top_level, tint_blend_mode top_blend_mode,
+            std::optional<float> top_contrast, std::optional<float> top_saturation,
         std::optional<float> top_brightness ) -> tint_config {
             tint_config cfg{};
             if( !obj.has_member( key ) )
@@ -2788,7 +2787,7 @@ void tileset_loader::load_tilejson_from_file( const JsonObject &config )
                     curr_subtile.pixelscale = sprite_pixelscale;
                     curr_subtile.rotates = true;
                     curr_subtile.is_multitile_subtile = std::ranges::find( multitile_keys,
-                                                        s_id ) != multitile_keys.end();
+                        s_id ) != multitile_keys.end();
                     curr_subtile.height_3d = t_h3d;
                     curr_subtile.animated = subentry.get_bool( "animated", false );
                     curr_subtile.default_tint = t_tint;
@@ -2810,7 +2809,7 @@ void tileset_loader::load_tilejson_from_file( const JsonObject &config )
         }
     }
     dbg( DL::Info ) << "Tile Width: " << ts.tile_width << " Tile Height: " << ts.tile_height <<
-                    " Tile Definitions: " << ts.tile_ids.size();
+                       " Tile Definitions: " << ts.tile_ids.size();
 }
 
 /**
@@ -3058,6 +3057,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
     init_light();
     map &here = get_map();
 
+    tile_iso = tileset_ptr ? tileset_ptr->get_tile_iso() : false;
     const bool iso_mode = tile_iso;
 
     const bool show_zones_overlay = g->show_zone_overlay && !iso_mode;
@@ -3116,9 +3116,9 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
             selected_max = point_bub_ms( min_x.max->x(), min_y.max->y() );
         } else {
             selected_min = point_bub_ms( std::min( sel_start.x(), sel_end.x() ), std::min( sel_start.y(),
-                                         sel_end.y() ) );
+                sel_end.y() ) );
             selected_max = point_bub_ms( std::max( sel_start.x(), sel_end.x() ), std::max( sel_start.y(),
-                                         sel_end.y() ) );
+                sel_end.y() ) );
         }
     }
 
@@ -3137,9 +3137,16 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
     o = iso_mode ? center.xy() : center.xy() - point( POSX, POSY );
 
     op = dest;
-    // Rounding up to include incomplete tiles at the bottom/right edges
-    screentile_width = divide_round_up( width, tile_width );
-    screentile_height = divide_round_up( height, tile_height );
+    viewport_width = width;
+    viewport_height = height;
+    if( iso_mode ) {
+        // In iso, tile grid spacing uses tile_width for both axes
+        screentile_width = divide_round_up( width * 2, tile_width ) + 1;
+        screentile_height = divide_round_up( height * 4, tile_width ) + 1;
+    } else {
+        screentile_width = divide_round_up( width, tile_width );
+        screentile_height = divide_round_up( height, tile_height );
+    }
 
     const int min_col = 0;
     const int max_col = s.x;
@@ -3205,7 +3212,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
             nullptr;
         offscreen_memory_points.clear();
         offscreen_memory_points.reserve( static_cast<size_t>( ( max_visible_x - min_visible_x + 1 ) *
-                                         ( max_visible_y - min_visible_y + 1 ) ) );
+                ( max_visible_y - min_visible_y + 1 ) ) );
         for( const auto mem_y : std::views::iota( min_visible_y, max_visible_y + 1 ) ) {
             const auto dy = std::abs( mem_y - center.y() );
             for( const auto mem_x : std::views::iota( min_visible_x, max_visible_x + 1 ) ) {
@@ -3324,7 +3331,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                     const int scent_value = g->scent.get( {temp_x, temp_y, center.z()} );
                     if( scent_value > 0 ) {
                         overlay_strings.emplace( player_to_screen( point_bub_ms( temp_x, temp_y ) ) + point( tile_width / 2,
-                                                 0 ),
+                                0 ),
                                                  formatted_text( std::to_string( scent_value ), 8 + catacurses::yellow,
                                                          direction::NORTH ) );
                     }
@@ -3335,7 +3342,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                     const scenttype_id scent_type = g->scent.get_type( {temp_x, temp_y, center.z()} );
                     if( !scent_type.is_empty() ) {
                         overlay_strings.emplace( player_to_screen( point_bub_ms( temp_x, temp_y ) ) + point( tile_width / 2,
-                                                 0 ),
+                                0 ),
                                                  formatted_text( scent_type.c_str(), 8 + catacurses::yellow,
                                                          direction::NORTH ) );
                     }
@@ -3353,7 +3360,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                             col = catacurses::cyan;
                         }
                         overlay_strings.emplace( player_to_screen( point_bub_ms( temp_x, temp_y ) ) + point( tile_width / 2,
-                                                 0 ),
+                                0 ),
                                                  formatted_text( std::to_string( rad_value ), 8 + col, direction::NORTH ) );
                     }
                 }
@@ -3382,7 +3389,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                                            : units::to_celsius( temp );
 
                     overlay_strings.emplace( player_to_screen( point_bub_ms( temp_x, temp_y ) ) + point( tile_width / 2,
-                                             0 ),
+                            0 ),
                                              formatted_text( std::to_string( temp_value ), color,
                                                      direction::NORTH ) );
                 }
@@ -3422,7 +3429,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
 
                     // string overlay
                     overlay_strings.emplace( tile_pos + quarter_tile, formatted_text( text, catacurses::black,
-                                             direction::NORTH ) );
+                            direction::NORTH ) );
                 };
 
                 if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
@@ -3555,7 +3562,10 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                 const int &x = temp_x;
                 const int &y = temp_y;
                 const auto queue_draw_point = [&]( tile_render_info info ) {
-                    info.screen_row = row;
+                    info.screen_row = row + ( tile_iso && info.pos.z() != center.z() && tile_width > 0
+                                              ? ( center.z() - info.pos.z() )
+                                              * tileset_ptr->get_zlevel_height() * 4 / tile_width
+                                              : 0 );
                     draw_points.push_back( info );
                 };
 
@@ -3625,7 +3635,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                             invisible[1 + i] = np.y < min_visible_y || np.y > max_visible_y ||
                                                np.x < min_visible_x || np.x > max_visible_x ||
                                                would_apply_vision_effects( here.get_visibility( ch.visibility_cache[ch.idx( np.x, np.y )],
-                                                       cache ) );
+                                                   cache ) );
                         }
 
                         if( !invisible[0] && apply_vision_effects( pos, visibility ) ) {
@@ -3993,7 +4003,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
             }
         }
         auto offscreen_scan_count = static_cast<int64_t>( full_memory_scan ?
-                                    offscreen_memory_points.size() : dirty_memory_candidates.size() );
+            offscreen_memory_points.size() : dirty_memory_candidates.size() );
         auto offscreen_refresh_count = int64_t{ 0 };
         auto offscreen_dirty_memory_count = int64_t{ 0 };
         auto offscreen_connecting_refresh_count = int64_t{ 0 };
@@ -4034,7 +4044,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                                    np.y() < min_visible_y || np.y() > max_visible_y ||
                                    np.x() < min_visible_x || np.x() > max_visible_x ||
                                    would_apply_vision_effects( here.get_visibility( ch.visibility_cache[ch.idx( np.x(), np.y() )],
-                                           cache ) );
+                                       cache ) );
             }
             // Bypass draw calls: these tiles are offscreen and only need map memory refresh.
             memorize_live_terrain( p, invisible );
@@ -4144,7 +4154,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
         if( auto indicator_offset = g->get_veh_dir_indicator_location( true ) ) {
             const tile_search_params tile { "cursor", C_NONE, empty_string, 0, 0 };
             const auto pos = indicator_offset->xy() + tripoint_bub_ms( g->u.bub_pos().x(), g->u.bub_pos().y(),
-                             center.z() );
+                center.z() );
             draw_from_id_string(
                 tile, pos, std::nullopt, std::nullopt,
                 lit_level::LIT, false, 0, false );
@@ -4156,13 +4166,13 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
 
     if( draw_submap_grid && !iso_mode ) {
         point_abs_sm sm_start = project_to<coords::sm>( bub_to_abs( point_bub_ms( min_col,
-                                min_row ) + o.raw() ) );
+            min_row ) + o.raw() ) );
         point_abs_sm sm_end = project_to<coords::sm>( bub_to_abs( point_bub_ms( max_col,
-                              max_row ) + o.raw() ) );
+            max_row ) + o.raw() ) );
         int mapsize = here.getmapsize();
         auto mappos = here.get_abs_sub();
         half_open_rectangle<point> maprect( mappos.raw(), mappos.raw() + point( mapsize,
-                                            mapsize ) );
+                mapsize ) );
 
         const auto is_map = [mappos, maprect]( const tripoint & p ) {
             if( !maprect.contains( p.xy() ) ) {
@@ -4280,8 +4290,8 @@ void cata_tiles::get_window_tile_counts( const int width, const int height, int 
         int &rows ) const
 {
     if( tile_iso ) {
-        columns = std::ceil( static_cast<double>( width ) / tile_width ) * 2 + 4;
-        rows = std::ceil( static_cast<double>( height ) / ( tile_width / 2.0 - 1 ) ) * 2 + 4;
+    columns = divide_round_up( width * 2, tile_width ) + 1;
+        rows = divide_round_up( height * 4, tile_width ) + 1;
     } else {
         columns = std::ceil( static_cast<double>( width ) / tile_width );
         rows = std::ceil( static_cast<double>( height ) / tile_height );
@@ -4302,10 +4312,10 @@ cata_tiles::find_tile_looks_like_by_string_id( const std::string &id, TILE_CATEG
 {
     const string_id<T> s_id( id );
     if( !s_id.is_valid() ) {
-        return std::nullopt;
-    }
-    const T &obj = s_id.obj();
-    return find_tile_looks_like( obj.looks_like, category, looks_like_jumps_limit - 1 );
+    return std::nullopt;
+}
+const T &obj = s_id.obj();
+return find_tile_looks_like( obj.looks_like, category, looks_like_jumps_limit - 1 );
 }
 
 auto cata_tiles::find_tile_looks_like( const std::string &id, TILE_CATEGORY category,
@@ -4488,10 +4498,18 @@ bool cata_tiles::draw_from_id_string(
     }
 
     // Trying to search for tile type
-    auto search_result = prevent_occlusion_transp && retract > 0 && tile.category != C_OVERMAP_TERRAIN
+    auto search_result = prevent_occlusion_transp && retract > 0
+                         && tile.category != C_OVERMAP_TERRAIN && tile.category != C_ITEM
                          ? tile_type_search( tile_search_params{ tile.id + "_transparent", tile.category,
-                                 tile.subcategory, tile.subtile, tile.rota } )
+                             tile.subcategory, tile.subtile, tile.rota } )
                          : std::optional<tile_search_result> {};
+    // Transparent variant is only useful when it shifts position (offset_retracted != offset).
+    // Without position shift, transparent pixels just reveal the black screen clear,
+    // creating a dark void circle around the player instead of useful see-through.
+    if( search_result.has_value()
+        && search_result.value().tt->offset_retracted == search_result.value().tt->offset ) {
+        search_result = std::nullopt;
+    }
     if( search_result == std::nullopt ) {
         search_result = tile_type_search( tile );
     }
@@ -4524,7 +4542,7 @@ bool cata_tiles::draw_from_id_string(
 
     // translate from player-relative to screen relative tile position
     const auto screen_pos = as_independent_entity ? pos.xy() : point_bub_ms( player_to_screen(
-                                pos.xy() ) );
+            pos.xy() ) );
 
     auto simple_point_hash = []( const auto & p ) {
         return p.x + p.y * 65536;
@@ -4841,7 +4859,7 @@ bool cata_tiles::draw_sprite_at( const tile_type &tile, point_bub_ms p,
 
     // Pass warp_hash and tile_offset to get_or_default - UV remapping is now handled there
     const auto [sprite_tex, warp_offset] = tileset_ptr->get_or_default( tile_idx, mask_idx, fx_type,
-                                           effective_tint, effective_warp_hash, tile_offset );
+        effective_tint, effective_warp_hash, tile_offset );
 
     if( !sprite_tex ) {
         return true;
@@ -4860,9 +4878,9 @@ bool cata_tiles::draw_sprite_at( const tile_type &tile, point_bub_ms p,
 
     SDL_Rect destination;
     destination.x = p.x() + divide_round_down( tile_offset.x * tile_width,
-                    tileset_ptr->get_tile_width() ) + warp_offset_screen_x;
+        tileset_ptr->get_tile_width() ) + warp_offset_screen_x;
     destination.y = p.y() + divide_round_down( ( tile_offset.y - height_3d_val ) * tile_width,
-                    tileset_ptr->get_tile_width() ) + warp_offset_screen_y;
+        tileset_ptr->get_tile_width() ) + warp_offset_screen_y;
     destination.w = width * tile_width * tile.pixelscale / tileset_ptr->get_tile_width();
     destination.h = height * tile_height * tile.pixelscale / tileset_ptr->get_tile_height();
 
@@ -5092,15 +5110,15 @@ template<typename T>
 auto get_map_memory_of_at( const tripoint_bub_ms &p ) -> std::optional<memorized_terrain_tile>
 {
     if( !g->u.should_show_map_memory() ) {
-        return std::nullopt;
-    }
+    return std::nullopt;
+}
 
-    const memorized_terrain_tile t = g->u.get_memorized_tile( bub_to_abs( p ) );
-    if( !string_id<T>( t.tile ).is_valid() ) {
-        return std::nullopt;
-    }
+const memorized_terrain_tile t = g->u.get_memorized_tile( bub_to_abs( p ) );
+if( !string_id<T>( t.tile ).is_valid() ) {
+    return std::nullopt;
+}
 
-    return t;
+return t;
 }
 
 template<>
@@ -5108,21 +5126,21 @@ auto get_map_memory_of_at<vpart_info>( const tripoint_bub_ms &p ) ->
 std::optional<memorized_terrain_tile>
 {
     if( !g->u.should_show_map_memory() ) {
-        return std::nullopt;
-    }
+    return std::nullopt;
+}
 
-    const memorized_terrain_tile t = g->u.get_memorized_tile( bub_to_abs( tripoint_bub_ms(
-                                         p ) ) );
+const memorized_terrain_tile t = g->u.get_memorized_tile( bub_to_abs( tripoint_bub_ms(
+        p ) ) );
     if( !t.tile.starts_with( "vp_" ) ) {
-        return std::nullopt;
-    }
+    return std::nullopt;
+}
 
-    const auto actual_part = t.tile.substr( 3 );
-    if( !string_id<vpart_info>( actual_part ).is_valid() ) {
-        return std::nullopt;
-    }
+const auto actual_part = t.tile.substr( 3 );
+if( !string_id<vpart_info>( actual_part ).is_valid() ) {
+    return std::nullopt;
+}
 
-    return t;
+return t;
 }
 
 bool cata_tiles::has_memory_at( const tripoint_bub_ms &p )
@@ -5144,14 +5162,14 @@ auto cata_tiles::get_ter_memory_at( const tripoint_bub_ms &p ) ->
 std::optional<memorized_terrain_tile>
 {
     if( !g->u.should_show_map_memory() ) {
-        return std::nullopt;
-    }
-    const memorized_terrain_tile t = g->u.get_terrain_tile( bub_to_abs( tripoint_bub_ms(
-                                         p ) ) );
+    return std::nullopt;
+}
+const memorized_terrain_tile t = g->u.get_terrain_tile( bub_to_abs( tripoint_bub_ms(
+        p ) ) );
     if( t.tile.empty() ) {
-        return std::nullopt;
-    }
-    return t;
+    return std::nullopt;
+}
+return t;
 }
 
 auto cata_tiles::get_furn_memory_at( const tripoint_bub_ms &p ) ->
@@ -5182,20 +5200,7 @@ bool cata_tiles::draw_block( const tripoint_bub_ms &p, SDL_Color color, int scal
         rect.h = ( rect.h * 2 ) / 3;
         rect.w = ( rect.w * 3 ) / 4;
     }
-    // translate from player-relative to screen relative tile position
-    point screen;
-    if( tile_iso ) {
-        screen.x = ( ( p.x() - o.x() ) - ( o.y() - p.y() ) + screentile_width - 2 ) * tile_width / 2 +
-                   op.x;
-        // y uses tile_width because width is definitive for iso tiles
-        // tile footprints are half as tall as wide, arbitrarily tall
-        screen.y = ( ( p.y() - o.y() ) - ( p.x() - o.x() ) - 4 ) * tile_width / 4 +
-                   screentile_height * tile_height / 2 + // TODO: more obvious centering math
-                   op.y;
-    } else {
-        screen.x = ( p.x() - o.x() ) * tile_width + op.x;
-        screen.y = ( p.y() - o.y() ) * tile_height + op.y;
-    }
+    const point screen = player_to_screen( p.xy() );
     rect.x = screen.x + ( tile_width - rect.w ) / 2;
     rect.y = screen.y + ( tile_height - rect.h ) / 2;
     if( tile_iso ) {
@@ -5364,7 +5369,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             const auto furn = [&]( const tripoint_bub_ms & q, const bool invis ) -> furn_id {
                 const auto it = furniture_override.find( q );
                 return it != furniture_override.end() ? it->second :
-                ( !overridden || !invis ) ? here.furn( tripoint_bub_ms( q ) ) : f_null;
+                                               ( !overridden || !invis ) ? here.furn( tripoint_bub_ms( q ) ) : f_null;
             };
             const int neighborhood[4] = {
                 static_cast<int>( furn( p + point_south, invisible[1] ) ),
@@ -5459,7 +5464,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
             const auto tr_at = [&]( const tripoint_bub_ms & q, const bool invis ) -> trap_id {
                 const auto it = trap_override.find( q );
                 return it != trap_override.end() ? it->second :
-                ( !overridden || !invis ) ? here.tr_at( tripoint_bub_ms( q ) ).loadid : tr_null;
+                                          ( !overridden || !invis ) ? here.tr_at( tripoint_bub_ms( q ) ).loadid : tr_null;
             };
             const int neighborhood[4] = {
                 static_cast<int>( tr_at( p + point_south, invisible[1] ) ),
@@ -5534,7 +5539,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
         auto field_at = [&]( const tripoint_bub_ms & q, const bool invis ) -> field_type_id {
             const auto it = field_override.find( q );
             return it != field_override.end() ? it->second :
-            ( !fld_overridden || !invis ) ? here.field_at( q ).displayed_field_type() : fd_null;
+                                       ( !fld_overridden || !invis ) ? here.field_at( q ).displayed_field_type() : fd_null;
         };
         // for rotation information
         const int neighborhood[4] = {
@@ -6766,15 +6771,15 @@ void cata_tiles::void_monster_override()
 bool cata_tiles::has_draw_override( const tripoint_bub_ms &p ) const
 {
     return radiation_override.contains( p ) ||
-           terrain_override.contains( p ) ||
-           furniture_override.contains( p ) ||
-           graffiti_override.contains( p ) ||
-           trap_override.contains( p ) ||
-           field_override.contains( p ) ||
-           item_override.contains( p ) ||
-           vpart_override.contains( p ) ||
-           draw_below_override.contains( p ) ||
-           monster_override.contains( p );
+    terrain_override.contains( p ) ||
+    furniture_override.contains( p ) ||
+    graffiti_override.contains( p ) ||
+    trap_override.contains( p ) ||
+    field_override.contains( p ) ||
+    item_override.contains( p ) ||
+    vpart_override.contains( p ) ||
+    draw_below_override.contains( p ) ||
+    monster_override.contains( p );
 }
 /* -- Animation Renders */
 void cata_tiles::draw_explosion_frame()
@@ -6964,7 +6969,7 @@ void cata_tiles::draw_line()
     draw_from_id_string(
     {line_endpoint_id, C_NONE, empty_string, 0, 0},
     line_trajectory.back(), std::nullopt, std::nullopt,
-    lit_level::LIT, false, 0, false
+                   lit_level::LIT, false, 0, false
     );
 }
 void cata_tiles::draw_cursor()
@@ -7143,7 +7148,7 @@ void cata_tiles::get_terrain_orientation( const tripoint_bub_ms &p, int &rota, i
     const auto ter = [&]( const tripoint_bub_ms & q, const bool invis ) -> ter_id {
         const auto override = ter_override.find( q );
         return override != ter_override.end() ? override->second :
-        ( !overridden || !invis ) ? here.ter( q ) : t_null;
+                                       ( !overridden || !invis ) ? here.ter( q ) : t_null;
     };
 
     // get terrain at x,y
@@ -7254,7 +7259,7 @@ void cata_tiles::get_connect_values( const tripoint_bub_ms &p, int &subtile, int
                                      const int connect_group, const std::map<tripoint_bub_ms, ter_id> &ter_override )
 {
     uint8_t connections = get_map().get_known_connections( p, connect_group,
-                          ter_override );
+        ter_override );
     get_rotation_and_subtile( connections, rotation, subtile );
 }
 
@@ -7263,7 +7268,7 @@ void cata_tiles::get_furn_connect_values( const tripoint_bub_ms &p, int &subtile
         furn_id> &furn_override )
 {
     uint8_t connections = get_map().get_known_connections_f( p, connect_group,
-                          furn_override );
+        furn_override );
     get_rotation_and_subtile( connections, rotation, subtile );
 }
 
@@ -7373,22 +7378,27 @@ void cata_tiles::do_tile_loading_report( const std::function<void( std::string )
     tile_loading_report<field_type>( field_type::count(), C_FIELD, out, "" );
 }
 
+point cata_tiles::player_to_tile( point_bub_ms p ) const
+{
+    if( tile_iso ) {
+    return point{
+        p.y() + p.x() + screentile_width / 2 - o.y() - o.x(),
+        p.y() - p.x() + screentile_height / 2 - o.y() + o.x()
+    };
+}
+return point{ p.x() - o.x(), p.y() - o.y() };
+}
+
 point cata_tiles::player_to_screen( point_bub_ms p ) const
 {
-    point screen;
+    const point colrow = player_to_tile( p );
     if( tile_iso ) {
-        screen.x = ( ( p.x() - o.x() ) - ( o.y() - p.y() ) + screentile_width - 2 ) * tile_width / 2 +
-                   op.x;
-        // y uses tile_width because width is definitive for iso tiles
-        // tile footprints are half as tall as wide, arbitrarily tall
-        screen.y = ( ( p.y() - o.y() ) - ( p.x() - o.x() ) - 4 ) * tile_width / 4 +
-                   screentile_height * tile_height / 2 + // TODO: more obvious centering math
-                   op.y;
-    } else {
-        screen.x = ( p.x() - o.x() ) * tile_width + op.x;
-        screen.y = ( p.y() - o.y() ) * tile_height + op.y;
+        return op + point{
+            divide_round_down( ( colrow.x - 1 ) * tile_width, 2 ),
+            divide_round_down( ( colrow.y + 1 ) * tile_width, 4 ) - tile_height,
+        };
     }
-    return {screen};
+    return op + point{ colrow.x * tile_width, colrow.y * tile_height };
 }
 
 template<typename Iter, typename Func>

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -190,7 +190,7 @@ auto render_light_tint_from_packed( const uint32_t packed ) -> render_light_tint
     const auto rank_fraction = static_cast<double>( rank ) / 255.0;
     const auto alpha_value = alpha_base + alpha_span * std::sqrt( rank_fraction );
     const auto alpha = static_cast<uint8_t>( std::clamp<int>(
-            static_cast<int>( std::lround( alpha_value ) ), 40, 176 ) );
+                           static_cast<int>( std::lround( alpha_value ) ), 40, 176 ) );
     return render_light_tint{
         .color = SDL_Color{
             .r = static_cast<uint8_t>( color_rgb >> 16 ),
@@ -420,9 +420,9 @@ tileset::find_tile_type_by_season( const std::string &id, season_type season ) c
     }
     auto &res = iter->second;
     if( res.season_tile ) {
-    return *res.season_tile;
-} else if( res.default_tile ) { // can skip this check, but just in case
-    return tile_lookup_res( iter->first, *res.default_tile );
+        return *res.season_tile;
+    } else if( res.default_tile ) { // can skip this check, but just in case
+        return tile_lookup_res( iter->first, *res.default_tile );
     }
     debugmsg( "empty record found in `tile_ids_by_season` for key: %s", id );
     return std::nullopt;
@@ -449,7 +449,7 @@ tile_type &tileset::create_tile_type( const std::string &id, tile_type &&new_til
             has_season_suffix = true;
             // key is id without _season suffix
             season_tile_value &value = tile_ids_by_season[i][id.substr( 0,
-                id.size() - strlen( season_suffix[i] ) )];
+                                       id.size() - strlen( season_suffix[i] ) )];
             // value stores reference to string id with _season suffix
             value.season_tile = tile_lookup_res( inserted_id, inserted_tile );
             break;
@@ -1117,17 +1117,17 @@ bool tileset_loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf, const
 {
     assert( surf );
     const rect_range<SDL_Rect> input_range(
-    sprite_width, sprite_height,
-    point( surf->w / sprite_width, surf->h / sprite_height ) );
+        sprite_width, sprite_height,
+        point( surf->w / sprite_width, surf->h / sprite_height ) );
 
     const std::shared_ptr<SDL_Texture> texture_ptr =
         CreateTextureFromSurface( renderer, surf );
     if( !texture_ptr ) {
-    return false;
-}
+        return false;
+    }
 
-for( const SDL_Rect rect : input_range ) {
-    assert( offset.x % sprite_width == 0 );
+    for( const SDL_Rect rect : input_range ) {
+        assert( offset.x % sprite_width == 0 );
         assert( offset.y % sprite_height == 0 );
         const point pos( offset + point( rect.x, rect.y ) );
         assert( pos.x % sprite_width == 0 );
@@ -1174,7 +1174,7 @@ bool tileset_loader::copy_surface_to_dynamic_atlas(
             ( pos.y / sprite_height ) * ( tile_atlas_width / sprite_width );
 
         SDL_FillSurfaceRect( st_surf, nullptr, SDL_MapRGBA( SDL_GetPixelFormatDetails( st_surf->format ),
-                nullptr, 255, 255, 255, 0 ) );
+                             nullptr, 255, 255, 255, 0 ) );
         SDL_BlitSurface( surf.get(), &src_rect, st_surf, &st_sub_rect );
 
         const auto surf_hash = get_surface_hash( st_surf, nullptr );
@@ -1317,9 +1317,9 @@ static void apply_surf_blend_effect(
             case tint_blend_mode::hardlight: {
                 auto hardlight_channel = []( const uint8_t base, const uint8_t blend ) -> uint8_t {
                     if( blend > 127 )
-                {
-                    return static_cast<uint8_t>( std::clamp<int>( 255 - ( 255 - blend ) * ( ( std::max( 255 - base,
-                        1 ) ) * 255 / 127 ) / 255, 0, 255 ) );
+                    {
+                        return static_cast<uint8_t>( std::clamp<int>( 255 - ( 255 - blend ) * ( ( std::max( 255 - base,
+                                                     1 ) ) * 255 / 127 ) / 255, 0, 255 ) );
                     } else
                     {
                         return static_cast<uint8_t>( std::clamp<int>( blend * ( base * 255 / 127 ) / 255, 0, 255 ) );
@@ -1336,9 +1336,9 @@ static void apply_surf_blend_effect(
             case tint_blend_mode::overlay: {
                 auto overlay_channel = []( const uint8_t base, const uint8_t blend ) -> uint8_t {
                     if( base > 127 )
-                {
-                    return static_cast<uint8_t>( std::clamp<int>( 255 - ( std::max( 255 - blend,
-                        1 ) ) * ( ( 255 - base ) * 255 / 127 ) / 255, 0, 255 ) );
+                    {
+                        return static_cast<uint8_t>( std::clamp<int>( 255 - ( std::max( 255 - blend,
+                                                     1 ) ) * ( ( 255 - base ) * 255 / 127 ) / 255, 0, 255 ) );
                     } else
                     {
                         return static_cast<uint8_t>( std::clamp<int>( blend * ( base * 255 / 127 ) / 255, 0, 255 ) );
@@ -1359,9 +1359,9 @@ static void apply_surf_blend_effect(
 
                 constexpr auto overlay = []( const uint8_t base, const uint8_t blend ) -> uint8_t {
                     if( base > 127 )
-                {
-                    return static_cast<uint8_t>( std::clamp<int>( 255 - ( std::max( 255 - blend,
-                        1 ) ) * ( ( 255 - base ) * 255 / 127 ) / 255, 0, 255 ) );
+                    {
+                        return static_cast<uint8_t>( std::clamp<int>( 255 - ( std::max( 255 - blend,
+                                                     1 ) ) * ( ( 255 - base ) * 255 / 127 ) / 255, 0, 255 ) );
                     } else
                     {
                         return static_cast<uint8_t>( std::clamp<int>( blend * ( base * 255 / 127 ) / 255, 0, 255 ) );
@@ -1751,7 +1751,7 @@ std::tuple<bool, SDL_Surface *, SDL_Rect> tileset::get_sprite_surface( int sprit
 void tileset::ensure_readback_loaded() const
 {
     if( tileset_atlas ) {
-    tileset_atlas->readback_load();
+        tileset_atlas->readback_load();
     }
 }
 
@@ -1814,7 +1814,7 @@ bool tileset_loader::create_textures_from_tile_atlas( const SDL_Surface_Ptr &til
     for( tiles_pixel_color_entry &entry : tile_values_data ) {
         std::vector<texture> *tile_values = std::get<0>( entry );
         color_pixel_function_pointer color_pixel_function = get_color_pixel_function( std::get<1>
-            ( entry ) );
+                ( entry ) );
         bool success;
         if( !color_pixel_function ) {
             // TODO: Move it inside apply_color_filter.
@@ -1882,7 +1882,7 @@ void tileset_loader::load_tileset( const std::string &img_path, const bool pump_
     if( max_texture_width == 0 ) {
         max_texture_width = sprite_width * min_tile_xcount;
         dbg( DL::Info ) <<
-        "max_texture_width was set to 0.  Changing it to " <<
+                        "max_texture_width was set to 0.  Changing it to " <<
                         max_texture_width;
     } else {
         throwErrorIf( max_texture_width < sprite_width,
@@ -1892,7 +1892,7 @@ void tileset_loader::load_tileset( const std::string &img_path, const bool pump_
     if( max_texture_height == 0 ) {
         max_texture_height = sprite_height * min_tile_ycount;
         dbg( DL::Info ) <<
-        "max_texture_height was set to 0.  Changing it to "
+                        "max_texture_height was set to 0.  Changing it to "
                         << max_texture_height;
     } else {
         throwErrorIf( max_texture_height < sprite_height,
@@ -2430,12 +2430,12 @@ void tileset_loader::load_internal( const JsonObject &config, const std::string 
         //     This is intentionally NOT rgba to allow brightness > 1.0
         auto parse_color = [&colors]( const std::string & color_str ) -> color_parse_result {
             if( color_str.empty() )
-        {
-            return { std::nullopt, std::nullopt };
-        }
-        if( color_str.starts_with( '#' ) )
-        {
-            const std::string hex_part = color_str.substr( 1 );
+            {
+                return { std::nullopt, std::nullopt };
+            }
+            if( color_str.starts_with( '#' ) )
+            {
+                const std::string hex_part = color_str.substr( 1 );
                 for( const char c : hex_part ) {
                     if( !std::isxdigit( c ) ) {
                         return { std::nullopt, std::nullopt };
@@ -2459,10 +2459,10 @@ void tileset_loader::load_internal( const JsonObject &config, const std::string 
             }
             const nc_color curse_color = colors.name_to_color( color_str );
             if( curse_color == c_unset )
-        {
-            return { std::nullopt, std::nullopt };
-        }
-        return { static_cast<SDL_Color>( curses_color_to_RGB( curse_color ) ), std::nullopt };
+            {
+                return { std::nullopt, std::nullopt };
+            }
+            return { static_cast<SDL_Color>( curses_color_to_RGB( curse_color ) ), std::nullopt };
         };
 
         auto parse_blend_mode = []( const std::string & str ) -> tint_blend_mode {
@@ -2472,9 +2472,9 @@ void tileset_loader::load_internal( const JsonObject &config, const std::string 
         // Parse a tint_config from either a string or an object
         // When has_top_level is true, fg_color/bg_color must be strings (simple mode)
         auto parse_tint_config = [&parse_color, &parse_blend_mode]( const JsonObject & obj,
-            const std::string & key,
-            bool has_top_level, tint_blend_mode top_blend_mode,
-            std::optional<float> top_contrast, std::optional<float> top_saturation,
+                                 const std::string & key,
+                                 bool has_top_level, tint_blend_mode top_blend_mode,
+                                 std::optional<float> top_contrast, std::optional<float> top_saturation,
         std::optional<float> top_brightness ) -> tint_config {
             tint_config cfg{};
             if( !obj.has_member( key ) )
@@ -2787,7 +2787,7 @@ void tileset_loader::load_tilejson_from_file( const JsonObject &config )
                     curr_subtile.pixelscale = sprite_pixelscale;
                     curr_subtile.rotates = true;
                     curr_subtile.is_multitile_subtile = std::ranges::find( multitile_keys,
-                        s_id ) != multitile_keys.end();
+                                                        s_id ) != multitile_keys.end();
                     curr_subtile.height_3d = t_h3d;
                     curr_subtile.animated = subentry.get_bool( "animated", false );
                     curr_subtile.default_tint = t_tint;
@@ -2809,7 +2809,7 @@ void tileset_loader::load_tilejson_from_file( const JsonObject &config )
         }
     }
     dbg( DL::Info ) << "Tile Width: " << ts.tile_width << " Tile Height: " << ts.tile_height <<
-                       " Tile Definitions: " << ts.tile_ids.size();
+                    " Tile Definitions: " << ts.tile_ids.size();
 }
 
 /**
@@ -3116,9 +3116,9 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
             selected_max = point_bub_ms( min_x.max->x(), min_y.max->y() );
         } else {
             selected_min = point_bub_ms( std::min( sel_start.x(), sel_end.x() ), std::min( sel_start.y(),
-                sel_end.y() ) );
+                                         sel_end.y() ) );
             selected_max = point_bub_ms( std::max( sel_start.x(), sel_end.x() ), std::max( sel_start.y(),
-                sel_end.y() ) );
+                                         sel_end.y() ) );
         }
     }
 
@@ -3212,7 +3212,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
             nullptr;
         offscreen_memory_points.clear();
         offscreen_memory_points.reserve( static_cast<size_t>( ( max_visible_x - min_visible_x + 1 ) *
-                ( max_visible_y - min_visible_y + 1 ) ) );
+                                         ( max_visible_y - min_visible_y + 1 ) ) );
         for( const auto mem_y : std::views::iota( min_visible_y, max_visible_y + 1 ) ) {
             const auto dy = std::abs( mem_y - center.y() );
             for( const auto mem_x : std::views::iota( min_visible_x, max_visible_x + 1 ) ) {
@@ -3331,7 +3331,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                     const int scent_value = g->scent.get( {temp_x, temp_y, center.z()} );
                     if( scent_value > 0 ) {
                         overlay_strings.emplace( player_to_screen( point_bub_ms( temp_x, temp_y ) ) + point( tile_width / 2,
-                                0 ),
+                                                 0 ),
                                                  formatted_text( std::to_string( scent_value ), 8 + catacurses::yellow,
                                                          direction::NORTH ) );
                     }
@@ -3342,7 +3342,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                     const scenttype_id scent_type = g->scent.get_type( {temp_x, temp_y, center.z()} );
                     if( !scent_type.is_empty() ) {
                         overlay_strings.emplace( player_to_screen( point_bub_ms( temp_x, temp_y ) ) + point( tile_width / 2,
-                                0 ),
+                                                 0 ),
                                                  formatted_text( scent_type.c_str(), 8 + catacurses::yellow,
                                                          direction::NORTH ) );
                     }
@@ -3360,7 +3360,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                             col = catacurses::cyan;
                         }
                         overlay_strings.emplace( player_to_screen( point_bub_ms( temp_x, temp_y ) ) + point( tile_width / 2,
-                                0 ),
+                                                 0 ),
                                                  formatted_text( std::to_string( rad_value ), 8 + col, direction::NORTH ) );
                     }
                 }
@@ -3389,7 +3389,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                                            : units::to_celsius( temp );
 
                     overlay_strings.emplace( player_to_screen( point_bub_ms( temp_x, temp_y ) ) + point( tile_width / 2,
-                            0 ),
+                                             0 ),
                                              formatted_text( std::to_string( temp_value ), color,
                                                      direction::NORTH ) );
                 }
@@ -3429,7 +3429,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
 
                     // string overlay
                     overlay_strings.emplace( tile_pos + quarter_tile, formatted_text( text, catacurses::black,
-                            direction::NORTH ) );
+                                             direction::NORTH ) );
                 };
 
                 if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
@@ -3635,7 +3635,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                             invisible[1 + i] = np.y < min_visible_y || np.y > max_visible_y ||
                                                np.x < min_visible_x || np.x > max_visible_x ||
                                                would_apply_vision_effects( here.get_visibility( ch.visibility_cache[ch.idx( np.x, np.y )],
-                                                   cache ) );
+                                                       cache ) );
                         }
 
                         if( !invisible[0] && apply_vision_effects( pos, visibility ) ) {
@@ -4003,7 +4003,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
             }
         }
         auto offscreen_scan_count = static_cast<int64_t>( full_memory_scan ?
-            offscreen_memory_points.size() : dirty_memory_candidates.size() );
+                                    offscreen_memory_points.size() : dirty_memory_candidates.size() );
         auto offscreen_refresh_count = int64_t{ 0 };
         auto offscreen_dirty_memory_count = int64_t{ 0 };
         auto offscreen_connecting_refresh_count = int64_t{ 0 };
@@ -4044,7 +4044,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
                                    np.y() < min_visible_y || np.y() > max_visible_y ||
                                    np.x() < min_visible_x || np.x() > max_visible_x ||
                                    would_apply_vision_effects( here.get_visibility( ch.visibility_cache[ch.idx( np.x(), np.y() )],
-                                       cache ) );
+                                           cache ) );
             }
             // Bypass draw calls: these tiles are offscreen and only need map memory refresh.
             memorize_live_terrain( p, invisible );
@@ -4154,7 +4154,7 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
         if( auto indicator_offset = g->get_veh_dir_indicator_location( true ) ) {
             const tile_search_params tile { "cursor", C_NONE, empty_string, 0, 0 };
             const auto pos = indicator_offset->xy() + tripoint_bub_ms( g->u.bub_pos().x(), g->u.bub_pos().y(),
-                center.z() );
+                             center.z() );
             draw_from_id_string(
                 tile, pos, std::nullopt, std::nullopt,
                 lit_level::LIT, false, 0, false );
@@ -4166,13 +4166,13 @@ void cata_tiles::draw( point dest, const tripoint_bub_ms &center, int width, int
 
     if( draw_submap_grid && !iso_mode ) {
         point_abs_sm sm_start = project_to<coords::sm>( bub_to_abs( point_bub_ms( min_col,
-            min_row ) + o.raw() ) );
+                                min_row ) + o.raw() ) );
         point_abs_sm sm_end = project_to<coords::sm>( bub_to_abs( point_bub_ms( max_col,
-            max_row ) + o.raw() ) );
+                              max_row ) + o.raw() ) );
         int mapsize = here.getmapsize();
         auto mappos = here.get_abs_sub();
         half_open_rectangle<point> maprect( mappos.raw(), mappos.raw() + point( mapsize,
-                mapsize ) );
+                                            mapsize ) );
 
         const auto is_map = [mappos, maprect]( const tripoint & p ) {
             if( !maprect.contains( p.xy() ) ) {
@@ -4290,7 +4290,7 @@ void cata_tiles::get_window_tile_counts( const int width, const int height, int 
         int &rows ) const
 {
     if( tile_iso ) {
-    columns = divide_round_up( width * 2, tile_width ) + 1;
+        columns = divide_round_up( width * 2, tile_width ) + 1;
         rows = divide_round_up( height * 4, tile_width ) + 1;
     } else {
         columns = std::ceil( static_cast<double>( width ) / tile_width );
@@ -4312,10 +4312,10 @@ cata_tiles::find_tile_looks_like_by_string_id( const std::string &id, TILE_CATEG
 {
     const string_id<T> s_id( id );
     if( !s_id.is_valid() ) {
-    return std::nullopt;
-}
-const T &obj = s_id.obj();
-return find_tile_looks_like( obj.looks_like, category, looks_like_jumps_limit - 1 );
+        return std::nullopt;
+    }
+    const T &obj = s_id.obj();
+    return find_tile_looks_like( obj.looks_like, category, looks_like_jumps_limit - 1 );
 }
 
 auto cata_tiles::find_tile_looks_like( const std::string &id, TILE_CATEGORY category,
@@ -4501,7 +4501,7 @@ bool cata_tiles::draw_from_id_string(
     auto search_result = prevent_occlusion_transp && retract > 0
                          && tile.category != C_OVERMAP_TERRAIN && tile.category != C_ITEM
                          ? tile_type_search( tile_search_params{ tile.id + "_transparent", tile.category,
-                             tile.subcategory, tile.subtile, tile.rota } )
+                                 tile.subcategory, tile.subtile, tile.rota } )
                          : std::optional<tile_search_result> {};
     // Transparent variant is only useful when it shifts position (offset_retracted != offset).
     // Without position shift, transparent pixels just reveal the black screen clear,
@@ -4542,7 +4542,7 @@ bool cata_tiles::draw_from_id_string(
 
     // translate from player-relative to screen relative tile position
     const auto screen_pos = as_independent_entity ? pos.xy() : point_bub_ms( player_to_screen(
-            pos.xy() ) );
+                                pos.xy() ) );
 
     auto simple_point_hash = []( const auto & p ) {
         return p.x + p.y * 65536;
@@ -4859,7 +4859,7 @@ bool cata_tiles::draw_sprite_at( const tile_type &tile, point_bub_ms p,
 
     // Pass warp_hash and tile_offset to get_or_default - UV remapping is now handled there
     const auto [sprite_tex, warp_offset] = tileset_ptr->get_or_default( tile_idx, mask_idx, fx_type,
-        effective_tint, effective_warp_hash, tile_offset );
+                                           effective_tint, effective_warp_hash, tile_offset );
 
     if( !sprite_tex ) {
         return true;
@@ -4878,9 +4878,9 @@ bool cata_tiles::draw_sprite_at( const tile_type &tile, point_bub_ms p,
 
     SDL_Rect destination;
     destination.x = p.x() + divide_round_down( tile_offset.x * tile_width,
-        tileset_ptr->get_tile_width() ) + warp_offset_screen_x;
+                    tileset_ptr->get_tile_width() ) + warp_offset_screen_x;
     destination.y = p.y() + divide_round_down( ( tile_offset.y - height_3d_val ) * tile_width,
-        tileset_ptr->get_tile_width() ) + warp_offset_screen_y;
+                    tileset_ptr->get_tile_width() ) + warp_offset_screen_y;
     destination.w = width * tile_width * tile.pixelscale / tileset_ptr->get_tile_width();
     destination.h = height * tile_height * tile.pixelscale / tileset_ptr->get_tile_height();
 
@@ -5110,15 +5110,15 @@ template<typename T>
 auto get_map_memory_of_at( const tripoint_bub_ms &p ) -> std::optional<memorized_terrain_tile>
 {
     if( !g->u.should_show_map_memory() ) {
-    return std::nullopt;
-}
+        return std::nullopt;
+    }
 
-const memorized_terrain_tile t = g->u.get_memorized_tile( bub_to_abs( p ) );
-if( !string_id<T>( t.tile ).is_valid() ) {
-    return std::nullopt;
-}
+    const memorized_terrain_tile t = g->u.get_memorized_tile( bub_to_abs( p ) );
+    if( !string_id<T>( t.tile ).is_valid() ) {
+        return std::nullopt;
+    }
 
-return t;
+    return t;
 }
 
 template<>
@@ -5126,21 +5126,21 @@ auto get_map_memory_of_at<vpart_info>( const tripoint_bub_ms &p ) ->
 std::optional<memorized_terrain_tile>
 {
     if( !g->u.should_show_map_memory() ) {
-    return std::nullopt;
-}
+        return std::nullopt;
+    }
 
-const memorized_terrain_tile t = g->u.get_memorized_tile( bub_to_abs( tripoint_bub_ms(
-        p ) ) );
+    const memorized_terrain_tile t = g->u.get_memorized_tile( bub_to_abs( tripoint_bub_ms(
+                                         p ) ) );
     if( !t.tile.starts_with( "vp_" ) ) {
-    return std::nullopt;
-}
+        return std::nullopt;
+    }
 
-const auto actual_part = t.tile.substr( 3 );
-if( !string_id<vpart_info>( actual_part ).is_valid() ) {
-    return std::nullopt;
-}
+    const auto actual_part = t.tile.substr( 3 );
+    if( !string_id<vpart_info>( actual_part ).is_valid() ) {
+        return std::nullopt;
+    }
 
-return t;
+    return t;
 }
 
 bool cata_tiles::has_memory_at( const tripoint_bub_ms &p )
@@ -5162,14 +5162,14 @@ auto cata_tiles::get_ter_memory_at( const tripoint_bub_ms &p ) ->
 std::optional<memorized_terrain_tile>
 {
     if( !g->u.should_show_map_memory() ) {
-    return std::nullopt;
-}
-const memorized_terrain_tile t = g->u.get_terrain_tile( bub_to_abs( tripoint_bub_ms(
-        p ) ) );
+        return std::nullopt;
+    }
+    const memorized_terrain_tile t = g->u.get_terrain_tile( bub_to_abs( tripoint_bub_ms(
+                                         p ) ) );
     if( t.tile.empty() ) {
-    return std::nullopt;
-}
-return t;
+        return std::nullopt;
+    }
+    return t;
 }
 
 auto cata_tiles::get_furn_memory_at( const tripoint_bub_ms &p ) ->
@@ -5369,7 +5369,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             const auto furn = [&]( const tripoint_bub_ms & q, const bool invis ) -> furn_id {
                 const auto it = furniture_override.find( q );
                 return it != furniture_override.end() ? it->second :
-                                               ( !overridden || !invis ) ? here.furn( tripoint_bub_ms( q ) ) : f_null;
+                ( !overridden || !invis ) ? here.furn( tripoint_bub_ms( q ) ) : f_null;
             };
             const int neighborhood[4] = {
                 static_cast<int>( furn( p + point_south, invisible[1] ) ),
@@ -5464,7 +5464,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
             const auto tr_at = [&]( const tripoint_bub_ms & q, const bool invis ) -> trap_id {
                 const auto it = trap_override.find( q );
                 return it != trap_override.end() ? it->second :
-                                          ( !overridden || !invis ) ? here.tr_at( tripoint_bub_ms( q ) ).loadid : tr_null;
+                ( !overridden || !invis ) ? here.tr_at( tripoint_bub_ms( q ) ).loadid : tr_null;
             };
             const int neighborhood[4] = {
                 static_cast<int>( tr_at( p + point_south, invisible[1] ) ),
@@ -5539,7 +5539,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
         auto field_at = [&]( const tripoint_bub_ms & q, const bool invis ) -> field_type_id {
             const auto it = field_override.find( q );
             return it != field_override.end() ? it->second :
-                                       ( !fld_overridden || !invis ) ? here.field_at( q ).displayed_field_type() : fd_null;
+            ( !fld_overridden || !invis ) ? here.field_at( q ).displayed_field_type() : fd_null;
         };
         // for rotation information
         const int neighborhood[4] = {
@@ -6771,15 +6771,15 @@ void cata_tiles::void_monster_override()
 bool cata_tiles::has_draw_override( const tripoint_bub_ms &p ) const
 {
     return radiation_override.contains( p ) ||
-    terrain_override.contains( p ) ||
-    furniture_override.contains( p ) ||
-    graffiti_override.contains( p ) ||
-    trap_override.contains( p ) ||
-    field_override.contains( p ) ||
-    item_override.contains( p ) ||
-    vpart_override.contains( p ) ||
-    draw_below_override.contains( p ) ||
-    monster_override.contains( p );
+           terrain_override.contains( p ) ||
+           furniture_override.contains( p ) ||
+           graffiti_override.contains( p ) ||
+           trap_override.contains( p ) ||
+           field_override.contains( p ) ||
+           item_override.contains( p ) ||
+           vpart_override.contains( p ) ||
+           draw_below_override.contains( p ) ||
+           monster_override.contains( p );
 }
 /* -- Animation Renders */
 void cata_tiles::draw_explosion_frame()
@@ -6969,7 +6969,7 @@ void cata_tiles::draw_line()
     draw_from_id_string(
     {line_endpoint_id, C_NONE, empty_string, 0, 0},
     line_trajectory.back(), std::nullopt, std::nullopt,
-                   lit_level::LIT, false, 0, false
+    lit_level::LIT, false, 0, false
     );
 }
 void cata_tiles::draw_cursor()
@@ -7148,7 +7148,7 @@ void cata_tiles::get_terrain_orientation( const tripoint_bub_ms &p, int &rota, i
     const auto ter = [&]( const tripoint_bub_ms & q, const bool invis ) -> ter_id {
         const auto override = ter_override.find( q );
         return override != ter_override.end() ? override->second :
-                                       ( !overridden || !invis ) ? here.ter( q ) : t_null;
+        ( !overridden || !invis ) ? here.ter( q ) : t_null;
     };
 
     // get terrain at x,y
@@ -7259,7 +7259,7 @@ void cata_tiles::get_connect_values( const tripoint_bub_ms &p, int &subtile, int
                                      const int connect_group, const std::map<tripoint_bub_ms, ter_id> &ter_override )
 {
     uint8_t connections = get_map().get_known_connections( p, connect_group,
-        ter_override );
+                          ter_override );
     get_rotation_and_subtile( connections, rotation, subtile );
 }
 
@@ -7268,7 +7268,7 @@ void cata_tiles::get_furn_connect_values( const tripoint_bub_ms &p, int &subtile
         furn_id> &furn_override )
 {
     uint8_t connections = get_map().get_known_connections_f( p, connect_group,
-        furn_override );
+                          furn_override );
     get_rotation_and_subtile( connections, rotation, subtile );
 }
 
@@ -7381,12 +7381,12 @@ void cata_tiles::do_tile_loading_report( const std::function<void( std::string )
 point cata_tiles::player_to_tile( point_bub_ms p ) const
 {
     if( tile_iso ) {
-    return point{
-        p.y() + p.x() + screentile_width / 2 - o.y() - o.x(),
-        p.y() - p.x() + screentile_height / 2 - o.y() + o.x()
-    };
-}
-return point{ p.x() - o.x(), p.y() - o.y() };
+        return point{
+            p.y() + p.x() + screentile_width / 2 - o.y() - o.x(),
+            p.y() - p.x() + screentile_height / 2 - o.y() + o.x()
+        };
+    }
+    return point{ p.x() - o.x(), p.y() - o.y() };
 }
 
 point cata_tiles::player_to_screen( point_bub_ms p ) const

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -139,7 +139,7 @@ class texture
             srcrect( rect ) { }
         texture( SDL_Texture_SharedPtr ptr, const SDL_Rect &rect ) : sdl_texture_ptr( ptr ),
             srcrect( { static_cast<float>( rect.x ), static_cast<float>( rect.y ),
-            static_cast<float>( rect.w ), static_cast<float>( rect.h ) } ) { }
+                     static_cast<float>( rect.w ), static_cast<float>( rect.h ) } ) { }
         texture() = default;
 
         /// Returns the width (first) and height (second) of the stored texture.
@@ -154,7 +154,7 @@ class texture
                              const double angle,
                              const SDL_FPoint *const center, const SDL_FlipMode flip ) const {
             return SDL_RenderTextureRotated( renderer.get(), sdl_texture_ptr.get(), &srcrect, dstrect,
-            angle, center, flip );
+                                             angle, center, flip );
         }
 
         bool render_copy_ex( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const dstrect,
@@ -162,11 +162,11 @@ class texture
                              const SDL_Point *const center, const SDL_FlipMode flip ) const {
             const std::optional<SDL_FRect> fdst = dstrect
                                                   ? std::optional<SDL_FRect>( SDL_FRect{ float( dstrect->x ), float( dstrect->y ),
-                                                      float( dstrect->w ), float( dstrect->h ) } )
-            : std::nullopt;
+                                                          float( dstrect->w ), float( dstrect->h ) } )
+                                                  : std::nullopt;
             const std::optional<SDL_FPoint> fcenter = center
-                ? std::optional<SDL_FPoint>( SDL_FPoint{ float( center->x ), float( center->y ) } )
-                : std::nullopt;
+                    ? std::optional<SDL_FPoint>( SDL_FPoint{ float( center->x ), float( center->y ) } )
+                    : std::nullopt;
             return SDL_RenderTextureRotated( renderer.get(), sdl_texture_ptr.get(), &srcrect,
                                              fdst ? &fdst.value() : nullptr, angle,
                                              fcenter ? &fcenter.value() : nullptr, flip );
@@ -179,10 +179,10 @@ class texture
 
         bool render_copy( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const dstrect ) const {
             if( !dstrect ) {
-            return SDL_RenderTexture( renderer.get(), sdl_texture_ptr.get(), &srcrect, nullptr );
+                return SDL_RenderTexture( renderer.get(), sdl_texture_ptr.get(), &srcrect, nullptr );
             }
             const SDL_FRect fdst{ float( dstrect->x ), float( dstrect->y ),
-                  float( dstrect->w ), float( dstrect->h ) };
+                                  float( dstrect->w ), float( dstrect->h ) };
             return SDL_RenderTexture( renderer.get(), sdl_texture_ptr.get(), &srcrect, &fdst );
         }
 
@@ -284,8 +284,8 @@ struct tint_config {
     bool has_value() const {
         return color != TILESET_NO_COLOR
                || fabs( contrast - 1.0f ) > 0.001f
-        || fabs( saturation - 1.0f ) > 0.001f
-        || fabs( brightness - 1.0f ) > 0.001f;
+               || fabs( saturation - 1.0f ) > 0.001f
+               || fabs( brightness - 1.0f ) > 0.001f;
     }
 
     bool operator==( const tint_config &other ) const {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -139,7 +139,7 @@ class texture
             srcrect( rect ) { }
         texture( SDL_Texture_SharedPtr ptr, const SDL_Rect &rect ) : sdl_texture_ptr( ptr ),
             srcrect( { static_cast<float>( rect.x ), static_cast<float>( rect.y ),
-                     static_cast<float>( rect.w ), static_cast<float>( rect.h ) } ) { }
+            static_cast<float>( rect.w ), static_cast<float>( rect.h ) } ) { }
         texture() = default;
 
         /// Returns the width (first) and height (second) of the stored texture.
@@ -154,7 +154,7 @@ class texture
                              const double angle,
                              const SDL_FPoint *const center, const SDL_FlipMode flip ) const {
             return SDL_RenderTextureRotated( renderer.get(), sdl_texture_ptr.get(), &srcrect, dstrect,
-                                             angle, center, flip );
+            angle, center, flip );
         }
 
         bool render_copy_ex( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const dstrect,
@@ -162,11 +162,11 @@ class texture
                              const SDL_Point *const center, const SDL_FlipMode flip ) const {
             const std::optional<SDL_FRect> fdst = dstrect
                                                   ? std::optional<SDL_FRect>( SDL_FRect{ float( dstrect->x ), float( dstrect->y ),
-                                                          float( dstrect->w ), float( dstrect->h ) } )
-                                                  : std::nullopt;
+                                                      float( dstrect->w ), float( dstrect->h ) } )
+            : std::nullopt;
             const std::optional<SDL_FPoint> fcenter = center
-                    ? std::optional<SDL_FPoint>( SDL_FPoint{ float( center->x ), float( center->y ) } )
-                    : std::nullopt;
+                ? std::optional<SDL_FPoint>( SDL_FPoint{ float( center->x ), float( center->y ) } )
+                : std::nullopt;
             return SDL_RenderTextureRotated( renderer.get(), sdl_texture_ptr.get(), &srcrect,
                                              fdst ? &fdst.value() : nullptr, angle,
                                              fcenter ? &fcenter.value() : nullptr, flip );
@@ -179,10 +179,10 @@ class texture
 
         bool render_copy( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const dstrect ) const {
             if( !dstrect ) {
-                return SDL_RenderTexture( renderer.get(), sdl_texture_ptr.get(), &srcrect, nullptr );
+            return SDL_RenderTexture( renderer.get(), sdl_texture_ptr.get(), &srcrect, nullptr );
             }
             const SDL_FRect fdst{ float( dstrect->x ), float( dstrect->y ),
-                                  float( dstrect->w ), float( dstrect->h ) };
+                  float( dstrect->w ), float( dstrect->h ) };
             return SDL_RenderTexture( renderer.get(), sdl_texture_ptr.get(), &srcrect, &fdst );
         }
 
@@ -284,8 +284,8 @@ struct tint_config {
     bool has_value() const {
         return color != TILESET_NO_COLOR
                || fabs( contrast - 1.0f ) > 0.001f
-               || fabs( saturation - 1.0f ) > 0.001f
-               || fabs( brightness - 1.0f ) > 0.001f;
+        || fabs( saturation - 1.0f ) > 0.001f
+        || fabs( brightness - 1.0f ) > 0.001f;
     }
 
     bool operator==( const tint_config &other ) const {
@@ -372,6 +372,7 @@ class tileset
         int tile_width;
         int tile_height;
         int zlevel_height = 0;
+        bool is_iso = false;
         float prevent_occlusion_min_dist = 0.0f;
         float prevent_occlusion_max_dist = 0.0f;
 
@@ -439,6 +440,9 @@ class tileset
         }
         auto get_zlevel_height() const -> int {
             return zlevel_height;
+        }
+        auto get_tile_iso() const -> bool {
+            return is_iso;
         }
         auto get_prevent_occlusion_min_dist() const -> float {
             return prevent_occlusion_min_dist;
@@ -1089,6 +1093,7 @@ class cata_tiles
             return tile_ratioy;
         }
         void do_tile_loading_report( const std::function<void( std::string )> &out );
+        point player_to_tile( point_bub_ms ) const;
         point player_to_screen( point_bub_ms ) const;
         static std::vector<options_manager::id_and_option> build_renderer_list();
         static std::vector<options_manager::id_and_option> build_display_list();
@@ -1130,6 +1135,8 @@ class cata_tiles
         // measured in map coordinates, *not* in pixels.
         int screentile_width = 0;
         int screentile_height = 0;
+        int viewport_width = 0;
+        int viewport_height = 0;
         float tile_ratiox = 0.0f;
         float tile_ratioy = 0.0f;
 

--- a/src/enchantments/enchantment.cpp
+++ b/src/enchantments/enchantment.cpp
@@ -1,5 +1,7 @@
 #include "enchantment.h"
 
+#define dbg(x) DebugLogFL((x), DC::Main)
+
 #include "bodypart.h"
 #include "calendar.h"
 #include "character.h"
@@ -429,7 +431,7 @@ void enchantment::force_add(const enchantment& rhs) {
 }
 
 bool enchantment::has_flag(const enchantment_flag_id flag) const {
-    if (!flag.is_valid()) { debugmsg("Tried to get invalid enchantment flag \"%s\".", flag); }
+    if (!flag.is_valid()) { return false; }
     if (flags.contains(flag)) {
         if (flags.at(flag) <= 0) {
             debugmsg("Flag \"%s\" was canceled but remains in the list", flag);
@@ -627,8 +629,8 @@ void enchantment::finalize() {
     }
 
     if (!problems.empty()) {
-        debugmsg("%s %s has: %s", ench_desc, id.c_str(),
-                 enumerate_as_string(problems, enumeration_conjunction::none));
+        dbg(DL::Error) << ench_desc << " " << id.c_str()
+                       << " has: " << enumerate_as_string(problems, enumeration_conjunction::none);
     }
 }
 
@@ -678,7 +680,8 @@ void enchantment::check(std::set<enchantment_condition_type> incompatible_cond_t
     }
     for (const trait_id& mut : mutations) {
         if (!mut.is_valid()) {
-            debugmsg("%s %s has invalid mutation %s", ench_desc, id.c_str(), mut.c_str());
+            dbg(DL::Error) << ench_desc << " " << id.c_str() << " has invalid mutation "
+                           << mut.c_str();
         }
 
         if (!nested_enchant_check(*this, id, std::set<trait_id>())) {
@@ -758,8 +761,8 @@ void enchantment::check(std::set<enchantment_condition_type> incompatible_cond_t
         }
     }
     if (!problems.empty()) {
-        debugmsg("%s %s has: %s", ench_desc, id.c_str(),
-                 enumerate_as_string(problems, enumeration_conjunction::none));
+        dbg(DL::Error) << ench_desc << " " << id.c_str()
+                       << " has: " << enumerate_as_string(problems, enumeration_conjunction::none);
     }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -630,6 +630,7 @@ void game::reload_tileset( [[maybe_unused]] const std::function<void( std::strin
         try {
             repoint_overmap_tilecontext();
             std::vector<mod_id> dummy;
+            const auto saved_tile_iso = tile_iso;
             overmap_tilecontext->load_tileset(
                 omTilesName,
                 world_generator->active_world ? world_generator->active_world->info->active_mod_order : dummy,
@@ -637,6 +638,7 @@ void game::reload_tileset( [[maybe_unused]] const std::function<void( std::strin
                 /*force=*/true,
                 /*pump_events=*/true
             );
+            tile_iso = saved_tile_iso;
             overmap_tilecontext->do_tile_loading_report( out );
         } catch( const std::exception &err ) {
             popup( _( "Loading the overmap tileset failed: %s" ), err.what() );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3711,6 +3711,7 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
                 repoint_overmap_tilecontext();
                 std::vector<mod_id> dummy;
 
+                const auto saved_tile_iso = tile_iso;
                 overmap_tilecontext->load_tileset(
                     omTilesName,
                     ingame ? world_generator->active_world->info->active_mod_order : dummy,
@@ -3718,6 +3719,7 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
                     /*force=*/force_tile_change,
                     /*pump_events=*/true
                 );
+                tile_iso = saved_tile_iso;
                 //game_ui::init_ui is called when zoom is changed
                 g->reset_zoom();
                 g->mark_main_ui_adaptor_resize();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -190,7 +190,7 @@ static bool SetupRenderTarget()
 {
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
     display_buffer.reset( SDL_CreateTexture( renderer.get(), SDL_PIXELFORMAT_ARGB8888,
-                          SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor, WindowHeight / scaling_factor ) );
+            SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor, WindowHeight / scaling_factor ) );
     SDL_SetTextureScaleMode( display_buffer.get(), SDL_SCALEMODE_NEAREST );
     if( printErrorIf( !display_buffer, "Failed to create window buffer" ) ) {
         return false;
@@ -329,7 +329,7 @@ static void WinCreate()
             }
             if( !SetupRenderTarget() ) {
                 dbg( DL::Error ) << "Failed to initialize display buffer under accelerated rendering, "
-                                 "falling back to software rendering.";
+                                    "falling back to software rendering.";
                 software_renderer = true;
                 display_buffer.reset();
                 renderer.reset();
@@ -374,7 +374,7 @@ static void WinCreate()
     if( get_option<bool>( "ENABLE_JOYSTICK" ) && numjoy >= 1 ) {
         if( numjoy > 1 ) {
             dbg( DL::Warn ) << "You have more than one gamepads/joysticks plugged in, "
-                            "only the first will be used.";
+                               "only the first will be used.";
         }
         joystick = SDL_OpenJoystick( joystick_ids[0] );
         printErrorIf( joystick == nullptr, "SDL_OpenJoystick failed" );
@@ -514,7 +514,7 @@ void refresh_display()
     ClearScreen();
 #if defined(__ANDROID__)
     SDL_FRect dstrect = get_android_render_rect( TERMINAL_WIDTH * fontwidth,
-                        TERMINAL_HEIGHT * fontheight );
+        TERMINAL_HEIGHT * fontheight );
     RenderCopy( renderer, display_buffer, nullptr, &dstrect );
 #else
     RenderCopy( renderer, display_buffer, nullptr, nullptr );
@@ -588,9 +588,9 @@ void reinitialize_framebuffer( const bool force_invalidate )
 static void invalidate_framebuffer_proportion( cata_cursesport::WINDOW *win )
 {
     const int oversized_width = std::max( TERMX, std::max( OVERMAP_WINDOW_WIDTH,
-                                          TERRAIN_WINDOW_WIDTH ) );
+        TERRAIN_WINDOW_WIDTH ) );
     const int oversized_height = std::max( TERMY, std::max( OVERMAP_WINDOW_HEIGHT,
-                                           TERRAIN_WINDOW_HEIGHT ) );
+        TERRAIN_WINDOW_HEIGHT ) );
 
     // check if the framebuffers/windows have been prepared yet
     if( oversized_height == 0 || oversized_width == 0 ) {
@@ -652,7 +652,7 @@ void clear_window_area( const catacurses::window &win_ )
 }
 
 static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow(
-            const inclusive_cuboid<tripoint_abs_omt> &overmap_area, const tripoint_abs_omt &center )
+    const inclusive_cuboid<tripoint_abs_omt> &overmap_area, const tripoint_abs_omt &center )
 {
     const auto *mission = get_avatar().get_active_mission();
     const bool custom_waypoint_valid = get_avatar().get_custom_mission_target() !=
@@ -685,7 +685,7 @@ static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow
     }
 
     const std::vector<tripoint_abs_omt> traj = line_to( center,
-            tripoint_abs_omt( mission_target.xy(), center.z() ) );
+        tripoint_abs_omt( mission_target.xy(), center.z() ) );
 
     if( traj.empty() ) {
         debugmsg( "Failed to gen overmap mission trajectory %s %s",
@@ -833,6 +833,13 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
     }
 #endif
 
+    // Overmap uses its own tileset (e.g. ASCIITiles) which is never iso.
+    // tile_iso is global and may be true from the main tileset (e.g. Ultica_iso).
+    // Reset from the overmap tileset so get_window_tile_counts, draw_from_id_string,
+    // and highlight rendering all use orthographic math.
+    const auto saved_tile_iso = tile_iso;
+    tile_iso = tileset_ptr ? tileset_ptr->get_tile_iso() : false;
+
     int width = OVERMAP_WINDOW_TERM_WIDTH * font->width;
     int height = OVERMAP_WINDOW_TERM_HEIGHT * font->height;
 
@@ -902,7 +909,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
     // Cache display_oter substitution strings for the active region.
     const regional_settings &active_region_settings = ACTIVE_OVERMAP_BUFFER.get_settings(
-                center_abs_omt );
+            center_abs_omt );
     const bool om_has_display_oter = !active_region_settings.display_oter.is_empty();
     const std::string om_default_oter_str = active_region_settings.default_oter.str();
     const std::string om_display_oter_str = om_has_display_oter
@@ -1009,15 +1016,15 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
                     const mongroup *mgp = *horde_it;
                     const MonsterGroup &group = mgp->type.obj();
                     const auto default_id = group.defaultMonster.is_valid()
-                    ? group.defaultMonster.str()
-                    : std::string( "mon_zombie" );
+                        ? group.defaultMonster.str()
+                        : std::string( "mon_zombie" );
                     if( group.monsters.empty() )
                     {
                         return default_id;
                     }
 
                     const auto best_entry = std::ranges::max_element( group.monsters, []( const auto & lhs,
-                            const auto & rhs )
+                        const auto & rhs )
                     {
                         return lhs.frequency < rhs.frequency;
                     } );
@@ -1189,7 +1196,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         inclusive_cuboid<tripoint_abs_omt> map_cursor_area = overmap_area;
         map_cursor_area.p_max.y()--;
         const std::optional<std::pair<tripoint_abs_omt, std::string>> mission_arrow =
-                    get_mission_arrow( map_cursor_area, center_abs_omt );
+            get_mission_arrow( map_cursor_area, center_abs_omt );
         if( mission_arrow ) {
             const tile_search_params tile { mission_arrow->second, C_NONE, empty_string, 0, 0 };
             draw_from_id_string(
@@ -1201,7 +1208,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
     if( !viewing_weather && uistate.overmap_show_city_labels ) {
         const auto abs_sm_to_draw_label = [&]( const tripoint_abs_sm & city_pos, const int label_length ) {
             const auto tile_draw_pos = global_omt_to_draw_position( project_to<coords::omt>
-                                       ( city_pos ) ) - o;
+                ( city_pos ) ) - o;
             point draw_point( tile_draw_pos.x() * tile_width + dest.x,
                               tile_draw_pos.y() * tile_height + dest.y );
             // center text on the tile
@@ -1249,7 +1256,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         // the tiles on the overmap are overmap tiles, so we need to use
         // coordinate conversions to make sure we're in the right place.
         const int radius = coords::project_to<coords::sm>( tripoint_abs_omt( std::min( max_col, max_row ),
-                           0, 0 ) ).x() / 2;
+            0, 0 ) ).x() / 2;
 
         for( const city_reference &city : ACTIVE_OVERMAP_BUFFER.get_cities_near(
                  coords::project_to<coords::sm>( center_abs_omt ), radius ) ) {
@@ -1294,7 +1301,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         const std::string &note_text = ACTIVE_OVERMAP_BUFFER.note( center_abs_omt );
         if( !note_text.empty() && !overmap_label_note::is_label_only( note_text ) ) {
             const std::tuple<char, nc_color, size_t> note_info = overmap_ui::get_note_display_info(
-                        note_text );
+                    note_text );
             const size_t pos = std::get<2>( note_info );
             if( pos != std::string::npos ) {
                 const auto display_note_text =
@@ -1333,9 +1340,9 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
         // Find screen coordinates to the right of the center tile
         auto center_sm = coords::project_to<coords::sm>( tripoint_abs_omt( center_abs_omt.x() + 1,
-                         center_abs_omt.y(), center_abs_omt.z() ) );
+            center_abs_omt.y(), center_abs_omt.z() ) );
         const auto tile_draw_pos = global_omt_to_draw_position( project_to<coords::omt>
-                                   ( center_sm ) ) - o;
+            ( center_sm ) ) - o;
         point draw_point( tile_draw_pos.x() * tile_width + dest.x,
                           tile_draw_pos.y() * tile_height + dest.y );
         draw_point += point( padding, padding );
@@ -1373,7 +1380,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
                 if( seg[0] == '<' ) {
                     const color_tag_parse_result::tag_type type = update_color_stack(
-                                color_stack, seg, report_color_error::no );
+                            color_stack, seg, report_color_error::no );
                     if( type != color_tag_parse_result::non_color_tag ) {
                         seg = rm_prefix( seg );
                     }
@@ -1406,6 +1413,8 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
     printErrorIf( !SDL_SetRenderClipRect( renderer.get(), nullptr ),
                   "SDL_SetRenderClipRect failed" );
+
+    tile_iso = saved_tile_iso;
 }
 
 static bool draw_window( Font_Ptr &font, const catacurses::window &w, point offset )
@@ -1418,7 +1427,7 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, point offs
     cata_cursesport::WINDOW *const win = w.get<cata_cursesport::WINDOW>();
     //Keeping track of the last drawn window
     const cata_cursesport::WINDOW *winBuffer = static_cast<cata_cursesport::WINDOW *>
-            ( ::winBuffer.lock().get() );
+        ( ::winBuffer.lock().get() );
     if( !fontScaleBuffer ) {
         fontScaleBuffer = tilecontext->get_tile_width();
     }
@@ -2250,7 +2259,7 @@ input_event *get_quick_shortcut_under_finger( bool down = false )
     }
 
     quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                 touch_input_context.get_category() )];
+            touch_input_context.get_category() )];
 
     float border, width, height;
     get_quick_shortcut_dimensions( qsl, border, width, height );
@@ -2300,7 +2309,7 @@ bool ignore_action_for_quick_shortcuts( const std::string &action )
              || action == "MOVE_ARMOR" // maps to ENTER
              || action == "ANY_INPUT"
              || action ==
-             "DELETE_TEMPLATE" // strictly we shouldn't have this one, but I don't like seeing the "d" on the main menu by default. :)
+                       "DELETE_TEMPLATE" // strictly we shouldn't have this one, but I don't like seeing the "d" on the main menu by default. :)
            );
 }
 
@@ -2576,7 +2585,7 @@ void draw_quick_shortcuts()
         std::string text = event.text;
         int key = event.get_first_input();
         float default_text_scale = std::floor( 0.75f * ( height /
-                                               font->height ) ); // default for single character strings
+            font->height ) ); // default for single character strings
         float text_scale = default_text_scale;
         if( text.empty() || text == " " ) {
             text = inp_mngr.get_keyname( key, event.type );
@@ -2651,7 +2660,7 @@ void draw_quick_shortcuts()
         int text_x, text_y;
         if( shortcut_right ) {
             text_x = ( WindowWidth - ( i + 0.5f ) * width - ( font->width * utf8_width(
-                           text ) ) * text_scale * 0.5f ) / text_scale;
+                    text ) ) * text_scale * 0.5f ) / text_scale;
         } else {
             text_x = ( ( i + 0.5f ) * width - ( font->width * utf8_width( text ) ) * text_scale * 0.5f ) /
                      text_scale;
@@ -2677,7 +2686,7 @@ void draw_quick_shortcuts()
                 int hint_length = utf8_width( hint_text );
                 if( WindowWidth * safe_margin < font->width * text_scale * hint_length ) {
                     text_scale *= ( WindowWidth * safe_margin ) / ( font->width * text_scale *
-                                  hint_length );    // scale to fit comfortably
+                        hint_length );    // scale to fit comfortably
                 }
                 SDL_SetRenderScale( renderer.get(), text_scale, text_scale );
                 text_x = ( WindowWidth - ( ( font->width  * hint_length ) * text_scale ) ) * 0.5f / text_scale;
@@ -2758,9 +2767,9 @@ void update_finger_repeat_delay()
                     0.0f, 1.0f );
     finger_repeat_delay = lerp( std::pow( t, get_option<float>( "ANDROID_SENSITIVITY_POWER" ) ),
                                 static_cast<Uint64>( std::max( get_option<int>( "ANDROID_REPEAT_DELAY_MIN" ),
-                                        get_option<int>( "ANDROID_REPEAT_DELAY_MAX" ) ) ),
+                                    get_option<int>( "ANDROID_REPEAT_DELAY_MAX" ) ) ),
                                 static_cast<Uint64>( std::min( get_option<int>( "ANDROID_REPEAT_DELAY_MIN" ),
-                                        get_option<int>( "ANDROID_REPEAT_DELAY_MAX" ) ) ) );
+                                    get_option<int>( "ANDROID_REPEAT_DELAY_MAX" ) ) ) );
 }
 
 // TODO: Is there a better way to detect when string entry is allowed?
@@ -2792,7 +2801,7 @@ void handle_finger_input( Uint64 ticks )
     bool handle_diagonals = touch_input_context.is_action_registered( "LEFTUP" );
     bool is_default_mode = touch_input_context.get_category() == "DEFAULTMODE";
     if( dist > ( get_option<float>( "ANDROID_DEADZONE_RANGE" ) * std::max( WindowWidth,
-                 WindowHeight ) ) ) {
+            WindowHeight ) ) ) {
         if( !handle_diagonals ) {
             if( delta_x >= 0 && delta_y >= 0 ) {
                 last_input = input_event( delta_x > delta_y ? KEY_RIGHT : KEY_DOWN, input_event_t::keyboard );
@@ -2958,7 +2967,7 @@ static void CheckMessages()
 
     bool is_default_mode = touch_input_context.get_category() == "DEFAULTMODE";
     quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                 touch_input_context.get_category() )];
+            touch_input_context.get_category() )];
 
     // Don't do this logic if we already need an update, otherwise we're likely to overload the game with too much input on hold repeat events
     if( !needupdate ) {
@@ -3161,7 +3170,7 @@ static void CheckMessages()
                     jobject activity = static_cast<jobject>( SDL_GetAndroidActivity() );
                     jclass clazz( env->GetObjectClass( activity ) );
                     jstring toast_message = env->NewStringUTF( quick_shortcuts_enabled ? "Shortcuts visible" :
-                                            "Shortcuts hidden" );
+                        "Shortcuts hidden" );
                     jmethodID method_id = env->GetMethodID( clazz, "toast", "(Ljava/lang/String;)V" );
                     env->CallVoidMethod( activity, method_id, toast_message );
                     env->DeleteLocalRef( activity );
@@ -3354,7 +3363,7 @@ static void CheckMessages()
                                 }
 
                                 quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                                             touch_input_context.get_category() )];
+                                        touch_input_context.get_category() )];
                                 qsl.remove( last_input );
                                 add_quick_shortcut( qsl, last_input, false, true );
                                 refresh_display();
@@ -3484,7 +3493,7 @@ static void CheckMessages()
                             last_input = *quick_shortcut;
                             if( get_option<bool>( "ANDROID_SHORTCUT_MOVE_FRONT" ) ) {
                                 quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                                             touch_input_context.get_category() )];
+                                        touch_input_context.get_category() )];
                                 reorder_quick_shortcut( qsl, quick_shortcut->get_first_input(), false );
                             }
                             quick_shortcut->shortcut_last_used_action_counter = g->get_user_action_counter();
@@ -3498,7 +3507,7 @@ static void CheckMessages()
                                 finger_down_y - finger_curr_y > std::abs( finger_down_x - finger_curr_x ) ) {
                                 // a flick up was detected, remove the quick shortcut!
                                 quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                                             touch_input_context.get_category() )];
+                                        touch_input_context.get_category() )];
                                 qsl.remove( *quick_shortcut );
                             }
                         }
@@ -3682,8 +3691,8 @@ static void init_term_size_and_scaling_factor()
         int display_count = 0;
         SDL_DisplayID *display_list = SDL_GetDisplays( &display_count );
         const SDL_DisplayID current_display_id = ( display_list && current_display_idx < display_count )
-                ? display_list[current_display_idx]
-                : SDL_GetPrimaryDisplay();
+            ? display_list[current_display_idx]
+            : SDL_GetPrimaryDisplay();
         SDL_free( display_list );
 
         const SDL_DisplayMode *current_display = SDL_GetDesktopDisplayMode( current_display_id );
@@ -3824,6 +3833,7 @@ void catacurses::init_interface()
         try {
             overmap_tilecontext = std::make_shared<cata_tiles>( renderer, geometry );
             std::vector<mod_id> dummy;
+            const auto saved_tile_iso = tile_iso;
             overmap_tilecontext->load_tileset(
                 omTilesName,
                 dummy,
@@ -3831,6 +3841,7 @@ void catacurses::init_interface()
                 /*force=*/false,
                 /*pump_events=*/true
             );
+            tile_iso = saved_tile_iso;
         } catch( const std::exception &err ) {
             dbg( DL::Error ) << "failed to check for overmap tileset: " << err.what();
             // use_tiles is the cached value of the USE_TILES option.
@@ -3847,13 +3858,13 @@ void catacurses::init_interface()
 
     try {
         font = std::make_unique<FontFallbackList>( renderer, format, fl.fontwidth, fl.fontheight,
-                windowsPalette, fl.typeface, fl.fontsize, fl.fontblending );
+            windowsPalette, fl.typeface, fl.fontsize, fl.fontblending );
         map_font = std::make_unique<FontFallbackList>( renderer, format, fl.map_fontwidth,
-                   fl.map_fontheight,
-                   windowsPalette, fl.map_typeface, fl.map_fontsize, fl.fontblending );
+            fl.map_fontheight,
+            windowsPalette, fl.map_typeface, fl.map_fontsize, fl.fontblending );
         overmap_font = std::make_unique<FontFallbackList>( renderer, format, fl.overmap_fontwidth,
-                       fl.overmap_fontheight,
-                       windowsPalette, fl.overmap_typeface, fl.overmap_fontsize, fl.fontblending );
+            fl.overmap_fontheight,
+            windowsPalette, fl.overmap_typeface, fl.overmap_fontsize, fl.fontblending );
     } catch( std::exception &e ) {
         font.reset();
         map_font.reset();
@@ -3895,6 +3906,7 @@ void load_tileset()
     } else {
         if( overmap_tilecontext ) {
             overmap_tilecontext = std::make_shared<cata_tiles>( renderer, geometry );
+            const auto saved_tile_iso = tile_iso;
             overmap_tilecontext->load_tileset(
                 omTilesName,
                 world_generator->active_world->info->active_mod_order,
@@ -3902,6 +3914,7 @@ void load_tileset()
                 /*force=*/false,
                 /*pump_events=*/true
             );
+            tile_iso = saved_tile_iso;
             overmap_tilecontext->do_tile_loading_report( []( const std::string & str ) {
                 DebugLog( DL::Info, DC::Main ) << str;
             } );
@@ -4104,7 +4117,7 @@ auto get_sdl_display_buffer_size() -> point
 auto get_sdl_window_size() -> point
 {
     return point( std::max( 1, WindowWidth / scaling_factor ),
-                  std::max( 1, WindowHeight / scaling_factor ) );
+    std::max( 1, WindowHeight / scaling_factor ) );
 }
 
 auto get_sdl_font_size() -> point
@@ -4266,7 +4279,7 @@ bool save_screenshot( const std::string &file_path )
     // Save screenshot as PNG file
     const bool ok = !printErrorIf( !IMG_SavePNG( readback.get(), file_path.c_str() ),
                                    std::string( "save_screenshot: cannot save screenshot file: " +
-                                           file_path ).c_str() );
+                                       file_path ).c_str() );
     return ok;
 }
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -190,7 +190,7 @@ static bool SetupRenderTarget()
 {
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
     display_buffer.reset( SDL_CreateTexture( renderer.get(), SDL_PIXELFORMAT_ARGB8888,
-            SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor, WindowHeight / scaling_factor ) );
+                          SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor, WindowHeight / scaling_factor ) );
     SDL_SetTextureScaleMode( display_buffer.get(), SDL_SCALEMODE_NEAREST );
     if( printErrorIf( !display_buffer, "Failed to create window buffer" ) ) {
         return false;
@@ -329,7 +329,7 @@ static void WinCreate()
             }
             if( !SetupRenderTarget() ) {
                 dbg( DL::Error ) << "Failed to initialize display buffer under accelerated rendering, "
-                                    "falling back to software rendering.";
+                                 "falling back to software rendering.";
                 software_renderer = true;
                 display_buffer.reset();
                 renderer.reset();
@@ -374,7 +374,7 @@ static void WinCreate()
     if( get_option<bool>( "ENABLE_JOYSTICK" ) && numjoy >= 1 ) {
         if( numjoy > 1 ) {
             dbg( DL::Warn ) << "You have more than one gamepads/joysticks plugged in, "
-                               "only the first will be used.";
+                            "only the first will be used.";
         }
         joystick = SDL_OpenJoystick( joystick_ids[0] );
         printErrorIf( joystick == nullptr, "SDL_OpenJoystick failed" );
@@ -514,7 +514,7 @@ void refresh_display()
     ClearScreen();
 #if defined(__ANDROID__)
     SDL_FRect dstrect = get_android_render_rect( TERMINAL_WIDTH * fontwidth,
-        TERMINAL_HEIGHT * fontheight );
+                        TERMINAL_HEIGHT * fontheight );
     RenderCopy( renderer, display_buffer, nullptr, &dstrect );
 #else
     RenderCopy( renderer, display_buffer, nullptr, nullptr );
@@ -588,9 +588,9 @@ void reinitialize_framebuffer( const bool force_invalidate )
 static void invalidate_framebuffer_proportion( cata_cursesport::WINDOW *win )
 {
     const int oversized_width = std::max( TERMX, std::max( OVERMAP_WINDOW_WIDTH,
-        TERRAIN_WINDOW_WIDTH ) );
+                                          TERRAIN_WINDOW_WIDTH ) );
     const int oversized_height = std::max( TERMY, std::max( OVERMAP_WINDOW_HEIGHT,
-        TERRAIN_WINDOW_HEIGHT ) );
+                                           TERRAIN_WINDOW_HEIGHT ) );
 
     // check if the framebuffers/windows have been prepared yet
     if( oversized_height == 0 || oversized_width == 0 ) {
@@ -652,7 +652,7 @@ void clear_window_area( const catacurses::window &win_ )
 }
 
 static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow(
-    const inclusive_cuboid<tripoint_abs_omt> &overmap_area, const tripoint_abs_omt &center )
+            const inclusive_cuboid<tripoint_abs_omt> &overmap_area, const tripoint_abs_omt &center )
 {
     const auto *mission = get_avatar().get_active_mission();
     const bool custom_waypoint_valid = get_avatar().get_custom_mission_target() !=
@@ -685,7 +685,7 @@ static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow
     }
 
     const std::vector<tripoint_abs_omt> traj = line_to( center,
-        tripoint_abs_omt( mission_target.xy(), center.z() ) );
+            tripoint_abs_omt( mission_target.xy(), center.z() ) );
 
     if( traj.empty() ) {
         debugmsg( "Failed to gen overmap mission trajectory %s %s",
@@ -909,7 +909,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
     // Cache display_oter substitution strings for the active region.
     const regional_settings &active_region_settings = ACTIVE_OVERMAP_BUFFER.get_settings(
-            center_abs_omt );
+                center_abs_omt );
     const bool om_has_display_oter = !active_region_settings.display_oter.is_empty();
     const std::string om_default_oter_str = active_region_settings.default_oter.str();
     const std::string om_display_oter_str = om_has_display_oter
@@ -1016,15 +1016,15 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
                     const mongroup *mgp = *horde_it;
                     const MonsterGroup &group = mgp->type.obj();
                     const auto default_id = group.defaultMonster.is_valid()
-                        ? group.defaultMonster.str()
-                        : std::string( "mon_zombie" );
+                    ? group.defaultMonster.str()
+                    : std::string( "mon_zombie" );
                     if( group.monsters.empty() )
                     {
                         return default_id;
                     }
 
                     const auto best_entry = std::ranges::max_element( group.monsters, []( const auto & lhs,
-                        const auto & rhs )
+                            const auto & rhs )
                     {
                         return lhs.frequency < rhs.frequency;
                     } );
@@ -1196,7 +1196,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         inclusive_cuboid<tripoint_abs_omt> map_cursor_area = overmap_area;
         map_cursor_area.p_max.y()--;
         const std::optional<std::pair<tripoint_abs_omt, std::string>> mission_arrow =
-            get_mission_arrow( map_cursor_area, center_abs_omt );
+                    get_mission_arrow( map_cursor_area, center_abs_omt );
         if( mission_arrow ) {
             const tile_search_params tile { mission_arrow->second, C_NONE, empty_string, 0, 0 };
             draw_from_id_string(
@@ -1208,7 +1208,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
     if( !viewing_weather && uistate.overmap_show_city_labels ) {
         const auto abs_sm_to_draw_label = [&]( const tripoint_abs_sm & city_pos, const int label_length ) {
             const auto tile_draw_pos = global_omt_to_draw_position( project_to<coords::omt>
-                ( city_pos ) ) - o;
+                                       ( city_pos ) ) - o;
             point draw_point( tile_draw_pos.x() * tile_width + dest.x,
                               tile_draw_pos.y() * tile_height + dest.y );
             // center text on the tile
@@ -1256,7 +1256,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         // the tiles on the overmap are overmap tiles, so we need to use
         // coordinate conversions to make sure we're in the right place.
         const int radius = coords::project_to<coords::sm>( tripoint_abs_omt( std::min( max_col, max_row ),
-            0, 0 ) ).x() / 2;
+                           0, 0 ) ).x() / 2;
 
         for( const city_reference &city : ACTIVE_OVERMAP_BUFFER.get_cities_near(
                  coords::project_to<coords::sm>( center_abs_omt ), radius ) ) {
@@ -1301,7 +1301,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         const std::string &note_text = ACTIVE_OVERMAP_BUFFER.note( center_abs_omt );
         if( !note_text.empty() && !overmap_label_note::is_label_only( note_text ) ) {
             const std::tuple<char, nc_color, size_t> note_info = overmap_ui::get_note_display_info(
-                    note_text );
+                        note_text );
             const size_t pos = std::get<2>( note_info );
             if( pos != std::string::npos ) {
                 const auto display_note_text =
@@ -1340,9 +1340,9 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
         // Find screen coordinates to the right of the center tile
         auto center_sm = coords::project_to<coords::sm>( tripoint_abs_omt( center_abs_omt.x() + 1,
-            center_abs_omt.y(), center_abs_omt.z() ) );
+                         center_abs_omt.y(), center_abs_omt.z() ) );
         const auto tile_draw_pos = global_omt_to_draw_position( project_to<coords::omt>
-            ( center_sm ) ) - o;
+                                   ( center_sm ) ) - o;
         point draw_point( tile_draw_pos.x() * tile_width + dest.x,
                           tile_draw_pos.y() * tile_height + dest.y );
         draw_point += point( padding, padding );
@@ -1380,7 +1380,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
                 if( seg[0] == '<' ) {
                     const color_tag_parse_result::tag_type type = update_color_stack(
-                            color_stack, seg, report_color_error::no );
+                                color_stack, seg, report_color_error::no );
                     if( type != color_tag_parse_result::non_color_tag ) {
                         seg = rm_prefix( seg );
                     }
@@ -1427,7 +1427,7 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, point offs
     cata_cursesport::WINDOW *const win = w.get<cata_cursesport::WINDOW>();
     //Keeping track of the last drawn window
     const cata_cursesport::WINDOW *winBuffer = static_cast<cata_cursesport::WINDOW *>
-        ( ::winBuffer.lock().get() );
+            ( ::winBuffer.lock().get() );
     if( !fontScaleBuffer ) {
         fontScaleBuffer = tilecontext->get_tile_width();
     }
@@ -2259,7 +2259,7 @@ input_event *get_quick_shortcut_under_finger( bool down = false )
     }
 
     quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-            touch_input_context.get_category() )];
+                                 touch_input_context.get_category() )];
 
     float border, width, height;
     get_quick_shortcut_dimensions( qsl, border, width, height );
@@ -2309,7 +2309,7 @@ bool ignore_action_for_quick_shortcuts( const std::string &action )
              || action == "MOVE_ARMOR" // maps to ENTER
              || action == "ANY_INPUT"
              || action ==
-                       "DELETE_TEMPLATE" // strictly we shouldn't have this one, but I don't like seeing the "d" on the main menu by default. :)
+             "DELETE_TEMPLATE" // strictly we shouldn't have this one, but I don't like seeing the "d" on the main menu by default. :)
            );
 }
 
@@ -2585,7 +2585,7 @@ void draw_quick_shortcuts()
         std::string text = event.text;
         int key = event.get_first_input();
         float default_text_scale = std::floor( 0.75f * ( height /
-            font->height ) ); // default for single character strings
+                                               font->height ) ); // default for single character strings
         float text_scale = default_text_scale;
         if( text.empty() || text == " " ) {
             text = inp_mngr.get_keyname( key, event.type );
@@ -2660,7 +2660,7 @@ void draw_quick_shortcuts()
         int text_x, text_y;
         if( shortcut_right ) {
             text_x = ( WindowWidth - ( i + 0.5f ) * width - ( font->width * utf8_width(
-                    text ) ) * text_scale * 0.5f ) / text_scale;
+                           text ) ) * text_scale * 0.5f ) / text_scale;
         } else {
             text_x = ( ( i + 0.5f ) * width - ( font->width * utf8_width( text ) ) * text_scale * 0.5f ) /
                      text_scale;
@@ -2686,7 +2686,7 @@ void draw_quick_shortcuts()
                 int hint_length = utf8_width( hint_text );
                 if( WindowWidth * safe_margin < font->width * text_scale * hint_length ) {
                     text_scale *= ( WindowWidth * safe_margin ) / ( font->width * text_scale *
-                        hint_length );    // scale to fit comfortably
+                                  hint_length );    // scale to fit comfortably
                 }
                 SDL_SetRenderScale( renderer.get(), text_scale, text_scale );
                 text_x = ( WindowWidth - ( ( font->width  * hint_length ) * text_scale ) ) * 0.5f / text_scale;
@@ -2767,9 +2767,9 @@ void update_finger_repeat_delay()
                     0.0f, 1.0f );
     finger_repeat_delay = lerp( std::pow( t, get_option<float>( "ANDROID_SENSITIVITY_POWER" ) ),
                                 static_cast<Uint64>( std::max( get_option<int>( "ANDROID_REPEAT_DELAY_MIN" ),
-                                    get_option<int>( "ANDROID_REPEAT_DELAY_MAX" ) ) ),
+                                        get_option<int>( "ANDROID_REPEAT_DELAY_MAX" ) ) ),
                                 static_cast<Uint64>( std::min( get_option<int>( "ANDROID_REPEAT_DELAY_MIN" ),
-                                    get_option<int>( "ANDROID_REPEAT_DELAY_MAX" ) ) ) );
+                                        get_option<int>( "ANDROID_REPEAT_DELAY_MAX" ) ) ) );
 }
 
 // TODO: Is there a better way to detect when string entry is allowed?
@@ -2801,7 +2801,7 @@ void handle_finger_input( Uint64 ticks )
     bool handle_diagonals = touch_input_context.is_action_registered( "LEFTUP" );
     bool is_default_mode = touch_input_context.get_category() == "DEFAULTMODE";
     if( dist > ( get_option<float>( "ANDROID_DEADZONE_RANGE" ) * std::max( WindowWidth,
-            WindowHeight ) ) ) {
+                 WindowHeight ) ) ) {
         if( !handle_diagonals ) {
             if( delta_x >= 0 && delta_y >= 0 ) {
                 last_input = input_event( delta_x > delta_y ? KEY_RIGHT : KEY_DOWN, input_event_t::keyboard );
@@ -2967,7 +2967,7 @@ static void CheckMessages()
 
     bool is_default_mode = touch_input_context.get_category() == "DEFAULTMODE";
     quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-            touch_input_context.get_category() )];
+                                 touch_input_context.get_category() )];
 
     // Don't do this logic if we already need an update, otherwise we're likely to overload the game with too much input on hold repeat events
     if( !needupdate ) {
@@ -3170,7 +3170,7 @@ static void CheckMessages()
                     jobject activity = static_cast<jobject>( SDL_GetAndroidActivity() );
                     jclass clazz( env->GetObjectClass( activity ) );
                     jstring toast_message = env->NewStringUTF( quick_shortcuts_enabled ? "Shortcuts visible" :
-                        "Shortcuts hidden" );
+                                            "Shortcuts hidden" );
                     jmethodID method_id = env->GetMethodID( clazz, "toast", "(Ljava/lang/String;)V" );
                     env->CallVoidMethod( activity, method_id, toast_message );
                     env->DeleteLocalRef( activity );
@@ -3363,7 +3363,7 @@ static void CheckMessages()
                                 }
 
                                 quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                        touch_input_context.get_category() )];
+                                                             touch_input_context.get_category() )];
                                 qsl.remove( last_input );
                                 add_quick_shortcut( qsl, last_input, false, true );
                                 refresh_display();
@@ -3493,7 +3493,7 @@ static void CheckMessages()
                             last_input = *quick_shortcut;
                             if( get_option<bool>( "ANDROID_SHORTCUT_MOVE_FRONT" ) ) {
                                 quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                        touch_input_context.get_category() )];
+                                                             touch_input_context.get_category() )];
                                 reorder_quick_shortcut( qsl, quick_shortcut->get_first_input(), false );
                             }
                             quick_shortcut->shortcut_last_used_action_counter = g->get_user_action_counter();
@@ -3507,7 +3507,7 @@ static void CheckMessages()
                                 finger_down_y - finger_curr_y > std::abs( finger_down_x - finger_curr_x ) ) {
                                 // a flick up was detected, remove the quick shortcut!
                                 quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                        touch_input_context.get_category() )];
+                                                             touch_input_context.get_category() )];
                                 qsl.remove( *quick_shortcut );
                             }
                         }
@@ -3691,8 +3691,8 @@ static void init_term_size_and_scaling_factor()
         int display_count = 0;
         SDL_DisplayID *display_list = SDL_GetDisplays( &display_count );
         const SDL_DisplayID current_display_id = ( display_list && current_display_idx < display_count )
-            ? display_list[current_display_idx]
-            : SDL_GetPrimaryDisplay();
+                ? display_list[current_display_idx]
+                : SDL_GetPrimaryDisplay();
         SDL_free( display_list );
 
         const SDL_DisplayMode *current_display = SDL_GetDesktopDisplayMode( current_display_id );
@@ -3858,13 +3858,13 @@ void catacurses::init_interface()
 
     try {
         font = std::make_unique<FontFallbackList>( renderer, format, fl.fontwidth, fl.fontheight,
-            windowsPalette, fl.typeface, fl.fontsize, fl.fontblending );
+                windowsPalette, fl.typeface, fl.fontsize, fl.fontblending );
         map_font = std::make_unique<FontFallbackList>( renderer, format, fl.map_fontwidth,
-            fl.map_fontheight,
-            windowsPalette, fl.map_typeface, fl.map_fontsize, fl.fontblending );
+                   fl.map_fontheight,
+                   windowsPalette, fl.map_typeface, fl.map_fontsize, fl.fontblending );
         overmap_font = std::make_unique<FontFallbackList>( renderer, format, fl.overmap_fontwidth,
-            fl.overmap_fontheight,
-            windowsPalette, fl.overmap_typeface, fl.overmap_fontsize, fl.fontblending );
+                       fl.overmap_fontheight,
+                       windowsPalette, fl.overmap_typeface, fl.overmap_fontsize, fl.fontblending );
     } catch( std::exception &e ) {
         font.reset();
         map_font.reset();
@@ -4117,7 +4117,7 @@ auto get_sdl_display_buffer_size() -> point
 auto get_sdl_window_size() -> point
 {
     return point( std::max( 1, WindowWidth / scaling_factor ),
-    std::max( 1, WindowHeight / scaling_factor ) );
+                  std::max( 1, WindowHeight / scaling_factor ) );
 }
 
 auto get_sdl_font_size() -> point
@@ -4279,7 +4279,7 @@ bool save_screenshot( const std::string &file_path )
     // Save screenshot as PNG file
     const bool ok = !printErrorIf( !IMG_SavePNG( readback.get(), file_path.c_str() ),
                                    std::string( "save_screenshot: cannot save screenshot file: " +
-                                       file_path ).c_str() );
+                                           file_path ).c_str() );
     return ok;
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

Ultica_iso and other isometric tilesets caused two critical issues:

1. **Black void bug**: Transparent tile variants created dark void circles around the player instead of useful see-through rendering. When `offset == offset_retracted` (both `(0,0)` in Ultica_iso), transparent pixels just reveal the black screen-clear, not adjacent tiles.
2. **Item rendering hang**: Loading item tiles (e.g. `rock`) triggered `item::spawn_temporary("rock_transparent")` → `debugmsg` → 30s backtrace hang per item. Every `C_ITEM` search attempted the transparent variant.

Additionally, the overmap tileset load in `game.cpp`/`options.cpp`/`sdltiles.cpp` overwrote the global `tile_iso` flag, causing the main tileset's iso setting to be lost when other non-iso tilesets (on overmap) were loaded.

## Describe the solution (The How)

- **Transparent variant skip**: After searching for `_transparent` variant, skip it if `offset_retracted == offset` (no position shift means black void)
- **C_ITEM exclusion**: Exclude `C_ITEM` category from transparent variant search
- (Optional) **Enchantment backtrace suppression**: Replace `debugmsg` → `dbg(DL::Error)` in `enchantment::check()` and `has_flag()` to prevent 30s backtrace hangs
- **tile_iso save/restore**: Save/restore `tile_iso` around overmap tileset loads in `game.cpp`, `options.cpp`, and `sdltiles.cpp`
- **draw_om iso reset**: Reset `tile_iso` from overmap tileset's `is_iso` flag at start of `draw_om()`
- **Iso screentile math**: Fix `screentile_width`/`screentile_height` calculation for iso to use `width*2/tile_width` and `height*4/tile_width`
- **Refactored player_to_screen**: Split into `player_to_tile` (iso colrow transform) + `player_to_screen` (pixel conversion), matching DDA's proven math

## Describe alternatives you've considered

- Skipping all transparent search instead of targeted `offset_retracted == offset` check — rejected because transparent variants with actual position shifts are useful
- Patching `item::spawn_temporary` to not debugmsg — rejected as too invasive

## Testing

- Built with `cmake --build out/build/linux-slim --target cataclysm-bn-tiles` — clean
- Manual testing with Ultica_iso tileset required (weather tiles `weather_rain_drop`, `weather_snowflake`, `weather_acid_drop` still need to be created for Ultica_iso)

## Checklist

- [x] I linked any relevant issues using github keyword syntax
- [x] This PR used AI assistance

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [4238c0a](https://github.com/cataclysmbn/Cataclysm-BN/commit/4238c0a5a910b7f3dd16e7f4e70d9451366e1b81) (style(autofix.ci): automated formatting) on 2026-07-24 00:01:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30031357872/artifacts/8574076036)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30031357872/artifacts/8574646395)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30031357872/artifacts/8573821652)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30031357872/artifacts/8573942006)
<!-- END artifact comment -->