### PR TITLE
fix(balance): buff charcoal fuel energy density to match IRL values

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -750,7 +750,7 @@
     "ammo_type": "charcoal",
     "count": 50,
     "stack_size": 10,
-    "fuel": { "energy": 1.6 },
+    "fuel": { "energy": 13 },
     "flags": [ "TINDER" ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

closes #10018 

Charcoal's `fuel.energy` (1.6 kJ/ml = 40 kJ per 25 ml charge) is ~5–9× below the real volumetric energy density of charcoal. In steam engines, which accept both coal and charcoal, charcoal burns ~18.75× faster than coal per charge (real ratio ~3–4×), making it nearly worthless as a renewable engine fuel.

## Describe the solution (The How)

One-line JSON change in `data/json/items/ammo.json`:
```
-   "fuel": { "energy": 1.6 },
+   "fuel": { "energy": 13 },
```
13 kJ/ml × 25 ml/charge = 325 kJ/charge → 29.5 MJ/kg at the item's 11 g weight, within the real 28–33 MJ/kg range. Coal:charcoal ratio becomes ~2.3×, still clearly favoring coal.

## Describe alternatives you've considered

- **8 kJ/ml (200 kJ/charge)** — matches typical lump-charcoal volumetric density, but gives 18 MJ/kg at the game's weight; per-mass inconsistency.
- **16 kJ/ml (400 kJ/charge)** — anchors per-kg energy, but exceeds the real volumetric range for this density.
- **Status quo (1.6)** — charcoal remains ~19× worse than coal per charge.
- 13 was chosen as the value consistent with both the item's existing density (11 g / 25 ml = 0.44 g/ml) and real per-kg energy (28–33 MJ/kg).

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

- `python3 -m json.tool data/json/items/ammo.json` — JSON parses cleanly.
- No cpp code touched: engine fuel consumption scales directly off the value (`vehicle.cpp` `fuel_energy()`), so no regression.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

- The 1.6 value originates from DDA PR #28579 (2019-03-10, commit `872949cdd2413b31685f7d760b6664f75d5c5589`) and predates BN.
- Real-world sources for the 28–33 MJ/kg / 0.2–0.4 g/ml figures are linked in #10018.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a35f6a5](https://github.com/cataclysmbn/Cataclysm-BN/commit/a35f6a5973754173e7d1a7478e5be776cffdf64b) (fix(balance): charcoal fuel energy density 5-9x too low) on 2026-08-05 06:17:06

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30978535330/artifacts/8919456219)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30978535330/artifacts/8920016204)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30978535330/artifacts/8919460284)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/30978535330/artifacts/8919549009)
<!-- END artifact comment -->