### PR TITLE
fix(UI): exclude `NO_REPAIR` items from repair item selection menu

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1562,7 +1562,7 @@ class repair_inventory_preset: public inventory_selector_preset
             return loc->made_of_any( actor->materials ) && ( !loc->count_by_charges() ||
                     loc->is_stackable() ) && ( loc->damage() > -1 ||
                                                ( loc->has_flag( flag_VARSIZE ) && !loc->has_flag( flag_FIT ) ) ) && !loc->count_by_charges() &&
-                   !loc->is_firearm() &&
+                   !loc->is_firearm() && !loc->has_flag( flag_NO_REPAIR ) &&
                    &*loc != main_tool;
         }
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

More random stuff that should not be cluttering up the repair item select menu reeee

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In game_inventory.cpp, set `repair_inventory_preset` to also exclude items that have the `NO_REPAIR` flag from showing up on the repair item menu.

## Describe alternatives you've considered

Screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Confirmed that a ceramic MBR vest no longer shows up on repair menu, but an empty MBR vest, regular clothes, and poorly-fitting items still do.
3. Checked affected file for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c13eba7](https://github.com/cataclysmbn/Cataclysm-BN/commit/c13eba702f4e0aacb9da12064f68edb22a7f5875) (Update game_inventory.cpp) on 2026-08-17 05:55:42

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31995502810/artifacts/9276868733)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31995502810)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31995502810/artifacts/9277562040)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/31995502810/artifacts/9276978331)
<!-- END artifact comment -->