### PR TITLE
feat: add magazine belt

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -2238,7 +2238,9 @@
       [ "apron_leather", 2 ],
       [ "tool_belt", 5 ],
       [ "bootsheath", 8 ],
-      [ "sheath", 5 ]
+      [ "sheath", 5 ],
+      [ "chestrig", 5 ],
+      [ "belt_magazine", 5 ]
     ]
   },
   {
@@ -3148,7 +3150,8 @@
           { "item": "quiver_large", "prob": 15 },
           { "item": "solarpack", "prob": 5 },
           { "item": "ammo_satchel", "prob": 10 },
-          { "item": "chestrig", "prob": 20 },
+          { "item": "chestrig", "prob": 10 },
+          { "item": "belt_magazine", "prob": 10 },
           { "item": "dive_bag", "prob": 50 },
           { "item": "petpack", "prob": 50 }
         ],

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -612,7 +612,9 @@
       { "group": "tinware", "prob": 10 },
       [ "shield_riot", 5 ],
       [ "pirate_flag", 5 ],
-      [ "professional_chemical_thrower", 5 ]
+      [ "professional_chemical_thrower", 5 ],
+      [ "chestrig", 5 ],
+      [ "belt_magazine", 5 ]
     ]
   },
   {
@@ -728,6 +730,8 @@
       [ "bfipowder", 20 ],
       [ "sheath", 10 ],
       [ "bootsheath", 10 ],
+      [ "chestrig", 10 ],
+      [ "belt_magazine", 10 ],
       [ "survnote", 1 ],
       [ "solarpack", 1 ],
       [ "tourist_table", 5 ],

--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -506,7 +506,7 @@
       [ "boots", 100 ],
       [ "pants", 100 ],
       [ "jacket_army", 100 ],
-      [ "chestrig", 75 ],
+      [ "belt_magazine", 75 ],
       [ "rucksack", 50 ],
       { "distribution": [ { "item": "helmet_steel", "prob": 75 }, { "item": "beret", "prob": 25 } ] }
     ]

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -529,7 +529,7 @@
       "type": "holster",
       "holster_prompt": "Stash ammo",
       "holster_msg": "You stash your %s.",
-      "multi": 6,
+      "multi": 8,
       "min_volume": "25 ml",
       "max_volume": "250 ml",
       "draw_cost": 40,

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -505,5 +505,37 @@
       "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
     },
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "COMPACT" ]
+  },
+  {
+    "id": "belt_magazine",
+    "type": "ARMOR",
+    "name": { "str_sp": "magazine belt" },
+    "description": "A belt worn across the waist, with pouches that can hold up to eight small magazines or speedloaders.",
+    "weight": "300 g",
+    "volume": "500 ml",
+    "price": "80 USD",
+    "price_postapoc": "25 USD",
+    "rigid": false,
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "looks_like": "tool_belt",
+    "color": "dark_gray",
+    "covers": [ "torso" ],
+    "coverage": 15,
+    "encumbrance": 1,
+    "max_encumbrance": 5,
+    "material_thickness": 2,
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Stash ammo",
+      "holster_msg": "You stash your %s.",
+      "multi": 6,
+      "min_volume": "25 ml",
+      "max_volume": "250 ml",
+      "draw_cost": 40,
+      "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
+    },
+    "valid_mods": [ "resized_large", "resized_small" ],
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "ALLOWS_WINGS" ]
   }
 ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2036,7 +2036,7 @@
           "rucksack"
         ],
         "entries": [
-          { "item": "chestrig", "contents-group": "temporal_soldier_garand" },
+          { "item": "belt_magazine", "contents-group": "temporal_soldier_garand" },
           { "item": "knife_combat", "container-item": "sheath" },
           { "item": "grenadebandolier", "contents-item": [ "grenade", "grenade" ] },
           { "item": "garand", "ammo-item": "3006", "charges": 8, "contents-item": [ "shoulder_strap" ] }

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -61,6 +61,18 @@
     "components": [ [ [ "fabric_hides_any", 15, "LIST" ] ] ]
   },
   {
+    "result": "belt_magazine",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "40 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 15 ] ],
+    "components": [ [ [ "fabric_hides_any", 8, "LIST" ] ] ]
+  },
+  {
     "result": "axe_ring",
     "type": "recipe",
     "category": "CC_ARMOR",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Adds another ammo storage option.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added a magazine belt, in the vein of WWI and WWII era cartridge belts used by the US to carry stripper clips for the M1903 and en-blocs for the M1 Garand. Went with 8 mags for this version, max of 250 ml.
2. Added associated recipe.
3. Replaced the technically-inaccurate chest rig the Army Infantry profession stores its en-blocs in with a magazine belt.
4. Added new item to itemgroups `bags_unisex`, `survival_armor`, `pawn`, `mil_surplus`, and `soa_wwii` (replacing the chestrig in this case).
5. Misc: Also added chest rigs to itemgroups `survival_armor`, `pawn`, and `mil_surplus`.

## Describe alternatives you've considered

Letting it hold more or less magazines. Eight seemed good for balance since it's a torso-slot item, compare the chest rig hoding 4 but being able to hold bigger ones.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in test build.
3. Spawned as an army infantry, confirmed I can remove and re-insert the Garand clips into it.
4. Spawned a .30-06 rifle clip, confirmed that fits in it too.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5206c92](https://github.com/cataclysmbn/Cataclysm-BN/commit/5206c9242bd29dc111afed51c4abd998296cad8b) (Update ammo_pouch.json) on 2026-08-09 23:33:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31339150471/artifacts/9045974990)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31339150471/artifacts/9045745540)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31339150471/artifacts/9045442046)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31339150471/artifacts/9045518584)
<!-- END artifact comment -->