### PR TITLE
fix(mods/Arcana): update name and description for Flame Ward's pattern scroll

### DIFF
--- a/data/mods/Arcana_BN/items/spellbooks.json
+++ b/data/mods/Arcana_BN/items/spellbooks.json
@@ -174,8 +174,8 @@
     "copy-from": "scroll_pattern_base",
     "type": "GENERIC",
     "category": "spellbooks",
-    "name": { "str": "Pattern Scroll (Heat Ward)", "str_pl": "Pattern Scrolls (Heat Ward)" },
-    "description": "This is a scroll with ornate patterns written on the paper, depicting strange geometric designs with an unnatural order to them.  Activate it to explore its secrets.  (( Remember to bind the \"spellcasting\" key! ))\n\"This spell will grant temporary resistance to heat and smoke, but not direct contact with fire.\"",
+    "name": { "str": "Pattern Scroll (Flame Ward)", "str_pl": "Pattern Scrolls (Flame Ward)" },
+    "description": "This is a scroll with ornate patterns written on the paper, depicting strange geometric designs with an unnatural order to them.  Activate it to explore its secrets.  (( Remember to bind the \"spellcasting\" key! ))\n\"This spell will grant temporary immunity to fire, as well as negating the effects of heat and smoke.\"",
     "price": "3000 USD",
     "price_postapoc": "100 USD",
     "use_action": { "type": "learn_spell", "spells": [ "arcana_magic_heat_ward" ] }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

I changed Heat Ward to Flame Ward a while back since it used to not provide actual immunity to fire-type damage, but forgot one relevant name and description.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Fixed that, duh.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

UNGA BUNGA WORDS CAN READ

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1cb786a](https://github.com/cataclysmbn/Cataclysm-BN/commit/1cb786a87b099358416d4796f0aeb8f97833a108) (fix(mods/Arcana): update name and description for Flame Ward's pattern scroll) on 2026-07-25 22:26:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30174700682/artifacts/8624429661)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30174700682/artifacts/8624625211)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30174700682/artifacts/8624001993)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30174700682/artifacts/8624011469)
<!-- END artifact comment -->