### PR TITLE
feat(balance): allow breaking treads/armor plates to drop some small plates, allow crafting treads with small plates

### DIFF
--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -2552,7 +2552,7 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_fabrication", 5 ], [ "welding_book", 6 ], [ "textbook_carpentry", 5 ] ],
     "using": [ [ "blacksmithing_advanced", 20 ], [ "steel_standard", 20 ] ],
-    "components": [ [ [ "hard_plate", 5 ], [ "steel_armor", 36 ] ], [ [ "chain", 2 ] ] ]
+    "components": [ [ [ "hard_plate", 5 ], [ "hard_steel_armor", 60 ] ], [ [ "chain", 2 ] ] ]
   },
   {
     "result": "NBC_seal",

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -2538,7 +2538,7 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_fabrication", 4 ], [ "welding_book", 5 ], [ "textbook_carpentry", 4 ] ],
     "using": [ [ "blacksmithing_intermediate", 15 ], [ "steel_standard", 15 ] ],
-    "components": [ [ [ "steel_plate", 3 ] ], [ [ "chain", 2 ] ] ]
+    "components": [ [ [ "steel_plate", 3 ], [ "steel_armor", 36 ] ], [ [ "chain", 2 ] ] ]
   },
   {
     "result": "tread3",
@@ -2552,7 +2552,7 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_fabrication", 5 ], [ "welding_book", 6 ], [ "textbook_carpentry", 5 ] ],
     "using": [ [ "blacksmithing_advanced", 20 ], [ "steel_standard", 20 ] ],
-    "components": [ [ [ "hard_plate", 5 ] ], [ [ "chain", 2 ] ] ]
+    "components": [ [ [ "hard_plate", 5 ], [ "steel_armor", 36 ] ], [ [ "chain", 2 ] ] ]
   },
   {
     "result": "NBC_seal",

--- a/data/json/vehicleparts/plating.json
+++ b/data/json/vehicleparts/plating.json
@@ -163,9 +163,10 @@
     },
     "flags": [ "ARMOR" ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
+      { "item": "steel_lump", "count": [ 2, 3 ] },
+      { "item": "steel_chunk", "count": [ 2, 3 ] },
+      { "item": "scrap", "count": [ 2, 3 ] },
+      { "item": "hard_steel_armor", "count": [ 3, 6 ] },
     ],
     "damage_reduction": { "all": 75 }
   },
@@ -187,9 +188,10 @@
     },
     "flags": [ "ARMOR" ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] },
+      { "item": "steel_lump", "count": [ 2, 3 ] },
+      { "item": "steel_chunk", "count": [ 2, 3 ] },
+      { "item": "scrap", "count": [ 2, 3 ] },
+      { "item": "hard_steel_armor", "count": [ 2, 4 ] },
       { "item": "ceramic_armor", "count": [ 0, 4 ] }
     ],
     "damage_reduction": { "all": 70, "cut": 95, "stab": 88 }

--- a/data/json/vehicleparts/plating.json
+++ b/data/json/vehicleparts/plating.json
@@ -166,7 +166,7 @@
       { "item": "steel_lump", "count": [ 2, 3 ] },
       { "item": "steel_chunk", "count": [ 2, 3 ] },
       { "item": "scrap", "count": [ 2, 3 ] },
-      { "item": "hard_steel_armor", "count": [ 3, 6 ] },
+      { "item": "hard_steel_armor", "count": [ 3, 6 ] }
     ],
     "damage_reduction": { "all": 75 }
   },

--- a/data/json/vehicleparts/rams.json
+++ b/data/json/vehicleparts/rams.json
@@ -47,7 +47,7 @@
       { "item": "steel_lump", "count": [ 2, 3 ] },
       { "item": "steel_chunk", "count": [ 2, 3 ] },
       { "item": "scrap", "count": [ 2, 3 ] },
