### PR TITLE
fix(mods/Arcana): life-drain effects no longer fail to trigger on one-shotting targets

### DIFF
--- a/data/mods/Arcana_BN/effects.json
+++ b/data/mods/Arcana_BN/effects.json
@@ -546,7 +546,7 @@
       "fatigue_min": [ 1 ],
       "fatigue_tick": [ 300 ]
     },
-    "base_enchantments": [ { "hit_you_effect": [ { "id": "arcana_react_drain_life" } ] } ],
+    "base_enchantments": [ { "hit_you_effect": [ { "id": "arcana_react_drain_life", "hit_self": true } ] } ],
     "flags": [ "EFFECT_NIGHT_VISION" ]
   },
   {
@@ -1200,13 +1200,13 @@
     "type": "effect_type",
     "id": "arcana_effect_drain_life",
     "name": [ "Drain Life" ],
-    "desc": [ "A strange radiance permeates your body, blinding attackers with otherworldly magic." ],
+    "desc": [ "A strange radiance permeates your body, draining life from your foes with each strike." ],
     "remove_message": "You feel momentarily weak as your life-draining spell fades.",
     "decay_messages": [ [ "You feel your lift-draining spell fading.", "bad" ] ],
     "rating": "good",
     "max_duration": "120 m",
     "max_intensity": 120,
     "int_dur_factor": "1 m",
-    "base_enchantments": [ { "hit_you_effect": [ { "id": "arcana_react_drain_life" } ] } ]
+    "base_enchantments": [ { "hit_you_effect": [ { "id": "arcana_react_drain_life", "hit_self": true } ] } ]
   }
 ]

