### PR TITLE
fix: apply COMPONENT flag in `add_component` fixing smoking racks having components rot

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11920,6 +11920,7 @@ detached_ptr<item> item::remove_component( item &it )
 void item::add_component( detached_ptr<item> &&comp )
 {
     components.push_back( std::move( comp ) );
+    components.back()->set_flag( flag_id( "COMPONENT" ) );
 }
 
 const location_vector<item> &item::get_components() const


### PR DESCRIPTION
## Purpose of change (The Why)
Fix fix fix

## Describe the solution (The How)
Add more `COMPONENT` everywhere

## Describe alternatives you've considered
Stop rotting things in `display_name`

## Testing
None

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bd0c223](https://github.com/cataclysmbn/Cataclysm-BN/commit/bd0c2232be0e06a73b508b8931578a772119a18a) (fix: apply COMPONENT flag in `add_component` fixing smoking racks having interior rotten items) on 2026-08-14 23:33:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31842895410/artifacts/9236317193)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31842895410/artifacts/9236871751)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31842895410)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31842895410/artifacts/9235410277)
<!-- END artifact comment -->