### PR TITLE
fix: metal sawing quality can salvage aluminum, add `NO_SALVAGE` to aluminum ignots

### DIFF
--- a/data/json/items/resources/metal.json
+++ b/data/json/items/resources/metal.json
@@ -108,7 +108,8 @@
     "material": [ "aluminum" ],
     "symbol": ",",
     "color": "light_gray",
-    "qualities": [ [ "HAMMER", 1 ] ]
+    "qualities": [ [ "HAMMER", 1 ] ],
+    "flags": [ "NO_SALVAGE" ]
   },
   {
     "id": "bismuth",

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -117,7 +117,21 @@
     "id": "SAW_M",
     "name": { "str": "metal sawing" },
     "usages": [ [ 2, [ "HACKSAW", "saw_barrel" ] ] ],
-    "salvagable_materials": [ "steel", "budget_steel", "tin", "lead", "silver", "gold", "copper", "platinum", "iron", "bronze", "brass", "zinc" ]
+    "salvagable_materials": [
+      "aluminum",
+      "steel",
+      "budget_steel",
+      "tin",
+      "lead",
+      "silver",
+      "gold",
+      "copper",
+      "platinum",
+      "iron",
+      "bronze",
+      "brass",
+      "zinc"
+    ]
   },
   {
     "type": "tool_quality",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Somehow I forgot a key part of https://github.com/cataclysmbn/Cataclysm-BN/pull/6978 to actually make aluminum salvagable.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added aluminum to the salvagable materials list of metal sawing quality.
2. Misc: Also added `NO_SALVAGE` to ingots as I found you could try and fail to salavage them into themselves, dumb.

## Describe alternatives you've considered

explode

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Confirmed I can `B` and salvage aluminum frames with a hacksaw in inventory.
3. Confirmed I can no longer try to salvage ingots into nothingness.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [553daed](https://github.com/cataclysmbn/Cataclysm-BN/commit/553daedb86c9f2b1514a4d4f8f9bf3fd50c26fa1) (Also add `NO_SALVAGE` dafuq) on 2026-07-27 20:35:50

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30298233002/artifacts/8665792469)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30298233002/artifacts/8666574404)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30298233002/artifacts/8666026714)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30298233002/artifacts/8665918939)
<!-- END artifact comment -->