### PR TITLE
feat: Add carbon fiber floor trunk, make floor trunk disassembleable

### DIFF
--- a/data/json/items/vehicle/cargo.json
+++ b/data/json/items/vehicle/cargo.json
@@ -96,6 +96,17 @@
     "price_postapoc": "5 USD"
   },
   {
+    "copy-from": "cargo_aisle",
+    "id": "cargo_aisle_carbon",
+    "type": "GENERIC",
+    "name": { "str": "carbon floor trunk" },
+    "description": "A section of carbon flooring with a cargo-space beneath, and a hinged door for access.",
+    "weight": "2 kg",
+    "material": [ "carbon_fiber" ],
+    "price": "500 USD",
+    "price_postapoc": "10 USD"
+  },
+  {
     "id": "livestock_carrier",
     "type": "GENERIC",
     "name": { "str": "livestock carrier" },

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -2304,7 +2304,6 @@
     "subcategory": "CSC_OTHER_VEHICLE",
     "skill_used": "computer",
     "difficulty": 4,
-    "reversible": true,
     "autolearn": true,
     "skills_required": [ [ "fabrication", 2 ] ],
     "time": "10 m",

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -1070,6 +1070,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "mechanics", 1 ],
     "difficulty": 4,
+    "reversible": true,
     "autolearn": true,
     "time": "1 h",
     "using": [ [ "welding_standard", 5 ] ],
@@ -2295,6 +2296,20 @@
     "batch_time_factors": [ 60, 1 ],
     "using": [ [ "3d_printing_standard", 20 ] ],
     "components": [ [ [ "carbon_fiber_filament", 300 ] ] ]
+  },
+  {
+    "result": "cargo_aisle_carbon",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "computer",
+    "difficulty": 4,
+    "reversible": true,
+    "autolearn": true,
+    "skills_required": [ [ "fabrication", 2 ] ],
+    "time": "10 m",
+    "using": [ [ "3d_printing_standard", 10 ] ],
+    "components": [ [ [ "sheet_carbon", 3 ] ], [ [ "carbon_fiber_filament", 50 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -362,6 +362,26 @@
     "breaks_into": "ig_vp_sheet_metal"
   },
   {
+    "copy-from": "trunk_floor",
+    "id": "trunk_floor_carbon",
+    "type": "vehicle_part",
+    "name": { "str": "carbon fiber floor trunk" },
+    "durability": 420,
+    "damage_reduction": { "all": 34 },
+    "description": "An aisle.  A hatch lets you access a cargo space beneath it.",
+    "size": "100 L",
+    "item": "cargo_aisle_carbon",
+    "breaks_into": "ig_vp_carbon",
+    "requirements": {
+      "repair": {
+        "skills": [ [ "mechanics", 2 ] ],
+        "time": "15 m",
+        "using": [ [ "welding_standard", 1 ], [ "vehicle_repair_carbon", 2 ] ]
+      }
+    },
+    "extend": { "flags": [ "SHOCK_RESISTANT" ] }
+  },
+  {
     "copy-from": "trunk_abstract",
     "type": "vehicle_part",
     "id": "trunk_flat",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

There are cargo fiber variants of many cargo vehicle parts, but not the floor trunk. In fact, it's the only walkable part with storage in the game.

## Describe the solution (The How)

I added one, trying to make it so roughly it to a regular floor trunk is the same as carbon fiber cargo space to regular cargo space. It's much lighter, holds a little more, and the recipe is similar to floor trunk except we swap door hinges for some filament (hinges are printed).

I also made both floor trunk recipes reversible.

## Describe alternatives you've considered

I wasn't sure if I wanted to add `"reversible": true,` to the second recipe because it doesn't currently handle 3d printers well, it ends up requiring 3d printer to disassemble. I decided that I'll probably add a handler for that along with a revision of 3d printer recipes to see which should be reversible later.

## Testing

Checked that the recipe appears in the crafting menu and that the part has the correct stats when installed.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [098f6e6](https://github.com/cataclysmbn/Cataclysm-BN/commit/098f6e6ee9a1582f17a160eb2b96659dfbdd67fe) (Apply suggestion from @chaosvolt) on 2026-07-25 01:30:16

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30137189078/artifacts/8613327306)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30137189078/artifacts/8613652919)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30137189078/artifacts/8613410448)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30137189078/artifacts/8613413878)
<!-- END artifact comment -->