### PR TITLE
feat(balance): bullets cause pain even if fully resisted by armor

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1304,6 +1304,10 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
 
     // Apply damage multiplier from skill, critical hits or grazes after all other modifications.
     int adjusted_damage = du.amount * du.damage_multiplier;
+    // Bullets cause pain even if fully resisted by armor to simulate force still applying through ballistic protection
+    if ( du.type == DT_BULLET && adjusted_damage <= 0 ) {
+        pain += roll_remainder( adjusted_damage * 2 / 4.0f );
+    }
     if( adjusted_damage <= 0 ) {
         return;
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1305,7 +1305,7 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
     // Apply damage multiplier from skill, critical hits or grazes after all other modifications.
     int adjusted_damage = du.amount * du.damage_multiplier;
     // Bullets cause pain even if fully resisted by armor to simulate force still applying through ballistic protection
-    if ( du.type == DT_BULLET && adjusted_damage <= 0 ) {
+    if( du.type == DT_BULLET && adjusted_damage <= 0 ) {
         pain += roll_remainder( du.amount * 2 / 4.0f );
     }
     if( adjusted_damage <= 0 ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1306,7 +1306,7 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
     int adjusted_damage = du.amount * du.damage_multiplier;
     // Bullets cause pain even if fully resisted by armor to simulate force still applying through ballistic protection
     if ( du.type == DT_BULLET && adjusted_damage <= 0 ) {
-        pain += roll_remainder( adjusted_damage * 2 / 4.0f );
+        pain += roll_remainder( du.amount * 2 / 4.0f );
     }
     if( adjusted_damage <= 0 ) {
         return;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
After the ballistic armor rebalance, it became pretty easy to obtain armor strong enough to shrug off most rounds found in game, leading to a drastic reduction in the danger of previously deadly enemies like turrets. There were suggestions of this in a reddit thread about armor being too powerful, and I agree this seems like a good way to keep bullets dangerous while not having them instagib you when you have proper protection.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes ballistic damage cause pain even if fully resisted by armor. 
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Build artifact, hope no explosions
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0a64848](https://github.com/cataclysmbn/Cataclysm-BN/commit/0a648487cec08ec6105591bbfb1b1e3306e82163) (Apply suggestion from @chaosvolt) on 2026-08-04 03:59:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30857065659/artifacts/8873511788)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30857065659)
- [⏳ macOS tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30857065659)
- [⏳ Android tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30857065659)
<!-- END artifact comment -->