### PR TITLE
feat: ballistic and cut damage causes bleed, make monsters actually able to bleed

### DIFF
--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -79,6 +79,7 @@ static const trait_id trait_DEBUG_STORAGE( "DEBUG_STORAGE" );
 
 static const trait_flag_str_id trait_flag_MUTATION_FLIGHT( "MUTATION_FLIGHT" );
 
+static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_bloodworms( "bloodworms" );
 static const efftype_id effect_brainworms( "brainworms" );
 static const efftype_id effect_darkness( "darkness" );
@@ -103,6 +104,7 @@ static const efftype_id effect_stim( "stim" );
 static const efftype_id effect_tapeworm( "tapeworm" );
 static const efftype_id effect_thirsty( "thirsty" );
 
+static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_swimming( "swimming" );
 static const skill_id skill_traps( "traps" );
 
@@ -1178,6 +1180,29 @@ void do_pause( Character &who )
             who.add_msg_player_or_npc( m_warning,
                                        _( "You attempt to put out the fire on you!" ),
                                        _( "<npcname> attempts to put out the fire on them!" ) );
+        }
+    } else if( who.has_effect( effect_bleed ) ) {
+        // Try to staunch bleeding if we're not busy being set on fire.
+        // Todo: possibly convert it to only affect one bodypart at a time in exchange for more effectiveness?
+        time_duration total_removed = 0_turns;
+        time_duration total_left = 0_turns;
+        for( const body_part bp : all_body_parts ) {
+            effect &eff = who.get_effect( effect_bleed, convert_bp( bp ) );
+            if( eff.is_null() ) {
+                continue;
+            }
+
+            total_left += eff.get_duration();
+            const time_duration dur_removed = 5_turns + 10_turns * who.get_skill_level( skill_firstaid );
+            eff.mod_duration( -dur_removed );
+            total_removed += dur_removed;
+        }
+
+        if( total_removed > 0_turns ) {
+            who.add_msg_player_or_npc( m_warning,
+                                       _( "You put pressure on your bleeding wounds." ),
+                                       _( "<npcname> puts pressure on their bleeding wounds." ) );
+            who.practice( skill_firstaid, 1, 2 );
         }
     }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1343,16 +1343,20 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
         case DT_BULLET:
             // Volatile enemies sometimes go up
             set_volatiles_on_fire( 16 );
-            // Cause bleed if high damage goes through armor
+            // Cause bleed if high damage goes through armor and enemy is made of flesh
             if( adjusted_damage > 15 ) {
-                add_effect( effect_bleed, 1_minutes * rng( 1, adjusted_damage ), bp.id() );
+                if( made_of_any( cmat_flesh ) ) {
+                    add_effect( effect_bleed, 1_minutes * rng( 1, adjusted_damage ), bp.id() );
+                }
             }
             break;
 
         case DT_CUT:
-            // Cause bleed if some damage goes through armor
+            // Cause bleed if some damage goes through armor and enemy is made of flesh
             if( adjusted_damage > 6 ) {
-                add_effect( effect_bleed, 1_minutes * rng( 1, adjusted_damage ), bp.id() );
+                if( made_of_any( cmat_flesh ) ) {
+                    add_effect( effect_bleed, 1_minutes * rng( 1, adjusted_damage ), bp.id() );
+                }
             }
             break;
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -138,6 +138,7 @@ static const ammo_effect_str_id ammo_effect_TANGLE( "TANGLE" );
 static const ammo_effect_str_id ammo_effect_THROWN( "THROWN" );
 
 static const efftype_id effect_badpoison( "badpoison" );
+static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bounced( "bounced" );
 static const efftype_id effect_downed( "downed" );
@@ -1342,6 +1343,17 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
         case DT_BULLET:
             // Volatile enemies sometimes go up
             set_volatiles_on_fire( 16 );
+            // Cause bleed if high damage goes through armor
+            if( adjusted_damage > 15 ) {
+                add_effect( effect_bleed, 1_minutes * rng( 1, adjusted_damage ), bp.id() );
+            }
+            break;
+
+        case DT_CUT:
+            // Cause bleed if some damage goes through armor
+            if( adjusted_damage > 6 ) {
+                add_effect( effect_bleed, 1_minutes * rng( 1, adjusted_damage ), bp.id() );
+            }
             break;
 
         case DT_ACID:

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1352,8 +1352,8 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
             break;
 
         case DT_CUT:
