### PR TITLE
fix: overusing stamina no longer gives full athletics exp

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8173,13 +8173,15 @@ void Character::set_stamina( int new_stamina )
 
 void Character::mod_stamina( int mod, bool skill )
 {
+    int lost_stamina = ( stamina + mod >= 0 ) ? mod : -stamina;
     // If we're burning stamina then train athletics, unless we're losing stamina due to status effects or other non-standard causes.
-    if( skill && mod < 0 ) {
-        as_player()->practice( skill_swimming, roll_remainder( std::abs( mod ) / 500.0 ), 10, true );
+    if( skill && lost_stamina < 0 ) {
+        as_player()->practice( skill_swimming, roll_remainder( std::abs( lost_stamina ) / 500.0 ), 10,
+                               true );
         // Athletics skill also reduces stamina drain for relevant activities.
         const int skill = get_skill_level( skill_swimming );
         const float skill_cost = std::max( 0.667f, ( ( 30.0f - skill ) / 30.0f ) );
-        mod *= skill_cost;
+        lost_stamina *= skill_cost;
     }
     stamina += mod;
     if( mod < 0 ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Fix a exploit

## Describe the solution (The How)
If it reduces stamina below 0, use -stamina for skill gain instead

## Describe alternatives you've considered
Use std::max now that I think of it

## Testing
Hold 10000 chunks of steel, no longer massivelevel athletics

## Additional context
How do people find these?

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c34b381](https://github.com/cataclysmbn/Cataclysm-BN/commit/c34b381f1122b0603ad94092b15e1bffc5373375) (fix: overusing stamina no longer gives full athletics exp) on 2026-08-11 00:38:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31442580311/artifacts/9083624412)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31442580311/artifacts/9084175590)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31442580311/artifacts/9083657729)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31442580311/artifacts/9083719882)
<!-- END artifact comment -->