### PR TITLE
fix: re-add old default batteries to relevant electrionics

### DIFF
--- a/data/json/items/generic/toys_and_sports.json
+++ b/data/json/items/generic/toys_and_sports.json
@@ -15,7 +15,7 @@
     "ammo": "battery",
     "charges_per_use": 1,
     "use_action": "DOLLCHAT",
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_minus_disposable_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -34,7 +34,7 @@
     "ammo": "battery",
     "charges_per_use": 1,
     "use_action": "DOLLCHAT",
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_minus_disposable_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   }
 ]

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -450,7 +450,7 @@
       "type": "transform"
     },
     "flags": [ "DURABLE_MELEE", "SHEATH_SPEAR" ],
-    "magazines": [ [ "battery", [ "medium_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "medium_plus_battery_cell", "medium_battery_cell" ] ] ],
     "magazine_well": "500 ml"
   },
   {

--- a/data/json/items/melee/misc.json
+++ b/data/json/items/melee/misc.json
@@ -123,7 +123,7 @@
     "ammo": "battery",
     "charges_per_use": 25,
     "use_action": "TAZER",
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml",
     "flags": [ "BELT_CLIP" ]
   }

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -880,7 +880,7 @@
     "charges_per_use": 5,
     "qualities": [ [ "COOK", 2 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
     "use_action": [ "HOTPLATE", "HEAT_FOOD" ],
-    "magazines": [ [ "battery", [ "medium_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "medium_plus_battery_cell", "medium_battery_cell" ] ] ],
     "magazine_well": "500 ml"
   },
   {

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -41,7 +41,7 @@
     "ammo": "battery",
     "charges_per_use": 5,
     "use_action": "CAMERA",
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -90,7 +90,7 @@
       "type": "transform"
     },
     "flags": [ "WATCH", "ALARMCLOCK" ],
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "100 ml"
   },
   {
@@ -874,7 +874,7 @@
     "symbol": ";",
     "color": "light_gray",
     "ammo": "battery",
-    "magazines": [ [ "battery", [ "heavy_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "heavy_plus_battery_cell", "heavy_battery_cell" ] ] ],
     "magazine_well": "2000 ml",
     "flags": [ "IS_UPS" ]
   },
@@ -949,7 +949,7 @@
     "color": "yellow",
     "ammo": "battery",
     "use_action": { "type": "gps_device", "radius": 40, "additional_charges_per_tile": 0.1 },
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ]
   },
   {
     "id": "mil_gps_device",
@@ -982,7 +982,7 @@
       "need_charges_msg": "The scanner doesn't have enough power.",
       "type": "transform"
     },
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ]
   },
   {
     "id": "bionic_scanner_on",
@@ -1016,7 +1016,7 @@
     "color": "light_cyan",
     "ammo": "battery",
     "use_action": [ { "type": "cloning_syringe", "moves": 250, "charges_to_use": 25 } ],
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ]
   },
   {
     "id": "dna_editor",
@@ -1038,7 +1038,7 @@
     "charges_per_use": 5,
     "use_action": { "type": "dna_editor", "charges_to_use": 5 },
     "flags": [ "ALLOWS_REMOTE_USE" ],
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "500 ml"
   },
   {

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -166,7 +166,7 @@
       "need_charges_msg": "The lantern has no batteries."
     },
     "flags": [ "RADIO_MODABLE", "ALLOWS_REMOTE_USE" ],
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_minus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "500 ml"
   },
   {
@@ -203,7 +203,7 @@
       "need_charges": 1,
       "need_charges_msg": "The flashlight's batteries are dead."
     },
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_disposable_cell", "light_battery_cell" ] ] ],
     "magazine_well": "100 ml"
   },
   {
@@ -381,7 +381,7 @@
       "need_charges": 1,
       "need_charges_msg": "The heavy duty flashlight's batteries are dead."
     },
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_disposable_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -542,7 +542,7 @@
       "need_charges_msg": "The reading light winks out.",
       "type": "transform"
     },
