### PR TITLE
fix: fix althetics stamina reduction not being correctly done

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8181,7 +8181,7 @@ void Character::mod_stamina( int mod, bool skill )
         // Athletics skill also reduces stamina drain for relevant activities.
         const int skill = get_skill_level( skill_swimming );
         const float skill_cost = std::max( 0.667f, ( ( 30.0f - skill ) / 30.0f ) );
-        lost_stamina *= skill_cost;
+        mod *= skill_cost;
     }
     stamina += mod;
     if( mod < 0 ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Realized I did a stupid in #10054 and replaced `mod` with `lost_stamina` too many times

## Describe the solution (The How)
Dont replace the reduction of cost with it

## Describe alternatives you've considered
None

## Testing
Eyes

## Additional context
Sorry

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [60f3243](https://github.com/cataclysmbn/Cataclysm-BN/commit/60f32431b284b6c7cf6585fbc800dbf1f75afa67) (fix: fix althetics stamina reduction not being correctly done) on 2026-08-11 21:42:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31508653205/artifacts/9108495195)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31508653205/artifacts/9109495554)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31508653205/artifacts/9108586030)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31508653205/artifacts/9108688019)
<!-- END artifact comment -->