### PR TITLE
fix: fix sweep unattack unable to be used with weapons

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -128,6 +128,7 @@
     "id": "SWEEP",
     "name": "Sweep Attack",
     "unarmed_allowed": true,
+    "melee_allowed": true,
     "down_dur": 2,
     "messages": [ "You sweep %s", "<npcname> sweeps %s" ],
     "description": "Down 2 turns"


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Closes #10034 
Many melee weapons have the sweep attack technique, but currently it is set to only be usable unarmed.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds melee_allowed to the sweep attack technique.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Bug
## Testing
Spawned in morningstar and fireaxe, attacked debug monster, sweep attack triggers as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Hopefully sweep attack wasn't disabled on melee weapons for a reason lol
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0db11e5](https://github.com/cataclysmbn/Cataclysm-BN/commit/0db11e5566a50b1e0bbad60f735a892196cbf93e) (Update techniques.json) on 2026-08-08 13:39:33

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31257534721/artifacts/9022425824)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31257534721/artifacts/9022203756)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31257534721/artifacts/9021972021)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31257534721/artifacts/9021978840)
<!-- END artifact comment -->