### PR TITLE
fix: add `force` support for spawning monsters in mapgen

### DIFF
--- a/data/json/mapgen/lab/lab_floorplans_1side.json
+++ b/data/json/mapgen/lab/lab_floorplans_1side.json
@@ -487,7 +487,7 @@
         "d": { "items": [ { "item": "office", "chance": 50 } ] }
       },
       "monsters": { ",": { "monster": "GROUP_LAB", "chance": 1, "density": 0.0005 } },
-      "place_monster": [ { "monster": [ "mon_zombie_scientist_admin" ], "x": [ 11, 12 ], "y": [ 18, 20 ], "chance": 100 } ],
+      "place_monster": [ { "monster": [ "mon_zombie_scientist_admin" ], "x": [ 11, 12 ], "y": [ 18, 20 ], "force": true } ],
       "place_nested": [
         { "chunks": [ "lab_spawn_9x9_crossdoors" ], "x": 1, "y": 1 },
         { "chunks": [ "lab_spawn_9x9_crossdoors" ], "x": 14, "y": 1 },

--- a/data/json/mapgen/lab/lab_floorplans_finale1level.json
+++ b/data/json/mapgen/lab/lab_floorplans_finale1level.json
@@ -141,7 +141,7 @@
       "terrain": { ",": "t_grass" },
       "place_nested": [ { "chunks": [ "lab_finale_loot" ], "x": 4, "y": 11 } ],
       "place_loot": [ { "item": "id_science", "x": 19, "y": [ 11, 13 ] } ],
-      "place_monster": [ { "monster": "mon_triffid_radiant_boss", "x": 12, "y": 12, "chance": 100 } ],
+      "place_monster": [ { "monster": "mon_triffid_radiant_boss", "x": 12, "y": 12, "force": true } ],
       "computers": { "6": { "name": "High Risk Subject Containment", "options": [ { "name": "UNLOCK ENTRANCE", "action": "unlock" } ] } }
     }
   },
@@ -285,7 +285,7 @@
         "........................"
       ],
       "palettes": [ "lab_palette" ],
