### PR TITLE
fix: items will always fall back into default containers

### DIFF
--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -413,7 +413,7 @@ std::vector<detached_ptr<item>> Single_item_creator::every_item_modified( bool m
             detached_ptr<item> itm = item::spawn( itype_id( id ) );
             if( modifier && modify && itm ) {
                 items.push_back( modifier->modify( std::move( itm ) ) );
-            } else if( itm ) {
+            } else if( modify && itm ) {
                 items.push_back( item::in_its_container( std::move( itm ) ) );
             }
             return items;
@@ -436,7 +436,7 @@ std::vector<detached_ptr<item>> Single_item_creator::every_item_modified( bool m
             for( auto &itm : item_group_items ) {
                 if( modifier && modify ) {
                     items.push_back( modifier->modify( std::move( itm ) ) );
-                } else {
+                } else if( modify ) {
                     items.push_back( item::in_its_container( std::move( itm ) ) );
                 }
             }

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -124,6 +124,10 @@ std::vector<detached_ptr<item>> Single_item_creator::create( const time_point &b
                 for( auto &elem : tmplist ) {
                     elem = modifier->modify( std::move( elem ) );
                 }
+            } else {
+                for( auto &itm : tmplist ) {
+                    itm = item::in_its_container( std::move( itm ) );
+                }
             }
             result.insert( result.end(), std::make_move_iterator( tmplist.begin() ),
                            std::make_move_iterator( tmplist.end() ) );
@@ -410,7 +414,7 @@ std::vector<detached_ptr<item>> Single_item_creator::every_item_modified( bool m
             if( modifier && modify && itm ) {
                 items.push_back( modifier->modify( std::move( itm ) ) );
             } else if( itm ) {
-                items.push_back( std::move( itm ) );
+                items.push_back( item::in_its_container( std::move( itm ) ) );
             }
             return items;
         }
@@ -433,7 +437,7 @@ std::vector<detached_ptr<item>> Single_item_creator::every_item_modified( bool m
                 if( modifier && modify ) {
                     items.push_back( modifier->modify( std::move( itm ) ) );
                 } else {
-                    items.push_back( std::move( itm ) );
+                    items.push_back( item::in_its_container( std::move( itm ) ) );
                 }
             }
             return items;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2389,7 +2389,8 @@ class jmapgen_spawn_item : public jmapgen_piece
 
             const point_omt_ms p = { x.get(), y.get() };
 
-            detached_ptr<item> itm = item::spawn( chosen_id, calendar::start_of_cataclysm );
+            detached_ptr<item> itm = item::in_its_container( item::spawn( chosen_id,
+                                     calendar::start_of_cataclysm ) );
 
             const int spawns = dat.m.edit_item_for_spawn_rate( *itm );
             const int total_spawns = spawn_count * spawns;


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #9953
Not quite sure how this ever worked

## Describe the solution (The How)
When no modifier, use default container in all methods of spawning items
I'm guessing one of them changed the used method and thus hit this issue

## Describe alternatives you've considered
None

## Testing
<img width="1920" height="1080" alt="Jul26::061154" src="https://github.com/user-attachments/assets/9620ef0e-b372-41ef-81a7-888dc97d07e9" />
<img width="1920" height="1080" alt="Jul26::075314" src="https://github.com/user-attachments/assets/e2744313-7fbb-437f-b4bb-aed22cb96989" />
I was told to look for syrums I found some

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f2f2522](https://github.com/cataclysmbn/Cataclysm-BN/commit/f2f2522a0ce4bbae8217deeb0092ed1949f2e6fb) (fix: apply to single spawned items ( non-itemgroup ) too) on 2026-07-26 17:25:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30207053459/artifacts/8634558763)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30207053459/artifacts/8634854799)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30207053459/artifacts/8634598533)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30207053459/artifacts/8634617244)
<!-- END artifact comment -->