### PR TITLE
feat: mention that `Sensory Dulling` CBM lets you autodoc without anesthesia

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -880,7 +880,7 @@
     "id": "bio_painkiller",
     "type": "bionic",
     "name": { "str": "Sensory Dulling" },
-    "description": "Your nervous system is wired to allow you to inhibit the signals of pain, allowing you to dull your senses at will.  However, the use of this system may cause delayed reaction time and drowsiness.",
+    "description": "Your nervous system is wired to allow you to inhibit the signals of pain, allowing you to dull your senses at will.  This also means you do not need anesthesia when undergoing bionic surgery with an Autodoc.  However, the use of this system may cause delayed reaction time and drowsiness.",
     "occupied_bodyparts": [ [ "head", 2 ] ],
     "points": 2,
     "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -702,7 +702,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Sensory Dulling CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "This module lets the user's nervous system inhibit pain signals, allowing them to dull their senses at will.  However, the use of this system may cause delayed reaction times and drowsiness.",
+    "description": "This module lets the user's nervous system inhibit pain signals, allowing them to dull their senses at will.  This also means the user does not need anesthesia when undergoing bionic surgery with an Autodoc.  However, the use of this system may cause delayed reaction times and drowsiness.",
     "price": "2 kUSD",
     "weight": "300 g",
     "difficulty": 4


### PR DESCRIPTION
requested by https://m.dcinside.com/board/rlike/521352

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d243a1f](https://github.com/cataclysmbn/Cataclysm-BN/commit/d243a1fbb6164be3467a9e4f0d9179735258b3c8) (feat: mention that `Sensory Dulling` CBM lets you autodoc without anesthesia) on 2026-07-29 09:50:57

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30436171521/artifacts/8719267945)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30436171521/artifacts/8718628134)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30436171521/artifacts/8717853131)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30436171521/artifacts/8717955854)
<!-- END artifact comment -->