### PR TITLE
fix: dont resume woodcutting activities when item location is lost

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4162,14 +4162,12 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
     // Quality of tool used and assistants can together both reduce intensity of work.
     if( act->get_tools().empty() ) {
         debugmsg( "woodcutting item location not set" );
-        resume_for_multi_activities( *p );
         return;
     }
 
     safe_reference<item> &loc = act->get_tools_mut()[ 0 ];
     if( !loc ) {
         debugmsg( "woodcutting item location lost" );
-        resume_for_multi_activities( *p );
         return;
     }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #9957

## Describe the solution (The How)
Instead of crashing because it expects the axe to still be valid when it resumes the activity
The NPC stops chopping trees

## Describe alternatives you've considered
Just wait until the beeg overhaul to help with out of bubble stuff
And let their save no longer work?

## Testing
Did the steps multiple times, NPC would not crash

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e56c889](https://github.com/cataclysmbn/Cataclysm-BN/commit/e56c88954580fb2d1ba38947bbb32dfa63e40066) (fix: dont resume woodcutting activities when item location is lost) on 2026-07-26 16:52:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30208555730/artifacts/8634277994)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30208555730/artifacts/8634546176)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30208555730/artifacts/8634298422)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30208555730/artifacts/8634319044)
<!-- END artifact comment -->