### PR TITLE
fix: replace the flat roof tiles on the roof of bungalow02 with shingle flat roof tiles

### DIFF
--- a/data/json/mapgen/house/bungalow02.json
+++ b/data/json/mapgen/house/bungalow02.json
@@ -98,6 +98,7 @@
         "         5------------  ",
         "                        "
       ],
+      "terrain": { ".": "t_shingle_flat_roof" },
       "place_nested": [
         { "chunks": [ "NC_res_roof_solar_4X4" ], "x": 11, "y": 8 },
         { "chunks": [ "NC_res_roof_chunk_3X3" ], "x": [ 11, 14 ], "y": [ 14, 16 ] }


### PR DESCRIPTION
## Purpose of change (The Why)
Because this house has the wrong type of roof.
## Describe the solution (The How)
title
## Describe alternatives you've considered
none
## Testing
I started a new game; checked bungalow02; no more flat roof on the roof
## Additional context

<details>
<summary>Screenshot (Before):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/1b1dcb24-0018-4c87-8e65-b8b44919e5b9"></a>
</details>

<details>
<summary>Screenshot (After):</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/ce46c28b-77b9-471a-95b2-1995209e2e26"></a>
</details>

## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [49f1df3](https://github.com/cataclysmbn/Cataclysm-BN/commit/49f1df33158bd2692f1ec1726e006388b19b1e64) (fix the roof) on 2026-08-16 17:43:07

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31957311273/artifacts/9266415252)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31957311273/artifacts/9267580294)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31957311273/artifacts/9266570514)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31957311273/artifacts/9266495889)
<!-- END artifact comment -->