### PR TITLE
feat(mods/Arcana): use NPC spell lists instead of custom dialogue to teach spells

### DIFF
--- a/data/mods/Arcana_BN/npcs/NC_FILES.json
+++ b/data/mods/Arcana_BN/npcs/NC_FILES.json
@@ -25,6 +25,11 @@
       { "skill": "melee", "level": { "rng": [ 1, 3 ] } },
       { "skill": "stabbing", "level": { "rng": [ 2, 4 ] } }
     ],
+    "spells": [
+      { "id": "arcana_magic_free_action", "level": 5 },
+      { "id": "arcana_magic_phase_shield", "level": 5 },
+      { "id": "arcana_magic_temporal_aura", "level": 5 }
+    ],
     "worn_override": "NC_HERMIT_worn",
     "carry_override": "NC_HERMIT_misc",
     "weapon_override": "NC_HERMIT_weapon",
@@ -88,6 +93,11 @@
       { "skill": "bashing", "level": { "rng": [ 1, 2 ] } },
       { "skill": "dodge", "level": { "rng": [ 3, 6 ] } },
       { "skill": "melee", "level": { "rng": [ 1, 3 ] } }
+    ],
+    "spells": [
+      { "id": "arcana_magic_heat_ward", "level": 5 },
+      { "id": "arcana_magic_poison_armor", "level": 5 },
+      { "id": "arcana_magic_ward_against_evil", "level": 5 }
     ],
     "carry_override": "NC_CF_REP_misc",
     "worn_override": "NC_CF_REP_worn",
@@ -194,6 +204,11 @@
       { "skill": "dodge", "level": { "rng": [ 3, 6 ] } },
       { "skill": "gun", "level": { "rng": [ 1, 3 ] } },
       { "skill": "pistol", "level": { "rng": [ 1, 3 ] } }
+    ],
+    "spells": [
+      { "id": "arcana_magic_capacitance", "level": 5 },
+      { "id": "arcana_magic_consecrate", "level": 5 },
+      { "id": "arcana_magic_open_lock", "level": 5 }
     ],
     "bionics": [
       { "id": "bio_batteries", "chance": 100 },
@@ -461,6 +476,11 @@
       { "skill": "mechanics", "level": { "rng": [ 1, 4 ] } },
       { "skill": "dodge", "level": { "rng": [ 2, 5 ] } },
       { "skill": "gun", "level": { "rng": [ 2, 5 ] } }
+    ],
+    "spells": [
+      { "id": "arcana_magic_agility", "level": 5 },
+      { "id": "arcana_magic_conjure_flame", "level": 5 },
+      { "id": "arcana_magic_dampening", "level": 5 }
     ],
     "worn_override": "NC_CF_AUX_MAGE_worn",
     "carry_override": "NC_CF_AUX_MAGE_misc",

--- a/data/mods/Arcana_BN/npcs/TALK_CF_AUX_MAGE.json
+++ b/data/mods/Arcana_BN/npcs/TALK_CF_AUX_MAGE.json
@@ -79,8 +79,8 @@
         "topic": "TALK_CF_AUX_MAGE_HOARD"
       },
       {
-        "text": "Can you teach me any spells?",
-        "topic": "TALK_CF_AUX_MAGE_SPELL_MENU",
+        "text": "Can you teach me anything?",
+        "topic": "TALK_TRAIN",
         "condition": { "not": { "u_has_var": "celine_all_spells_known", "type": "flag", "context": "knowledge", "value": "yes" } }
       },
       { "text": "I see.", "topic": "TALK_CF_AUX_MAGE" }
