### PR TITLE
fix: make hellfire missile rack sprite rotate

### DIFF
--- a/data/json/external_tileset/External_Tileset_DP_dmd.json
+++ b/data/json/external_tileset/External_Tileset_DP_dmd.json
@@ -46,7 +46,7 @@
           { "id": [ "hellfire_launcher", "overlay_wielded_hellfire_launcher" ], "fg": 38 },
           { "id": [ "hellfire_heat", "overlay_wielded_hellfire_heat" ], "fg": 39 },
           { "id": [ "hellfire_ninja", "overlay_wielded_hellfire_ninja" ], "fg": 40 },
-          { "id": "vp_hellfire_turret", "fg": 41 },
+          { "id": "vp_hellfire_turret", "fg": 41, "rotates": true },
           { "id": "tac_fullhelmet", "fg": 42 },
           { "id": "tac_helmet", "fg": 44 },
           { "id": [ "clam", "overlay_wielded_clam" ], "fg": 46 },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
The vehicle mounted hellfire missile rack doesn't rotate with vehicles, which looks weird
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes them rotate correctly
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
No
## Testing
Spawned in apache, flew around, hellfire missile rack rotates correctly
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c9d969f](https://github.com/cataclysmbn/Cataclysm-BN/commit/c9d969fcf41e4b5a36d9bed73afb9cb90b0322f8) (Update External_Tileset_DP_dmd.json) on 2026-08-17 01:31:36

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31981249329/artifacts/9272547520)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31981249329/artifacts/9273498086)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31981249329/artifacts/9272709152)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31981249329/artifacts/9272638569)
<!-- END artifact comment -->