-    "magazines": [ [ "battery", [ "light_minus_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_minus_disposable_cell", "light_minus_battery_cell" ] ] ],
     "magazine_well": "100 ml"
   },
   {

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -64,33 +64,6 @@
     "use_action": "BELL"
   },
   {
-    "type": "TOOL",
-    "category": "tools",
-    "id": "dab_pen",
-    "name": { "str": "dab pen" },
-    "description": "A battery operated dab pen used for smoking cannabis distillate cartridges.",
-    "symbol": "!",
-    "color": "dark_gray",
-    "looks_like": "ecig",
-    "weight": "20 g",
-    "volume": "100 ml",
-    "price": "25 USD",
-    "price_postapoc": "1 USD",
-    "material": "plastic",
-    "ammo": "battery",
-    "magazines": [ [ "battery", [ "light_minus_battery_cell" ] ] ],
-    "charges_per_use": 1,
-    "max_charges": 100,
-    "use_action": {
-      "target": "dab_pen_on",
-      "msg": "You turn on the dab pen.",
-      "active": true,
-      "need_charges": 1,
-      "need_charges_msg": "The dab pen's batteries need more charge.",
-      "type": "transform"
-    }
-  },
-  {
     "id": "debug_active_relic_test",
     "type": "TOOL",
     "category": "tools",
@@ -111,7 +84,7 @@
       "need_charges": 1,
       "need_charges_msg": "Batteries not included."
     },
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_disposable_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml",
     "relic_data": {
       "recharge_scheme": [ { "type": "time", "req": "none", "interval": "10 m", "rate": 1 } ],
@@ -657,7 +630,7 @@
     "use_action": [ { "type": "paint_stuff", "charge_cost": 1 }, { "type": "paint_stuff_cfg", "color_swap": true } ],
     "flags": [ "WRITE_MESSAGE", "NO_PAINT" ],
     "ammo": "battery",
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "light_disposable_cell", "light_battery_cell" ] ] ]
   },
   {
     "id": "stepladder",

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -38,7 +38,7 @@
     "turns_per_charge": 5,
     "proportional": { "weight": 0.21, "volume": 0.25, "price": 0.2 },
     "use_action": "RADIOCONTROL",
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_disposable_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -53,7 +53,7 @@
     "charges_per_use": 1,
     "proportional": { "weight": 0.73, "volume": 0.75, "price": 0.8 },
     "use_action": "RADIOCAR",
-    "magazines": [ [ "battery", [ "light_minus_battery_cell" ] ] ]
+    "magazines": [ [ "battery", [ "light_minus_disposable_cell", "light_minus_battery_cell" ] ] ]
   },
   {
     "id": "radio_car_on",
@@ -101,7 +101,7 @@
     "charges_per_use": 1,
     "flags": [ "WEATHER_FORECAST" ],
     "use_action": [ "RADIO_OFF", "WEATHER_TOOL" ],
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_disposable_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -133,7 +133,7 @@
     "ammo": "battery",
     "charges_per_use": 1,
     "flags": [ "TWO_WAY_RADIO" ],
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_disposable_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {

--- a/data/json/items/tool/smoking.json
+++ b/data/json/items/tool/smoking.json
@@ -142,7 +142,7 @@
     "material": "plastic",
     "ammo": "battery",
     "power_draw": 9000,
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_minus_battery_cell", "light_battery_cell" ] ] ],
     "charges_per_use": 1,
     "flags": [ "NO_INGEST" ],
     "use_action": {

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1055,7 +1055,7 @@
       { "flame": false, "type": "cauterize" }
     ],
     "flags": [ "STAB", "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_minus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -451,7 +451,7 @@
     "warmth": 10,
     "coverage": 100,
     "material_thickness": 1,
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -675,7 +675,7 @@
       "need_charges": 1,
       "need_charges_msg": "The fursuit's batteries are dead."
     },
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml",
     "extend": { "flags": [ "FANCY" ] }
   },
@@ -718,7 +718,7 @@
     "covers": [ "head" ],
     "coverage": 20,
     "material_thickness": 1,
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -1415,7 +1415,7 @@
     "encumbrance": 5,
     "coverage": 10,
     "material_thickness": 2,
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -1471,7 +1471,7 @@
     "encumbrance": 5,
     "coverage": 15,
     "material_thickness": 2,
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -1526,7 +1526,7 @@
     "encumbrance": 5,
     "coverage": 10,
     "material_thickness": 2,
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -2628,7 +2628,7 @@
     "coverage": 10,
     "material_thickness": 2,
     "hearing_protection": 40,
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {
@@ -2676,7 +2676,7 @@
     "coverage": 10,
     "material_thickness": 2,
     "hearing_protection": 40,
-    "magazines": [ [ "battery", [ "light_battery_cell" ] ] ],
+    "magazines": [ [ "battery", [ "light_plus_battery_cell", "light_battery_cell" ] ] ],
     "magazine_well": "250 ml"
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Followup to https://github.com/cataclysmbn/Cataclysm-BN/pull/9948

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

This re-adds the original default batteries to all affected items that were converted to get their battery list from `reloads_like`, just to restore how available certain batteries had been previously. Items where the default battery was unchanged were not touched.

Misc: there was a redundant copy of item `dab_pen` in misc.json that transforms into an obsoleted active version, which just gets overriden by the version in smoking.json. Removed that.

## Describe alternatives you've considered

In the future I'd want to shift several item spawns to use `contents-group` to pick a battery at random but that's a lot more work, this is nice for now.

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Checked shelter to confirm flashlights were now spawning with a disposable battery again.
4. Spawned some different affected items, confirmed they spawn with their default battery.
5. Checked item descriptions to make sure the specified battery doesn't show up twice on the compatible magazine list.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [14fb9a0](https://github.com/cataclysmbn/Cataclysm-BN/commit/14fb9a0c811bf05096ab35087f488ca5b81783d0) (fix: re-add old default batteries to relevant electrionics) on 2026-08-02 22:54:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30765522165/artifacts/8838933788)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30765522165/artifacts/8839258638)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30765522165/artifacts/8839998382)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30765522165/artifacts/8839003081)
<!-- END artifact comment -->