### PR TITLE
fix: gun sounds can now stack

### DIFF
--- a/src/catalua_bindings_game.cpp
+++ b/src/catalua_bindings_game.cpp
@@ -270,7 +270,7 @@ void cata::detail::reg_game_api( sol::state &lua )
                       sol::resolve<void( const std::string &, const std::string &, int, bool )>
                       ( &sfx::play_variant_sound ),
                       sol::resolve<void( const std::string &, const std::string &, int,
-                                         units::angle, double, double )>( &sfx::play_variant_sound )
+                                         units::angle, double, double, bool )>( &sfx::play_variant_sound )
                   ) );
     luna::set_fx( lib, "play_ambient_variant_sound", &sfx::play_ambient_variant_sound );
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -826,7 +826,8 @@ bool mattack::shockstorm( monster *z )
         add_msg( msg_type, _( "A bolt of electricity arcs towards %s!" ), target->disp_name() );
     }
     if( !g->u.is_deaf() ) {
-        sfx::play_variant_sound( "fire_gun", "bio_lightning", sfx::get_heard_volume( z->bub_pos(), 95 ) );
+        sfx::play_variant_sound( "fire_gun", "bio_lightning", sfx::get_heard_volume( z->bub_pos(), 95 ),
+                                 true );
     }
     tripoint_bub_ms tarp( target->bub_pos().x() + rng( -1, 1 ) + rng( -1, 1 ),
                           target->bub_pos().y() + rng( -1, 1 ) + rng( -1, 1 ),

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -624,7 +624,7 @@ auto sfx::play_variant_sound( const std::string &id, const std::string &variant,
 
 auto sfx::play_variant_sound( const std::string &id, const std::string &variant, const int volume,
                               const units::angle angle,
-                              double /*pitch_min*/, double /*pitch_max*/ ) -> void
+                              double /*pitch_min*/, double /*pitch_max*/, const bool stacks ) -> void
 {
     if( test_mode ) {
         return;
@@ -641,7 +641,7 @@ auto sfx::play_variant_sound( const std::string &id, const std::string &variant,
 
     const auto res_id = eff->resource_id;
     auto *audio = get_sfx_resource( res_id );
-    if( !valid_last_time_played( audio, res_id, id + "_" + variant ) ) {
+    if( !stacks && !valid_last_time_played( audio, res_id, id + "_" + variant ) ) {
         return;
     }
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <bitset>
 #include <chrono>
 #include <cmath>
@@ -3401,7 +3402,7 @@ void sfx::generate_gun_sound( const tripoint_bub_ms &source, const item &firing,
         }
     }
 
-    play_variant_sound( selected_sound, weapon_id.str(), heard_volume, angle, 0.8, 1.2 );
+    play_variant_sound( selected_sound, weapon_id.str(), heard_volume, angle, 0.8, 1.2, true );
     start_sfx_timestamp = std::chrono::high_resolution_clock::now();
 }
 
@@ -3895,7 +3896,7 @@ void sfx::load_sound_effects( const JsonObject & ) { }
 void sfx::load_sound_effect_preload( const JsonObject & ) { }
 void sfx::load_playlist( const JsonObject & ) { }
 void sfx::play_variant_sound( const std::string &, const std::string &, int, units::angle, double,
-                              double ) { }
+                              double, const bool ) { }
 void sfx::play_variant_sound( const std::string &, const std::string &, int, bool ) { }
 void sfx::play_ambient_variant_sound( const std::string &, const std::string &, int, channel, int,
                                       double, int ) { }

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -443,7 +443,7 @@ void load_sound_effects( const JsonObject &jsobj );
 void load_sound_effect_preload( const JsonObject &jsobj );
 void load_playlist( const JsonObject &jsobj );
 void play_variant_sound( const std::string &id, const std::string &variant, int volume,
-                         units::angle angle, double pitch_min = -1.0, double pitch_max = -1.0 );
+                         units::angle angle, double pitch_min = -1.0, double pitch_max = -1.0, const bool stacks = false );
 void play_variant_sound( const std::string &id, const std::string &variant, int volume,
                          const bool stacks = true );
 void play_ambient_variant_sound( const std::string &id, const std::string &variant, int volume,


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #10040

## Describe the solution (The How)
Add `stacks` bool to other `play_variant_sound`
Set `stacks` to true for playing `generate_gun_sound` ( the other instances are for special effects and thus deemed unneeded )

## Describe alternatives you've considered
Stop dealing with sound bugs

## Testing
It compiles
The logic is sound

## Additional context
Can't test sound right now

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f9d56a7](https://github.com/cataclysmbn/Cataclysm-BN/commit/f9d56a7b3fc2f6d02203f4db0170d2c32b6e825d) (fix: gun sounds can now stack) on 2026-08-09 03:28:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31289497349/artifacts/9031544861)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31289497349/artifacts/9031836541)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31289497349/artifacts/9031429485)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31289497349/artifacts/9031323090)
<!-- END artifact comment -->