### PR TITLE
fix(mods/Arcana): point hermit mapgen update to correct z-level

### DIFF
--- a/data/mods/Arcana_BN/npcs/TALK_HERMIT.json
+++ b/data/mods/Arcana_BN/npcs/TALK_HERMIT.json
@@ -77,7 +77,8 @@
             "mapgen_update": "arcana_hermit_spawn_npcs",
             "om_terrain": "cf_church_1",
             "om_special": "cf_rural_church",
-            "must_see": true
+            "must_see": true,
+            "z": 0
           }
         ]
       },
@@ -433,7 +434,8 @@
             "mapgen_update": "arcana_hermit_spawn_npcs",
             "om_terrain": "cf_church_1",
             "om_special": "cf_rural_church",
-            "must_see": true
+            "must_see": true,
+            "z": 0
           }
         ],
         "topic": "TALK_HERMIT_CF_REP_MISSION_ALLIES_DEAL"


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Old man forgets he lives on the second floor.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Set the mapgen updates for spawning Celine and Abe when you talk the hermit into helping the Cleansing Flame to point to the correct z-level so they don't explode.

## Describe alternatives you've considered

Explode.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Ported change to playthrough build, correctly got through dialogue without it hanging up for a long time then erroring.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b6ea280](https://github.com/cataclysmbn/Cataclysm-BN/commit/b6ea280dcf3dd351dcb6c27f03d22baae3b9f88a) (fix(mods/Arcana_BN): point hermit mapgen update to correct z-level) on 2026-08-15 02:00:44

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31855098911/artifacts/9238900022)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31855098911/artifacts/9239291770)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31855098911)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31855098911/artifacts/9239011673)
<!-- END artifact comment -->