### PR TITLE
feat(lua): add istate on_puff callback

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -918,11 +918,12 @@ void reg_lua_icallback_actors( lua_state &state, Item_factory &ifactory )
                 auto on_tick = tbl.get_or<sol::function>( "on_tick", sol::lua_nil );
                 auto on_pickup = tbl.get_or<sol::function>( "on_pickup", sol::lua_nil );
                 auto on_drop = tbl.get_or<sol::function>( "on_drop", sol::lua_nil );
+                auto on_puff = tbl.get_or<sol::function>( "on_puff", sol::lua_nil );
                 ifactory.add_istate_actor(
                     itype_id( key ),
                     std::make_unique<lua_istate_actor>(
                         key, std::move( on_tick ), std::move( on_pickup ),
-                        std::move( on_drop ) ) );
+                        std::move( on_drop ), std::move( on_puff ) ) );
             } catch( std::runtime_error &e ) {
                 debugmsg( "Failed to extract istate_functions k='%s': %s", key, e.what() );
                 break;

--- a/src/catalua_icallback_actor.cpp
+++ b/src/catalua_icallback_actor.cpp
@@ -324,11 +324,13 @@ void lua_iequippable_actor::call_on_break( Character &who, item &it ) const
 lua_istate_actor::lua_istate_actor( const std::string &item_id,
                                     sol::protected_function &&on_tick,
                                     sol::protected_function &&on_pickup,
-                                    sol::protected_function &&on_drop )
+                                    sol::protected_function &&on_drop,
+                                    sol::protected_function &&on_puff )
     : lua_icallback_actor_base( item_id ),
       on_tick_func( std::move( on_tick ) ),
       on_pickup_func( std::move( on_pickup ) ),
-      on_drop_func( std::move( on_drop ) ) {}
+      on_drop_func( std::move( on_drop ) ),
+      on_puff_func( std::move( on_puff ) ) {}
 
 bool lua_istate_actor::has_on_tick() const
 {
@@ -390,6 +392,23 @@ bool lua_istate_actor::call_on_drop( Character &who, item &it, const tripoint_bu
         debugmsg( "Failed to run istate on_drop for '%s': %s", item_id, e.what() );
     }
     return false;
+}
+
+void lua_istate_actor::call_on_puff( Character &who, item &it ) const
+{
+    if( on_puff_func == sol::lua_nil ) {
+        return;
+    }
+    try {
+        sol::state_view lua( on_puff_func.lua_state() );
+        auto params = lua.create_table();
+        params["user"] = &who;
+        params["item"] = &it;
+        sol::protected_function_result res = on_puff_func( params );
+        check_func_result( res );
+    } catch( std::runtime_error &e ) {
+        debugmsg( "Failed to run istate on_puff for '%s': %s", item_id, e.what() );
+    }
 }
 
 // --- lua_imelee_actor ---

--- a/src/catalua_icallback_actor.h
+++ b/src/catalua_icallback_actor.h
@@ -123,16 +123,19 @@ class lua_istate_actor : public lua_icallback_actor_base
         sol::protected_function on_tick_func;
         sol::protected_function on_pickup_func;
         sol::protected_function on_drop_func;
+        sol::protected_function on_puff_func;
 
     public:
         lua_istate_actor( const std::string &item_id,
                           sol::protected_function &&on_tick,
                           sol::protected_function &&on_pickup,
-                          sol::protected_function &&on_drop );
+                          sol::protected_function &&on_drop,
+                          sol::protected_function &&on_puff );
 
         bool has_on_tick() const;
         auto call_on_tick( Character &who, item &it, const tripoint_bub_ms &pos ) const -> void;
         void call_on_pickup( Character &who, item &it ) const;
+        void call_on_puff( Character &who, item &it ) const;
         bool call_on_drop( Character &who, item &it, const tripoint_bub_ms &pos ) const;
 };
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10654,6 +10654,9 @@ detached_ptr<item> item::process_litcig( detached_ptr<item> &&self, player *carr
             duration = 30_seconds;
         }
         carrier->add_msg_if_player( m_neutral, _( "You take a puff of your %s." ), it.tname() );
+        if( it.type->istate_callbacks ) {
+            it.type->istate_callbacks->call_on_puff( *carrier, it );
+        }
 
         // we need to figure out a way to get the item before this got converted,
         // but i don't think that's going to be very easy...


### PR DESCRIPTION
## Purpose of change (The Why)

New hook for lua when smoking

## Describe the solution (The How)

Calls the on_puff hook every time a puff is taken

## Describe alternatives you've considered

## Testing

```lua
game.istate_functions["green_herb_joint_lit"] = {on_puff = function(...) return mod.on_puff(...) end}

mod.on_puff = function(params)
    gdebug.log_info("Medicinal herbs: On Puff Called")
    local character = params.user
    local item_name = params.item:get_type():str()
    gdebug.log_info(string.format("Medicinal herbs: Puff %s", item_name))
end
```

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [ ] This PR used AI assistance.
  - [ ] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [x] This PR modifies lua scripts or the lua API.
  - [x] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [afa633e](https://github.com/cataclysmbn/Cataclysm-BN/commit/afa633ed1f821ba917b841ead792719992364984) (add on_puff istate lua callback) on 2026-08-08 16:07:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31262635616/artifacts/9023906052)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31262635616/artifacts/9024176193)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31262635616/artifacts/9023719560)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31262635616/artifacts/9023690083)
<!-- END artifact comment -->