### PR TITLE
fix: remove upgrade time set from monster constructor

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -391,7 +391,6 @@ monster::monster( const mtype_id &id ) : monster()
     if( monster::has_flag( MF_AQUATIC ) ) {
         fish_population = dice( 1, 20 );
     }
-    upgrade_time = next_upgrade_time() + to_days<int>( calendar::turn - calendar::turn_zero );
 }
 
 monster::monster( const mtype_id &id, const tripoint_bub_ms &p ) : monster( id )


### PR DESCRIPTION
## Purpose of change (The Why)
Caused by: #9992
Resolves: #10069

## Describe the solution (The How)
Remove the upgrade time set line, it instead should be set whenever `try_upgrade` is called
Meaning there is no issue with the logic added with the PR

## Describe alternatives you've considered
None

## Testing
Set to +365 days
Lots of evolved zombies

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [cd5525e](https://github.com/cataclysmbn/Cataclysm-BN/commit/cd5525e47e606f9c57b5c93a9bb662d5c3126a4a) (fix: remove upgrade time set from monster constructor) on 2026-08-16 03:32:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31909804012/artifacts/9253451129)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31909804012/artifacts/9253817948)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31909804012/artifacts/9253498128)
- [⏳ Android tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31909804012)
<!-- END artifact comment -->