### PR TITLE
feat(balance): bullets can cause pain through armor with new armor mechanics on, scale by armor effectiveness

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9314,7 +9314,7 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
         if( absorbed_ballistic_damage > 0 ) {
             // Bonus idiotproofing against divide-by-zero, this SHOULD never trigger if armor resist was zero since then absorbed_ballistic_damage would be zero but just to be safe
             float ballistic_mult = armor.damage_resist( du.type,
-                                   true ) > 0 ? absorbed_ballistic_damage / armor.damage_resist( du.type, true ) / 2 : 1;
+                                   true ) > 0 ? absorbed_ballistic_damage / armor.damage_resist( du.type, true ) : 1;
             mod_pain( absorbed_ballistic_damage * ballistic_mult );
         }
         // We're indestructible, bail out here.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9299,7 +9299,26 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
         // Don't damage armor as much when bypassed by armor piercing
         // Most armor piercing damage comes from bypassing armor, not forcing through
         const int raw_dmg = du.amount * std::min( 1.0f, du.damage_multiplier );
+        int ballistic_damage = 0;
+        float absorbed_ballistic_damage = 0.0f;
+        if( du.type == DT_BULLET ) {
+            ballistic_damage += raw_dmg;
+        }
+        add_msg_if_player( m_info, _( "ballistic_damage is %s" ), ballistic_damage );
         armor.mitigate_damage( du );
+        // Track how much ballistic damage we soaked up.
+        if( du.type == DT_BULLET && du.amount < ballistic_damage ) {
+            absorbed_ballistic_damage += ballistic_damage - du.amount;
+        }
+        add_msg_if_player( m_info, _( "absorbed_ballistic_damage is %s" ), absorbed_ballistic_damage );
+        // Add a fraction of the pain from soaking up that we would've taken without armor
+        // Scale this pain down based on how effective the armor was.
+        if( absorbed_ballistic_damage > 0 ) {
+            // Bonus idiotproofing against divide-by-zero, this SHOULD never trigger if armor resist was zero since then absorbed_ballistic_damage would be zero but just to be safe
+            float ballistic_mult = armor.damage_resist( du.type,
+                                   true ) > 0 ? absorbed_ballistic_damage / armor.damage_resist( du.type, true ) : 1;
+            mod_pain( absorbed_ballistic_damage * ballistic_mult );
+        }
         // We're indestructible, bail out here.
         if( armor.has_flag( flag_UNBREAKABLE ) ) {
             return false;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9314,7 +9314,7 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
         if( absorbed_ballistic_damage > 0 ) {
             // Bonus idiotproofing against divide-by-zero, this SHOULD never trigger if armor resist was zero since then absorbed_ballistic_damage would be zero but just to be safe
             float ballistic_mult = armor.damage_resist( du.type,
-                                   true ) > 0 ? absorbed_ballistic_damage / armor.damage_resist( du.type, true ) : 1;
+                                   true ) > 0 ? absorbed_ballistic_damage / armor.damage_resist( du.type, true ) / 2 : 1;
             mod_pain( absorbed_ballistic_damage * ballistic_mult );
         }
         // We're indestructible, bail out here.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9304,13 +9304,11 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
         if( du.type == DT_BULLET ) {
             ballistic_damage += raw_dmg;
         }
-        add_msg_if_player( m_info, _( "ballistic_damage is %s" ), ballistic_damage );
         armor.mitigate_damage( du );
         // Track how much ballistic damage we soaked up.
         if( du.type == DT_BULLET && du.amount < ballistic_damage ) {
             absorbed_ballistic_damage += ballistic_damage - du.amount;
         }
