### PR TITLE
fix: dodge tests no longer fail

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6656,8 +6656,8 @@ float Character::get_dodge_base() const
     /** @EFFECT_DEX increases dodge base */
     /** @EFFECT_DODGE increases dodge_base */
     return get_dex() / 4.0f + ( has_active_bionic( bionic_id( bio_cqb ) ) ? std::max( get_skill_level(
-                skill_dodge ), BIO_CQB_LEVEL ) : get_skill_level(
-               skill_dodge ) );
+                                    skill_dodge ), BIO_CQB_LEVEL ) : get_skill_level(
+                                    skill_dodge ) );
 }
 float Character::get_hit_base() const
 {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6655,9 +6655,9 @@ float Character::get_dodge_base() const
 {
     /** @EFFECT_DEX increases dodge base */
     /** @EFFECT_DODGE increases dodge_base */
-    return get_dex() / 4.0f + has_active_bionic( bionic_id( bio_cqb ) ) ? std::max( get_skill_level(
+    return get_dex() / 4.0f + ( has_active_bionic( bionic_id( bio_cqb ) ) ? std::max( get_skill_level(
                 skill_dodge ), BIO_CQB_LEVEL ) : get_skill_level(
-               skill_dodge );
+               skill_dodge ) );
 }
 float Character::get_hit_base() const
 {


### PR DESCRIPTION
## Purpose of change (The Why)
Caused by: #10047
Seen in: #10050 ( I.E. https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31394417921/job/93475725436?pr=10050 )

## Describe the solution (The How)
Use parenthesis right

## Describe alternatives you've considered
Scream

## Testing
Running tests worked locally

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [79735e1](https://github.com/cataclysmbn/Cataclysm-BN/commit/79735e14d78265dafcab4e25ad15fe30e4d7e173) (format) on 2026-08-10 14:57:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31397192401/artifacts/9066522916)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31397192401/artifacts/9067504677)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31397192401/artifacts/9066598771)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31397192401/artifacts/9066730323)
<!-- END artifact comment -->