### PR TITLE
fix: add proper obsoletion to deleted apartment sections

### DIFF
--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -2263,5 +2263,16 @@
       "items": [ { "item": "pointy_stick", "count": 4 }, { "item": "string_6", "count": 4 }, { "item": "tarp", "count": 1 } ]
     },
     "flags": [ "TRANSPARENT", "FLAMMABLE", "THIN_OBSTACLE", "MOUNTABLE", "EASY_DECONSTRUCT", "FLAT", "BLOCK_WIND" ]
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "apartments_con_tower_001", "apartments_con_tower_101" ],
+    "object": { "fill_ter": "t_floor" }
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "apartments_con_tower_001", "apartments_con_tower_101" ],
+    "copy-from": "apartments_tower_any"
   }
 ]

--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -2265,10 +2265,46 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE", "THIN_OBSTACLE", "MOUNTABLE", "EASY_DECONSTRUCT", "FLAT", "BLOCK_WIND" ]
   },
   {
-    "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "apartments_con_tower_001", "apartments_con_tower_101" ],
-    "object": { "fill_ter": "t_floor" }
+    "object": {
+      "fill_ter": "t_floor",
+      "rows": [
+        "***|------|-|-|-|---|......|---|-|-|-|------|***",
+        "***|.dBBd.+r|u+..e3u|......|u3e..+u|r+.dBBd.|***",
+        "***w..BB..|-|-|..ii2|......|2ii..|-|-|..BB..w***",
+        "***w......|STb|..iiO|......|Oii..|bTS|......w***",
+        "***|ooH...+iib|j.uu1|^.....|uu1.j|bii+...HX.|***",
+        "***|--|-+-|-+-|..lll|......|lll..|-+-|-+-|--|***",
+        "***R,,+...tn........|......|........nt...+,,R***",
+        "***R,,w.............D......D.............w,,R***",
+        "***R,,w..A....A..|+-|p....p|-+|I..htth...w,,R***",
+        "***R,Q|...FFFI..^|.Y|......|Y.|^..htth.oo|Q,R***",
+        "***|------|-|-|--|--|......|--|--|-|-|------|***",
+        "***|.dBBd.+r|u+..e3u|......|u3e..+u|r+.dBBd.|***",
+        "***w..BB..|-|-|..ii2|.....^|2ii..|-|-|..BB..w***",
+        "***w......|STb|..iiO|......|Oii..|bTS|......w***",
+        "***|.XH...+iib|j.uu1|......|uu1.j|bii+...HX.|***",
+        "***|--|-+-|-+-|^.lll|......|lll..|-+-|-+-|--|***",
+        "***R,,+...A..nt.....|p....p|........tn...+,,R***",
+        "***R,,w.............D......D...........A.w,,R***",
+        "***R,,w.........o|+-|-WWWW-|-+|..A...h...w,,R***",
+        "***R,Q|..A.FFFI.o|.Y|zzzzzz|Y.|o...ICxC.^|Q,R***",
+        "***|RR|--ww---ww-|--|zzzzzz|--|-ww---ww--|RR|***",
+        "************************************************",
+        "************************************************",
+        "************************************************"
+      ],
+      "palettes": [ "apartment_palette" ],
+      "place_monsters": [
+        { "monster": "GROUP_ZOMBIE", "x": [ 4, 23 ], "y": [ 2, 23 ], "repeat": [ 1, 2 ] },
+        { "monster": "GROUP_ZOMBIE", "x": [ 24, 43 ], "y": [ 2, 23 ], "repeat": [ 1, 2 ] },
+        { "monster": "GROUP_ZOMBIE", "x": [ 4, 23 ], "y": [ 24, 43 ], "repeat": [ 1, 2 ] },
+        { "monster": "GROUP_ZOMBIE", "x": [ 24, 43 ], "y": [ 24, 43 ], "repeat": [ 1, 2 ] }
+      ]
+    },
+    "om_terrain": [ [ "apartments_con_tower_101", "apartments_con_tower_001" ] ],
+    "type": "mapgen",
+    "weight": 250
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fix an oversight in https://github.com/cataclysmbn/Cataclysm-BN/pull/9955

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Re-added the two apartment mapgen and overmap_terrain entries that were removed to obsoletion folder.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Created a save in an older build with the old apartments, one recently visited and one spawned outside reality bubble when saved.
2. Ported save to test, no errors and I load into a still-intact apartment.
3. Teleported to the other old apartment not yet entered into reality bubble, it uses different terrain but no errors and no big patch of empty dirt.

<img width="777" height="765" alt="image" src="https://github.com/user-attachments/assets/63fc4a44-c71f-4fa5-ae17-09a9c1678d97" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3563276](https://github.com/cataclysmbn/Cataclysm-BN/commit/35632760b80c43bf00611d37c1795755b5beb00e) (Actually do it more gooder) on 2026-07-28 00:31:45

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30314166439/artifacts/8671704865)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30314166439/artifacts/8672244915)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30314166439/artifacts/8671920414)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30314166439/artifacts/8671806701)
<!-- END artifact comment -->