### PR TITLE
fix(lua): do not share a parsed hook list between Lua states

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -556,6 +556,13 @@ struct hook_entry {
 };
 
 struct hook_cache_entry {
+    // Which state the entries were parsed from. The cache is process-wide and
+    // keyed by hook name alone, so without this a second state holding the same
+    // number of handlers for that name silently inherits the first state's
+    // parse -- and an entry parsed as a plain function is then used against a
+    // table, or the priority order of one state is imposed on the other.
+    // Raw length cannot catch it, because the two counts are equal.
+    const void *owner = nullptr;
     int rawlen = -1;
     std::vector<hook_entry> entries;
 };
@@ -644,8 +651,10 @@ auto get_hook_entries( sol::state_view lua, std::string_view hook_name,
     auto &cache = get_hook_cache();
     auto &entry = cache[std::string{ hook_name }];
 
+    const void *owner = lua.lua_state();
     const int len = table_rawlen( lua, hooks );
-    if( entry.rawlen != len ) {
+    if( entry.owner != owner || entry.rawlen != len ) {
+        entry.owner = owner;
         entry.rawlen = len;
         entry.entries = build_hook_entries( lua, hook_name, hooks );
     }

--- a/tests/hook_state_cache_test.cpp
+++ b/tests/hook_state_cache_test.cpp
@@ -1,0 +1,85 @@
+#include "catalua.h"
+#include "catalua_hooks.h"
+#include "catalua_impl.h"
+#include "catalua_sol.h"
+#include "catch/catch.hpp"
+#include "mod_manager.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+// The parse of a hook list is cached per hook name for the whole process, and
+// invalidated by the raw length of that list. Two Lua states holding the same
+// number of handlers for one name therefore have equal lengths, and the second
+// one to fire would inherit the first one's parse: an entry read as a plain
+// function used against a table, or one state's priority order imposed on the
+// other's list.
+//
+// Nothing in the engine states that only one Lua state may exist at a time,
+// which is the assumption the cache was written under.
+
+namespace {
+
+auto fresh_state() -> std::unique_ptr<cata::lua_state, cata::lua_state_deleter> {
+    auto state = cata::make_wrapped_state();
+    cata::init_global_state_tables(*state, std::vector<mod_id>{});
+    cata::define_hooks(*state);
+    return state;
+}
+
+// The two shapes a hook entry may take. One each, so both lists are one long
+// and the length check cannot tell the states apart.
+void register_table_form(cata::lua_state& state, const char* mark) {
+    state.lua.script(
+        std::string("game.hooks.on_dialogue_start[1] = { priority = 0, fn = function( params ) "
+                    "params.results.mark = '")
+        + mark + "' end }");
+}
+
+void register_function_form(cata::lua_state& state, const char* mark) {
+    state.lua.script(
+        std::string("game.hooks.on_dialogue_start[1] = function( params ) "
+                    "params.results.mark = '")
+        + mark + "' end");
+}
+
+auto fire(cata::lua_state& state) -> std::string {
+    sol::table results = cata::run_hooks("on_dialogue_start", nullptr, {.state = &state});
+    return results.get_or<std::string>("mark", "nothing ran");
+}
+
+} // namespace
+
+TEST_CASE("hook_entries_are_not_shared_between_states", "[lua]") {
+    SECTION("table form parsed first") {
+        auto first = fresh_state();
+        auto second = fresh_state();
+        register_table_form(*first, "first");
+        register_function_form(*second, "second");
+
+        CHECK(fire(*first) == "first");
+        CHECK(fire(*second) == "second");
+    }
+
+    SECTION("function form parsed first") {
+        auto first = fresh_state();
+        auto second = fresh_state();
+        register_function_form(*first, "first");
+        register_table_form(*second, "second");
+
+        CHECK(fire(*first) == "first");
+        CHECK(fire(*second) == "second");
+    }
+
+    SECTION("a state keeps answering after another has fired") {
+        auto first = fresh_state();
+        auto second = fresh_state();
+        register_table_form(*first, "first");
+        register_function_form(*second, "second");
+
+        CHECK(fire(*first) == "first");
+        CHECK(fire(*second) == "second");
+        CHECK(fire(*first) == "first");
+    }
+}


### PR DESCRIPTION
Fixes #10077.

The hook entry cache in `get_hook_entries` is process-wide and keyed by hook name alone, and it rebuilds only when the raw length of the list changes. Two `lua_state`s holding the same number of handlers for one hook name therefore have equal lengths, and the second to fire inherits the first one's parse: `is_table`, `priority`, `mod_id` and the index all then describe the wrong list. An entry registered as a plain function is looked up as a table, or the reverse, and that handler does not run at all.

This records which state a cache entry was parsed from and reparses when asked about another. One field; the raw length check is unchanged, so a list that grows or shrinks within one state still invalidates as before.

Nothing states that only one state may exist at a time, and nothing enforces it. It is not reachable in the game today, because `DynamicDataLoader` builds the only state and `lua_state_deleter` clears the cache when it goes. It is reachable as soon as anything holds a second one — which is how it surfaced: an accessibility fork keeps a Lua state of its own beside the world's, so its hooks are alive on the screens that exist before a world does and after one is left.

`tests/hook_state_cache_test.cpp` covers both orders and a return to the first state. Verified by reverting the one-line change: all three sections fail, and the second state's handler reports `nothing ran` rather than a wrong value, which is the shape this takes in practice — a hook that silently does not fire.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [16cbf52](https://github.com/cataclysmbn/Cataclysm-BN/commit/16cbf52918d06e4b2340972ca74b3482111ad2da) (Do not share a parsed hook list between Lua states) on 2026-08-15 23:32:52

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31914180611/artifacts/9254567726)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31914180611)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31914180611)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31914180611)
<!-- END artifact comment -->