### PR TITLE
fix(mods/Arcana): use `removes_effects` instead of `blocks_effects` for gilded aegis healing

### DIFF
--- a/data/mods/Arcana_BN/effects.json
+++ b/data/mods/Arcana_BN/effects.json
@@ -722,7 +722,7 @@
   {
     "type": "effect_type",
     "id": "arcana_aegis_mending",
-    "blocks_effects": [ "bleed" ],
+    "removes_effects": [ "bleed" ],
     "rating": "good"
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Gilded aegis is meant to mend bleeding, somehow (probably because bleeding was stupidly rare until recently) I never noticed it doesn't.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Use the correct effect field.

## Describe alternatives you've considered

Exploding.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Ported changes to playthrough build, got shot, used aegis, healing fixes the bleeding.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f46ab20](https://github.com/cataclysmbn/Cataclysm-BN/commit/f46ab20fc9074b12331653a168030756a5f4a51d) (fix(mods/Arcana): use `removes_effects` instead of `blocks_effects` for gilded aegis healing) on 2026-07-28 05:04:51

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30326472433/artifacts/8676814592)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30326472433/artifacts/8677174018)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30326472433/artifacts/8676074847)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30326472433/artifacts/8676089927)
<!-- END artifact comment -->