### PR TITLE
fix: helicopter crash map extra helicopter spawns in swamps

### DIFF
--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -436,8 +436,22 @@ static bool mx_helicopter( mapgen_constructor &m, const tripoint_abs_omt &abs_of
     int x1 = clamp( c.x() + x_offset, x_min, x_max );
     int y1 = clamp( c.y() + y_offset, y_min, y_max );
 
+    for( point_omt_ms pnt : point_range( point_omt_ms( x1, y1 ), point_omt_ms( x1 + x_length,
+                                         y1 + y_length ) ) ) {
+        if( m.impassable( pnt ) ) {
+            m.bash( pnt, 9999, true );
+        }
+        if( m.has_flag_ter( TFLAG_DEEP_WATER, pnt ) ) {
+            m.ter_set( pnt, t_dirtmound );
+        }
+    }
+
     vehicle *wreckage = m.add_vehicle(
                             crashed_hull, point_omt_ms( x1, y1 ), dir1, rng( 1, 33 ), 1 );
+
+    if( !wreckage ) {
+        debugmsg( "Map extra helicopter failed to spawn at ( %s, %s ).", x1, y1 );
+    }
 
     // During mapgen, m is the constructor surface while vpart_position::pos() uses get_map().
     const auto local_part_pos = [&m]( const vehicle & wreckage,
@@ -619,8 +633,22 @@ static bool mx_aircraft( mapgen_constructor &m, const tripoint_abs_omt &abs_offs
     int x1 = clamp( c.x() + x_offset, x_min, x_max );
     int y1 = clamp( c.y() + y_offset, y_min, y_max );
 
+    for( point_omt_ms pnt : point_range( point_omt_ms( x1, y1 ), point_omt_ms( x1 + x_length,
+                                         y1 + y_length ) ) ) {
+        if( m.impassable( pnt ) ) {
+            m.bash( pnt, 9999, true );
+        }
+        if( m.has_flag_ter( TFLAG_DEEP_WATER, pnt ) ) {
+            m.ter_set( pnt, t_dirtmound );
+        }
+    }
+
     vehicle *wreckage = m.add_vehicle(
                             crashed_hull, point_omt_ms( x1, y1 ), dir1, rng( 1, 33 ), 1 );
+
+    if( !wreckage ) {
+        debugmsg( "Map extra aircraft failed to spawn at ( %s, %s ).", x1, y1 );
+    }
 
     // During mapgen, m is the constructor surface while vpart_position::pos() uses get_map().
     const auto local_part_pos = [&m]( const vehicle & wreckage,


### PR DESCRIPTION
## Purpose of change (The Why)
dedmem said that helicopter didn't spawn when he spawned in swamp
Ran it a few times and it seemed to always spawn
Issue appears to be if it tried to spawn on deep water ( like what is present in swamps )
But I also checked impassable terrain for good measure

## Describe the solution (The How)
If spot is impassable -> bash it
If spot is deep water -> dirtify it

## Describe alternatives you've considered
None

## Testing
Helicopter crash scenario at swamps a bunch of times
Never got the new debugmessage

## Additional context
I may have just been really lucky but I dont see another fail point

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bc76e76](https://github.com/cataclysmbn/Cataclysm-BN/commit/bc76e76299f3fa762a4c00e8b976b5acfd523716) (fix: fix helicopter crash map extra helicopter spawns in swamps) on 2026-08-02 13:28:47

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30748579224/artifacts/8833806476)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30748579224/artifacts/8834093310)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30748579224/artifacts/8833827977)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30748579224/artifacts/8833853640)
<!-- END artifact comment -->