### PR TITLE
fix(mods): warn not error on lockfile mismatch

### DIFF
--- a/build-scripts/bundle-registry-mods.ts
+++ b/build-scripts/bundle-registry-mods.ts
@@ -67,8 +67,8 @@ export const selectEntries = (
     const found = registryById[lock.id]
     if (!found) throw new Error(`${lock.id} is not present in the mod registry`)
     if (found.version !== lock.version) {
-      throw new Error(
-        `${lock.id} version mismatch: lockfile has ${lock.version}, registry has ${found.version}`,
+      console.warn(
+        `${lock.id} version mismatch: lockfile has ${lock.version}, registry has ${found.version}; using locked version`,
       )
     }
     return { ...found, lock }

--- a/build-scripts/bundle-registry-mods_test.ts
+++ b/build-scripts/bundle-registry-mods_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert"
+import { assertEquals } from "@std/assert"
 import { exists } from "@std/fs"
 import { join } from "@std/path"
 import { BlobWriter, terminateWorkers, TextReader, ZipWriter } from "@zip-js/zip-js"
@@ -15,16 +15,16 @@ const zipUrl = async (files: Record<string, string>): Promise<string> => {
   return `data:application/zip;base64,${btoa(binary)}`
 }
 
-Deno.test("selectEntries rejects stale lock versions", () => {
-  assertThrows(
-    () =>
-      selectEntries(
-        [{ id: "demo", version: "1.0.0", url: "https://example.com/demo.zip" }],
-        [{ id: "demo", version: "2.0.0", display_name: "Demo", package_type: "mod", source: {} }],
-      ),
-    Error,
-    "version mismatch",
+Deno.test("selectEntries accepts stale lock versions", () => {
+  const entries = selectEntries(
+    [{ id: "demo", version: "1.0.0", url: "https://example.com/demo-1.0.0.zip" }],
+    [{ id: "demo", version: "2.0.0", display_name: "Demo", package_type: "mod", source: {} }],
   )
+
+  assertEquals(entries.length, 1)
+  assertEquals(entries[0].lock.version, "1.0.0")
+  assertEquals(entries[0].lock.url, "https://example.com/demo-1.0.0.zip")
+  assertEquals(entries[0].version, "2.0.0")
 })
 
 Deno.test("bundle extracts mods, skips excluded soundpacks, and writes credits", async () => {


### PR DESCRIPTION
## Purpose of change (The Why)

closes #10021

The registry mod bundler aborted when a locked version differed from the latest registry version, preventing use of the locked download URL

## Describe the solution (The How)

- warn on registry and lockfile version mismatches instead of throwing
- continue using the locked version and URL
- update regression coverage for stale lock versions

## Testing

- `deno test --allow-read --allow-write --allow-net build-scripts/bundle-registry-mods_test.ts` — 2 passed
- `deno lint build-scripts/bundle-registry-mods.ts build-scripts/bundle-registry-mods_test.ts` — passed

## Checklist

### Mandatory

- [x] I linked any relevant issues using github keyword syntax like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically

### Optional

- [x] This PR used AI assistance
  - [x] I added an [`Assisted-by:` trailer](https://docs.kernel.org/process/coding-assistants.html) to every AI-assisted commit

<sub>PR opened by gpt-5.6-luna high on pi</sub>

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c0d216e](https://github.com/cataclysmbn/Cataclysm-BN/commit/c0d216e6d7abbf9ad739905b9a550efe2f38c3ef) (fix(mods): allow locked registry mod versions) on 2026-08-10 13:27:47

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31389641399/artifacts/9063415478)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31389641399/artifacts/9064353151)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31389641399/artifacts/9063541416)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31389641399/artifacts/9063606645)
<!-- END artifact comment -->