### PR TITLE
fix: make ROBOT_FLYING and ELECTRONIC visible on electrosense

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7393,7 +7393,7 @@ bool Character::sees_with_specials( const Creature &critter ) const
 
     // electroreceptors grants vision of robots and electric monsters through walls
     if( has_enchantment_flag( ench_flag_ELECTROSENSE ) &&
-        ( critter.in_species( ROBOT ) || critter.has_flag( MF_ELECTRIC ) ) ) {
+        ( critter.in_species( ROBOT ) || critter.in_species( ROBOT_FLYING ) || critter.has_flag( MF_ELECTRIC ) || critter.has_flag( MF_ELECTRONIC ) ) ) {
         return true;
     }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7393,7 +7393,8 @@ bool Character::sees_with_specials( const Creature &critter ) const
 
     // electroreceptors grants vision of robots and electric monsters through walls
     if( has_enchantment_flag( ench_flag_ELECTROSENSE ) &&
-        ( critter.in_species( ROBOT ) || critter.in_species( ROBOT_FLYING ) || critter.has_flag( MF_ELECTRIC ) || critter.has_flag( MF_ELECTRONIC ) ) ) {
+        ( critter.in_species( ROBOT ) || critter.in_species( ROBOT_FLYING ) ||
+          critter.has_flag( MF_ELECTRIC ) || critter.has_flag( MF_ELECTRONIC ) ) ) {
         return true;
     }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -231,6 +231,7 @@ static const skill_id skill_throw( "throw" );
 
 static const species_id HUMAN( "HUMAN" );
 static const species_id ROBOT( "ROBOT" );
+static const species_id ROBOT( "ROBOT_FLYING" );
 
 namespace
 {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -231,7 +231,7 @@ static const skill_id skill_throw( "throw" );
 
 static const species_id HUMAN( "HUMAN" );
 static const species_id ROBOT( "ROBOT" );
-static const species_id ROBOT( "ROBOT_FLYING" );
+static const species_id ROBOT_FLYING( "ROBOT_FLYING" );
 
 namespace
 {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
closes #10068

electrosense is supposed to display anything that is sufficiently electronic, yet for some reason flying robots and enemies with the literal electronic flag are not checked for. This causes manhacks to not show up on electrosense.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes electrosense also check for the ROBOT_FLYING species and the ELECTRONIC monster flag.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Non-electronic manhacks
## Testing
Build artifact, but cmon I changed like one line...
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
I am become duck, destroyer of bugs
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a3049bd](https://github.com/cataclysmbn/Cataclysm-BN/commit/a3049bda048b59a4a665af48dffc64c8afb33d05) (Apply suggestion from @chaosvolt) on 2026-08-16 02:40:23

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31919696813/artifacts/9256663834)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31919696813/artifacts/9256403555)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31919696813/artifacts/9256153612)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31919696813/artifacts/9256162196)
<!-- END artifact comment -->