### PR TITLE
feat: make old guard doctor mission camp spawn actual placed cots instead of cot items

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -266,15 +266,17 @@
           "T": { "items": [ { "item": "ammo_swat", "chance": 100 } ] },
           "S": { "items": [ { "item": "classified_file_docmission", "chance": 100 } ] }
         },
+        "set": [
+          { "point": "trap", "id": "tr_cot", "x": 8, "y": 8 },
+          { "point": "trap", "id": "tr_cot", "x": 10, "y": 12 },
+          { "point": "trap", "id": "tr_cot", "x": 15, "y": 11 },
+          { "point": "trap", "id": "tr_cot", "x": 15, "y": 8 }
+        ],
         "place_items": [
           { "item": "bed", "x": 8, "y": 8, "chance": 100, "repeat": 1 },
           { "item": "bed", "x": 10, "y": 12, "chance": 100, "repeat": 1 },
           { "item": "bed", "x": 15, "y": 11, "chance": 100, "repeat": 1 },
           { "item": "bed", "x": 15, "y": 8, "chance": 100, "repeat": 1 },
-          { "item": "cot", "x": 8, "y": 8, "chance": 100, "repeat": 1 },
-          { "item": "cot", "x": 10, "y": 12, "chance": 100, "repeat": 1 },
-          { "item": "cot", "x": 15, "y": 11, "chance": 100, "repeat": 1 },
-          { "item": "cot", "x": 15, "y": 8, "chance": 100, "repeat": 1 },
           { "item": "mil_food_nodrugs", "x": [ 10, 13 ], "y": 6, "chance": 100, "repeat": [ 2, 5 ] },
           { "item": "mil_food", "x": [ 13, 15 ], "y": 5, "chance": 100, "repeat": [ 2, 5 ] }
         ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The old guard tcl mission spawns an npc camp, and they are supposed to have cots to sleep on, but they are spawned as items instead of as placed cots.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Replaces the item cots with placed cots.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
No Cots?
## Testing
Debug started the mission, teleported to, cots are placed correctly
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
I don't think I knew you could even do this when I was making this mission lol
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [de750fd](https://github.com/cataclysmbn/Cataclysm-BN/commit/de750fd4dd585ca451f8c30bd0ac4b84c1bea3f9) (Update NPC_old_guard_doctor.json) on 2026-08-08 10:09:01

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31238442197/artifacts/9017055687)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31238442197/artifacts/9017173035)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31238442197/artifacts/9016463273)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31238442197/artifacts/9016559728)
<!-- END artifact comment -->