-      { "item": "hard_steel_armor", "count": [ 3, 6 ] },
+      { "item": "hard_steel_armor", "count": [ 3, 6 ] }
     ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },

--- a/data/json/vehicleparts/rams.json
+++ b/data/json/vehicleparts/rams.json
@@ -44,9 +44,10 @@
     "broken_color": "cyan",
     "durability": 860,
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
+      { "item": "steel_lump", "count": [ 2, 3 ] },
+      { "item": "steel_chunk", "count": [ 2, 3 ] },
+      { "item": "scrap", "count": [ 2, 3 ] },
+      { "item": "hard_steel_armor", "count": [ 3, 6 ] },
     ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
@@ -65,9 +66,10 @@
     "broken_color": "green",
     "durability": 800,
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] },
+      { "item": "steel_lump", "count": [ 2, 3 ] },
+      { "item": "steel_chunk", "count": [ 2, 3 ] },
+      { "item": "scrap", "count": [ 2, 3 ] },
+      { "item": "hard_steel_armor", "count": [ 2, 4 ] },
       { "item": "ceramic_armor", "count": [ 0, 4 ] }
     ],
     "requirements": {

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -791,9 +791,10 @@
     "damage_modifier": 50,
     "description": "A section of continuous track, the kind mounted on construction vehicles and military fighting vehicles.  It acts as a wheel, and the broad surface provides plenty of traction to move heavy vehicles off-road, but at the cost of speed due to the heavy weight.",
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 8, 16 ] },
-      { "item": "steel_chunk", "count": [ 20, 40 ] },
-      { "item": "scrap", "count": [ 50, 75 ] },
+      { "item": "steel_lump", "count": [ 4, 8 ] },
+      { "item": "steel_chunk", "count": [ 10, 20 ] },
+      { "item": "scrap", "count": [ 25, 50 ] },
+      { "item": "steel_armor", "count": [ 9, 18 ] },
       { "item": "chain", "count": [ 0, 1 ] }
     ],
     "rolling_resistance": 3,
@@ -820,9 +821,10 @@
     "damage_modifier": 50,
     "description": "A section of continuous track, the kind mounted on construction vehicles and military fighting vehicles.  It acts as a wheel, and the broad surface provides plenty of traction to move heavy vehicles off-road, but at the cost of speed due to the heavy weight.",
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 12, 30 ] },
-      { "item": "steel_chunk", "count": [ 25, 60 ] },
-      { "item": "scrap", "count": [ 60, 120 ] },
+      { "item": "steel_lump", "count": [ 7, 15 ] },
+      { "item": "steel_chunk", "count": [ 15, 30 ] },
+      { "item": "scrap", "count": [ 30, 60 ] },
+      { "item": "hard_steel_armor", "count": [ 15, 30 ] },
       { "item": "chain", "count": [ 0, 1 ] }
     ],
     "rolling_resistance": 3,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Some adjustments to vehiclepart stuff to make hard steel and composite plating less of a pain to work with.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Set it so the recipes for tier 2 and 3 treads allow an equivalent number of the small plate items as alternatives to full vehicle plating.
2. Changed break results of those treads to include some potential small plates dropped on breaking, cutting the amount of assorted scrap metal in half to compensate.
3. Likewise set it so hard steel and composite plating/ram vehicleparts also return some of the relevant small plates when broken, at the expense of generic metal scraps.

## Describe alternatives you've considered


Also doing this for all vehicleparts made from steel plating?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported changes to playthrough build and load-tested.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ef58dc6](https://github.com/cataclysmbn/Cataclysm-BN/commit/ef58dc6b47e63f32a8b168c45af47bb3efede1ba) (Apply suggestion from @chaosvolt) on 2026-08-08 22:15:43

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31277864302/artifacts/9027653774)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31277864302/artifacts/9028466565)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31277864302/artifacts/9027683296)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31277864302/artifacts/9027720911)
<!-- END artifact comment -->