### PR TITLE
fix: add winches and lab override code usability for aftershock lab rooms

### DIFF
--- a/data/mods/Aftershock/maps/lab_vehicle_track.json
+++ b/data/mods/Aftershock/maps/lab_vehicle_track.json
@@ -50,7 +50,7 @@
         "6": {
           "name": "Vehicle Testing Track",
           "security": 1,
-          "options": [ 
+          "options": [
             { "name": "UNLOCK ENTRANCE", "action": "unlock", "security": 5 },
             { "name": "ENTER EMERGENCY OVERRIDE CODE", "action": "unlock_labpass" }
           ],

--- a/data/mods/Aftershock/maps/lab_vehicle_track.json
+++ b/data/mods/Aftershock/maps/lab_vehicle_track.json
@@ -11,7 +11,7 @@
         "|--------|....|--------|",
         "|llllllllg...6gllllllll|",
         "|#.......-gLLg-.......#|",
-        "|#....................#|",
+        "|#........%...........#|",
         "|......................|",
         "|......................|",
         "|......................|",
@@ -49,8 +49,11 @@
       "computers": {
         "6": {
           "name": "Vehicle Testing Track",
-          "security": 4,
-          "options": [ { "name": "UNLOCK ENTRANCE", "action": "unlock", "security": 5 } ],
+          "security": 1,
+          "options": [ 
+            { "name": "UNLOCK ENTRANCE", "action": "unlock", "security": 5 },
+            { "name": "ENTER EMERGENCY OVERRIDE CODE", "action": "unlock_labpass" }
+          ],
           "failures": [ { "action": "damage" }, { "action": "shutdown" } ]
         }
       },

--- a/data/mods/Aftershock/maps/lab_weapons_range.json
+++ b/data/mods/Aftershock/maps/lab_weapons_range.json
@@ -13,7 +13,7 @@
         "|........|...6|........|",
         "|x......S|....|htth...&|",
         "|x......S|-LL-|htth....|",
-        "|........|....|........|",
+        "|........|%...|........|",
         "|......................|",
         "|-----|................|",
         "|rrrrr|................|",
@@ -55,14 +55,20 @@
       "computers": {
         "6": {
           "name": "Weapons Testing Range",
-          "security": 3,
-          "options": [ { "name": "UNLOCK ENTRANCE", "action": "unlock", "security": 5 } ],
+          "security": 1,
+          "options": [
+            { "name": "UNLOCK ENTRANCE", "action": "unlock", "security": 5 },
+            { "name": "ENTER EMERGENCY OVERRIDE CODE", "action": "unlock_labpass" }
+          ],
           "failures": [ { "action": "damage" }, { "action": "shutdown" } ]
         },
         "7": {
           "name": "Armory Entrance",
-          "security": 6,
-          "options": [ { "name": "UNLOCK ENTRANCE", "action": "unlock_disarm", "security": 7 } ],
+          "security": 1,
+          "options": [
+            { "name": "UNLOCK ENTRANCE", "action": "unlock_disarm", "security": 7 },
+            { "name": "ENTER EMERGENCY OVERRIDE CODE", "action": "unlock_labpass" }
+          ],
           "failures": [ { "action": "damage" }, { "action": "shutdown" } ]
         }
       }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
closes #10025

The aftershock lab end rooms are lacking the winches to open the doors from the inside and the ability to use the lab override code to open the doors.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Fixes the above problems, and makes the initial hack 1 security to align with other lab terminals after the lab override code update.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Letting wishduck do some stuff
## Testing
Found the rooms, winch and override code successful
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Yeah, I'm back
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1504f19](https://github.com/cataclysmbn/Cataclysm-BN/commit/1504f1913e3533da83b684a94f9d1fc13245488c) (Update lab_weapons_range.json) on 2026-08-16 04:02:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31922546338/artifacts/9257643829)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31922546338/artifacts/9257515641)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31922546338/artifacts/9257122863)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31922546338/artifacts/9257316058)
<!-- END artifact comment -->