### PR TITLE
fix(mods/resurrection_tech): add autolearn to resurrection anchor

### DIFF
--- a/data/mods/resurrection_mod/recipes.json
+++ b/data/mods/resurrection_mod/recipes.json
@@ -9,6 +9,7 @@
     "difficulty": 8,
     "time": 100000,
     "decomp_learn": 3,
+    "autolearn": true,
     "reversible": true,
     "using": [ [ "soldering_standard", 150 ], [ "welding_standard", 500 ] ],
     "components": [


### PR DESCRIPTION
## Purpose of change (The Why)
Minor oops

## Describe the solution (The How)
Autolearn

## Describe alternatives you've considered
No

## Testing
Says I can autolearn

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d99c20b](https://github.com/cataclysmbn/Cataclysm-BN/commit/d99c20bf6e81586eb9ca253a2c9c2b17f785f091) (fix(mods/resurrection_mod): add autolearn to resurrection anchor) on 2026-08-02 02:24:50

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30726140698/artifacts/8826525475)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30726140698/artifacts/8826809249)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30726140698/artifacts/8827265773)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30726140698/artifacts/8826596528)
<!-- END artifact comment -->