### PR TITLE
fix: setmap bash now destroys furniture without a bash furn_set

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4001,7 +4001,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const point_rel_ms &offset ) 
             }
             break;
             case JMAPGEN_SETMAP_BASH: {
-                m.bash( point_omt_ms( x_get(), y_get() ), 9999 );
+                m.bash( point_omt_ms( x_get(), y_get() ), 9999, true );
             }
             break;
 


### PR DESCRIPTION
## Purpose of change (The Why)
Derg central lab showed issue

## Describe the solution (The How)
Destroy = true

## Describe alternatives you've considered
None

## Testing
Derg lab destroyed room worky

## Additional context
<img width="1920" height="1080" alt="Jul24::131501" src="https://github.com/user-attachments/assets/1e82c94a-863d-43cd-9e4d-80606dff7614" />


## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e3d3454](https://github.com/cataclysmbn/Cataclysm-BN/commit/e3d34549dec225fd8c0df275e6fc41b985e15aa8) (fix: setmap bash now destroys furniture without a bash furn_set) on 2026-07-25 02:22:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30123614220/artifacts/8608669328)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30123614220/artifacts/8609299314)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30123614220/artifacts/8608959056)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30123614220/artifacts/8608968340)
<!-- END artifact comment -->