### PR TITLE
feat: make the cqb bionic give a lower bound of 5 skill rather than a set 5 skill

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -132,6 +132,7 @@ static const activity_id ACT_TRY_SLEEP( "ACT_TRY_SLEEP" );
 static const activity_id ACT_WAIT_STAMINA( "ACT_WAIT_STAMINA" );
 
 static const bionic_id bio_eye_optic( "bio_eye_optic" );
+static const bionic_id bio_cqb( "bio_cqb" );
 
 static const matec_id WBLOCK_1( "WBLOCK_1" );
 static const matec_id WBLOCK_2( "WBLOCK_2" );
@@ -6654,7 +6655,9 @@ float Character::get_dodge_base() const
 {
     /** @EFFECT_DEX increases dodge base */
     /** @EFFECT_DODGE increases dodge_base */
-    return get_dex() / 4.0f + get_skill_level( skill_dodge );
+    return get_dex() / 4.0f + has_active_bionic( bionic_id( bio_cqb ) ) ? std::max( get_skill_level(
+                skill_dodge ), BIO_CQB_LEVEL ) : get_skill_level(
+               skill_dodge );
 }
 float Character::get_hit_base() const
 {
@@ -9462,7 +9465,10 @@ void Character::on_dodge( Creature *source, int difficulty )
 
     // Even if we are not to train still call practice to prevent skill rust
     difficulty = std::max( difficulty, 0 );
-    as_player()->practice( skill_dodge, difficulty * 2, difficulty );
+    // Practice dodge skill except when using CQB bionic
+    if( !has_active_bionic( bio_cqb ) ) {
+        as_player()->practice( skill_dodge, difficulty * 2, difficulty );
+    }
 
     martial_arts_data->ma_ondodge_effects( *this );
 

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -844,7 +844,7 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
             int level_num = you.get_skill_level( aSkill->ident() );
             bool locked = false;
             if( you.has_active_bionic( bionic_id( "bio_cqb" ) ) && is_cqb_skill( aSkill->ident() ) ) {
-                level_num = 5;
+                level_num = std::max( level_num, 5 );
                 exercise = 0;
                 locked = true;
             }

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -358,9 +358,9 @@ static bool is_cqb_skill( const skill_id &id )
     // TODO: this skill list here is used in other places as well. Useless redundancy and
     // dependency. Maybe change it into a flag of the skill that indicates it's a skill used
     // by the bionic?
-    static const std::array<skill_id, 5> cqb_skills = { {
+    static const std::array<skill_id, 6> cqb_skills = { {
             skill_id( "melee" ), skill_id( "unarmed" ), skill_id( "cutting" ),
-            skill_id( "bashing" ), skill_id( "stabbing" ),
+            skill_id( "bashing" ), skill_id( "stabbing" ), skill_id( "dodge" ),
         }
     };
     return std::ranges::contains( cqb_skills, id );
@@ -744,7 +744,9 @@ struct HeaderSkill {
 
 int character_display::display_empty_handed_base_damage( const Character &you )
 {
-    int empty_hand_base_damage = you.get_skill_level( skill_unarmed );
+    int empty_hand_base_damage = you.has_active_bionic( bionic_id( "bio_cqb" ) ) ? std::max( you.get_skill_level(
+                                     skill_unarmed ), BIO_CQB_LEVEL ) : you.get_skill_level(
+                                     skill_unarmed );
     const bool left_empty = !you.natural_attack_restricted_on( bodypart_id( "hand_l" ) );
     const bool right_empty = !you.natural_attack_restricted_on( bodypart_id( "hand_r" ) );
 
@@ -844,7 +846,7 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
             int level_num = you.get_skill_level( aSkill->ident() );
             bool locked = false;
             if( you.has_active_bionic( bionic_id( "bio_cqb" ) ) && is_cqb_skill( aSkill->ident() ) ) {
-                level_num = std::max( level_num, 5 );
+                level_num = std::max( level_num, BIO_CQB_LEVEL );
                 exercise = 0;
                 locked = true;
             }

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -744,8 +744,9 @@ struct HeaderSkill {
 
 int character_display::display_empty_handed_base_damage( const Character &you )
 {
-    int empty_hand_base_damage = you.has_active_bionic( bionic_id( "bio_cqb" ) ) ? std::max( you.get_skill_level(
-                                     skill_unarmed ), BIO_CQB_LEVEL ) : you.get_skill_level(
+    int empty_hand_base_damage = you.has_active_bionic( bionic_id( "bio_cqb" ) ) ? std::max(
+                                     you.get_skill_level(
+                                         skill_unarmed ), BIO_CQB_LEVEL ) : you.get_skill_level(
                                      skill_unarmed );
     const bool left_empty = !you.natural_attack_restricted_on( bodypart_id( "hand_l" ) );
     const bool right_empty = !you.natural_attack_restricted_on( bodypart_id( "hand_r" ) );

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -545,7 +545,7 @@ std::string ma_requirements::get_description( bool buff ) const
         min_skill.end(), []( const std::pair<skill_id, int>  &pr ) {
             int player_skill = get_player_character().get_skill_level( skill_id( pr.first ) );
             if( get_player_character().has_active_bionic( bio_cqb ) ) {
-                player_skill = BIO_CQB_LEVEL;
+                player_skill = std::max( player_skill, BIO_CQB_LEVEL );;
             }
             return string_format( "%s: <stat>%d</stat>/<stat>%d</stat>", pr.first->name(), player_skill,
                                   pr.second );
@@ -1024,7 +1024,7 @@ bool character_martial_arts::can_leg_block( const Character &owner ) const
 {
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform leg block
-    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
+    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? std::max( owner.get_skill_level( skill_unarmed ), 5 ) : owner.get_skill_level(
                             skill_unarmed );
 
     // Success conditions.
@@ -1043,7 +1043,7 @@ bool character_martial_arts::can_arm_block( const Character &owner ) const
 {
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform arm block
-    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
+    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? std::max( owner.get_skill_level( skill_unarmed ), 5 ) : owner.get_skill_level(
                             skill_unarmed );
 
     // Success conditions.
@@ -1522,7 +1522,7 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
             ma.leg_block_with_bio_armor_legs || ma.leg_block != 99 ) {
             int unarmed_skill =  get_player_character().get_skill_level( skill_unarmed );
             if( get_player_character().has_active_bionic( bio_cqb ) ) {
-                unarmed_skill = BIO_CQB_LEVEL;
+                unarmed_skill = std::max( unarmed_skill, BIO_CQB_LEVEL );
             }
             if( ma.arm_block_with_bio_armor_arms ) {
                 buffer += _( "You can <info>arm block</info> by installing the <info>Arms Alloy Plating CBM</info>" );

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -483,7 +483,8 @@ bool ma_requirements::is_valid_character( const Character &u ) const
     }
 
     for( const auto &pr : min_skill ) {
-        if( ( cqb ? 5 : u.get_skill_level( pr.first ) ) < pr.second ) {
+        if( ( cqb ? std::max( u.get_skill_level(
+                                  pr.first ), BIO_CQB_LEVEL ) : u.get_skill_level( pr.first ) ) < pr.second ) {
             return false;
         }
     }
@@ -1025,7 +1026,7 @@ bool character_martial_arts::can_leg_block( const Character &owner ) const
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform leg block
     int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? std::max( owner.get_skill_level(
-                            skill_unarmed ), 5 ) : owner.get_skill_level(
+                            skill_unarmed ), BIO_CQB_LEVEL ) : owner.get_skill_level(
                             skill_unarmed );
 
     // Success conditions.
@@ -1045,7 +1046,7 @@ bool character_martial_arts::can_arm_block( const Character &owner ) const
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform arm block
     int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? std::max( owner.get_skill_level(
-                            skill_unarmed ), 5 ) : owner.get_skill_level(
+                            skill_unarmed ), BIO_CQB_LEVEL ) : owner.get_skill_level(
                             skill_unarmed );
 
     // Success conditions.

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1024,7 +1024,8 @@ bool character_martial_arts::can_leg_block( const Character &owner ) const
 {
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform leg block
-    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? std::max( owner.get_skill_level( skill_unarmed ), 5 ) : owner.get_skill_level(
+    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? std::max( owner.get_skill_level(
+                            skill_unarmed ), 5 ) : owner.get_skill_level(
                             skill_unarmed );
 
     // Success conditions.
@@ -1043,7 +1044,8 @@ bool character_martial_arts::can_arm_block( const Character &owner ) const
 {
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform arm block
-    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? std::max( owner.get_skill_level( skill_unarmed ), 5 ) : owner.get_skill_level(
+    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? std::max( owner.get_skill_level(
+                            skill_unarmed ), 5 ) : owner.get_skill_level(
                             skill_unarmed );
 
     // Success conditions.

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2040,7 +2040,7 @@ void melee::roll_bash_damage( const Character &c, bool crit, damage_instance &di
     const bool unarmed = weap.is_unarmed_weapon();
     int skill = c.get_skill_level( unarmed ? skill_unarmed : skill_bashing );
     if( c.has_active_bionic( bio_cqb ) ) {
-        skill = BIO_CQB_LEVEL;
+        skill = std::max( skill, BIO_CQB_LEVEL );
     }
 
     const int stat = c.get_str();
@@ -2162,7 +2162,7 @@ void melee::roll_cut_damage( const Character &c, bool crit, damage_instance &di,
     int cutting_skill = c.get_skill_level( skill_cutting );
 
     if( c.has_active_bionic( bio_cqb ) ) {
-        cutting_skill = BIO_CQB_LEVEL;
+        cutting_skill = std::max( cutting_skill, BIO_CQB_LEVEL );
     }
 
     if( weap.is_unarmed_weapon() ) {
@@ -2242,7 +2242,7 @@ void melee::roll_stab_damage( const Character &c, bool crit, damage_instance &di
     int stabbing_skill = c.get_skill_level( skill_stabbing );
 
     if( c.has_active_bionic( bio_cqb ) ) {
-        stabbing_skill = BIO_CQB_LEVEL;
+        stabbing_skill = std::max( stabbing_skill, BIO_CQB_LEVEL );
     }
 
     if( weap.is_unarmed_weapon() ) {
@@ -3522,7 +3522,7 @@ void player_hit_message( Character *attacker, const std::string &message,
 int Character::attack_cost( const item &weap ) const
 {
     const int base_move_cost = weap.attack_cost() / 2;
-    const int melee_skill = has_active_bionic( bionic_id( bio_cqb ) ) ? BIO_CQB_LEVEL : get_skill_level(
+    const int melee_skill = has_active_bionic( bionic_id( bio_cqb ) ) ? std::max( get_skill_level( skill_melee ), BIO_CQB_LEVEL ) : get_skill_level(
                                 skill_melee );
     /** @EFFECT_MELEE increases melee attack speed */
     const int skill_cost = ( base_move_cost * ( 15 - melee_skill ) / 15 );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -597,7 +597,8 @@ auto character_requirement_reason( const Character &self, const ma_technique &te
     if( !tec.reqs.min_skill.empty() ) {
         auto missing_skills = std::vector<std::string>();
         for( const auto &req : tec.reqs.min_skill ) {
-            const auto current_skill = cqb ? 5 : self.get_skill_level( req.first );
+            const auto current_skill = cqb ? std::max( self.get_skill_level(
+                                           req.first ), BIO_CQB_LEVEL ) : self.get_skill_level( req.first );
             if( current_skill < req.second ) {
                 missing_skills.push_back( string_format( _( "%s %d+ (have %d)" ),
                                           req.first->name(), req.second,

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -3522,7 +3522,8 @@ void player_hit_message( Character *attacker, const std::string &message,
 int Character::attack_cost( const item &weap ) const
 {
     const int base_move_cost = weap.attack_cost() / 2;
-    const int melee_skill = has_active_bionic( bionic_id( bio_cqb ) ) ? std::max( get_skill_level( skill_melee ), BIO_CQB_LEVEL ) : get_skill_level(
+    const int melee_skill = has_active_bionic( bionic_id( bio_cqb ) ) ? std::max( get_skill_level(
+                                skill_melee ), BIO_CQB_LEVEL ) : get_skill_level(
                                 skill_melee );
     /** @EFFECT_MELEE increases melee attack speed */
     const int skill_cost = ( base_move_cost * ( 15 - melee_skill ) / 15 );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
the CQB bionic when activated gives the player a flat 5 in melee skills, making it lose effectiveness quickly if you're playing a dedicated melee character. 
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes the 5 skill on the cqb bionic a lower bound instead, meaning that if your skills are higher than 5, the cqb bionic will not nerf them back to 5.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
level 5 hells raider vs level 99 john cataclysm
## Testing
Build artifacts
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a9592ee](https://github.com/cataclysmbn/Cataclysm-BN/commit/a9592eeb38b987094a316b88942a2bb0a20e5693) (style(autofix.ci): automated formatting) on 2026-08-10 13:20:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31365514552/artifacts/9054257424)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31365514552)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31365514552/artifacts/9054337801)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31365514552/artifacts/9054435076)
<!-- END artifact comment -->