### PR TITLE
feat(mods): Add Cata++ and MST Extra as bundled mods

### DIFF
--- a/data/mods/external.json
+++ b/data/mods/external.json
@@ -30,5 +30,29 @@
     "id": "otopack_bn_mk_2",
     "version": "2026.2.12",
     "url": "https://github.com/NarandBD/Otopack-BN-Mk-2/archive/refs/tags/sorrynotsorry.zip"
+  },
+  {
+    "id": "cata",
+    "version": "0.0.0",
+    "url": "https://github.com/Noctifer-de-Mortem/nocts_cata_mod/archive/refs/heads/master.zip",
+    "extract_path": "nocts_cata_mod_BN"
+  },
+  {
+    "id": "arcana_cata_patch",
+    "version": "0.0.0",
+    "url": "https://github.com/Noctifer-de-Mortem/nocts_cata_mod/archive/refs/heads/master.zip",
+    "extract_path": "Patchmods/BN_Arcana_Cata++_Patch"
+  },
+  {
+    "id": "cata_exotic_ammo_patch",
+    "version": "0.0.0",
+    "url": "https://github.com/Noctifer-de-Mortem/nocts_cata_mod/archive/refs/heads/master.zip",
+    "extract_path": "Patchmods/BN_Cata++_ExoticAmmo_Patch"
+  },
+  {
+    "id": "mst_extra",
+    "version": "0.0.0",
+    "url": "https://github.com/chaosvolt/MST_Extra_Mod/archive/refs/heads/master.zip",
+    "extract_path": "MST_Extra_BN"
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)
With #10048 merged it is now possible

## Describe the solution (The How)
Add them as external mods that always pull from upstream

## Describe alternatives you've considered
None

## Testing
Bundler command bundles, now awaiting it to run here

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This PR adds/removes a mod.
  - [x] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a1dc99b](https://github.com/cataclysmbn/Cataclysm-BN/commit/a1dc99b0068e186b3248db07340e0d70f05e1024) (Merge branch 'cataclysmbn:main' into mainline_mst_and_cata) on 2026-08-10 16:17:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31404229269/artifacts/9069319758)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31404229269)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31404229269/artifacts/9069639452)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31404229269/artifacts/9069497903)
<!-- END artifact comment -->