### PR TITLE
feat(balance): add mall and home improvement superstore as city finales

### DIFF
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -1252,6 +1252,8 @@
         "s_electronics_2": 200,
         "s_gun_2": 200,
         "megastore": 200,
+        "mall": 200,
+        "home_improvement_superstore_new": 200,
         "town_hall": 200,
         "police_1": 200,
         "s_gun_1": 200,

--- a/data/mods/JP_Weather_Variants/weather_regional_map_settings.json
+++ b/data/mods/JP_Weather_Variants/weather_regional_map_settings.json
@@ -1253,6 +1253,8 @@
         "s_electronics_2": 200,
         "s_gun_2": 200,
         "megastore": 200,
+        "mall": 200,
+        "home_improvement_superstore_new": 200,
         "town_hall": 200,
         "police_1": 200,
         "s_gun_1": 200,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Closes #9989 
Malls are extremely large locations, meaning that with the new city "radius" settings malls spawn very rarely now. Home improvement superstores are also relatively rare due to their size.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds these locations as city "finales", increasing their chance to spawn while still keeping them as difficult locations to reach and not causing undue damage to existing mapgen weights.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
No malls
## Testing
Created some worlds, spawn rates seem better.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9a5d933](https://github.com/cataclysmbn/Cataclysm-BN/commit/9a5d933d5dcabad01db7ab629290152c3a60cb93) (Update weather_regional_map_settings.json) on 2026-08-01 04:47:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30681353203/artifacts/8812986458)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30681353203/artifacts/8813441040)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30681353203/artifacts/8812611384)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30681353203/artifacts/8812720418)
<!-- END artifact comment -->