### PR TITLE
fix: greatly reduce `CLUMSY` mutations' effect

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1150,7 +1150,7 @@
     "description": "You make more noise while walking.",
     "starting_trait": true,
     "cancels": [ "LIGHTSTEP" ],
-    "noise_modifier": 2
+    "mut_enchantments": [ { "values": [ { "value": "NOISE", "add": 12 } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
## Purpose of change (The Why)
Closes #10009

## Describe the solution (The How)
`noise_modifier` multiplies sound values while walking.
Previously `noise_modifier` would double the tiles value, now it doubles the decibes value.
Meaning 50 -> 100.
Instead add 12 decibels, roughly 4x increase ( a little more then running amount )

## Describe alternatives you've considered
Make it +6, about half running increase

## Testing
I no longer deafen myself while walking

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [48ed3f7](https://github.com/cataclysmbn/Cataclysm-BN/commit/48ed3f76050a6721879eae987acb85ebf3e84452) (fix: greatly reduce `CLUMSY` mutations' effect) on 2026-08-04 21:41:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30946235755/artifacts/8907497285)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30946235755/artifacts/8909534080)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30946235755/artifacts/8909999418)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30946235755/artifacts/8907674390)
<!-- END artifact comment -->