### PR TITLE
build: update bundled overhaul tileset

### DIFF
--- a/build-scripts/bundle-registry-mods.ts
+++ b/build-scripts/bundle-registry-mods.ts
@@ -3,7 +3,7 @@
 /**
  * @module
  *
- * Bundles pinned Cataclysm: Bright Nights registry mods into release data.
+ * Bundles Cataclysm: Bright Nights registry mods into release data.
  */
 
 import { Command } from "@cliffy/command"
@@ -20,6 +20,7 @@ const LockSchema = v.array(v.object({
   id: v.string(),
   version: v.string(),
   url: v.pipe(v.string(), v.url()),
+  extract_path: v.optional(v.string()),
 }))
 const RegistrySchema = v.array(v.looseObject({
   id: v.string(),
@@ -74,12 +75,14 @@ export const selectEntries = (
   }).filter((entry) => !excludedPackageTypes.has(packageType(entry)))
 }
 
+const extractPath = (entry: BundleEntry) => entry.lock.extract_path ?? entry.source.extract_path
+
 const targetDir = (entry: BundleEntry, outputRoot: string) =>
   join(
     outputRoot,
     "data",
     packageType(entry) === "soundpack" ? "sound" : "mods",
-    entry.source.extract_path ? pathParts(entry.source.extract_path).at(-1)! : entry.id,
+    extractPath(entry) ? pathParts(extractPath(entry)!).at(-1)! : entry.id,
   )
 
 const download = async (entry: BundleEntry, cacheDir: string) => {
@@ -103,12 +106,13 @@ const findSingleDir = async (root: string) => {
 }
 
 const findExtractDir = async (entry: BundleEntry, root: string) => {
-  const extract = pathParts(entry.source.extract_path ?? "")
+  const sourcePath = extractPath(entry)
+  const extract = pathParts(sourcePath ?? "")
   if (!extract.length) return await findSingleDir(root)
   for await (const { path } of walk(root, { includeFiles: false })) {
     if (pathParts(path).slice(-extract.length).join("/") === extract.join("/")) return path
   }
-  throw new Error(`${entry.id} archive did not contain ${entry.source.extract_path}`)
+  throw new Error(`${entry.id} archive did not contain ${sourcePath}`)
 }
 
 const extract = async (entry: BundleEntry, archive: string, outputRoot: string) => {
@@ -166,7 +170,7 @@ export const bundle = async (options: BundleOptions): Promise<BundleEntry[]> => 
 const main = () =>
   new Command()
     .name("bundle-registry-mods")
-    .description("Bundle pinned BN mod registry entries into release data.")
+    .description("Bundle BN mod registry entries into release data.")
     .option("--manifest <path:string>", "External registry lockfile path", {
       default: "data/mods/external.json",
     })

--- a/data/mods/external.json
+++ b/data/mods/external.json
@@ -17,12 +17,14 @@
   {
     "id": "overhaul",
     "version": "0.0.2",
-    "url": "https://github.com/scarf005/Overhaul/archive/refs/tags/v0.0.2.zip"
+    "url": "https://github.com/scarf005/Overhaul/archive/9180c5a2b93c07908c7b5dd714bf92bb3d7a4e20.zip",
+    "extract_path": "overhaul"
   },
   {
     "id": "overhaul_additions",
     "version": "0.0.2",
-    "url": "https://github.com/scarf005/Overhaul/archive/refs/tags/v0.0.2.zip"
+    "url": "https://github.com/scarf005/Overhaul/archive/9180c5a2b93c07908c7b5dd714bf92bb3d7a4e20.zip",
+    "extract_path": "overhaul_additions"
   },
   {
     "id": "otopack_bn_mk_2",


### PR DESCRIPTION
## Purpose of change (The Why)

apply https://github.com/scarf005/Overhaul/pull/2

## Describe the solution (The How)

- add `extract_path` support because it was only supported for registry mods before
- bump overhaul tileset version

## Testing

```
deno run --allow-read --allow-write --allow-net build-scripts/bundle-registry-mods.ts
cbn_sky_island: Sky Island (mod)
bundled cbn_sky_island -> data/mods/cbn_sky_island
jake_s_squirrel_mod: 프로젝트: 다람쥐 (mod)
bundled jake_s_squirrel_mod -> data/mods/ProjectSquirrel
ny_transformers: Transformers (mod)
bundled ny_transformers -> data/mods/transformers_beta2.2
overhaul: Overhaul Tileset (mod)
bundled overhaul -> data/mods/overhaul
overhaul_additions: Overhaul Additions (mod)
bundled overhaul_additions -> data/mods/overhaul_additions
otopack_bn_mk_2: Otopack BN Mk 2 (soundpack)
bundled otopack_bn_mk_2 -> data/sound/Otopack+ModsUpdates BN
```
```
lsd -alh data/mods/overhaul
drwxr-xr-x. scarf scarf 614 B  2026-08-05 수 20:58:50  .
drwxr-xr-x. scarf scarf 2.6 KB 2026-08-05 수 20:59:21  ..
drwxr-xr-x. scarf scarf 236 B  2026-08-05 수 20:58:50  appearance
.rw-r--r--. scarf scarf 334 B  2026-08-05 수 20:58:50  modinfo.json
.rw-r--r--. scarf scarf 207 B  2026-08-05 수 20:58:50  mutation_ordering.json
drwxr-xr-x. scarf scarf  56 B  2026-08-05 수 20:58:50  mutations
.rw-r--r--. scarf scarf  74 KB 2026-08-05 수 20:58:50  overhaul.png
.rw-r--r--. scarf scarf  42 KB 2026-08-05 수 20:58:50  overhaul48.png
.rw-r--r--. scarf scarf  13 KB 2026-08-05 수 20:58:50  overhaul_customization_base.png
.rw-r--r--. scarf scarf  75 KB 2026-08-05 수 20:58:50  overhaul_customization_hair.png
.rw-r--r--. scarf scarf  31 KB 2026-08-05 수 20:58:50  overhaul_customization_hair2.png
.rw-r--r--. scarf scarf 7.7 KB 2026-08-05 수 20:58:50  overhaul_customization_hair_tintable.png
.rw-r--r--. scarf scarf 7.1 KB 2026-08-05 수 20:58:50  overhaul_interface.png
.rw-r--r--. scarf scarf 1.1 KB 2026-08-05 수 20:58:50  overhaul_interface_tiles.json
.rw-r--r--. scarf scarf  31 KB 2026-08-05 수 20:58:50  overhaul_mutation.png
.rw-r--r--. scarf scarf  10 KB 2026-08-05 수 20:58:50  tiles.json
.rw-r--r--. scarf scarf 4.2 KB 2026-08-05 수 20:58:50  tiles48.json
```
bundling works fine

<img width="1410" height="850" alt="image" src="https://github.com/user-attachments/assets/56c30a2b-df8c-4e0a-99c0-5b6a4873cd20" />

game loads fine without errors with both overhaul mods
also spawned like 10 NPCs without errors

## Checklist


### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional


- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3bea114](https://github.com/cataclysmbn/Cataclysm-BN/commit/3bea1141f40bb6716f916bf565e968b9af43ebdb) (fix: pin overhaul bundles to commit) on 2026-08-05 16:28:49

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31005574599/artifacts/8938120256)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31005574599/artifacts/8931333596)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31005574599/artifacts/8930645898)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31005574599/artifacts/8930643025)
<!-- END artifact comment -->