--- a/data/mods/Arcana_BN/items/ranged.json
+++ b/data/mods/Arcana_BN/items/ranged.json
@@ -310,7 +310,7 @@
       "passive_effects": [
         {
           "conditions": [ "WIELD" ],
-          "hit_you_effect": [ { "id": "arcana_react_drain_life", "once_in": 3 } ],
+          "hit_you_effect": [ { "id": "arcana_react_drain_life", "once_in": 3, "hit_self": true } ],
           "intermittent_activation": { "effects": [ { "frequency": "25 minutes", "spell_effects": [ { "id": "arcana_react_evil_mimic" } ] } ] },
           "ench_effects": [ { "effect": "arcana_evil_mimic_active", "intensity": 1 } ]
         }

--- a/data/mods/Arcana_BN/items/tools.json
+++ b/data/mods/Arcana_BN/items/tools.json
@@ -1567,7 +1567,12 @@
     "max_charges": 24,
     "ammo": "essence_blood_type",
     "relic_data": {
-      "passive_effects": [ { "conditions": [ "WIELD", "ACTIVE" ], "hit_you_effect": [ { "id": "arcana_react_drain_life", "once_in": 5 } ] } ]
+      "passive_effects": [
+        {
+          "conditions": [ "WIELD", "ACTIVE" ],
+          "hit_you_effect": [ { "id": "arcana_react_drain_life", "once_in": 5, "hit_self": true } ]
+        }
+      ]
     },
     "use_action": [
       {
@@ -1624,7 +1629,10 @@
       "passive_effects": [
         {
           "conditions": [ "WIELD" ],
-          "hit_you_effect": [ { "id": "arcana_react_drain_life", "once_in": 5 }, { "id": "arcana_react_moonstone_touch", "once_in": 10 } ],
+          "hit_you_effect": [
+            { "id": "arcana_react_drain_life", "once_in": 5, "hit_self": true },
+            { "id": "arcana_react_moonstone_touch", "once_in": 10 }
+          ],
           "hit_me_effect": [
             {
               "id": "arcana_react_shadowy_shield",
@@ -1771,7 +1779,7 @@
         {
           "conditions": [ "WIELD" ],
           "mutations": [ "ARCANA_STAFF_EFFECT" ],
-          "hit_you_effect": [ { "id": "arcana_react_sanguine_staff_drain" } ]
+          "hit_you_effect": [ { "id": "arcana_react_sanguine_staff_drain", "hit_self": true }, { "id": "arcana_react_sanguine_staff_drain_2" } ]
         }
       ],
       "recharge_scheme": [
@@ -1829,7 +1837,7 @@
           "conditions": [ "WIELD", "ACTIVE" ],
           "mutations": [ "ARCANA_BERSERK_EFFECT" ],
           "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "DEXTERITY", "add": 2 } ],
-          "hit_you_effect": [ { "id": "arcana_react_drain_life_improved" } ],
+          "hit_you_effect": [ { "id": "arcana_react_drain_life_improved", "hit_self": true }, { "id": "arcana_react_drain_life_improved_2" } ],
           "intermittent_activation": { "effects": [ { "frequency": "3 minutes", "spell_effects": [ { "id": "arcana_react_evil_mimic" } ] } ] },
           "ench_effects": [ { "effect": "arcana_evil_mimic_active", "intensity": 1 } ]
         }
@@ -1892,7 +1900,7 @@
           "conditions": [ "WIELD", "ACTIVE" ],
           "mutations": [ "ARCANA_BERSERK_EFFECT" ],
           "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "DEXTERITY", "add": 2 } ],
-          "hit_you_effect": [ { "id": "arcana_react_drain_life_improved" } ],
+          "hit_you_effect": [ { "id": "arcana_react_drain_life_improved", "hit_self": true }, { "id": "arcana_react_drain_life_improved_2" } ],
           "intermittent_activation": { "effects": [ { "frequency": "3 minutes", "spell_effects": [ { "id": "arcana_react_evil_mimic" } ] } ] },
           "ench_effects": [ { "effect": "arcana_evil_mimic_active", "intensity": 1 } ]
         }

--- a/data/mods/Arcana_BN/obsolete.json
+++ b/data/mods/Arcana_BN/obsolete.json
@@ -2048,7 +2048,9 @@
     "name": { "str": "horned halo" },
     "description": "A strange radiance permeating your body, granting you a life-draining touch.",
     "color": "dark_gray",
-    "relic_data": { "passive_effects": [ { "conditions": [ "WORN" ], "hit_you_effect": [ { "id": "arcana_react_drain_life" } ] } ] },
+    "relic_data": {
+      "passive_effects": [ { "conditions": [ "WORN" ], "hit_you_effect": [ { "id": "arcana_react_drain_life", "hit_self": true } ] } ]
+    },
     "extend": { "flags": [ "ONLY_ONE", "NO_TAKEOFF" ] }
   },
   {
@@ -2067,5 +2069,18 @@
     "id": "arcana_clairvoyance_hidden",
     "//": "This version is used by the orb of the veil.",
     "flags": [ "EFFECT_CLAIRVOYANCE" ]
+  },
+  {
+    "type": "SPELL",
+    "id": "arcana_react_drain_life_2",
+    "name": { "str": "React: Drain Life Shell" },
+    "description": "This exists only to trigger on-self effects from an on-hit action.",
+    "valid_targets": [ "hostile" ],
+    "message": "",
+    "min_range": 3,
+    "max_range": 3,
+    "effect": "target_attack",
+    "flags": [ "NO_EXPLOSION_VFX", "SILENT" ],
+    "extra_effects": [ { "id": "arcana_react_drain_life", "hit_self": true } ]
   }
 ]

--- a/data/mods/Arcana_BN/spells/spells_react.json
+++ b/data/mods/Arcana_BN/spells/spells_react.json
@@ -58,20 +58,7 @@
     "max_duration": 400
   },
   {
-    "type": "SPELL",
     "id": "arcana_react_drain_life",
-    "name": { "str": "React: Drain Life Shell" },
-    "description": "This exists only to trigger on-self effects from an on-hit action.",
-    "valid_targets": [ "hostile" ],
-    "message": "",
-    "min_range": 3,
-    "max_range": 3,
-    "effect": "target_attack",
-    "flags": [ "NO_EXPLOSION_VFX", "SILENT" ],
-    "extra_effects": [ { "id": "arcana_react_drain_life_2", "hit_self": true } ]
-  },
-  {
-    "id": "arcana_react_drain_life_2",
     "type": "SPELL",
     "name": { "str": "React: Drain Life Effect" },
     "description": "This creates the effect that heals the caster.",
@@ -86,23 +73,7 @@
     "max_duration": 1000
   },
   {
-    "type": "SPELL",
     "id": "arcana_react_drain_life_improved",
-    "name": { "str": "React: Improved Drain Life Shell" },
-    "description": "This exists only to trigger on-self effects from an on-hit action.",
-    "valid_targets": [ "hostile" ],
-    "message": "",
-    "effect_str": "arcana_lingering_chill",
-    "min_range": 1,
-    "max_range": 1,
-    "min_duration": 1000,
-    "max_duration": 2000,
-    "effect": "target_attack",
-    "flags": [ "NO_EXPLOSION_VFX", "SILENT" ],
-    "extra_effects": [ { "id": "arcana_react_drain_life_improved_2", "hit_self": true } ]
-  },
-  {
-    "id": "arcana_react_drain_life_improved_2",
     "type": "SPELL",
     "name": { "str": "React: Drain Life Effect" },
     "description": "This creates the effect that heals the caster.",
@@ -115,6 +86,21 @@
     "flags": [ "NO_EXPLOSION_VFX", "RANDOM_DURATION", "RANDOM_DAMAGE", "SILENT" ],
     "min_duration": 600,
     "max_duration": 1200
+  },
+  {
+    "type": "SPELL",
+    "id": "arcana_react_drain_life_improved_2",
+    "name": { "str": "React: Improved Drain Life Chill" },
+    "description": "This adds a DoT effect to targets hit by the cursed blade.",
+    "valid_targets": [ "hostile" ],
+    "message": "",
+    "effect_str": "arcana_lingering_chill",
+    "min_range": 1,
+    "max_range": 1,
+    "min_duration": 1000,
+    "max_duration": 2000,
+    "effect": "target_attack",
+    "flags": [ "NO_EXPLOSION_VFX", "SILENT" ]
   },
   {
     "type": "SPELL",
@@ -174,7 +160,7 @@
     "type": "SPELL",
     "id": "arcana_react_sanguine_staff_drain",
     "name": { "str": "React: Life's Bane Shell" },
-    "description": "This exists only to trigger on-self effects from an on-hit action.",
+    "description": "This adds a DoT effect to targets hit by the staff.",
     "valid_targets": [ "hostile" ],
     "message": "",
     "effect_str": "arcana_lingering_chill",
@@ -183,8 +169,7 @@
     "min_duration": 100,
     "max_duration": 300,
     "effect": "target_attack",
-    "flags": [ "NO_EXPLOSION_VFX", "SILENT" ],
-    "extra_effects": [ { "id": "arcana_react_sanguine_staff_drain_2", "hit_self": true } ]
+    "flags": [ "NO_EXPLOSION_VFX", "SILENT" ]
   },
   {
     "id": "arcana_react_sanguine_staff_drain_2",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fixes an oopsie caused by redundant spell stuff.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Phased out the hack of drain life spells hitting the target with a fake spell that exists only to cast a healing spell on the caster, as whatever drunken hackery required me to do that for drain life to work has long since been fixed it seems, and it was having the side effect of drain life not proccing if the attack one-shots your victim. The two items that used the "shell" effect to debug the target now call both spells separately in the on-hit relic data instead of chaining them via extra effects.

Also fixed an effect description, derp.

## Describe alternatives you've considered

Exploding.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported changes to playthrough build and load-tested.
3. Resumed ripping and tearing as my Dragonblood knight character, no longer seeing the healing message fail to proc on one-shots.
4. Spawned and tested a cursed blade, still works even on one-shots and confirmed lingering chill applies correctly to targets that survive.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e3ed3d5](https://github.com/cataclysmbn/Cataclysm-BN/commit/e3ed3d50b8ec3e399e43cc6837746dc39043bffc) (fix(mods/Arcana): life-drain effects no longer fail to trigger on one-shotting targets) on 2026-08-15 03:52:20

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31859833908/artifacts/9241023432)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31859833908/artifacts/9240740423)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31859833908/artifacts/9240369637)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31859833908/artifacts/9240457722)
<!-- END artifact comment -->