### PR TITLE
feat(balance): add more ways to obtain rare and obscure guns from soldier zombies

### DIFF
--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -940,7 +940,7 @@
           }
         ]
       },
-      { "group": "military_specops_guns", "prob": 70, "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_specops_guns", "prob": 100, "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ] },
       { "group": "pwr_armor_acc", "count": [ 1, 2 ], "damage": [ 1, 4 ], "prob": 90 },
       { "item": "heavy_power_armor_frame", "damage": [ 1, 3 ], "prob": 100 }
     ]

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -78,9 +78,9 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_specops_guns", "prob": 10, "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_specops_guns", "prob": 40, "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ] },
       { "item": "holster" },
-      { "group": "carried_guns_pistol_milspec", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 0, 1500 ] },
+      { "group": "carried_guns_pistol_milspec", "prob": 100, "damage": [ 0, 2 ], "dirt": [ 0, 1500 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       {

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -74,7 +74,7 @@
         "damage_max_instance": [ { "damage_type": "stab", "amount": 8, "armor_multiplier": 0.8 } ]
       }
     ],
-    "death_drops": "mon_zombie_soldier_death_drops",
+    "death_drops": "mon_zombie_bio_op_death_drops",
     "death_function": [ "NORMAL" ],
     "upgrades": { "half_life": 38, "into": "mon_zombie_soldier_blackops_2" },
     "burn_into": "mon_zombie_scorched",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
There's a whole list of specops guns which very few people have seen because most zombie soldiers only drop generic m4s and maybe an m27, and the only source of specops guns are rare bio-operators that pretty much only spawn in labs once or twice. This is a real shame as it greatly diminishes weapon variety in most playthroughs.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Changes the feral armored bioop miniboss to have a 100% chance of dropping a specops gun. Increases bio-operators to have a 40% chance to drop a specops gun, up from 10%, and makes them always drop a specops pistol. Makes the black-ops zombie and its evolution use the bio-operator loot list (basically the only differences are the addition of the specops guns and ballistic shields) as it makes sense for black-ops soldiers to drop special guns (i know it's an evolution and traditionally that's not supposed to change loot but i mean it makes sense thematically).
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Lack of cool guns
## Testing
Spawned in a bunch of black-ops zombies, bio-operators, etc, a lot more guns leading to more variety.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [003c67b](https://github.com/cataclysmbn/Cataclysm-BN/commit/003c67b7c8a20ca8fadcb2245a3d924f9c7659ea) (Update zed_soldiers.json) on 2026-07-30 03:34:22

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30507669341/artifacts/8746904418)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30507669341/artifacts/8747262658)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30507669341/artifacts/8746120626)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30507669341/artifacts/8746191851)
<!-- END artifact comment -->