-        add_msg_if_player( m_info, _( "absorbed_ballistic_damage is %s" ), absorbed_ballistic_damage );
         // Add a fraction of the pain from soaking up that we would've taken without armor
         // Scale this pain down based on how effective the armor was.
         if( absorbed_ballistic_damage > 0 ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -62,6 +62,8 @@
 #include "overmapbuffer_registry.h"
 #include "profile.h"
 
+static const trait_id trait_NOPAIN( "NOPAIN" );
+
 auto Creature::get_dimension() const -> const dimension_id &
 {
     return g_active_dimension_id;
@@ -1276,6 +1278,13 @@ dealt_damage_instance Creature::deal_damage( Creature *source, bodypart_id bp,
         if( cur_damage > 0 ) {
             dealt_dams.dealt_dams[ it.type ] += cur_damage;
             total_damage += cur_damage;
+        } else if( it.type == DT_BULLET && get_option<bool>( "NEW_ARMOR_CALCULATION" ) ) {
+            // This just serves to warn the player of why they suffered pain if the hit dealt zero damage.
+            // Actual pain increase scales with armor and thus is in Character::armor_absorb
+            if( !has_trait( trait_NOPAIN ) ) {
+                add_msg_if_player( m_bad, _( "Your %s aches from the impact." ),
+                                   body_part_name_accusative( bp ) );
+            }
         }
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2851,7 +2851,7 @@ void options_manager::add_options_debug()
 
     add( "NEW_ARMOR_CALCULATION", debug, translate_marker( "New armor damage calculation" ),
          translate_marker( "If true, armor will be able to take damage from attacks that don't penetrate it, but attacks in general damage armor less frequently.  "
-                           "Bullets will also deal pain through armor, reduced by how effect that armor is." ),
+                           "Bullets will also deal pain through armor, reduced by how effective that armor is." ),
          true );
 
     add_empty_line();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2850,7 +2850,8 @@ void options_manager::add_options_debug()
          false );
 
     add( "NEW_ARMOR_CALCULATION", debug, translate_marker( "New armor damage calculation" ),
-         translate_marker( "If true, armor will be able to take damage from attacks that don't penetrate it, but attacks in general damage armor less frequently." ),
+         translate_marker( "If true, armor will be able to take damage from attacks that don't penetrate it, but attacks in general damage armor less frequently.  "
+                           "Bullets will also deal pain through armor, reduced by how effect that armor is." ),
          true );
 
     add_empty_line();


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This implements a thing dedmem wanted (attempted in https://github.com/cataclysmbn/Cataclysm-BN/pull/10010) that allows bullets to inflict pain through armor, but gave up because he wanted the pain to scale based on how effective the armor is.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In character.cpp, added to `Character::armor_absorb`. If the new armor damage mechanics are turned on, then it will check for ballistic damage and make note of it, then additionally determine the difference between initial damage and damage after mitigation to determine exactly how much damage was absorbed by the armor. Then if it absorbed anything, it'll add pain at a rate reduced by the total ballistic resistance of said armor, making it so better armor will make you suffer less pain through it.
2. In creature.cpp, added a thing in `Creature::deal_damage` that checks if you took a zero-damage hit from a bullet with the new armor system on. If so it'll print a message to explain why you're getting pain from a non-damaging hit. Set not to print if you actually took damage because the player already should be able to link the pain to the fact they took damage.
3. Added mention of new feature in description of the option in options.cpp

## Describe alternatives you've considered

Letting other damagetypes do this too?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Let a turret shoot me while naked, hits tended to give 20-23 pain. No extra pain message as expected.
3. Retested in light power armor, I suffered 11 pain despite taking no damage, pain message prints.
4. Swapped for heavy power armor and retested, I suffered 3 pain instead.
5. Turned new armor mechanics off, no pain from zero-damage hits.
6. Tested having the setting on and taking hits with Deadened, no pain and no extra pain message.
7. Spawned an armored zombie to confirm trait check doesn't act up when hitting monsters.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9b90701](https://github.com/cataclysmbn/Cataclysm-BN/commit/9b907010c1e7ade156f2a17a85fc460dfc9c5b14) (Update character.cpp) on 2026-08-04 05:24:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30876068945/artifacts/8879786774)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30876068945/artifacts/8881112102)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30876068945/artifacts/8879881915)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30876068945/artifacts/8879927469)
<!-- END artifact comment -->