@@ -162,96 +162,6 @@
     "responses": [
       { "text": "Sure, let's see what you have.", "effect": "start_trade", "topic": "TALK_CF_AUX_MAGE" },
       { "text": "Maybe another time, thank you.", "topic": "TALK_CF_AUX_MAGE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_AUX_MAGE_SPELL_MENU",
-    "dynamic_line": "I know a few tricks I could teach you, Magic Signs as they've been called.  The arts of Agility, Conjure Flame, and Displacement.  If you have the coin, I'll put the materials and such together to help with learning the spell pattern.  Same sort of Golden Scales the others here use.",
-    "responses": [
-      {
-        "text": "What can you tell me about Agility?",
-        "condition": { "not": { "u_has_trait": "SPELL_AGILE" } },
-        "topic": "TALK_CF_AUX_MAGE_SPELL_MENU_1"
-      },
-      {
-        "text": "What can you tell me about Conjure Flame?",
-        "condition": { "not": { "u_has_trait": "SPELL_FIRE" } },
-        "topic": "TALK_CF_AUX_MAGE_SPELL_MENU_2"
-      },
-      {
-        "text": "What can you tell me about Displacement?",
-        "condition": { "not": { "u_has_trait": "SPELL_DAMPENING" } },
-        "topic": "TALK_CF_AUX_MAGE_SPELL_MENU_3"
-      },
-      {
-        "text": "I already know all of those, thanks anyway.",
-        "switch": true,
-        "condition": { "and": [ { "u_has_trait": "SPELL_AGILE" }, { "u_has_trait": "SPELL_FIRE" }, { "u_has_trait": "SPELL_DAMPENING" } ] },
-        "effect": { "u_add_var": "celine_all_spells_known", "type": "flag", "context": "knowledge", "value": "yes" },
-        "topic": "TALK_CF_AUX_MAGE"
-      },
-      { "text": "Maybe another time.", "switch": true, "default": true, "topic": "TALK_CF_AUX_MAGE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_AUX_MAGE_SPELL_MENU_1",
-    "dynamic_line": "It's a fairly simple spell that increases dexterity, and affects your speed as well.  I've gotten out of some close scrapes in the past using it on myself and occasionally traveling partners.  I'll teach it to you for 3 Golden Scales.",
-    "responses": [
-      {
-        "text": "[GS3] You have a deal, then.",
-        "condition": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } },
-        "effect": [ { "u_consume_item": "CF_golden_scale", "count": 3 }, { "u_add_trait": "SPELL_AGILE" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need more Scales for that.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } } },
-        "topic": "TALK_CF_AUX_MAGE"
-      },
-      { "text": "Not right now.", "switch": true, "default": true, "topic": "TALK_CF_AUX_MAGE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_AUX_MAGE_SPELL_MENU_2",
-    "dynamic_line": "Whatever area you target with it goes up in flames.  Its damage is best when you center it on whatever you want dead, just be careful since it can blow out windows or otherwise wreck the place.  Not to mention accidentally blowing up your ally or burning your house down wouldn't be a good idea.  I'll teach it to you for 3 Golden Scales.",
-    "responses": [
-      {
-        "text": "[GS4] You have a deal, then.",
-        "condition": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } },
-        "effect": [ { "u_consume_item": "CF_golden_scale", "count": 3 }, { "u_add_trait": "SPELL_FIRE" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need more Scales for that.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } } },
-        "topic": "TALK_CF_AUX_MAGE"
-      },
-      { "text": "Not right now.", "switch": true, "default": true, "topic": "TALK_CF_AUX_MAGE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_AUX_MAGE_SPELL_MENU_3",
-    "dynamic_line": "Pick a target, and instantly swap places with them.  Not only will they be left staggered afterward, but so will anyone standing near where you emerge.  I'll teach it to you for 3 Golden Scales.",
-    "responses": [
-      {
-        "text": "[GS3] You have a deal, then.",
-        "condition": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } },
-        "effect": [ { "u_consume_item": "CF_golden_scale", "count": 3 }, { "u_add_trait": "SPELL_DAMPENING" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need more Scales for that.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } } },
-        "topic": "TALK_CF_AUX_MAGE"
-      },
-      { "text": "Not right now.", "switch": true, "default": true, "topic": "TALK_CF_AUX_MAGE" }
     ]
   }
 ]

