### PR TITLE
feat: add `DESTROY_ON_DROP` flag

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -245,6 +245,11 @@
     "context": [  ]
   },
   {
+    "id": "DESTROY_ON_DROP",
+    "type": "json_flag",
+    "context": [  ]
+  },
+  {
     "id": "DIAMOND",
     "type": "json_flag",
     "context": [ "GENERIC", "TOOL" ],

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -508,7 +508,7 @@
       "explosion_data": { "chance_hot": 2, "chance_cold": 2, "factor": 0.5, "fiery": true, "size_factor": 0.1 }
     },
     "effects": [ "INCENDIARY" ],
-    "flags": [ "NO_DROP", "IRREMOVABLE" ]
+    "flags": [ "DESTROY_ON_DROP", "IRREMOVABLE" ]
   },
   {
     "type": "AMMO",

--- a/data/json/items/ammo/spray_paint.json
+++ b/data/json/items/ammo/spray_paint.json
@@ -15,6 +15,6 @@
     "stack_size": 100,
     "ammo_type": "spray_paint",
     "phase": "liquid",
-    "flags": [ "NO_DROP", "IRREMOVABLE" ]
+    "flags": [ "DESTROY_ON_DROP", "IRREMOVABLE" ]
   }
 ]

--- a/data/json/items/ammo/weldgas.json
+++ b/data/json/items/ammo/weldgas.json
@@ -18,6 +18,6 @@
     "effects": [ "COOKOFF" ],
     "explode_in_fire": true,
     "explosion": { "power": 20, "shrapnel": 0 },
-    "flags": [ "NO_DROP", "IRREMOVABLE" ]
+    "flags": [ "DESTROY_ON_DROP", "IRREMOVABLE" ]
   }
 ]

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1458,7 +1458,7 @@
     "phase": "liquid",
     "explode_in_fire": true,
     "explosion": { "power": 20, "shrapnel": 0 },
-    "flags": [ "NO_DROP", "IRREMOVABLE" ]
+    "flags": [ "DESTROY_ON_DROP", "IRREMOVABLE" ]
   },
   {
     "type": "COMESTIBLE",

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -691,6 +691,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `DANGEROUS` ... NPCs will not accept this item. Explosion iuse actor implies this flag. Implies
   "NPC_THROW_NOW".
 - `DESTROY_ON_DECHARGE` ... This item should be destroyed if loses charges.
+- `DESTROY_ON_DROP` ... When dropped on the ground, it will be destroyed.
 - `DURABLE_MELEE` ... Item is made to hit stuff and it does it well, so it's considered to be a lot
   tougher than other weapons made of the same materials.
 - `FAKE_MILL` ... Item is a fake item, to denote a partially milled product by @ref

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -81,6 +81,7 @@ const flag_id flag_DANGEROUS( "DANGEROUS" );
 const flag_id flag_DARK_IMMUNE( "DARK_IMMUNE" );
 const flag_id flag_DEAF( "DEAF" );
 const flag_id flag_DESTROY_ON_DECHARGE( "DESTROY_ON_DECHARGE" );
+const flag_id flag_DESTROY_ON_DROP( "DESTROY_ON_DROP" );
 const flag_id flag_DIAMOND( "DIAMOND" );
 const flag_id flag_DIG_TOOL( "DIG_TOOL" );
 const flag_id flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -81,6 +81,7 @@ extern const flag_id flag_DANGEROUS;
 extern const flag_id flag_DARK_IMMUNE;
 extern const flag_id flag_DEAF;
 extern const flag_id flag_DESTROY_ON_DECHARGE;
+extern const flag_id flag_DESTROY_ON_DROP;
 extern const flag_id flag_DIAMOND;
 extern const flag_id flag_DIG_TOOL;
 extern const flag_id flag_DIMENSIONAL_ANCHOR;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11639,6 +11639,11 @@ bool item::on_drop( const tripoint_bub_ms &pos, map &m )
         }
     }
 
+    // Prevent items with DESTROY_ON_DROP from being dropped
+    if( has_flag( flag_DESTROY_ON_DROP ) ) {
+        return true;
+    }
+
     // dropping liquids, even currently frozen ones, on the ground makes them
     // dirty
     if( made_of( LIQUID ) && !m.has_flag( flag_LIQUIDCONT, pos ) &&

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11639,8 +11639,9 @@ bool item::on_drop( const tripoint_bub_ms &pos, map &m )
         }
     }
 
-    // Prevent items with DESTROY_ON_DROP from being dropped
-    if( has_flag( flag_DESTROY_ON_DROP ) ) {
+    // Prevent items with DESTROY_ON_DROP from being dropped onto the ground
+    if( has_flag( flag_DESTROY_ON_DROP ) && ( !made_of( LIQUID ) ||
+            !m.has_flag( flag_LIQUIDCONT, pos ) ) ) {
         return true;
     }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Hydrogen gas uses `NO_DROP` this has a few problems
https://github.com/cataclysmbn/Cataclysm-BN/commit/5dab0768875 made it so `NO_DROP` items cannot have any mass
`NO_DROP` means it cannot be placed into tanks during mapgen
`NO_DROP` means it cannot be poured onto the ground into tanks

## Describe the solution (The How)
Add `DESTROY_ON_DROP` which as it says, will destroy it upon being dropped onto the ground

## Describe alternatives you've considered
If this doesn't go through
I'll just do it in lua for the crit PR
Shrug

## Testing
Spawned hydrogen, disappears when unloading
Hydrogen can now spawn in tanks on mapgen

## Additional Context
One flaw: mapgen will not block this item from spawning on the ground at this point

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
<!-- BEGIN docs comment -->

## Translations

| post                             | changed | stale  | missing |
| -------------------------------- | ------- | ------ | ------- |
| mod/json/reference/json_flags.md | en      | ja, ko |         |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ec8d44f](https://github.com/cataclysmbn/Cataclysm-BN/commit/ec8d44f09a9fa35ce0f8040b9a6ab6eec2bda62d) (Add to other craftable ammos) on 2026-07-25 03:49:01

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30140768409/artifacts/8614980244)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30140768409/artifacts/8614866622)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30140768409/artifacts/8614553633)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30140768409/artifacts/8614574195)
<!-- END artifact comment -->