### PR TITLE
feat(UI): crafting menu scrolling

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -74,12 +74,12 @@ std::map<std::string, std::vector<std::string> > craft_subcat_list;
 std::map<std::string, std::string> normalized_names;
 
 static bool query_is_yes( const std::string &query );
-static void draw_hidden_amount( const catacurses::window &w, int amount, int num_recipe );
+static int draw_hidden_amount( const catacurses::window &w, int amount, int num_recipe );
 static void draw_can_craft_indicator( const catacurses::window &w, const recipe &rec,
                                       const Character &crafter );
 static void draw_recipe_tabs( const catacurses::window &w, const std::string &tab,
                               TAB_MODE mode, const bool filtered_unread,
-                              std::map<std::string, bool> &unread );
+                              std::map<std::string, bool> &unread, int width_for_tabs );
 static void draw_recipe_subtabs( const catacurses::window &w, const std::string &tab,
                                  const std::string &subtab,
                                  const recipe_subset &available_recipes, TAB_MODE mode,
@@ -919,8 +919,16 @@ const recipe *select_crafting_recipe( int &batch_size_out, Character &crafter )
 
     int recipe_scroll_window_min = 0;
     ui.on_redraw( [&]( ui_adaptor & ui ) {
+        int lost_width = 0;
+        // Need to do this to get the width
+        // But draw tabs removes the text
+        if( !show_hidden ) {
+            lost_width = 5  + draw_hidden_amount( w_head, num_hidden, num_recipe );
+        }
+
         const TAB_MODE m = ( batch ) ? BATCH : ( filterstring.empty() ) ? NORMAL : FILTERED;
-        draw_recipe_tabs( w_head, tab.cur(), m, is_filtered_unread, is_cat_unread );
+        draw_recipe_tabs( w_head, tab.cur(), m, is_filtered_unread, is_cat_unread,
+                          getmaxx( w_head ) - lost_width );
         const auto &shown_recipes = show_unavailable ? all_recipes : available_recipes;
         draw_recipe_subtabs( w_subhead, tab.cur(), subtab.cur(), shown_recipes, m,
                              is_subcat_unread[tab.cur()] );
@@ -1986,18 +1994,20 @@ static bool query_is_yes( const std::string &query )
            query == pgettext( "memorized recipe search term", "yes" );
 }
 
-static void draw_hidden_amount( const catacurses::window &w, int amount, int num_recipe )
+static int draw_hidden_amount( const catacurses::window &w, int amount, int num_recipe )
 {
+    std::string str = "";
     if( amount == 1 ) {
-        right_print( w, 1, 1, c_red, string_format( _( "* %s hidden recipe - %s in category *" ), amount,
-                     num_recipe ) );
+        str = string_format( _( "* %s hidden recipe - %s in category *" ), amount, num_recipe );
+        right_print( w, 1, 1, c_red,  str );
     } else if( amount >= 2 ) {
-        right_print( w, 1, 1, c_red, string_format( _( "* %s hidden recipes - %s in category *" ), amount,
-                     num_recipe ) );
+        str = string_format( _( "* %s hidden recipes - %s in category *" ), amount, num_recipe );
+        right_print( w, 1, 1, c_red,  str );
     } else if( amount == 0 ) {
-        right_print( w, 1, 1, c_green, string_format( _( "* No hidden recipe - %s in category *" ),
-                     num_recipe ) );
+        str = string_format( _( "* No hidden recipe - %s in category *" ), num_recipe );
+        right_print( w, 1, 1, c_green,  str );
     }
+    return utf8_width( str );
 }
 
 // Anchors top-right
@@ -2019,20 +2029,30 @@ static void draw_can_craft_indicator( const catacurses::window &w, const recipe 
 }
 
 static void draw_recipe_tabs( const catacurses::window &w, const std::string &tab, TAB_MODE mode,
-                              const bool filtered_unread, std::map<std::string, bool> &unread )
+                              const bool filtered_unread, std::map<std::string, bool> &unread, int width_for_tabs )
 {
     werase( w );
 
     switch( mode ) {
         case NORMAL: {
-            draw_tabs( w, normalized_names, craft_cat_list, tab );
-            int pos_x = 2;
-            for( const std::string &cat : craft_cat_list ) {
-                pos_x += utf8_width( normalized_names[cat] ) + 3;
-                if( unread[cat] ) {
-                    mvwprintz( w, point( pos_x - 2, 1 ), c_light_green, "⁺" );
+            std::string real_tab;
+            std::vector<std::string> tabs;
+
+            for( const auto tab_val : craft_cat_list ) {
+                if( unread[tab_val] ) {
+                    tabs.push_back( normalized_names[tab_val] + " ⁺" );
+                    if( tab_val == tab ) {
+                        real_tab = normalized_names[tab_val] + " ⁺";
+                    }
+                } else {
+                    tabs.push_back( normalized_names[tab_val] );
+                    if( tab_val == tab ) {
+                        real_tab = normalized_names[tab_val];
+                    }
                 }
             }
+
+            draw_tabs( w, tabs, real_tab, width_for_tabs );
             break;
         }
         case FILTERED: {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1290,9 +1290,36 @@ void draw_subtab( const catacurses::window &w, int iOffsetX, const std::string &
 }
 
 void draw_tabs( const catacurses::window &w, const std::vector<std::string> &tab_texts,
-                size_t current_tab )
+                size_t current_tab, int max_tab_width )
 {
+    const int tab_step = 3;
+    if( max_tab_width == -1 ) {
+        max_tab_width = getmaxx( w );
+    }
+    int total_used_width = 0;
+    int current = 0;
+    for( size_t i = 0; i < tab_texts.size(); ++i ) {
+        const std::string &tab_text = tab_texts[i];
+        total_used_width += utf8_width( tab_text ) + tab_step;
+        if( i == current_tab ) {
+            current = total_used_width;
+        }
+    }
+    int start = 0;
+    calcStartPos( start, current, max_tab_width, total_used_width );
     int width = getmaxx( w );
+    current = 0;
+    int start_i = 0;
+    if( start != 0 ) {
+        for( size_t i = 0; i < tab_texts.size(); ++i ) {
+            const std::string &tab_text = tab_texts[i];
+            current += utf8_width( tab_text ) + tab_step;
+            if( current >= start ) {
+                start_i = i + 1;
+                break;
+            }
+        }
+    }
     for( int i = 0; i < width; i++ ) {
         mvwputch( w, point( i, 2 ), BORDER_COLOR, LINE_OXOX ); // -
     }
@@ -1300,21 +1327,23 @@ void draw_tabs( const catacurses::window &w, const std::vector<std::string> &tab
     mvwputch( w, point( 0, 2 ), BORDER_COLOR, LINE_OXXO ); // |^
     mvwputch( w, point( width - 1, 2 ), BORDER_COLOR, LINE_OOXX ); // ^|
 
-    const int tab_step = 3;
     int x = 2;
-    for( size_t i = 0; i < tab_texts.size(); ++i ) {
+    for( size_t i = start_i; i < tab_texts.size(); ++i ) {
         const std::string &tab_text = tab_texts[i];
-        draw_tab( w, x, tab_text, i == current_tab );
-        x += utf8_width( tab_text ) + tab_step;
+        int newx = x + utf8_width( tab_text ) + tab_step;
+        if( newx <= max_tab_width ) {
+            draw_tab( w, x, tab_text, i == current_tab );
+        }
+        x = newx;
     }
 }
 
 void draw_tabs( const catacurses::window &w, const std::vector<std::string> &tab_texts,
-                const std::string &current_tab )
+                const std::string &current_tab, int width )
 {
     auto it = std::ranges::find( tab_texts, current_tab );
     assert( it != tab_texts.end() );
-    draw_tabs( w, tab_texts, it - tab_texts.begin() );
+    draw_tabs( w, tab_texts, it - tab_texts.begin(), width );
 }
 
 /**

--- a/src/output.h
+++ b/src/output.h
@@ -760,10 +760,10 @@ void draw_subtab( const catacurses::window &w, int iOffsetX, const std::string &
 //   │ TAB1 │ │ TAB2 │
 // ┌─┴──────┴─┘      └───────────┐
 void draw_tabs( const catacurses::window &, const std::vector<std::string> &tab_texts,
-                size_t current_tab );
+                size_t current_tab, int max_tab_width = -1 );
 // As above, but specify current tab by its label rather than position
 void draw_tabs( const catacurses::window &, const std::vector<std::string> &tab_texts,
-                const std::string &current_tab );
+                const std::string &current_tab, int max_tab_width = -1 );
 
 // This overload of draw_tabs is intended for use when you track the current
 // tab via some other value (like an enum) linked to each tab.  Expected use
@@ -777,7 +777,7 @@ void draw_tabs( const catacurses::window &, const std::vector<std::string> &tab_
 // draw_tabs( w, tabs, current_tab );
 template<typename TabList, typename CurrentTab>
 void draw_tabs( const catacurses::window &w, const TabList &tab_list,
-                const CurrentTab &current_tab )
+                const CurrentTab &current_tab, int max_tab_width = -1 )
 requires std::is_same_v<CurrentTab,
 std::remove_const_t<typename TabList::value_type::first_type>> {
     std::vector<std::string> tab_text;
@@ -792,14 +792,14 @@ std::remove_const_t<typename TabList::value_type::first_type>> {
         return pair.first == current_tab;
     } );
     assert( current_tab_it != tab_list.end() );
-    draw_tabs( w, tab_text, std::distance( tab_list.begin(), current_tab_it ) );
+    draw_tabs( w, tab_text, std::distance( tab_list.begin(), current_tab_it ), max_tab_width );
 }
 
 // Similar to the above, but where the order of tabs is specified separately
 // TabList is expected to be a map type.
 template<typename TabList, typename TabKeys, typename CurrentTab>
 void draw_tabs( const catacurses::window &w, const TabList &tab_list, const TabKeys &keys,
-                const CurrentTab &current_tab )
+                const CurrentTab &current_tab, int max_tab_width = -1 )
 requires std::is_same_v<CurrentTab,
 std::remove_const_t<typename TabList::value_type::first_type>> {
     std::vector<typename TabList::value_type> ordered_tab_list;
@@ -809,7 +809,7 @@ std::remove_const_t<typename TabList::value_type::first_type>> {
         assert( it != tab_list.end() );
         ordered_tab_list.push_back( *it );
     }
-    draw_tabs( w, ordered_tab_list, current_tab );
+    draw_tabs( w, ordered_tab_list, current_tab, max_tab_width );
 }
 
 // Legacy function, use class scrollbar instead!


### PR DESCRIPTION
## Purpose of change (The Why)
If you load all in repo mods it gets very close to a full crafting menu with that side text
Thus we must make it scroll

## Describe the solution (The How)
Draw tabs now scrolls

## Describe alternatives you've considered
None

## Testing
Load all in repo mods, it scrolls right
Character creation ( which uses the same function ) acts as normal

## Additional Context
After fighting with it for too long the green `+` is now just part of the tab text
It should still be visible enough, but due to lack of color support the color is gone

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [baf6b86](https://github.com/cataclysmbn/Cataclysm-BN/commit/baf6b86d22829e8c906b9d42828c4b1fa2c3027a) (feat: permit crafting menu scrolling) on 2026-07-27 00:12:54

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30224787369/artifacts/8638575155)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30224787369/artifacts/8638796604)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30224787369/artifacts/8638673467)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30224787369/artifacts/8638529418)
<!-- END artifact comment -->