### PR TITLE
docs: 'Correct' Fedora package install instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 
 [![Stable][stable-releases-badge]][stable-releases] [![Flatpak][flathub-badge]][flathub-releases]
 
-[![Recent][all-releases-badge]][all-releases] [![Experiemental][experimental-badge]][experimental-releases] 
+[![Recent][all-releases-badge]][all-releases] [![Experiemental][experimental-badge]][experimental-releases]
 
 ### Launchers
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,9 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 
 ### Executables
 
-[![Stable][stable-releases-badge]][stable-releases] [![Recent][all-releases-badge]][all-releases] [![Experiemental][experimental-badge]][experimental-releases] [![Flatpak][flathub-badge]][flathub-releases]
+[![Stable][stable-releases-badge]][stable-releases] [![Flatpak][flathub-badge]][flathub-releases]
 
-#### Linux Instructions
-
-While many of the dependencies that the game depends on are likely installed by default, some likely aren't installed by default on your distro.
-
-Here are the commands for some of the most popular distro families:
-
-- Ubuntu / Debian: `sudo apt install libsdl3-0 libsdl3-image-0 libsdl3-ttf-0 libsdl3-mixer-0 libfreetype6 zip libsqlite3-0`
-- Fedora: `sudo dnf install SDL3 SDL3_image SDL3_ttf SDL3_mixer freetype zip sqlite`
-- Arch: `sudo pacman -S sdl3 sdl3_image sdl3_ttf sdl3_mixer zip sqlite`
+[![Recent][all-releases-badge]][all-releases] [![Experiemental][experimental-badge]][experimental-releases] 
 
 ### Launchers
 
@@ -71,14 +63,13 @@ Bright Nights uses a [mod registry](https://mods.cataclysmbn.org/) for easier di
 [clone]: https://github.com/cataclysmbn/Cataclysm-BN/ "clone from our GitHub repo"
 [clone-badge]: https://img.shields.io/badge/Clone%20From%20Repo-black?style=for-the-badge&logo=github
 
-## Building
+#### Building from source
 
-- [with cmake](docs/en/dev/guides/building/cmake.md)
-- [with MSYS2](docs/en/dev/guides/building/msys.md)
-- [with vcpkg](docs/en/dev/guides/building/vs_vcpkg.md)
+Please read the official docs for details:
 
-Please read the [official docs](https://docs.cataclysmbn.org/dev/guides/building/cmake/) for
-details.
+- [building with cmake](docs/en/dev/guides/building/cmake.md)
+- [building with MSYS2](docs/en/dev/guides/building/msys.md)
+- [building with vcpkg](docs/en/dev/guides/building/vs_vcpkg.md)
 
 ## Contributing
 

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -74,7 +74,7 @@ sqlite-devel zlib-devel
 > These libraries will be build automatically when compiling
 
 - For Arch based distros:
- 
+
 ```sh
 sudo pacman -S sdl3 sdl3_image sdl3_ttf sdl3_mixer zip sqlite
 ```

--- a/docs/en/dev/guides/building/cmake.md
+++ b/docs/en/dev/guides/building/cmake.md
@@ -73,6 +73,12 @@ sqlite-devel zlib-devel
 > Neither Ubuntu or Fedora ship SDL3_mixer or shadercross
 > These libraries will be build automatically when compiling
 
+- For Arch based distros:
+ 
+```sh
+sudo pacman -S sdl3 sdl3_image sdl3_ttf sdl3_mixer zip sqlite
+```
+
 #### Verifying Compiler Version
 
 You need Clang 22 or newer to build CataclysmBN. You can check your compiler version with:


### PR DESCRIPTION
Onboarding to the project (hello!), I noticed the fedora required package instructions in the readme.md were incorrect. It suggests installing sdl3_mixer, which is unfortunately [stuck in package review](https://bugzilla.redhat.com/show_bug.cgi?id=2454358) and not yet available on fedora. It set me off on a path to install or build it myself until I caught the instructions on the docs pages.

I can confirm the fedora instructions on the docs pages work, since they leave out sdl3_mixer to let the build system download it itself. I figured it is better to have the build instructions in one place anyway, so I reworked the readme to direct people to the docs pages on them, making sure the Arch instructions are included there as well.

I also reordered the readme's binary download badges so the recent and experimental builds are on a separate line from the stable and flatpak ones, looks a bit nicer.

I did not touch the other language readme.mds or docs pages. Is it okay to leave those for another maintainer to pick that up later?
