### PR TITLE
fix: aftershock advanced UPS now extends instead of overwriting flags

### DIFF
--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -189,7 +189,7 @@
     "coverage": 5,
     "encumbrance": 1,
     "covers": [ "leg_either" ],
-    "extend": { "flags": [ "WAIST", "COMPACT", "FRAGILE", "OVERSIZE", "POWERARMOR_COMPATIBLE", "ALLOWS_TAIL_SNAKE"  ] }
+    "extend": { "flags": [ "WAIST", "COMPACT", "FRAGILE", "OVERSIZE", "POWERARMOR_COMPATIBLE", "ALLOWS_TAIL_SNAKE" ] }
   },
   {
     "id": "bionic_maintenance_toolkit",

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -189,7 +189,7 @@
     "coverage": 5,
     "encumbrance": 1,
     "covers": [ "leg_either" ],
-    "flags": [ "WAIST", "COMPACT", "FRAGILE", "OVERSIZE", "IS_UPS", "POWERARMOR_COMPATIBLE", "ALLOWS_TAIL_SNAKE" ]
+    "extend": { "flags": [ "WAIST", "COMPACT", "FRAGILE", "OVERSIZE", "POWERARMOR_COMPATIBLE", "ALLOWS_TAIL_SNAKE"  ] }
   },
   {
     "id": "bionic_maintenance_toolkit",


### PR DESCRIPTION
## Purpose of change (The Why)
Aftershock UPS can be unloaded

## Describe the solution (The How)
Dont make me update two places

## Describe alternatives you've considered
Delete leak when damaged flag

## Testing
It loads

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [258ff5f](https://github.com/cataclysmbn/Cataclysm-BN/commit/258ff5f31b8be42cb38b8a1127d4e4d47f552560) (style(autofix.ci): automated formatting) on 2026-08-09 14:12:32

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31316992408/artifacts/9039160582)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31316992408)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31316992408)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31316992408)
<!-- END artifact comment -->