### PR TITLE
fix: close infinite reward loop for recruiting beggars

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
@@ -452,8 +452,7 @@
       {
         "text": "...",
         "topic": "TALK_EVAC_MERCHANT_BEGGARS2_Reward2",
-        "condition": { "not": { "npc_has_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" } },
-        "effect": { "npc_add_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" }
+        "condition": { "not": { "npc_has_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" } }
       },
       {
         "text": "...",
@@ -467,7 +466,12 @@
     "id": "TALK_EVAC_MERCHANT_BEGGARS2_Reward2",
     "type": "talk_topic",
     "dynamic_line": "You didn't do the full job, but we're fair people here.  Here's five merch a head for the folks you found a new home for.",
-    "speaker_effect": { "effect": { "u_buy_item": "FMCNote", "count": 20 } },
+    "speaker_effect": {
+      "effect": [
+        { "u_buy_item": "FMCNote", "count": 20 },
+        { "npc_add_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" }
+      ]
+    },
     "responses": [ { "text": "Thanks.", "topic": "TALK_EVAC_MERCHANT" } ]
   },
   {

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
@@ -447,9 +447,34 @@
   {
     "id": "TALK_EVAC_MERCHANT_BEGGARS2_Reward",
     "type": "talk_topic",
-    "dynamic_line": "And so we did.  You didn't do the full job, but we're fair people here.  Here's five merch a head for the folks you found a new home for.",
+    "dynamic_line": "And so we did...",
+    "responses": [
+      {
+        "text": "...",
+        "topic": "TALK_EVAC_MERCHANT_BEGGARS2_Reward2",
+        "condition": { "not": { "npc_has_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" } },
+        "effect": { "npc_add_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" },
+      },
+      {
+        "text": "...",
+        "topic": "TALK_EVAC_MERCHANT_BEGGARS2_RewardNo",
+        "condition": { "npc_has_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes"  }
+      },
+      { "text": "Nevermind.", "topic": "TALK_EVAC_MERCHANT" }
+    ]
+  },
+  {
+    "id": "TALK_EVAC_MERCHANT_BEGGARS2_Reward2",
+    "type": "talk_topic",
+    "dynamic_line": "You didn't do the full job, but we're fair people here.  Here's five merch a head for the folks you found a new home for.",
     "speaker_effect": { "effect": { "u_buy_item": "FMCNote", "count": 20 } },
     "responses": [ { "text": "Thanks.", "topic": "TALK_EVAC_MERCHANT" } ]
+  },
+  {
+    "id": "TALK_EVAC_MERCHANT_BEGGARS2_RewardNo",
+    "type": "talk_topic",
+    "dynamic_line": "Did you hit your head?  I already paid you.",
+    "responses": [ { "text": "Oh, my bad.", "topic": "TALK_EVAC_MERCHANT" } ]
   },
   {
     "id": "TALK_EVAC_MERCHANT_RANCH",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
@@ -453,12 +453,12 @@
         "text": "...",
         "topic": "TALK_EVAC_MERCHANT_BEGGARS2_Reward2",
         "condition": { "not": { "npc_has_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" } },
-        "effect": { "npc_add_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" },
+        "effect": { "npc_add_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" }
       },
       {
         "text": "...",
         "topic": "TALK_EVAC_MERCHANT_BEGGARS2_RewardNo",
-        "condition": { "npc_has_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes"  }
+        "condition": { "npc_has_var": "beggars_reward_collected", "type": "general", "context": "recruit", "value": "yes" }
       },
       { "text": "Nevermind.", "topic": "TALK_EVAC_MERCHANT" }
     ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
closes #10043

after recruiting the beggars the merchant will infinitely give you money for the job.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Closes the loop by adding a bit of dialogue and some npc vars stuff
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
POV you're the federal reserve in 2020
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
I couldn't actually test this cause i literally don't know HOW to recruit the beggars, but it should work.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [80dd35b](https://github.com/cataclysmbn/Cataclysm-BN/commit/80dd35b4bd127a47bf2d9fb9067b2f00935ccc55) (Update NPC_free_merchant_shopkeep.json) on 2026-08-16 03:27:43

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31921500913/artifacts/9257189165)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31921500913/artifacts/9256866590)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31921500913/artifacts/9256608560)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31921500913/artifacts/9256654946)
<!-- END artifact comment -->