### PR TITLE
fix: remove SMOKABLE flag from dehydrated meat, veggy, and fish

### DIFF
--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -378,6 +378,7 @@
     "description": "Dehydrated fish flakes.  With proper storage, this dried food will remain edible for an incredibly long time.",
     "price": "5 USD",
     "price_postapoc": "250 cent",
+    "delete": { "flags": [ "SMOKABLE" ] },
     "volume": "125 ml"
   },
   {
@@ -1287,7 +1288,7 @@
     "description": "Dehydrated meat flakes.  With proper storage, this dried food will remain edible for an incredibly long time.",
     "price": "9 USD",
     "price_postapoc": "3 USD",
-    "delete": { "flags": [ "NUTRIENT_OVERRIDE" ] },
+    "delete": { "flags": [ "NUTRIENT_OVERRIDE", "SMOKABLE" ] },
     "extend": { "flags": [ "SMOKED" ] },
     "material": [ "flesh" ],
     "primary_material": "cured_meat",
@@ -1414,7 +1415,7 @@
     "material": [ "flesh" ],
     "volume": "125 ml",
     "fun": -4,
-    "delete": { "flags": [ "RAW" ] },
+    "delete": { "flags": [ "RAW", "SMOKABLE" ] },
     "extend": { "flags": [ "SMOKED" ] },
     "vitamins": [ [ "meat_allergen", 1 ] ]
   },

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -665,7 +665,7 @@
     "primary_material": "dried_vegetable",
     "volume": "250 ml",
     "charges": 2,
-    "delete": { "flags": [ "RAW" ] },
+    "delete": { "flags": [ "RAW", "SMOKABLE" ] },
     "vitamins": [ [ "veggy_allergen", 1 ] ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
dehydrated meat, veggy, and fish are supposed to be the most "smoked" version of the item, however because these items use copy-froms from items that do have the SMOKABLE flag, and don't delete that flag, you can infinitely resmoke dehydrated meat, veggy, and fish.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Properly removes the smokable flag from these dehydrated items.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Smokeception
## Testing
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/f306af28-66c0-44cb-af29-d547f3396925" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Thanks to Sato Monster on discord for the bug report
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [67a0c1d](https://github.com/cataclysmbn/Cataclysm-BN/commit/67a0c1d2e89eef697a05a8f18b290a95d6c65325) (Update meat_dishes.json) on 2026-08-03 10:06:51

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30783508697/artifacts/8844632626)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30783508697)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30783508697/artifacts/8844653719)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30783508697/artifacts/8844727852)
<!-- END artifact comment -->