### PR TITLE
fix: fix melee sounds attempt 2

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -599,7 +599,7 @@ auto sfx::play_variant_sound( const std::string &id, const std::string &variant,
 
     const auto res_id = eff->resource_id;
     auto *audio = get_sfx_resource( res_id );
-    if( !stacks && !valid_last_time_played( audio, res_id, variant ) ) {
+    if( !stacks && !valid_last_time_played( audio, res_id, id + "_" + variant ) ) {
         return;
     }
 
@@ -641,7 +641,7 @@ auto sfx::play_variant_sound( const std::string &id, const std::string &variant,
 
     const auto res_id = eff->resource_id;
     auto *audio = get_sfx_resource( res_id );
-    if( !valid_last_time_played( audio, res_id, variant ) ) {
+    if( !valid_last_time_played( audio, res_id, id + "_" + variant ) ) {
         return;
     }
 
@@ -693,7 +693,7 @@ auto sfx::play_ambient_variant_sound( const std::string &id, const std::string &
 
     const auto res_id = eff->resource_id;
     auto *audio = get_sfx_resource( res_id );
-    if( !valid_last_time_played( audio, res_id, variant ) ) {
+    if( !valid_last_time_played( audio, res_id, id + "_" + variant ) ) {
         return;
     }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Closes #10007
Followup to: #9940

## Describe the solution (The How)
In #9940 I was too hung over the multithreading stuff that I was pretty sure that I heard the melee hit sounds but was wrong

Change key from variant to id + "_" + variant

## Describe alternatives you've considered
None

## Testing
Once again I think my ears work
I really hope they do this time
And they dont get burned by a pickaxe

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2969838](https://github.com/cataclysmbn/Cataclysm-BN/commit/2969838a4c1fc376874416dd9397f78721d21e3f) (fix: fix melee sounds attempt 2) on 2026-08-04 21:50:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30947612253/artifacts/8908082867)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30947612253)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30947612253/artifacts/8908149104)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30947612253/artifacts/8908267701)
<!-- END artifact comment -->