### PR TITLE
fix: components can no longer rot when their display names are checked

### DIFF
--- a/data/json/external_tileset/External_Tileset_DP_dmd.json
+++ b/data/json/external_tileset/External_Tileset_DP_dmd.json
@@ -180,11 +180,35 @@
           { "id": "overlay_wielded_c4_breaching", "fg": 112 },
           { "id": "c4_breaching_armed", "fg": 113 },
           { "id": "overlay_wielded_c4_breaching_armed", "fg": 114 },
-          { "id": [ "power_armor_exo_1", "power_armor_exo_1_on", "overlay_wielded_power_armor_exo_1", "overlay_wielded_power_armor_exo_1_on" ], "fg": 115 },
+          {
+            "id": [
+              "power_armor_exo_1",
+              "power_armor_exo_1_on",
+              "overlay_wielded_power_armor_exo_1",
+              "overlay_wielded_power_armor_exo_1_on"
+            ],
+            "fg": 115
+          },
           { "id": [ "overlay_worn_power_armor_exo_1", "overlay_worn_power_armor_exo_1_on" ], "fg": 116 },
-          { "id": [ "power_armor_exo_2", "power_armor_exo_2_on", "overlay_wielded_power_armor_exo_2", "overlay_wielded_power_armor_exo_2_on" ], "fg": 117 },
+          {
+            "id": [
+              "power_armor_exo_2",
+              "power_armor_exo_2_on",
+              "overlay_wielded_power_armor_exo_2",
+              "overlay_wielded_power_armor_exo_2_on"
+            ],
+            "fg": 117
+          },
           { "id": [ "overlay_worn_power_armor_exo_2", "overlay_worn_power_armor_exo_2_on" ], "fg": 118 },
-          { "id": [ "power_armor_exo_3", "power_armor_exo_3_on", "overlay_wielded_power_armor_exo_3", "overlay_wielded_power_armor_exo_3_on" ], "fg": 119 },
+          {
+            "id": [
+              "power_armor_exo_3",
+              "power_armor_exo_3_on",
+              "overlay_wielded_power_armor_exo_3",
+              "overlay_wielded_power_armor_exo_3_on"
+            ],
+            "fg": 119
+          },
           { "id": [ "overlay_worn_power_armor_exo_3", "overlay_worn_power_armor_exo_3_on" ], "fg": 120 },
           { "id": [ "depowered_exo", "overlay_wielded_depowered_exo" ], "fg": 121 },
           { "id": "overlay_worn_depowered_exo", "fg": 122 }
@@ -197,10 +221,7 @@
         "sprite_width": 32,
         "sprite_height": 32,
         "sprite_offset_y": -16,
-        "tiles": [ 
-          { "id": "overlay_worn_tac_fullhelmet", "fg": 43 },
-          { "id": "overlay_worn_tac_helmet", "fg": 45 }
-        ]
+        "tiles": [ { "id": "overlay_worn_tac_fullhelmet", "fg": 43 }, { "id": "overlay_worn_tac_helmet", "fg": 45 } ]
       }
     ]
   }

--- a/data/json/external_tileset/armor.json
+++ b/data/json/external_tileset/armor.json
@@ -68,7 +68,7 @@
         "sprite_width": 32,
         "sprite_height": 32,
         "sprite_offset_y": -4,
-        "tiles": [ 
+        "tiles": [
           { "id": "overlay_worn_goggles_ir", "fg": 11, "masks": [ { "type": "tint", "fg": 27 } ], "rotates": true },
           { "id": "overlay_worn_goggles_nv", "fg": 15, "masks": [ { "type": "tint", "fg": 31 } ], "rotates": true },
           {

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2053,6 +2053,11 @@
     "context": [  ]
   },
   {
+    "id": "COMPONENT",
+    "type": "json_flag",
+    "context": [  ]
+  },
+  {
     "id": "PROCESSING",
     "type": "json_flag",
     "context": [  ]

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -680,6 +680,7 @@ static void set_components( item &of, const std::vector<item *> &used,
     if( batch_size <= 1 ) {
         for( item * const &it : used ) {
             components.push_back( item::spawn( *it ) );
+            components.back()->set_flag( flag_id( "COMPONENT" ) );
         }
         return;
     }
@@ -691,9 +692,11 @@ static void set_components( item &of, const std::vector<item *> &used,
             // This assumes all (count-by-charges) items of the same type have been merged into one,
             // which has a charges value that can be evenly divided by batch_size.
             components.back()->charges = tmp->charges / batch_size;
+            components.back()->set_flag( flag_id( "COMPONENT" ) );
         } else {
             if( ( non_charges_counter + offset ) % batch_size == 0 ) {
                 components.push_back( item::spawn( *tmp ) );
+                components.back()->set_flag( flag_id( "COMPONENT" ) );
             }
             non_charges_counter++;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -29,6 +29,7 @@
 #include "bionics.h"
 #include "bodypart.h"
 #include "cached_item_options.h"
+#include "calendar.h"
 #include "catalua_icallback_actor.h"
 #include "cata_utility.h"
 #include "catacharset.h"
@@ -6454,6 +6455,10 @@ time_duration item::get_shelf_life() const
 
 double item::get_relative_rot() const
 {
+    // Components are frozen in time, when they are returned they are new items
+    if( has_flag( flag_id( "COMPONENT" ) ) ) {
+        return rot / get_shelf_life();
+    }
     if( goes_bad() ) {
         const_cast<item *>( this )->update_rot_from_location( temperature_flag::TEMP_NORMAL );
         return rot / get_shelf_life();


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #10028
Continuation of: #9098 #9010 and friends

## Describe the solution (The How)
Add the `COMPONENT` flag, it is autoapplied to created component items, and it prevents `display_name` from causing rot while still keeping previous time values if they become important

## Describe alternatives you've considered
Dont update rot when checking display names

## Testing
Made some smoked meat
Skipped 2 years
It still says fresh

## Additional Context
This is ***NOT*** a retroactive fix
## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [11a3ed1](https://github.com/cataclysmbn/Cataclysm-BN/commit/11a3ed173f2f2650921c495bba3749801043b9d8) (eepy and forgetful) on 2026-08-07 04:32:56

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31143274110/artifacts/8981657028)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31143274110/artifacts/8982075011)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31143274110/artifacts/8980888975)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31143274110/artifacts/8980887259)
<!-- END artifact comment -->