### PR TITLE
feat: mapgen colors definitions via an inline `colors` array

### DIFF
--- a/docs/en/mod/json/reference/map/mapgen.md
+++ b/docs/en/mod/json/reference/map/mapgen.md
@@ -368,6 +368,8 @@ Example:
 The palette causes the furniture to be default painted based off the palette
 The palette randomly chooses a color based of the position on the global overmap
 
+Can also defined an inline palette as a seperate option
+
 ## Set terrain, furniture, or traps with a "set" array
 
 **optional** Specific commands to set terrain, furniture, traps, radiation, etc. Array is processed
@@ -662,6 +664,8 @@ times):
 
 It is also possible to specify a color palette to apply
 The palette is a `mapgen_color_palette`
+
+Can also defined an inline palette as a seperate option
 
 ````json
 "terrain": {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2513,6 +2513,10 @@ class jmapgen_furniture : public jmapgen_piece
         jmapgen_furniture( const JsonObject &jsi ) : id( jsi.get_member( "furn" ) ) {
             // Used in simple cases
             assign( jsi, "palette", palette );
+
+            if( jsi.has_array( "colors" ) ) {
+                palette = MapgenColorPalette::define_new_palette( jsi );
+            }
         }
 
         jmapgen_furniture( const JsonValue &jsv ) {
@@ -2523,6 +2527,9 @@ class jmapgen_furniture : public jmapgen_piece
                 if( jsi.has_member( "furn" ) ) {
                     id = mapgen_value<furn_id>( jsi.get_member( "furn" ) );
                     assign( jsi, "palette", palette );
+                    if( jsi.has_array( "colors" ) ) {
+                        palette = MapgenColorPalette::define_new_palette( jsi );
+                    }
                 } else {
                     // If this object is using parameters distributions etc
                     id = mapgen_value<furn_id>( jsi );
@@ -2582,6 +2589,9 @@ class jmapgen_terrain : public jmapgen_piece
         jmapgen_terrain( const JsonObject &jsi ) : jmapgen_terrain( jsi.get_member( "ter" ) ) {
             // Used in simple cases
             assign( jsi, "palette", palette );
+            if( jsi.has_array( "colors" ) ) {
+                palette = MapgenColorPalette::define_new_palette( jsi );
+            }
         }
         jmapgen_terrain( const JsonValue &jsv ) {
             // Okay so we have an object
@@ -2591,6 +2601,9 @@ class jmapgen_terrain : public jmapgen_piece
                 if( jsi.has_member( "ter" ) ) {
                     id = mapgen_value<ter_id>( jsi.get_member( "ter" ) );
                     assign( jsi, "palette", palette );
+                    if( jsi.has_array( "colors" ) ) {
+                        palette = MapgenColorPalette::define_new_palette( jsi );
+                    }
                 } else {
                     // If this object is using parameters distributions etc
                     id = mapgen_value<ter_id>( jsi );

--- a/src/mapgen_color_palette.cpp
+++ b/src/mapgen_color_palette.cpp
@@ -37,6 +37,27 @@ void MapgenColorPalette::load_palette( const JsonObject &jo, const std::string &
     all_palettes.load( jo, src );
 }
 
+int MapgenColorPalette::next_id = 0;
+
+mpalette_id MapgenColorPalette::define_new_palette( const JsonObject &obj )
+{
+    MapgenColorPalette pal = MapgenColorPalette();
+    pal.load( obj, "" );
+    pal.id = get_unique_id();
+    all_palettes.insert( pal );
+    return pal.id;
+}
+
+mpalette_id MapgenColorPalette::get_unique_id()
+{
+    static const std::string unique_prefix = "\u01F7 ";
+    while( true ) {
+        const mpalette_id new_group = mpalette_id( unique_prefix + std::to_string( next_id++ ) );
+        if( !new_group.is_valid() ) {
+            return new_group;
+        }
+    }
+}
 void MapgenColorPalette::load( const JsonObject &jo, const std::string & )
 {
     if( jo.has_bool( "clear" ) && jo.get_bool( "clear" ) ) {

--- a/src/mapgen_color_palette.h
+++ b/src/mapgen_color_palette.h
@@ -39,6 +39,13 @@ class MapgenColorPalette
 
         bool was_loaded;
 
+        static mpalette_id define_new_palette( const JsonObject &obj );
+
     private:
         weighted_int_list<std::string> colors;
+
+        static mpalette_id get_unique_id();
+
+        static int next_id;
+
 };


### PR DESCRIPTION
## Purpose of change (The Why)
Request from @Fentanylreactor 

## Describe the solution (The How)
Allow inline color palette definitions like inline itemgroup definitions

## Describe alternatives you've considered
Dont do this

## Testing
Replace `palette: xxx` with `colors: [ "Cataclysm Red" ]`
in `data/json/mapgen_palette/house_general_palette.json`
They are always cataclysm red

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
<!-- BEGIN docs comment -->

## Translations

| post                             | changed | stale | missing |
| -------------------------------- | ------- | ----- | ------- |
| mod/json/reference/map/mapgen.md | en      | ko    | ja      |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e10b233](https://github.com/cataclysmbn/Cataclysm-BN/commit/e10b23346f5b5781c54f2d7b9c20e618dc9e6d75) (feat: mapgen colors definitions via an inline `colors` array) on 2026-08-18 01:43:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32062152247/artifacts/9300411540)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32062152247)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32062152247/artifacts/9299280296)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32062152247/artifacts/9299256012)
<!-- END artifact comment -->