-      "monster": { "?": { "monster": "mon_shade_boss" } },
+      "monster": { "?": { "monster": "mon_shade_boss", "force": true } },
       "terrain": { "o": "t_radio_tower" },
       "mapping": { "r": { "items": [ { "item": "portal_room_gear", "chance": 100 } ] } },
       "computers": {

--- a/docs/en/mod/json/reference/map/mapgen.md
+++ b/docs/en/mod/json/reference/map/mapgen.md
@@ -520,6 +520,7 @@ Value: `[ array of {objects} ]: [ { "monster": ... } ]`
 | friendly    | Set true to make the monster friendly. Default false.                                                                                                                                                             |
 | name        | Extra name to display on the monster.                                                                                                                                                                             |
 | target      | Set to true to make this into mission target. Only works when the monster is spawned from a mission.                                                                                                              |
+| force       | Set to true to always spawn one copy of this monster, ignoring spawn density                                                                                                                                      |
 
 Note that high spawn density game setting can cause extra monsters to spawn when `monster` is used.
 When `group` is used only one monster will spawn.

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2202,6 +2202,7 @@ class jmapgen_monster : public jmapgen_piece
         std::string name;
         bool target;
         bool use_pack_size;
+        bool force;
         jmapgen_monster( const JsonObject &jsi ) :
             chance( jsi, "chance", 100, 100 )
             , pack_size( jsi, "pack_size", 1, 1 )
@@ -2210,7 +2211,8 @@ class jmapgen_monster : public jmapgen_piece
             , friendly( jsi.get_bool( "friendly", false ) )
             , name( jsi.get_string( "name", "NONE" ) )
             , target( jsi.get_bool( "target", false ) )
-            , use_pack_size( jsi.get_bool( "use_pack_size", false ) ) {
+            , use_pack_size( jsi.get_bool( "use_pack_size", false ) )
+            , force( jsi.get_bool( "force", false ) ) {
             if( jsi.has_member( "group" ) ) {
                 jsi.read( "group", m_id );
             } else if( jsi.has_array( "monster" ) ) {
@@ -2232,35 +2234,38 @@ class jmapgen_monster : public jmapgen_piece
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y
                   ) const override {
 
-            int raw_odds = chance.get();
+            int spawn_count = 1;
+            if( !force ) {
+                int raw_odds = chance.get();
 
-            // Handle spawn density: Increase odds, but don't let the odds of absence go below half the odds at density 1.
-            // Instead, apply a multipler to the number of monsters for really high densities.
-            // For example, a 50% chance at spawn density 4 becomes a 75% chance of ~2.7 monsters.
-            int odds_after_density = raw_odds * get_option<float>( "SPAWN_DENSITY" );
-            int max_odds = ( 100 + raw_odds ) / 2;
-            float density_multiplier = 1;
-            if( odds_after_density > max_odds ) {
-                density_multiplier = 1.0f * odds_after_density / max_odds;
-                odds_after_density = max_odds;
+                // Handle spawn density: Increase odds, but don't let the odds of absence go below half the odds at density 1.
+                // Instead, apply a multipler to the number of monsters for really high densities.
+                // For example, a 50% chance at spawn density 4 becomes a 75% chance of ~2.7 monsters.
+                int odds_after_density = raw_odds * get_option<float>( "SPAWN_DENSITY" );
+                int max_odds = ( 100 + raw_odds ) / 2;
+                float density_multiplier = 1;
+                if( odds_after_density > max_odds ) {
+                    density_multiplier = 1.0f * odds_after_density / max_odds;
+                    odds_after_density = max_odds;
+                }
+
+                int spawn_count = roll_remainder( density_multiplier );
+
+                if( one_or_none ) { // don't let high spawn density alone cause more than 1 to spawn.
+                    spawn_count = std::min( spawn_count, 1 );
+                }
+                if( raw_odds == 100 ) { // don't spawn less than 1 if odds were 100%, even with low spawn density.
+                    spawn_count = std::max( spawn_count, 1 );
+                } else {
+                    if( !x_in_y( odds_after_density, 100 ) ) {
+                        return;
+                    }
+                }
             }
 
             int mission_id = -1;
             if( dat.mission() && target ) {
                 mission_id = dat.mission()->get_id();
-            }
-
-            int spawn_count = roll_remainder( density_multiplier );
-
-            if( one_or_none ) { // don't let high spawn density alone cause more than 1 to spawn.
-                spawn_count = std::min( spawn_count, 1 );
-            }
-            if( raw_odds == 100 ) { // don't spawn less than 1 if odds were 100%, even with low spawn density.
-                spawn_count = std::max( spawn_count, 1 );
-            } else {
-                if( !x_in_y( odds_after_density, 100 ) ) {
-                    return;
-                }
             }
 
             mongroup_id chosen_group = m_id.get( dat );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
thought it closes but it doesn't: #9954
It's been around since day 1, appears to be monster spawn density messing up the 100% chance

## Describe the solution (The How)
Add `force` which forces one copy of the monster to spawn

## Describe alternatives you've considered
Make 100% always spawn something

## Testing
Went through 5 triffid things, they all spawned

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.<!-- BEGIN docs comment -->

## Translations

| post                             | changed | stale | missing |
| -------------------------------- | ------- | ----- | ------- |
| mod/json/reference/map/mapgen.md | en      | ko    | ja      |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [525d7b3](https://github.com/cataclysmbn/Cataclysm-BN/commit/525d7b36c57dec9dda16a7b10eaa4ef8f6cee50a) (add docs) on 2026-07-26 14:47:17

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30206582931)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30206582931)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30206582931)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30206582931)
<!-- END artifact comment -->