--- a/data/mods/Arcana_BN/npcs/TALK_CF_PURIFIER.json
+++ b/data/mods/Arcana_BN/npcs/TALK_CF_PURIFIER.json
@@ -44,17 +44,9 @@
       { "text": "What do you do here?", "topic": "TALK_CF_PURIFIER_DO" },
       { "text": "What can you tell me about this place?", "topic": "TALK_CF_PURIFIER_WHERE" },
       {
-        "text": "Can you teach me any spells?",
-        "topic": "TALK_CF_PURIFIER_SPELL_MENU",
-        "condition": {
-          "and": [
-            { "u_has_effect": "cf_mission_1" },
-            { "npc_has_trait": "FIX_CF_GM" },
-            {
-              "not": { "u_has_var": "nicholas_all_spells_known", "type": "flag", "context": "knowledge", "value": "yes" }
-            }
-          ]
-        }
+        "text": "Can you teach me anything?",
+        "topic": "TALK_TRAIN",
+        "condition": { "and": [ { "u_has_effect": "cf_mission_1" }, { "npc_has_trait": "FIX_CF_GM" } ] }
       },
       {
         "text": "Do you have anything to trade?",
@@ -179,102 +171,6 @@
       "no": "I haven't been here in a long time.  Before I became a member of the Cleansing Flame, might've been a teenager in fact.  To be honest, I recall a distinct lack of palisades back then.  But, I bet the padre was the same guy Sofia had an agreement with, letting us use this place.  Though I guess the deacon back at the center is technically in charge now."
     },
     "responses": [ { "text": "Oh, okay.", "topic": "TALK_CF_PURIFIER" } ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_PURIFIER_SPELL_MENU",
-    "dynamic_line": "With how you've helped us out, I could try to teach you a few things.  I have experience with Capacitance, Consecrate, and Opening, should you need it.  That said, I will need a few Golden Scales for the deed.  Binding a spell pattern safely takes a special touch, and the local scavengers don't part with materials easily.",
-    "responses": [
-      {
-        "text": "What can you tell me about Capacitance?",
-        "condition": { "and": [ { "not": { "u_has_trait": "PROF_CLEANSINGFLAME2" } }, { "not": { "u_has_trait": "SPELL_CAPACITANCE" } } ] },
-        "topic": "TALK_CF_PURIFIER_SPELL_MENU_1"
-      },
-      {
-        "text": "What can you tell me about Consecrate?",
-        "condition": { "not": { "u_has_trait": "SPELL_CONSECRATELESSER" } },
-        "topic": "TALK_CF_PURIFIER_SPELL_MENU_2"
-      },
-      {
-        "text": "What can you tell me about Opening?",
-        "condition": { "not": { "u_has_trait": "SPELL_LOCKPICK" } },
-        "topic": "TALK_CF_PURIFIER_SPELL_MENU_3"
-      },
-      {
-        "text": "I already know all of those, nevermind.",
-        "switch": true,
-        "condition": {
-          "and": [
-            { "u_has_any_trait": [ "PROF_CLEANSINGFLAME2", "SPELL_CAPACITANCE" ] },
-            { "u_has_trait": "SPELL_CONSECRATELESSER" },
-            { "u_has_trait": "SPELL_LOCKPICK" }
-          ]
-        },
-        "effect": { "u_add_var": "nicholas_all_spells_known", "type": "flag", "context": "knowledge", "value": "yes" },
-        "topic": "TALK_CF_PURIFIER"
-      },
-      { "text": "Maybe another time.", "switch": true, "default": true, "topic": "TALK_CF_PURIFIER" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_PURIFIER_SPELL_MENU_1",
-    "dynamic_line": "A specialty of the Cleansing Flame's associates and allies who dealt with bionics.  It dumps the energy it calls up directly into power storage, so it's only useful if you have any capacity for bionic power set up.  Not good to use in a fight either, doesn't hurt or anything but your muscles freeze up when it activates.  I'll need 4 Golden Scales to cover everything that a proper ritual will require.",
-    "responses": [
-      {
-        "text": "[GS4] You have a deal, then.",
-        "condition": { "u_has_items": { "item": "CF_golden_scale", "count": 4 } },
-        "effect": [ { "u_consume_item": "CF_golden_scale", "count": 4 }, { "u_add_trait": "SPELL_CAPACITANCE" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need more Scales for that.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_items": { "item": "CF_golden_scale", "count": 4 } } },
-        "topic": "TALK_CF_PURIFIER"
-      },
-      { "text": "Not right now.", "switch": true, "default": true, "topic": "TALK_CF_PURIFIER" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_PURIFIER_SPELL_MENU_2",
-    "dynamic_line": "Consecrate is designed to purify the terrain, either petrifying or disintegrating most anomalous or otherworldly alterations to the landscape.  Less well-known is what it does to most otherworldly monsters caught in its effect.  It's not intended as an offensive spell first and foremost, but it'll damage most such monsters and leave them reeling.  I'll need 4 Golden Scales to cover everything that a proper ritual will require.",
-    "responses": [
-      {
-        "text": "[GS4] You have a deal, then.",
-        "condition": { "u_has_items": { "item": "CF_golden_scale", "count": 4 } },
-        "effect": [ { "u_consume_item": "CF_golden_scale", "count": 4 }, { "u_add_trait": "SPELL_CONSECRATELESSER" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need more Scales for that.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_items": { "item": "CF_golden_scale", "count": 4 } } },
-        "topic": "TALK_CF_PURIFIER"
-      },
-      { "text": "Not right now.", "switch": true, "default": true, "topic": "TALK_CF_PURIFIER" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_PURIFIER_SPELL_MENU_3",
-    "dynamic_line": "An extremely versatile entry tool.  Most locked doors will yield silently, windows slide open, metal garage doors, what-have-you.  Some field reports have mentioned it clearing rubble or a few other sorts of obstacles too.  I'll need 3 Golden Scales to cover everything that a proper ritual will require.",
-    "responses": [
-      {
-        "text": "[GS3] You have a deal, then.",
-        "condition": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } },
-        "effect": [ { "u_consume_item": "CF_golden_scale", "count": 3 }, { "u_add_trait": "SPELL_LOCKPICK" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need more Scales for that.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } } },
-        "topic": "TALK_CF_PURIFIER"
-      },
-      { "text": "Not right now.", "switch": true, "default": true, "topic": "TALK_CF_PURIFIER" }
-    ]
   },
   {
     "id": "TALK_CF_PURIFIER_INTERLUDE_MISSION",

--- a/data/mods/Arcana_BN/npcs/TALK_CF_REP.json
+++ b/data/mods/Arcana_BN/npcs/TALK_CF_REP.json
@@ -251,16 +251,9 @@
         "topic": "TALK_CF_REP_DEACON_MOTIVE"
       },
       {
-        "text": "Can you teach me any spells?",
-        "topic": "TALK_CF_REP_SPELL_MENU",
-        "condition": {
-          "and": [
-            { "u_has_effect": "cf_mission_1" },
-            {
-              "not": { "u_has_var": "sofia_all_spells_known", "type": "flag", "context": "knowledge", "value": "yes" }
-            }
-          ]
-        }
+        "text": "Can you teach me anything?",
+        "topic": "TALK_TRAIN",
+        "condition": { "and": [ { "u_has_effect": "cf_mission_1" } ] }
       },
       {
         "text": "Do you have anything to trade?",
@@ -933,98 +926,6 @@
     "type": "talk_topic",
     "dynamic_line": "A few others among our order, some having had contact with our fellows working closer to the cities.  Grandmaster Leone seems to be the most senior of the group, and he provided me with a lot of information I'll need to examine closely.  Might lead us to other survivors to get in touch with.  Might be a good idea to speak with him as well.",
     "responses": [ { "text": "We'll see.", "topic": "TALK_CF_REP" } ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_REP_SPELL_MENU",
-    "dynamic_line": "There are a few Magic Signs I could pass on to you.  Since you've aided us, I could teach you the use of Heat Ward, Poison Armor, or Ward Against Evil, if you don't already know them.  I will need a given amount of Golden Scales, to cover the materials and essence that go into copying these secrets into a form others can use.",
-    "responses": [
-      {
-        "text": "What can you tell me about Heat Ward?",
-        "condition": { "not": { "u_has_trait": "SPELL_FLAMEARMOR" } },
-        "topic": "TALK_CF_REP_SPELL_MENU_1"
-      },
-      {
-        "text": "What can you tell me about Poison Armor?",
-        "condition": { "not": { "u_has_trait": "SPELL_POISONARMOR" } },
-        "topic": "TALK_CF_REP_SPELL_MENU_2"
-      },
-      {
-        "text": "What can you tell me about Ward Against Evil?",
-        "condition": { "not": { "u_has_trait": "SPELL_CLERIC" } },
-        "topic": "TALK_CF_REP_SPELL_MENU_3"
-      },
-      {
-        "text": "There's nothing more I could learn from you.  Thanks anyway.",
-        "switch": true,
-        "condition": {
-          "and": [ { "u_has_trait": "SPELL_FLAMEARMOR" }, { "u_has_trait": "SPELL_POISONARMOR" }, { "u_has_trait": "SPELL_CLERIC" } ]
-        },
-        "effect": { "u_add_var": "sofia_all_spells_known", "type": "flag", "context": "knowledge", "value": "yes" },
-        "topic": "TALK_CF_REP"
-      },
-      { "text": "Maybe another time.", "switch": true, "default": true, "topic": "TALK_CF_REP" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_REP_SPELL_MENU_1",
-    "dynamic_line": "It's a spell some of our hunters learn to protect against overheating and smoke inhalation.  It's not enough to negate being immersed in flame, but you won't catch alight from it.  I'll need 4 Golden Scales to cover the cost of materials and for warding the ritual preparations.",
-    "responses": [
-      {
-        "text": "[GS4] You have a deal, then.",
-        "condition": { "u_has_items": { "item": "CF_golden_scale", "count": 4 } },
-        "effect": [ { "u_consume_item": "CF_golden_scale", "count": 4 }, { "u_add_trait": "SPELL_FLAMEARMOR" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need more Scales for that.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_items": { "item": "CF_golden_scale", "count": 4 } } },
-        "topic": "TALK_CF_REP"
-      },
-      { "text": "Not right now.", "switch": true, "default": true, "topic": "TALK_CF_REP" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_REP_SPELL_MENU_2",
-    "dynamic_line": "It guards the body against toxins of nearly any sort.  Poison gas, venom from mutant beasts, I've seen it ease signs of radiation sickness as well.  I'll need 3 Golden Scales to cover the cost of materials and for warding the ritual preparations.",
-    "responses": [
-      {
-        "text": "[GS3] You have a deal, then.",
-        "condition": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } },
-        "effect": [ { "u_consume_item": "CF_golden_scale", "count": 3 }, { "u_add_trait": "SPELL_POISONARMOR" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need more Scales for that.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_items": { "item": "CF_golden_scale", "count": 3 } } },
-        "topic": "TALK_CF_REP"
-      },
-      { "text": "Not right now.", "switch": true, "default": true, "topic": "TALK_CF_REP" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_CF_REP_SPELL_MENU_3",
-    "dynamic_line": "This is a sacred protective spell against otherworldly influences.  Things that draw attention from Beyond or instability on the victim, likely the most common example.  I'll need 4 Golden Scales to cover the cost of materials and for warding the ritual preparations.",
-    "responses": [
-      {
-        "text": "[GS4] You have a deal, then.",
-        "condition": { "u_has_items": { "item": "CF_golden_scale", "count": 4 } },
-        "effect": [ { "u_consume_item": "CF_golden_scale", "count": 4 }, { "u_add_trait": "SPELL_CLERIC" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need more Scales for that.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_items": { "item": "CF_golden_scale", "count": 4 } } },
-        "topic": "TALK_CF_REP"
-      },
-      { "text": "Not right now.", "switch": true, "default": true, "topic": "TALK_CF_REP" }
-    ]
   },
   {
     "type": "talk_topic",

--- a/data/mods/Arcana_BN/npcs/TALK_HERMIT.json
+++ b/data/mods/Arcana_BN/npcs/TALK_HERMIT.json
@@ -99,17 +99,9 @@
       { "text": "Who are you?", "topic": "TALK_HERMIT_WHO" },
       { "text": "What are you doing here?", "topic": "TALK_HERMIT_DOING" },
       {
-        "text": "Are there any spells you could teach me?",
-        "topic": "TALK_HERMIT_SPELL_MENU",
-        "condition": {
-          "and": [
-            { "u_has_effect": "hermit_earned_trust_2" },
-            { "u_has_trait_flag": "explorer_of_the_veil" },
-            {
-              "not": { "u_has_var": "hermit_all_spells_known", "type": "flag", "context": "knowledge", "value": "yes" }
-            }
-          ]
-        }
+        "text": "Is there anything you could teach me?",
+        "topic": "TALK_TRAIN",
+        "condition": { "and": [ { "u_has_effect": "hermit_earned_trust_2" }, { "u_has_trait_flag": "explorer_of_the_veil" } ] }
       },
       {
         "switch": true,
@@ -2378,102 +2370,6 @@
     "id": "TALK_HERMIT_DOING_ASKED",
     "dynamic_line": "You already pried about personal matters quite recently.  Please, it's fine.",
     "responses": [ { "text": "…", "topic": "TALK_HERMIT" } ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_HERMIT_SPELL_MENU",
-    "dynamic_line": "There are many secrets that He From Beyond The Veil will reward you with, if you make proper use of His relic.  I do know a few tricks from my youth that may compliment the tools He will give you, however.  I can pass onto you the Magic Signs of Free Action, Phase Shield, or Transcendent Aura.  I ask that you bring crystallized essence in exchange, as I can use it for these rituals and for other wards I maintain here.",
-    "responses": [
-      {
-        "text": "What can you tell me about Free Action?",
-        "condition": { "not": { "u_has_trait": "SPELL_FREEACTION" } },
-        "topic": "TALK_HERMIT_SPELL_MENU_1"
-      },
-      {
-        "text": "What can you tell me about Phase Shield?",
-        "condition": { "not": { "u_has_trait": "SPELL_PHASESHIELD" } },
-        "topic": "TALK_HERMIT_SPELL_MENU_2"
-      },
-      {
-        "text": "What can you tell me about Transcendent Aura?",
-        "condition": { "and": [ { "not": { "u_has_trait": "PROF_CHALICE2" } }, { "not": { "u_has_trait": "SPELL_TRANSCENDENTAURA" } } ] },
-        "topic": "TALK_HERMIT_SPELL_MENU_3"
-      },
-      {
-        "text": "I already know all of these.  Thanks anyway.",
-        "switch": true,
-        "condition": {
-          "and": [
-            { "u_has_trait": "SPELL_FREEACTION" },
-            { "u_has_trait": "SPELL_PHASESHIELD" },
-            { "u_has_any_trait": [ "PROF_CHALICE2", "SPELL_TRANSCENDENTAURA" ] }
-          ]
-        },
-        "effect": { "u_add_var": "hermit_all_spells_known", "type": "flag", "context": "knowledge", "value": "yes" },
-        "topic": "TALK_HERMIT"
-      },
-      { "text": "Maybe another time.", "switch": true, "default": true, "topic": "TALK_HERMIT" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_HERMIT_SPELL_MENU_1",
-    "dynamic_line": "Though both it and Surging Force can halt time briefly, the main purpose of Free Action is in traversing rough terrain, slipping out of a monster's grasp, or negating other hazards that might slow you down.  I use it to traverse the woods when gathering firewood or hunting, I'm not as light on my feet as I used to be.  If you bring me 1 crystallized essence, I can imprint this knowledge upon you.",
-    "responses": [
-      {
-        "text": "Sure, here you go.",
-        "condition": { "u_has_item": "essence_pure" },
-        "effect": [ { "u_consume_item": "essence_pure" }, { "u_add_trait": "SPELL_FREEACTION" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need to obtain one.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_item": "essence_pure" } },
-        "topic": "TALK_HERMIT"
-      },
-      { "text": "Let me think about it.", "switch": true, "default": true, "topic": "TALK_HERMIT" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_HERMIT_SPELL_MENU_2",
-    "dynamic_line": "It's a warding spell that lashes out against those who strike you, similar to the more well-known Shadowy Shield.  Rather than harming your attacker directly, it shunts them a short distance away from you.  It does the same to any other threats close enough, when it activates.  If you bring me 1 crystallized essence, I can imprint this knowledge upon you.",
-    "responses": [
-      {
-        "text": "Sure, here you go.",
-        "condition": { "u_has_item": "essence_pure" },
-        "effect": [ { "u_consume_item": "essence_pure" }, { "u_add_trait": "SPELL_PHASESHIELD" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need to obtain one.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_item": "essence_pure" } },
-        "topic": "TALK_HERMIT"
-      },
-      { "text": "Let me think about it.", "switch": true, "default": true, "topic": "TALK_HERMIT" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_HERMIT_SPELL_MENU_3",
-    "dynamic_line": "This secret has been passed down among a few of the more learned ascetics of my order.  It shrouds your aura against monsters from Beyond, blinding them to your presence.  It doesn't hide you from the undead I've found, earthly life in general seems to spot you more easily under its effect, but it has its uses.  If you bring me 1 crystallized essence, I can imprint this knowledge upon you.",
-    "responses": [
-      {
-        "text": "Sure, here you go.",
-        "condition": { "u_has_item": "essence_pure" },
-        "effect": [ { "u_consume_item": "essence_pure" }, { "u_add_trait": "SPELL_TRANSCENDENTAURA" } ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "I'll need to obtain one.  Maybe later.",
-        "switch": true,
-        "condition": { "not": { "u_has_item": "essence_pure" } },
-        "topic": "TALK_HERMIT"
-      },
-      { "text": "Let me think about it.", "switch": true, "default": true, "topic": "TALK_HERMIT" }
-    ]
   },
   {
     "type": "talk_topic",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

I was gonna fix an outdated reference to Flame Ward formerly being Heat Ward, when I realized that NPC dialogue teaching you spells still relies on granting the obsoleted spellcasting mutations.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Gave spell lists to the NPC classes used by the NPCs who previously had spells to teach you in dialogue (the hermit, Sofia, arcane purifier, and the merchant that shows up if you do Sofia's quest involving the hermit peacefully).
2. Deleted the old spell menu dialogue for buying spells from affected NPCs, and instead set the relevant dialogue to call `TALK_TRAIN`.

## Describe alternatives you've considered

Keeping the traits as a hack for this one exact thing.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned the hermit and confirmed that asking for training requires at least one PoTV spell to unlock, and he charges for it.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [12c1374](https://github.com/cataclysmbn/Cataclysm-BN/commit/12c1374b160c34875fe401b2fc06f81fe2253d22) (feat(mods/Arcana): use NPC spell lists instead of custom dialogue to teach spells) on 2026-07-28 15:58:57

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30331191654/artifacts/8694679858)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30331191654/artifacts/8679056072)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30331191654/artifacts/8677625104)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30331191654/artifacts/8677707027)
<!-- END artifact comment -->