### PR TITLE
fix: re-add clothing mods to power armor plating

### DIFF
--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -49,6 +49,7 @@
     "material_thickness": 5,
     "environmental_protection": 0,
     "resistance": { "bullet": 60 },
+    "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
     "use_action": {
       "type": "set_transformed",
       "dependencies": "POWERARMOR_EXO",
@@ -227,6 +228,7 @@
     "warmth": 30,
     "material_thickness": 11,
     "environmental_protection": 0,
+    "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
     "use_action": {
       "type": "set_transformed",
       "dependencies": "POWERARMOR_EXO",
@@ -352,6 +354,7 @@
     "warmth": 30,
     "material_thickness": 9,
     "environmental_protection": 0,
+    "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
     "use_action": {
       "type": "set_transformed",
       "dependencies": "POWERARMOR_EXO",
@@ -477,6 +480,7 @@
     "warmth": 30,
     "material_thickness": 7,
     "environmental_protection": 0,
+    "valid_mods": [ "steel_padded", "hard_steel_padded", "alloy_padded", "resized_large", "resized_small" ],
     "use_action": {
       "type": "set_transformed",
       "dependencies": "POWERARMOR_EXO",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fix a lil oversight in https://github.com/cataclysmbn/Cataclysm-BN/pull/10014, which lets you apply clothing mods to the undersuit power armor now has but removed the ability to up-armor and resize the actual plating layer.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Re-added compatibility with resizing and up-armoring clothing mods to power armor plating. Consistent with how you can resize but not up-armor depowered exos, and both resize and up-armor depowered PA plating.

## Describe alternatives you've considered

1. Also allowing you to up-armor the undersuit as a bootleg protection option.
2. Not letting ogres have power armor.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Checked affected file for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5403838](https://github.com/cataclysmbn/Cataclysm-BN/commit/5403838afae5fa0cf47109478ccca341375d3312) (fix: re-add clothing mods to power armor plating) on 2026-08-07 22:15:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31220412889/artifacts/9010407505)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31220412889/artifacts/9011039774)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31220412889/artifacts/9010488457)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31220412889/artifacts/9010612087)
<!-- END artifact comment -->