### PR TITLE
feat(mods/DinoMod,port): spawn sauropods by streams

### DIFF
--- a/data/mods/DinoMod/monstergroups/wilderness.json
+++ b/data/mods/DinoMod/monstergroups/wilderness.json
@@ -320,7 +320,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_sarahsaurus",
@@ -359,7 +359,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_anchisaurus",
@@ -398,7 +398,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_issi",
@@ -437,7 +437,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_moabosaurus",
@@ -476,7 +476,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_apatosaurus",
@@ -515,7 +515,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_brontosaurus",
@@ -554,7 +554,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_diplodocus",
@@ -593,7 +593,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_camarasaurus",
@@ -632,7 +632,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_brachiosaurus",
@@ -671,7 +671,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_astrodon",
@@ -710,7 +710,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "122 days"
+        "ends": 122
       },
       {
         "monster": "mon_alamosaurus",
@@ -723,8 +723,20 @@
       { "monster": "mon_zarahsaurus", "freq": 2, "cost_multiplier": 30, "starts": 72, "pack_size": [ 4, 12 ] },
       { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
-      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      {
+        "monster": "mon_zanchisaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 112
+      },
+      {
+        "monster": "mon_zanchisaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 360
+      },
       { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
@@ -733,42 +745,162 @@
       { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
       { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
-      { "monster": "mon_zaplocanthosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
-      { "monster": "mon_zaplocanthosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      { "monster": "mon_zaplocanthosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
-      { "monster": "mon_zaplocanthosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
-      { "monster": "mon_zamargasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
-      { "monster": "mon_zamargasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      { "monster": "mon_zamargasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
-      { "monster": "mon_zamargasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      {
+        "monster": "mon_zaplocanthosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 12
+      },
+      {
+        "monster": "mon_zaplocanthosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 28
+      },
+      {
+        "monster": "mon_zaplocanthosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 112
+      },
+      {
+        "monster": "mon_zaplocanthosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 360
+      },
+      {
+        "monster": "mon_zamargasaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 12
+      },
+      {
+        "monster": "mon_zamargasaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 28
+      },
+      {
+        "monster": "mon_zamargasaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 112
+      },
+      {
+        "monster": "mon_zamargasaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 360
+      },
       { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
-      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      {
+        "monster": "mon_zapatosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 112
+      },
+      {
+        "monster": "mon_zapatosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 360
+      },
       { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
-      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      {
+        "monster": "mon_zrontosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 112
+      },
+      {
+        "monster": "mon_zrontosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 360
+      },
       { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
       { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
-      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
-      { "monster": "mon_zrachiosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
-      { "monster": "mon_zrachiosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      { "monster": "mon_zrachiosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
-      { "monster": "mon_zrachiosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      {
+        "monster": "mon_zamarasaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 112
+      },
+      {
+        "monster": "mon_zamarasaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 360
+      },
+      {
+        "monster": "mon_zrachiosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 12
+      },
+      {
+        "monster": "mon_zrachiosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 28
+      },
+      {
+        "monster": "mon_zrachiosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 112
+      },
+      {
+        "monster": "mon_zrachiosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 360
+      },
       { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
       { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
-      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 }
+      {
+        "monster": "mon_zalamosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 112
+      },
+      {
+        "monster": "mon_zalamosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 360
+      }
     ]
   },
   {

--- a/data/mods/DinoMod/monstergroups/wilderness.json
+++ b/data/mods/DinoMod/monstergroups/wilderness.json
@@ -232,6 +232,676 @@
   },
   {
     "type": "monstergroup",
+    "id": "GROUP_STREAM",
+    "monsters": [
+      {
+        "monster": "mon_coelophysis",
+        "freq": 1,
+        "cost_multiplier": 5,
+        "pack_size": [ 4, 8 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      { "monster": "mon_ceratosaurus", "freq": 1, "cost_multiplier": 30 },
+      { "monster": "mon_zeratosaurus", "freq": 1, "cost_multiplier": 35, "starts": 168 },
+      { "monster": "mon_allosaurus", "freq": 2, "cost_multiplier": 30 },
+      { "monster": "mon_zallosaurus", "freq": 1, "cost_multiplier": 35, "starts": 72 },
+      { "monster": "mon_zallosaurus", "freq": 1, "cost_multiplier": 35, "starts": 672 },
+      { "monster": "mon_acrocanthosaurus", "freq": 2, "cost_multiplier": 40 },
+      { "monster": "mon_zacrocanthosaurus", "freq": 1, "cost_multiplier": 45, "starts": 72 },
+      { "monster": "mon_zacrocanthosaurus", "freq": 1, "cost_multiplier": 45, "starts": 672 },
+      { "monster": "mon_siats", "freq": 2, "cost_multiplier": 40 },
+      { "monster": "mon_ziats", "freq": 1, "cost_multiplier": 45, "starts": 72 },
+      { "monster": "mon_ziats", "freq": 1, "cost_multiplier": 45, "starts": 672 },
+      { "monster": "mon_tyrannosaurus", "freq": 2, "cost_multiplier": 40 },
+      { "monster": "mon_zyrannosaurus", "freq": 1, "cost_multiplier": 80, "starts": 72 },
+      { "monster": "mon_zyrannosaurus", "freq": 1, "cost_multiplier": 80, "starts": 672 },
+      { "monster": "mon_gorgosaurus", "freq": 1, "cost_multiplier": 35 },
+      { "monster": "mon_zorgosaurus", "freq": 1, "cost_multiplier": 35, "starts": 168 },
+      { "monster": "mon_albertosaurus", "freq": 1, "cost_multiplier": 35 },
+      { "monster": "mon_zalbertosaurus", "freq": 1, "cost_multiplier": 35, "starts": 168 },
+      {
+        "monster": "mon_nothronychus",
+        "freq": 3,
+        "cost_multiplier": 30,
+        "pack_size": [ 1, 2 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      { "monster": "mon_zothronychus", "freq": 1, "cost_multiplier": 30, "starts": 72, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zothronychus", "freq": 1, "cost_multiplier": 30, "starts": 168, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zothronychus", "freq": 1, "cost_multiplier": 30, "starts": 672, "pack_size": [ 1, 2 ] },
+      {
+        "monster": "mon_deinonychus",
+        "freq": 3,
+        "cost_multiplier": 15,
+        "pack_size": [ 2, 3 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      { "monster": "mon_zeinonychus", "freq": 1, "cost_multiplier": 30, "starts": 72, "pack_size": [ 2, 3 ] },
+      { "monster": "mon_zeinonychus", "freq": 1, "cost_multiplier": 30, "starts": 168, "pack_size": [ 2, 3 ] },
+      { "monster": "mon_zeinonychus", "freq": 1, "cost_multiplier": 30, "starts": 672, "pack_size": [ 2, 3 ] },
+      {
+        "monster": "mon_utahraptor",
+        "freq": 3,
+        "cost_multiplier": 30,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      { "monster": "mon_zutahraptor", "freq": 1, "cost_multiplier": 30, "starts": 72 },
+      { "monster": "mon_zutahraptor", "freq": 1, "cost_multiplier": 30, "starts": 168 },
+      { "monster": "mon_zutahraptor", "freq": 1, "cost_multiplier": 30, "starts": 672 },
+      {
+        "monster": "mon_sarahsaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_sarahsaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_sarahsaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_sarahsaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_sarahsaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_anchisaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_anchisaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_anchisaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_anchisaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_anchisaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_issi",
+        "freq": 5,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_issi",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_issi",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_issi",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_issi",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_moabosaurus",
+        "freq": 5,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_moabosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_moabosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_moabosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_moabosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_apatosaurus",
+        "freq": 5,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_apatosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_apatosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_apatosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_apatosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_brontosaurus",
+        "freq": 5,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_brontosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_brontosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_brontosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_brontosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_diplodocus",
+        "freq": 10,
+        "cost_multiplier": 20,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_diplodocus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_diplodocus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_diplodocus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_diplodocus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_camarasaurus",
+        "freq": 5,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_camarasaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_camarasaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_camarasaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_camarasaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_brachiosaurus",
+        "freq": 5,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_brachiosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_brachiosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_brachiosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_brachiosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_astrodon",
+        "freq": 5,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_astrodon",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_astrodon",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_astrodon",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_astrodon",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      {
+        "monster": "mon_alamosaurus",
+        "freq": 5,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_alamosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "12 days"
+      },
+      {
+        "monster": "mon_alamosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "28 days"
+      },
+      {
+        "monster": "mon_alamosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "122 days"
+      },
+      {
+        "monster": "mon_alamosaurus",
+        "freq": 2,
+        "cost_multiplier": 25,
+        "pack_size": [ 4, 12 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "ends": "360 days"
+      },
+      { "monster": "mon_zarahsaurus", "freq": 5, "cost_multiplier": 30, "starts": 72, "pack_size": [ 4, 12 ] },
+      { "monster": "mon_zanchisaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zanchisaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      {
+        "monster": "mon_zanchisaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "112 days"
+      },
+      {
+        "monster": "mon_zanchisaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "360 days"
+      },
+      { "monster": "mon_zissi", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zissi", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zissi", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
+      { "monster": "mon_zissi", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
+      { "monster": "mon_zoabosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zoabosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zoabosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
+      { "monster": "mon_zoabosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
+      {
+        "monster": "mon_zaplocanthosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "12 days"
+      },
+      {
+        "monster": "mon_zaplocanthosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "28 days"
+      },
+      {
+        "monster": "mon_zaplocanthosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "112 days"
+      },
+      {
+        "monster": "mon_zaplocanthosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "360 days"
+      },
+      {
+        "monster": "mon_zamargasaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "12 days"
+      },
+      {
+        "monster": "mon_zamargasaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "28 days"
+      },
+      {
+        "monster": "mon_zamargasaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "112 days"
+      },
+      {
+        "monster": "mon_zamargasaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "360 days"
+      },
+      { "monster": "mon_zapatosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zapatosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      {
+        "monster": "mon_zapatosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "112 days"
+      },
+      {
+        "monster": "mon_zapatosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "360 days"
+      },
+      { "monster": "mon_zrontosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zrontosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      {
+        "monster": "mon_zrontosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "112 days"
+      },
+      {
+        "monster": "mon_zrontosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "360 days"
+      },
+      { "monster": "mon_ziplodocus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_ziplodocus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_ziplodocus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
+      { "monster": "mon_ziplodocus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
+      { "monster": "mon_zamarasaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zamarasaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      {
+        "monster": "mon_zamarasaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "112 days"
+      },
+      {
+        "monster": "mon_zamarasaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "360 days"
+      },
+      {
+        "monster": "mon_zrachiosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "12 days"
+      },
+      {
+        "monster": "mon_zrachiosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "28 days"
+      },
+      {
+        "monster": "mon_zrachiosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "112 days"
+      },
+      {
+        "monster": "mon_zrachiosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "360 days"
+      },
+      { "monster": "mon_zastrodon", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zastrodon", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zastrodon", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
+      { "monster": "mon_zastrodon", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
+      { "monster": "mon_zalamosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zalamosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      {
+        "monster": "mon_zalamosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "112 days"
+      },
+      {
+        "monster": "mon_zalamosaurus",
+        "freq": 5,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": "360 days"
+      }
+    ]
+  },
+  {
+    "type": "monstergroup",
     "name": "GROUP_SWAMP",
     "default": "mon_null",
     "//": "Current SPRING first DAY count is 104.  Note that 'freq' units are tenth of a percent, with default filling in the gap.",

--- a/data/mods/DinoMod/monstergroups/wilderness.json
+++ b/data/mods/DinoMod/monstergroups/wilderness.json
@@ -232,7 +232,10 @@
   },
   {
     "type": "monstergroup",
-    "id": "GROUP_STREAM",
+    "name": "GROUP_STREAM",
+    "default": "mon_null",
+    "//": "Note that 'freq' units are tenth of a percent, with default filling in the gap.",
+    "is_animal": true,
     "monsters": [
       {
         "monster": "mon_coelophysis",

--- a/data/mods/DinoMod/monstergroups/wilderness.json
+++ b/data/mods/DinoMod/monstergroups/wilderness.json
@@ -304,7 +304,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_sarahsaurus",
@@ -312,7 +312,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_sarahsaurus",
@@ -328,7 +328,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_anchisaurus",
@@ -343,7 +343,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_anchisaurus",
@@ -351,7 +351,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_anchisaurus",
@@ -367,7 +367,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_issi",
@@ -382,7 +382,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_issi",
@@ -390,7 +390,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_issi",
@@ -406,7 +406,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_moabosaurus",
@@ -421,7 +421,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_moabosaurus",
@@ -429,7 +429,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_moabosaurus",
@@ -445,7 +445,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_apatosaurus",
@@ -460,7 +460,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_apatosaurus",
@@ -468,7 +468,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_apatosaurus",
@@ -484,7 +484,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_brontosaurus",
@@ -499,7 +499,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_brontosaurus",
@@ -507,7 +507,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_brontosaurus",
@@ -523,7 +523,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_diplodocus",
@@ -538,7 +538,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_diplodocus",
@@ -546,7 +546,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_diplodocus",
@@ -562,7 +562,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_camarasaurus",
@@ -577,7 +577,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_camarasaurus",
@@ -585,7 +585,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_camarasaurus",
@@ -601,7 +601,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_brachiosaurus",
@@ -616,7 +616,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_brachiosaurus",
@@ -624,7 +624,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_brachiosaurus",
@@ -640,7 +640,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_astrodon",
@@ -655,7 +655,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_astrodon",
@@ -663,7 +663,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_astrodon",
@@ -679,7 +679,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       {
         "monster": "mon_alamosaurus",
@@ -694,7 +694,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "12 days"
+        "ends": 12
       },
       {
         "monster": "mon_alamosaurus",
@@ -702,7 +702,7 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "28 days"
+        "ends": 28
       },
       {
         "monster": "mon_alamosaurus",
@@ -718,188 +718,188 @@
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
-        "ends": "360 days"
+        "ends": 360
       },
       { "monster": "mon_zarahsaurus", "freq": 2, "cost_multiplier": 30, "starts": 72, "pack_size": [ 4, 12 ] },
-      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       {
         "monster": "mon_zanchisaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "112 days"
+        "starts": 112
       },
       {
         "monster": "mon_zanchisaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "360 days"
+        "starts": 360
       },
-      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
-      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
-      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
-      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
-      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
-      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
+      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
+      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
+      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       {
         "monster": "mon_zaplocanthosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "12 days"
-      },
-      {
-        "monster": "mon_zaplocanthosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": "28 days"
+        "starts": 12
       },
       {
         "monster": "mon_zaplocanthosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "112 days"
+        "starts": 28
       },
       {
         "monster": "mon_zaplocanthosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "360 days"
+        "starts": 112
+      },
+      {
+        "monster": "mon_zaplocanthosaurus",
+        "freq": 2,
+        "cost_multiplier": 30,
+        "pack_size": [ 4, 12 ],
+        "starts": 360
       },
       {
         "monster": "mon_zamargasaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "12 days"
+        "starts": 12
       },
       {
         "monster": "mon_zamargasaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "28 days"
+        "starts": 28
       },
       {
         "monster": "mon_zamargasaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "112 days"
+        "starts": 112
       },
       {
         "monster": "mon_zamargasaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "360 days"
+        "starts": 360
       },
-      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       {
         "monster": "mon_zapatosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "112 days"
+        "starts": 112
       },
       {
         "monster": "mon_zapatosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "360 days"
+        "starts": 360
       },
-      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       {
         "monster": "mon_zrontosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "112 days"
+        "starts": 112
       },
       {
         "monster": "mon_zrontosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "360 days"
+        "starts": 360
       },
-      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
-      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
-      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
-      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
+      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       {
         "monster": "mon_zamarasaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "112 days"
+        "starts": 112
       },
       {
         "monster": "mon_zamarasaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "360 days"
+        "starts": 360
       },
       {
         "monster": "mon_zrachiosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "12 days"
+        "starts": 12
       },
       {
         "monster": "mon_zrachiosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "28 days"
+        "starts": 28
       },
       {
         "monster": "mon_zrachiosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "112 days"
+        "starts": 112
       },
       {
         "monster": "mon_zrachiosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "360 days"
+        "starts": 360
       },
-      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
-      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
-      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
-      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
+      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       {
         "monster": "mon_zalamosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "112 days"
+        "starts": 112
       },
       {
         "monster": "mon_zalamosaurus",
         "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
-        "starts": "360 days"
+        "starts": 360
       }
     ]
   },

--- a/data/mods/DinoMod/monstergroups/wilderness.json
+++ b/data/mods/DinoMod/monstergroups/wilderness.json
@@ -723,20 +723,8 @@
       { "monster": "mon_zarahsaurus", "freq": 2, "cost_multiplier": 30, "starts": 72, "pack_size": [ 4, 12 ] },
       { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      {
-        "monster": "mon_zanchisaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 112
-      },
-      {
-        "monster": "mon_zanchisaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 360
-      },
+      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
@@ -745,162 +733,42 @@
       { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
       { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
-      {
-        "monster": "mon_zaplocanthosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 12
-      },
-      {
-        "monster": "mon_zaplocanthosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 28
-      },
-      {
-        "monster": "mon_zaplocanthosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 112
-      },
-      {
-        "monster": "mon_zaplocanthosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 360
-      },
-      {
-        "monster": "mon_zamargasaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 12
-      },
-      {
-        "monster": "mon_zamargasaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 28
-      },
-      {
-        "monster": "mon_zamargasaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 112
-      },
-      {
-        "monster": "mon_zamargasaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 360
-      },
+      { "monster": "mon_zaplocanthosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zaplocanthosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
+      { "monster": "mon_zaplocanthosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zaplocanthosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      { "monster": "mon_zamargasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zamargasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
+      { "monster": "mon_zamargasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zamargasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      {
-        "monster": "mon_zapatosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 112
-      },
-      {
-        "monster": "mon_zapatosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 360
-      },
+      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      {
-        "monster": "mon_zrontosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 112
-      },
-      {
-        "monster": "mon_zrontosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 360
-      },
+      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
       { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      {
-        "monster": "mon_zamarasaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 112
-      },
-      {
-        "monster": "mon_zamarasaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 360
-      },
-      {
-        "monster": "mon_zrachiosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 12
-      },
-      {
-        "monster": "mon_zrachiosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 28
-      },
-      {
-        "monster": "mon_zrachiosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 112
-      },
-      {
-        "monster": "mon_zrachiosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 360
-      },
+      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
+      { "monster": "mon_zrachiosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
+      { "monster": "mon_zrachiosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
+      { "monster": "mon_zrachiosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zrachiosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
       { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
       { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 },
       { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 12 },
       { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 28 },
-      {
-        "monster": "mon_zalamosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 112
-      },
-      {
-        "monster": "mon_zalamosaurus",
-        "freq": 2,
-        "cost_multiplier": 30,
-        "pack_size": [ 4, 12 ],
-        "starts": 360
-      }
+      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 112 },
+      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": 360 }
     ]
   },
   {

--- a/data/mods/DinoMod/monstergroups/wilderness.json
+++ b/data/mods/DinoMod/monstergroups/wilderness.json
@@ -368,7 +368,7 @@
       },
       {
         "monster": "mon_issi",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
@@ -407,7 +407,7 @@
       },
       {
         "monster": "mon_moabosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
@@ -446,7 +446,7 @@
       },
       {
         "monster": "mon_apatosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
@@ -485,7 +485,7 @@
       },
       {
         "monster": "mon_brontosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
@@ -524,7 +524,7 @@
       },
       {
         "monster": "mon_diplodocus",
-        "freq": 10,
+        "freq": 2,
         "cost_multiplier": 20,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
@@ -563,7 +563,7 @@
       },
       {
         "monster": "mon_camarasaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
@@ -602,7 +602,7 @@
       },
       {
         "monster": "mon_brachiosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
@@ -641,7 +641,7 @@
       },
       {
         "monster": "mon_astrodon",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
@@ -680,7 +680,7 @@
       },
       {
         "monster": "mon_alamosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 25,
         "pack_size": [ 4, 12 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
@@ -717,183 +717,183 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
         "ends": "360 days"
       },
-      { "monster": "mon_zarahsaurus", "freq": 5, "cost_multiplier": 30, "starts": 72, "pack_size": [ 4, 12 ] },
-      { "monster": "mon_zanchisaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zanchisaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zarahsaurus", "freq": 2, "cost_multiplier": 30, "starts": 72, "pack_size": [ 4, 12 ] },
+      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zanchisaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
       {
         "monster": "mon_zanchisaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "112 days"
       },
       {
         "monster": "mon_zanchisaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "360 days"
       },
-      { "monster": "mon_zissi", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zissi", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
-      { "monster": "mon_zissi", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
-      { "monster": "mon_zissi", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
-      { "monster": "mon_zoabosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zoabosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
-      { "monster": "mon_zoabosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
-      { "monster": "mon_zoabosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
+      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
+      { "monster": "mon_zissi", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
+      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
+      { "monster": "mon_zoabosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
       {
         "monster": "mon_zaplocanthosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "12 days"
       },
       {
         "monster": "mon_zaplocanthosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "28 days"
       },
       {
         "monster": "mon_zaplocanthosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "112 days"
       },
       {
         "monster": "mon_zaplocanthosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "360 days"
       },
       {
         "monster": "mon_zamargasaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "12 days"
       },
       {
         "monster": "mon_zamargasaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "28 days"
       },
       {
         "monster": "mon_zamargasaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "112 days"
       },
       {
         "monster": "mon_zamargasaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "360 days"
       },
-      { "monster": "mon_zapatosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zapatosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zapatosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
       {
         "monster": "mon_zapatosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "112 days"
       },
       {
         "monster": "mon_zapatosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "360 days"
       },
-      { "monster": "mon_zrontosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zrontosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zrontosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
       {
         "monster": "mon_zrontosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "112 days"
       },
       {
         "monster": "mon_zrontosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "360 days"
       },
-      { "monster": "mon_ziplodocus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_ziplodocus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
-      { "monster": "mon_ziplodocus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
-      { "monster": "mon_ziplodocus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
-      { "monster": "mon_zamarasaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zamarasaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
+      { "monster": "mon_ziplodocus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
+      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zamarasaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
       {
         "monster": "mon_zamarasaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "112 days"
       },
       {
         "monster": "mon_zamarasaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "360 days"
       },
       {
         "monster": "mon_zrachiosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "12 days"
       },
       {
         "monster": "mon_zrachiosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "28 days"
       },
       {
         "monster": "mon_zrachiosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "112 days"
       },
       {
         "monster": "mon_zrachiosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "360 days"
       },
-      { "monster": "mon_zastrodon", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zastrodon", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
-      { "monster": "mon_zastrodon", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
-      { "monster": "mon_zastrodon", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
-      { "monster": "mon_zalamosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
-      { "monster": "mon_zalamosaurus", "freq": 5, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
+      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "112 days" },
+      { "monster": "mon_zastrodon", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "360 days" },
+      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "12 days" },
+      { "monster": "mon_zalamosaurus", "freq": 2, "cost_multiplier": 30, "pack_size": [ 4, 12 ], "starts": "28 days" },
       {
         "monster": "mon_zalamosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "112 days"
       },
       {
         "monster": "mon_zalamosaurus",
-        "freq": 5,
+        "freq": 2,
         "cost_multiplier": 30,
         "pack_size": [ 4, 12 ],
         "starts": "360 days"


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

More engaging gameplay, better and more authentic interaction with DinoMod content

## Describe the solution (The How)

Takes advantage of the GROUP_STREAM spawn list from #5987 to introduce sauropods to the overmap in places that make sense given what we know of them. Their numbers decrease over time and they are replaced by zombie equivalents

## Describe alternatives you've considered

N/A

## Testing

Game starts no errors

Debug spawned a stream map special, teleported to it, didn't see dinos, did it again, saw a dino from the list

<img width="1164" height="790" alt="Screenshot 2026-07-31 at 10 50 13 PM" src="https://github.com/user-attachments/assets/7d0ffc55-380c-463a-b9ec-e48447ce07f9" />


## Additional context

Port of my work on https://github.com/CleverRaven/Cataclysm-DDA/pull/76639

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

## Build Artifacts

PR build for commit [454033f](https://github.com/cataclysmbn/Cataclysm-BN/commit/454033ffcea9017185816218d0bf40208218e43f) ([DinoMod] spawn sauropods by streams) on 2026-08-01 01:52:07

- [⏳ Linux tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30678641935)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30678641935)
- [⏳ macOS tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30678641935)
- [⏳ Android tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30678641935)
<!-- END artifact comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3204632](https://github.com/cataclysmbn/Cataclysm-BN/commit/3204632d9d6b80d0d436300e472beb669a112535) (style(autofix.ci): automated formatting) on 2026-08-01 13:01:15

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30680384224/artifacts/8812573827)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30680384224/artifacts/8818761352)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30680384224/artifacts/8812212573)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30680384224/artifacts/8812159824)
<!-- END artifact comment -->