### PR TITLE
feat(balance): adjust chip resist roll in new armor system

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9317,10 +9317,11 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
         if( !one_in( num_parts_covered ) ) {
             return false;
         }
-        const int dmg_percent = std::max( raw_dmg - armor.chip_resistance( !armor.has_flag( flag_STURDY ) ),
-                                          1 );
-        // Chance to avoid armor damage is 50/67% (if sturdy) + 100 - ( raw_dmg - chip_resist )%
-        if( !one_in( armor.has_flag( flag_STURDY ) ? 3 : 2 ) || !x_in_y( dmg_percent, 100 ) ) {
+        const int armor_chip_resist = armor.chip_resistance( !armor.has_flag( flag_STURDY ) );
+        const bool armor_resisted = raw_dmg >= armor_chip_resist ? rng( 1,
+                                    raw_dmg ) <= armor_chip_resist : !one_in( 100 );
+        // Base chance to avoid armor damage is 50/67% (if sturdy), or if chip resist exceeds 1d<damage> (floor of 1%)
+        if( !one_in( armor.has_flag( flag_STURDY ) ? 3 : 2 ) || armor_resisted ) {
             return false;
         }
     }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This tweaks the new armor chip damage mechanics a bit, as I feel like I overcorrected slightly in https://github.com/cataclysmbn/Cataclysm-BN/pull/9757.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In character.cpp, changed how armor chip damage roll in `Character::armor_absorb` is handled. Instead of a percentage roll that takes total damage and subtracts chip resist, the main roll is instead 1d`damage` vs chip resist.

To preserve the old "floor of 1% for the roll to fail" behavior, added a separate percentage chance for if damage is less than chip resist.

## Describe alternatives you've considered

`std::min`ing chip resist vs armor's actual protection to get the value for the damage roll to trigger?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned a power armor soldier, light turret inflicted a single tick of damage after waiting 5 minutes in front of it.
3. Spawned as a normal profession, debugged health up high then spawned a zombie, items took a couple hits after 10 minutes of waiting.

Rough math:
1. Before, shooting medium power armor with 7.62x51mm had a base damage of 48, becoming a 28% chance to fail the save after subtracting its 20 chip resist. Actual chance to damage the suit itself was cut in third due to sturdy, then cut into a nineth due to covering all body parts, for an actual damage chance of ~1.037%.
2. After, the same roll will fail the save if 1d48 returns a result over 20, or a base chance of about ~58.333%, final damage chance of ~2.16%
3. Basic cloth clothing has a chip resist of 6, so assuming a zombie dealt max damage with its basic attack it had a 3% chance to trigger. Now said attack would have a ~33.333% chance to trigger assuming max damage was rolled. While this is a boost, the original math would be a 43.75% chance to fail the save in the worst-case scenario (max damage of 9, armor only provided 1 protection, chance to pass save is thus 1 in 8, bonus save of 1 in 2, only covers one bodypart). Actual chance of damage will be lower in all cases since obviously the zombie won't deal a perfect roll, in practice average of 3d3 is only 4.5 so the majority of hits will likely only get the fallback 1% failure chance.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e1c413d](https://github.com/cataclysmbn/Cataclysm-BN/commit/e1c413d05c545582e688b771a94ffdc0450aa750) (Merge remote-tracking branch 'upstream/main' into explodes-power-armor-with-mind) on 2026-08-05 02:28:23

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30965710334/artifacts/8915763992)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30965710334/artifacts/8915923114)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30965710334/artifacts/8914869435)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30965710334/artifacts/8914967174)
<!-- END artifact comment -->