### PR TITLE
feat(balance): give miltiary exo, UPS and uncanny dodge bionics to bionic operator

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4610,7 +4610,7 @@
     "age": { "min": 20, "max": 40 },
     "points": 8,
     "traits": [ "PROF_MILITARY" ],
-    "CBMs": [ "bio_cqb", "bio_carbon", "bio_night_vision", "bio_torsionratchet", "bio_claws", "bio_power_storage_mkII" ],
+    "CBMs": [ "bio_cqb", "bio_carbon", "bio_night_vision", "bio_torsionratchet", "bio_claws", "bio_ups", "bio_power_storage_mkII" ],
     "skills": [
       { "level": 5, "name": "swimming" },
       { "level": 6, "name": "gun" },
@@ -4643,6 +4643,7 @@
           "molle_pack"
         ],
         "entries": [
+          { "item": "exosuit_military", "charges": 500 },
           { "group": "charged_headseat", "custom-flags": [ "no_auto_equip" ] },
           { "item": "winter_jacket_army" },
           { "item": "modularvestsuper", "contents-group": "army_mags_rm216" },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4610,7 +4610,16 @@
     "age": { "min": 20, "max": 40 },
     "points": 8,
     "traits": [ "PROF_MILITARY" ],
-    "CBMs": [ "bio_cqb", "bio_carbon", "bio_night_vision", "bio_torsionratchet", "bio_claws", "bio_ups", "bio_power_storage_mkII" ],
+    "CBMs": [
+      "bio_cqb",
+      "bio_carbon",
+      "bio_night_vision",
+      "bio_torsionratchet",
+      "bio_claws",
+      "bio_ups",
+      "bio_uncanny_dodge",
+      "bio_power_storage_mkII"
+    ],
     "skills": [
       { "level": 5, "name": "swimming" },
       { "level": 6, "name": "gun" },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This allows the tactical exos to get some representation in professions, and make the bionic operator a lil more distinct from the regular bionic soldier profession and more worth the tradeoff of getting a worse gun, armor, and being limited to a more niche set of bionics despite costing a point more.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Granted a military exo and the UPS bionic to bionic operator. This fits since their bionics setup is geared more towards melee over ranged and thus this exo more directly benefits them than it would the bionic soldier.

Also random musings in the discord server gave me the bonus idea of adding uncanny dodge because is neat :3

## Describe alternatives you've considered

1. Giving it to bionic soldier anyway.
2. Adding a dedicated exo soldier profession.
3. Downgrading the profession from an SMG to just a pistol to nudge them even more into a close combat role.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Load-tested in test build, started as a bionic operator, I indeed have an exo and can run it off the UPS bionic.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a2aa049](https://github.com/cataclysmbn/Cataclysm-BN/commit/a2aa049f5579ab2556a16a61d5dea50005aa4a45) (:3) on 2026-08-10 02:52:07

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31347665721/artifacts/9048779638)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31347665721/artifacts/9048397045)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31347665721/artifacts/9048097485)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31347665721/artifacts/9048114040)
<!-- END artifact comment -->