### PR TITLE
fix: use correct spawn count in item spawning mapgen

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2397,7 +2397,8 @@ class jmapgen_spawn_item : public jmapgen_piece
             if( total_spawns == 0 ) {
                 return;
             }
-            for( int i = 1; i < spawns; i++ ) {
+
+            for( int i = 1; i < total_spawns; i++ ) {
                 detached_ptr<item> tmp = item::spawn( *itm );
                 if( activate_on_spawn ) {
                     tmp->activate();


### PR DESCRIPTION
## Purpose of change (The Why)
Introduced in: #9935
Accidentally used `spawns` instead of `total_spawns` in the loop

## Describe the solution (The How)
Dont make stupid typo

## Describe alternatives you've considered
Bap myself

## Testing
Mapgen works right

## Checklist
### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ca7d780](https://github.com/cataclysmbn/Cataclysm-BN/commit/ca7d780e09ab20b5c44ab62bc2ca7ada6076fe3f) (fix: use `total_spawns` and not `spawns` for determining item count in mapgen) on 2026-07-28 03:32:57

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30322286506/artifacts/8675314987)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30322286506/artifacts/8675729414)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30322286506/artifacts/8674606939)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30322286506/artifacts/8674662283)
<!-- END artifact comment -->