-            // Cause bleed if some damage goes through armor and enemy is made of flesh
-            if( adjusted_damage > 6 ) {
+            // Cause bleed if high damage goes through armor and enemy is made of flesh
+            if( adjusted_damage > 15 ) {
                 if( made_of_any( cmat_flesh ) ) {
                     add_effect( effect_bleed, 1_minutes * rng( 1, adjusted_damage ), bp.id() );
                 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1345,7 +1345,7 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
             set_volatiles_on_fire( 16 );
             // Cause bleed if high damage goes through armor and enemy is made of flesh
             if( adjusted_damage > 15 ) {
-                if( made_of_any( cmat_flesh ) ) {
+                if( !is_immune_effect( effect_bleed ) ) {
                     add_effect( effect_bleed, 1_minutes * rng( 1, adjusted_damage ), bp.id() );
                 }
             }
@@ -1354,7 +1354,7 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
         case DT_CUT:
             // Cause bleed if high damage goes through armor and enemy is made of flesh
             if( adjusted_damage > 15 ) {
-                if( made_of_any( cmat_flesh ) ) {
+                if( !is_immune_effect( effect_bleed ) ) {
                     add_effect( effect_bleed, 1_minutes * rng( 1, adjusted_damage ), bp.id() );
                 }
             }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1352,6 +1352,7 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
             break;
 
         case DT_CUT:
+        case DT_STAB:
             // Cause bleed if high damage goes through armor and enemy is made of flesh
             if( adjusted_damage > 15 ) {
                 if( !is_immune_effect( effect_bleed ) ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3784,7 +3784,7 @@ void monster::process_one_effect( effect &it, bool is_new )
     } else if( id == effect_bleed ) {
         int intense = it.get_intensity();
         if( one_in( 36 / intense ) ) {
-        apply_damage( nullptr, bodypart_id( "torso" ), 1 );
+            apply_damage( nullptr, bodypart_id( "torso" ), 1 );
             bleed();
         }
     } else if( id == effect_run ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3782,20 +3782,12 @@ void monster::process_one_effect( effect &it, bool is_new )
             it.set_duration( 0_turns );
         }
     } else if( id == effect_bleed ) {
-        int dam = 0;
         int intense = it.get_intensity();
-        if( made_of( material_id( "flesh" ) ) || made_of( material_id( "iflesh" ) ) ) {
-            dam = 1;
+        if( one_in( 36 / intense ) {
+        apply_damage( nullptr, bodypart_id( "torso" ), 1 );
+            bleed();
         }
-
-        if( dam > 0 ) {
-            if( one_in( 36 / intense ) {
-            apply_damage( nullptr, bodypart_id( "torso" ), dam );
-                bleed();
-            }
-        } else {
-            it.set_duration( 0_turns );
-        }
+    }
     } else if( id == effect_run ) {
         effect_cache[FLEEING] = true;
     } else if( id == effect_no_sight || id == effect_blind ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -147,6 +147,7 @@ static const efftype_id effect_monster_armor( "monster_armor" );
 static const efftype_id effect_monster_disarmed( "monster_disarmed" );
 static const efftype_id effect_no_sight( "no_sight" );
 static const efftype_id effect_onfire( "onfire" );
+static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_pacified( "pacified" );
 static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_pet_bonding( "pet_bonding" );
@@ -3778,6 +3779,21 @@ void monster::process_one_effect( effect &it, bool is_new )
         dam -= get_armor_type( DT_HEAT, bodypart_id( "torso" ) );
         if( dam > 0 ) {
             apply_damage( nullptr, bodypart_id( "torso" ), dam );
+        } else {
+            it.set_duration( 0_turns );
+        }
+    } else if( id == effect_bleed ) {
+        int dam = 0;
+        int intense = it.get_intensity();
+        if( made_of( material_id( "flesh" ) ) || made_of( material_id( "iflesh" ) ) ) {
+            dam = 1;
+        }
+        
+        if( dam > 0 ) {
+            if( one_in( 36 / intense ) {
+                apply_damage( nullptr, bodypart_id( "torso" ), dam );
+                bleed();
+            }
         } else {
             it.set_duration( 0_turns );
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3783,11 +3783,10 @@ void monster::process_one_effect( effect &it, bool is_new )
         }
     } else if( id == effect_bleed ) {
         int intense = it.get_intensity();
-        if( one_in( 36 / intense ) {
+        if( one_in( 36 / intense ) ) {
         apply_damage( nullptr, bodypart_id( "torso" ), 1 );
             bleed();
         }
-    }
     } else if( id == effect_run ) {
         effect_cache[FLEEING] = true;
     } else if( id == effect_no_sight || id == effect_blind ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3787,10 +3787,10 @@ void monster::process_one_effect( effect &it, bool is_new )
         if( made_of( material_id( "flesh" ) ) || made_of( material_id( "iflesh" ) ) ) {
             dam = 1;
         }
-        
+
         if( dam > 0 ) {
             if( one_in( 36 / intense ) {
-                apply_damage( nullptr, bodypart_id( "torso" ), dam );
+            apply_damage( nullptr, bodypart_id( "torso" ), dam );
                 bleed();
             }
         } else {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -147,7 +147,6 @@ static const efftype_id effect_monster_armor( "monster_armor" );
 static const efftype_id effect_monster_disarmed( "monster_disarmed" );
 static const efftype_id effect_no_sight( "no_sight" );
 static const efftype_id effect_onfire( "onfire" );
-static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_pacified( "pacified" );
 static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_pet_bonding( "pet_bonding" );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Bleed is an extremely rare effect for some reason, making things like hemostatic powder completely useless, and invalidating a large part of what most people imagine to be "wound care". Also, this causes annoying situations like zombies having like 5 health left and having to waste another bullet on them. Finally, for some reason monsters as of now are unable to actually take damage or have any effects from bleeding.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds a base rate for bleed to happen on any cut damage greater than 15 (after armor), and any ballistic damage greater than 15 (after armor), if the enemy is made of flesh, with higher damage resulting in longer bleeds. Monsters are now able to bleed as well, having similar damage mechanics to the player.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
No bleeds
## Testing
Build artifacts
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
This technically means you can cause any enemy made of flesh to bleed, not sure if this could lead to some funky stuff but i guess we'll just have to see
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9cadc67](https://github.com/cataclysmbn/Cataclysm-BN/commit/9cadc67f603326dd5213a25d26cd86db9ee69544) (Allow putting pressure on bleeding wounds, also stabbing lets you bleed too) on 2026-07-27 19:36:20

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30293384866/artifacts/8663958803)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30293384866/artifacts/8665720310)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30293384866/artifacts/8664082265)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30293384866/artifacts/8664092920)
<!-- END artifact comment -->