### PR TITLE
feat: jump over tiles & crash through windows

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -1876,6 +1876,12 @@
   },
   {
     "type": "keybinding",
+    "name": "Jump across an adjacent tile",
+    "category": "DEFAULTMODE",
+    "id": "jump"
+  },
+  {
+    "type": "keybinding",
     "name": "Advanced Inventory management",
     "category": "DEFAULTMODE",
     "id": "advinv",

--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -1878,7 +1878,8 @@
     "type": "keybinding",
     "name": "Jump across an adjacent tile",
     "category": "DEFAULTMODE",
-    "id": "jump"
+    "id": "jump",
+    "bindings": [ { "input_method": "keyboard", "key": "SPACE" } ]
   },
   {
     "type": "keybinding",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -97,6 +97,7 @@ std::string io::enum_to_string<action_id>( action_id data )
             PAIR( ACTION_CLOSE )
             PAIR( ACTION_SMASH )
             PAIR( ACTION_EXAMINE )
+            PAIR( ACTION_JUMP )
             PAIR( ACTION_PICKUP )
             PAIR( ACTION_PICKUP_ALL )
             PAIR( ACTION_PICKUP_FEET )
@@ -312,6 +313,8 @@ std::string action_ident( action_id act )
             return "smash";
         case ACTION_EXAMINE:
             return "examine";
+        case ACTION_JUMP:
+            return "jump";
         case ACTION_ADVANCEDINV:
             return "advinv";
         case ACTION_PICKUP:
@@ -868,6 +871,8 @@ bool can_interact_at( action_id action, const tripoint_bub_ms &p )
             return can_move_vertical_at( p, -1 );
         case ACTION_EXAMINE:
             return can_examine_at( p );
+        case ACTION_JUMP:
+            return iexamine::can_jump_over_tile( get_avatar(), p );
         case ACTION_PICKUP:
         case ACTION_PICKUP_ALL:
         case ACTION_PICKUP_FEET:
@@ -1146,7 +1151,7 @@ action_id handle_action_menu()
             register_lua_action_entries( category_id );
         } else if( category_id == "interact" ) {
             register_actions( {
-                ACTION_EXAMINE, ACTION_SMASH, ACTION_MOVE_DOWN, ACTION_MOVE_UP,
+                ACTION_EXAMINE, ACTION_JUMP, ACTION_SMASH, ACTION_MOVE_DOWN, ACTION_MOVE_UP,
                 ACTION_OPEN, ACTION_CLOSE, ACTION_CHAT, ACTION_PICKUP,
                 ACTION_PICKUP_ALL, ACTION_PICKUP_FEET, ACTION_GRAB, ACTION_HAUL, ACTION_BUTCHER, ACTION_LOOT,
             } );

--- a/src/action.h
+++ b/src/action.h
@@ -102,6 +102,8 @@ enum action_id : int {
     ACTION_SMASH,
     /** Examine or pick up items from adjacent square */
     ACTION_EXAMINE,
+    /** Jump across a single adjacent tile */
+    ACTION_JUMP,
     /** Pick up items from one current/adjacent square */
     ACTION_PICKUP,
     /** Pick up items from all current/adjacent squares */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -333,6 +333,7 @@ static const efftype_id effect_adrenaline_mycus( "adrenaline_mycus" );
 static const efftype_id effect_ai_controlled( "ai_controlled" );
 static const efftype_id effect_ai_waiting( "ai_waiting" );
 static const efftype_id effect_assisted( "assisted" );
+static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_contacts( "contacts" );
@@ -12303,6 +12304,13 @@ bool game::is_dangerous_tile( const tripoint_bub_ms &dest_loc ) const
 
 bool game::prompt_dangerous_tile( const tripoint_bub_ms &dest_loc ) const
 {
+    return prompt_dangerous_tile( dest_loc, _( "Really step into %s?" ), true );
+}
+
+bool game::prompt_dangerous_tile( const tripoint_bub_ms &dest_loc,
+                                  std::string_view query_message,
+                                  const bool allow_ledge_examine ) const
+{
     static const iexamine_function ledge_examine = iexamine_function_from_string( "ledge" );
     std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
 
@@ -12310,8 +12318,9 @@ bool game::prompt_dangerous_tile( const tripoint_bub_ms &dest_loc ) const
         return true;
     }
 
-    if( !( harmful_stuff.size() == 1 && m.tr_at( dest_loc ).loadid == tr_ledge ) ) {
-        return query_yn( _( "Really step into %s?" ), enumerate_as_string( harmful_stuff ) ) ;
+    if( !allow_ledge_examine ||
+        !( harmful_stuff.size() == 1 && m.tr_at( dest_loc ).loadid == tr_ledge ) ) {
+        return query_yn( query_message.data(), enumerate_as_string( harmful_stuff ) );
     }
 
     if( !u.is_mounted() ) {
@@ -12323,8 +12332,8 @@ bool game::prompt_dangerous_tile( const tripoint_bub_ms &dest_loc ) const
     } else {
         auto crit = u.mounted_creature.get();
         if( crit->has_flag( MF_MOUNTABLE_LEDGE ) ) {
-            return query_yn( _( "Really step into %s?" ),
-                             enumerate_as_string( harmful_stuff ) ) ; // mount can climb down ledges
+            return query_yn( query_message.data(),
+                             enumerate_as_string( harmful_stuff ) ); // mount can climb down ledges
         }
     }
 
@@ -12900,12 +12909,16 @@ auto game::place_player( const tripoint_bub_ms &dest_loc ) -> point_rel_sm
             u.mounted_creature->apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 10 ) );
         } else {
             const bodypart_id bp = u.get_random_body_part();
+            const auto damaged_bp = bp->main_part.id();
             if( u.deal_damage( nullptr, bp, damage_instance( DT_CUT, rng( 1, 10 ) ) ).total_damage() > 0 ) {
                 //~ 1$s - bodypart name in accusative, 2$s is terrain name.
                 add_msg( m_bad, _( "You cut your %1$s on the %2$s!" ),
-                         body_part_name_accusative( bp->token ),
+                         body_part_name_accusative( damaged_bp ),
                          m.has_flag_ter( "SHARP", dest_loc ) ? m.tername( dest_loc ) : m.furnname(
                              dest_loc ) );
+                if( one_in( 2 ) && !u.is_immune_effect( effect_bleed ) ) {
+                    u.add_effect( effect_bleed, rng( 2_minutes, 5_minutes ), bp.id() );
+                }
             }
         }
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3407,6 +3407,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "smash" );
     ctxt.register_action( "loot" );
     ctxt.register_action( "examine" );
+    ctxt.register_action( "jump" );
     ctxt.register_action( "advinv" );
     ctxt.register_action( "pickup" );
     ctxt.register_action( "pickup_all" );

--- a/src/game.h
+++ b/src/game.h
@@ -977,6 +977,8 @@ class game : public submap_load_listener
         bool is_dangerous_tile( const tripoint_bub_ms &dest_loc ) const;
         std::vector<std::string> get_dangerous_tile( const tripoint_bub_ms &dest_loc ) const;
         bool prompt_dangerous_tile( const tripoint_bub_ms &dest_loc ) const;
+        bool prompt_dangerous_tile( const tripoint_bub_ms &dest_loc, std::string_view query_message,
+                                    bool allow_ledge_examine ) const;
     private:
         auto player_visibility_cache_current() const -> bool;
         void chat(); // Talk to a nearby NPC  'C'

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -728,6 +728,10 @@ static void close()
 static auto jump() -> void
 {
     auto &you = get_avatar();
+    if( !iexamine::can_start_jump_over_tile( you, true ) ) {
+        return;
+    }
+
     const auto allowed = [&you]( const tripoint_bub_ms & pos ) {
         return iexamine::can_jump_over_tile( you, pos );
     };

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -52,6 +52,7 @@
 #include "gates.h"
 #include "gun_mode.h"
 #include "help.h"
+#include "iexamine.h"
 #include "input.h"
 #include "int_id.h"
 #include "item.h"
@@ -722,6 +723,23 @@ static void close()
             ACTION_CLOSE, false ) ) {
         doors::close_door( get_map(), g->u, *pnt );
     }
+}
+
+static auto jump() -> void
+{
+    auto &you = get_avatar();
+    const auto allowed = [&you]( const tripoint_bub_ms &pos ) {
+        return iexamine::can_jump_over_tile( you, pos );
+    };
+    const auto jump_target = choose_adjacent_highlight(
+                                 _( "Jump across where?" ),
+                                 _( "There is no adjacent tile you can jump across." ),
+                                 allowed );
+    if( !jump_target ) {
+        return;
+    }
+
+    iexamine::jump_over_tile( you, *jump_target );
 }
 
 // Establish or release a grab on a vehicle
@@ -2365,6 +2383,14 @@ bool game::handle_action()
                     examine( *mouse_target );
                 } else {
                     examine();
+                }
+                break;
+
+            case ACTION_JUMP:
+                if( mouse_target && iexamine::can_jump_over_tile( u, *mouse_target ) ) {
+                    iexamine::jump_over_tile( u, *mouse_target );
+                } else {
+                    jump();
                 }
                 break;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -728,7 +728,7 @@ static void close()
 static auto jump() -> void
 {
     auto &you = get_avatar();
-    const auto allowed = [&you]( const tripoint_bub_ms &pos ) {
+    const auto allowed = [&you]( const tripoint_bub_ms & pos ) {
         return iexamine::can_jump_over_tile( you, pos );
     };
     const auto jump_target = choose_adjacent_highlight(

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5598,6 +5598,101 @@ void iexamine::pay_gas( player &p, const tripoint_bub_ms &examp )
     }
 }
 
+namespace
+{
+
+struct jump_over_tile_state {
+    tripoint_abs_ms examp = tripoint_abs_ms::zero();
+    tripoint_abs_ms dest = tripoint_abs_ms::zero();
+};
+
+static constexpr auto jump_over_tile_base_move_cost = 200;
+
+auto get_jump_over_tile_state( const player &p,
+                               const tripoint_bub_ms &examp_bub ) -> jump_over_tile_state
+{
+    const auto examp = bub_to_abs( examp_bub );
+    const auto impulse = ( examp - p.abs_pos() ).xy() * 2;
+    return {
+        .examp = examp,
+        .dest = p.abs_pos() + impulse,
+    };
+}
+
+auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
+                              const bool show_messages ) -> bool
+{
+    const auto jump_state = get_jump_over_tile_state( p, examp_bub );
+    const auto dir = jump_state.examp - p.abs_pos();
+    if( jump_state.examp == p.abs_pos() || dir.z() != 0 ||
+        std::abs( dir.x() ) > 1 || std::abs( dir.y() ) > 1 ) {
+        return false;
+    }
+
+    if( p.get_str() < 4 ) {
+        if( show_messages ) {
+            add_msg( m_warning, _( "You are too weak to jump over an obstacle." ) );
+        }
+        return false;
+    }
+
+    if( 100 * p.weight_carried() / p.weight_capacity() > 25 ) {
+        if( show_messages ) {
+            add_msg( m_warning, _( "You are too burdened to jump over an obstacle." ) );
+        }
+        return false;
+    }
+
+    auto &buffer = p.get_mapbuffer();
+    if( !buffer.valid_move( jump_state.examp, jump_state.dest, { .flying = true } ) ) {
+        if( show_messages ) {
+            add_msg( m_warning, _( "You cannot jump over an obstacle - something is blocking the way." ) );
+        }
+        return false;
+    }
+
+    if( const auto blocking_creature = buffer.creature_at( jump_state.dest ) ) {
+        if( show_messages ) {
+            add_msg( m_warning, _( "You cannot jump over an obstacle - there is %s blocking the way." ),
+                     blocking_creature->disp_name() );
+        }
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+auto iexamine::can_jump_over_tile( const player &p, const tripoint_bub_ms &examp ) -> bool
+{
+    return can_jump_over_tile_impl( p, examp, false );
+}
+
+auto iexamine::jump_over_tile( player &p, const tripoint_bub_ms &examp ) -> bool
+{
+    if( p.in_vehicle ) {
+        if( !character_funcs::can_fly( p ) &&
+            !query_yn( _( "Do you really want to jump off the vehicle?" ) ) ) {
+            return false;
+        }
+        get_map().unboard_vehicle( p.bub_pos() );
+    }
+
+    if( !can_jump_over_tile_impl( p, examp, true ) ) {
+        return false;
+    }
+
+    const auto jump_state = get_jump_over_tile_state( p, examp );
+    const auto move_cost = p.run_cost( jump_over_tile_base_move_cost );
+    add_msg( m_info, _( "You jump over an obstacle." ) );
+    p.mod_moves( -move_cost );
+    p.burn_move_stamina( move_cost );
+    p.setpos( jump_state.dest );
+    get_map().creature_on_trap( p, false );
+    return true;
+}
+
 void iexamine::ledge( player &p, const tripoint_bub_ms &examp_bub )
 {
     const auto examp = bub_to_abs( examp_bub );
@@ -5658,24 +5753,7 @@ void iexamine::ledge( player &p, const tripoint_bub_ms &examp_bub )
     cmenu.query();
     switch( cmenu.ret ) {
         case ledge_action::jump_over: {
-            const auto impulse = dir * 2;
-            const auto dest = p.abs_pos() + impulse;
-            if( p.get_str() < 4 ) {
-                add_msg( m_warning, _( "You are too weak to jump over an obstacle." ) );
-            } else if( 100 * p.weight_carried() / p.weight_capacity() > 25 ) {
-                add_msg( m_warning, _( "You are too burdened to jump over an obstacle." ) );
-            } else if( !buffer.valid_move( examp, dest, { .flying = true } ) ) {
-                add_msg( m_warning, _( "You cannot jump over an obstacle - something is blocking the way." ) );
-            } else if( const auto blocking_creature = buffer.creature_at( dest ) ) {
-                add_msg( m_warning, _( "You cannot jump over an obstacle - there is %s blocking the way." ),
-                         blocking_creature->disp_name() );
-            } else if( const auto dest_tile = tile_reader.get_tile( dest );
-                       dest_tile && dest_tile->get_ter_t().trap == tr_ledge ) {
-                add_msg( m_warning, _( "You are not going to jump over an obstacle only to fall down." ) );
-            } else {
-                add_msg( m_info, _( "You jump over an obstacle." ) );
-                p.setpos( dest );
-            }
+            iexamine::jump_over_tile( p, examp_bub );
             break;
         }
         case ledge_action::climb_down: {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5651,7 +5651,7 @@ auto jump_over_tile_has_stumble_risk( const map &here,
     return here.has_flag( "WINDOW", jumped_tile ) || here.has_furn( jumped_tile );
 }
 
-auto jump_over_tile_bashes_window( const map &here,
+auto jump_over_tile_bashes_window( const map &here, const player &p,
                                    const tripoint_bub_ms &jumped_tile ) -> bool
 {
     if( !here.impassable( jumped_tile ) || !here.has_flag( "WINDOW", jumped_tile ) ||
@@ -5664,9 +5664,10 @@ auto jump_over_tile_bashes_window( const map &here,
         return false;
     }
 
-    return bash.ter_set->movecost > 0 ||
-           bash.ter_set->has_flag( TFLAG_THIN_OBSTACLE ) ||
-           bash.ter_set->has_flag( TFLAG_SMALL_PASSAGE );
+    return ( bash.ter_set->movecost > 0 ||
+             bash.ter_set->has_flag( TFLAG_THIN_OBSTACLE ) ||
+             bash.ter_set->has_flag( TFLAG_SMALL_PASSAGE ) ) &&
+           here.bash_rating( p.get_str(), jumped_tile ) > 0;
 }
 
 auto bash_window_for_jump( map &here, const player &p,
@@ -5675,9 +5676,9 @@ auto bash_window_for_jump( map &here, const player &p,
     const auto bash = bash_params{
         .strength = std::max( p.get_str(), 1 ),
         .silent = false,
-        .destroy = true,
+        .destroy = false,
         .bash_floor = false,
-        .roll = 1.0f,
+        .roll = static_cast<float>( rng_float( 0, 1.0f ) ),
         .bashing_from_above = false,
         .caused_by_player = p.is_avatar(),
     };
@@ -5787,7 +5788,7 @@ auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
     auto &here = get_map();
     const auto jumped_tile = abs_to_bub( jump_state.examp );
     if( here.impassable( jumped_tile ) &&
-        !jump_over_tile_bashes_window( here, jumped_tile ) ) {
+        !jump_over_tile_bashes_window( here, p, jumped_tile ) ) {
         if( show_messages ) {
             add_msg( m_warning, _( "You cannot jump through the %s." ),
                      here.obstacle_name( jumped_tile ) );
@@ -5870,23 +5871,24 @@ auto iexamine::jump_over_tile( player &p, const tripoint_bub_ms &examp ) -> bool
     auto &here = get_map();
     const auto jumped_tile = abs_to_bub( jump_state.examp );
     const auto jumped_obstacle_name = here.name( jumped_tile );
-    const auto bashed_window = jump_over_tile_bashes_window( here, jumped_tile );
+    const auto bashed_window = jump_over_tile_bashes_window( here, p, jumped_tile );
     if( bashed_window && !confirm_crash_through_window( p, jumped_obstacle_name ) ) {
         return false;
     }
     const auto stumbled = ( bashed_window || jump_over_tile_has_stumble_risk( here, jumped_tile ) ) &&
                           jump_over_tile_stumble_roll( p );
+    p.mod_moves( -move_cost );
+    p.mod_stamina( -stamina_cost, false );
     if( bashed_window ) {
-        add_msg( m_info, _( "You crash through the %s." ), jumped_obstacle_name );
         if( !bash_window_for_jump( here, p, jumped_tile ) ) {
+            add_msg( m_warning, _( "You fail to crash through the %s." ), jumped_obstacle_name );
             return false;
         }
+        add_msg( m_info, _( "You crash through the %s." ), jumped_obstacle_name );
         maybe_cut_from_smashing_window( p, jumped_obstacle_name );
     } else {
         add_msg( m_info, _( "You leap across." ) );
     }
-    p.mod_moves( -move_cost );
-    p.mod_stamina( -stamina_cost, false );
     p.setpos( jump_state.dest );
     if( stumbled ) {
         add_msg( m_bad, _( "You misjudge the leap past %s and crash to the ground." ),

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5651,8 +5651,85 @@ auto jump_over_tile_has_stumble_risk( const map &here,
     return here.has_flag( "WINDOW", jumped_tile ) || here.has_furn( jumped_tile );
 }
 
+auto jump_over_tile_bashes_window( const map &here,
+                                   const tripoint_bub_ms &jumped_tile ) -> bool
+{
+    if( !here.impassable( jumped_tile ) || !here.has_flag( "WINDOW", jumped_tile ) ||
+        !here.is_bashable_ter( jumped_tile ) ) {
+        return false;
+    }
+
+    const auto &bash = here.ter( jumped_tile ).obj().bash;
+    if( !bash.ter_set ) {
+        return false;
+    }
+
+    return bash.ter_set->movecost > 0 ||
+           bash.ter_set->has_flag( TFLAG_THIN_OBSTACLE ) ||
+           bash.ter_set->has_flag( TFLAG_SMALL_PASSAGE );
+}
+
+auto bash_window_for_jump( map &here, const player &p,
+                           const tripoint_bub_ms &jumped_tile ) -> bool
+{
+    const auto bash = bash_params{
+        .strength = std::max( p.get_str(), 1 ),
+        .silent = false,
+        .destroy = true,
+        .bash_floor = false,
+        .roll = 1.0f,
+        .bashing_from_above = false,
+        .caused_by_player = p.is_avatar(),
+    };
+    const auto bash_result = here.bash( jumped_tile, bash );
+    return bash_result.success && !here.impassable( jumped_tile );
+}
+
+auto jump_over_tile_window_cut_bodyparts( const player &p ) -> std::vector<bodypart_id>
+{
+    static const auto risky_bodyparts = std::array{
+        bodypart_id( "hand_l" ), bodypart_id( "hand_r" ),
+        bodypart_id( "arm_l" ), bodypart_id( "arm_r" ),
+        bodypart_id( "leg_l" ), bodypart_id( "leg_r" ),
+        bodypart_id( "torso" )
+    };
+    namespace ranges = std::ranges;
+    using namespace std::views;
+
+    return risky_bodyparts
+           | filter( [&p]( const bodypart_id &bp ) {
+               return !p.wearing_something_on( bp );
+           } )
+           | ranges::to<std::vector>();
+}
+
+auto maybe_cut_from_smashing_window( player &p,
+                                     const std::string &obstacle_name ) -> void
+{
+    const auto exposed_bodyparts = jump_over_tile_window_cut_bodyparts( p );
+    if( exposed_bodyparts.empty() ) {
+        return;
+    }
+
+    if( one_in( 3 ) || x_in_y( 1 + p.dex_cur / 2.0, 40 ) ||
+        ( p.mutation_value( "movecost_obstacle_modifier" ) <= 0.5f && !one_in( 4 ) ) ||
+        ( p.has_trait( trait_id( "THICKSKIN" ) ) && one_in( 8 ) ) ) {
+        return;
+    }
+
+    const auto bp = random_entry( exposed_bodyparts );
+    if( p.deal_damage( nullptr, bp, damage_instance( DT_CUT, rng( 1, 10 ) ) ).total_damage() > 0 ) {
+        add_msg( m_bad, _( "You smash through the %1$s and cut your %2$s on the broken glass!" ),
+                 obstacle_name, body_part_name_accusative( bp ) );
+    }
+}
+
 auto jump_over_tile_stumble_roll( const player &p ) -> bool
 {
+    if( p.has_trait( trait_id( "PARKOUR" ) ) ) {
+        return false;
+    }
+
     auto climb = p.dex_cur;
     if( p.has_trait( trait_BADKNEES ) ) {
         climb /= 2;
@@ -5682,6 +5759,16 @@ auto confirm_dangerous_jump_landing( const player &p,
     return query_yn( _( "Really jump into %s?" ), enumerate_as_string( harmful_stuff ) );
 }
 
+auto confirm_crash_through_window( const player &p,
+                                   const std::string &obstacle_name ) -> bool
+{
+    if( !p.is_avatar() ) {
+        return true;
+    }
+
+    return query_yn( _( "Crash through the %s?" ), obstacle_name );
+}
+
 auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
                               const bool show_messages ) -> bool
 {
@@ -5699,7 +5786,8 @@ auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
     auto &buffer = p.get_mapbuffer();
     auto &here = get_map();
     const auto jumped_tile = abs_to_bub( jump_state.examp );
-    if( here.impassable( jumped_tile ) ) {
+    if( here.impassable( jumped_tile ) &&
+        !jump_over_tile_bashes_window( here, jumped_tile ) ) {
         if( show_messages ) {
             add_msg( m_warning, _( "You cannot jump through the %s." ),
                      here.obstacle_name( jumped_tile ) );
@@ -5781,15 +5869,28 @@ auto iexamine::jump_over_tile( player &p, const tripoint_bub_ms &examp ) -> bool
     const auto stamina_cost = jump_over_tile_stamina_cost( p, move_cost );
     auto &here = get_map();
     const auto jumped_tile = abs_to_bub( jump_state.examp );
-    const auto stumbled = jump_over_tile_has_stumble_risk( here, jumped_tile ) &&
+    const auto jumped_obstacle_name = here.name( jumped_tile );
+    const auto bashed_window = jump_over_tile_bashes_window( here, jumped_tile );
+    if( bashed_window && !confirm_crash_through_window( p, jumped_obstacle_name ) ) {
+        return false;
+    }
+    const auto stumbled = ( bashed_window || jump_over_tile_has_stumble_risk( here, jumped_tile ) ) &&
                           jump_over_tile_stumble_roll( p );
-    add_msg( m_info, _( "You leap across." ) );
+    if( bashed_window ) {
+        add_msg( m_info, _( "You crash through the %s." ), jumped_obstacle_name );
+        if( !bash_window_for_jump( here, p, jumped_tile ) ) {
+            return false;
+        }
+        maybe_cut_from_smashing_window( p, jumped_obstacle_name );
+    } else {
+        add_msg( m_info, _( "You leap across." ) );
+    }
     p.mod_moves( -move_cost );
     p.mod_stamina( -stamina_cost, false );
     p.setpos( jump_state.dest );
     if( stumbled ) {
         add_msg( m_bad, _( "You misjudge the leap past %s and crash to the ground." ),
-                 here.name( jumped_tile ) );
+                 jumped_obstacle_name );
         p.add_effect( effect_downed, 2_turns, bodypart_str_id::NULL_ID(), 0, true );
     }
     here.creature_on_trap( p, false );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5607,6 +5607,30 @@ struct jump_over_tile_state {
 };
 
 static constexpr auto jump_over_tile_base_move_cost = 200;
+static constexpr auto jump_over_tile_min_strength = 4;
+static constexpr auto jump_over_tile_stamina_burn_ratio = 7;
+
+auto jump_over_tile_carried_weight_percentage( const player &p ) -> int
+{
+    const auto carried_weight_grams = units::to_gram( p.weight_carried() );
+    const auto carry_capacity_grams = std::max( units::to_gram( p.weight_capacity() ), 1L );
+    return std::clamp( static_cast<int>( carried_weight_grams * 100 / carry_capacity_grams ), 0, 100 );
+}
+
+auto scale_jump_over_tile_cost_round_up( const int value, const int numerator,
+        const int denominator ) -> int
+{
+    return divide_round_up( value * numerator, denominator );
+}
+
+auto jump_over_tile_stamina_cost( const player &p, const int move_cost ) -> int
+{
+    const auto base_stamina_cost = scale_jump_over_tile_cost_round_up(
+                                       get_option<int>( "PLAYER_BASE_STAMINA_BURN_RATE" ) * move_cost,
+                                       jump_over_tile_stamina_burn_ratio, 100 );
+    return scale_jump_over_tile_cost_round_up(
+               base_stamina_cost, 100 + jump_over_tile_carried_weight_percentage( p ), 100 );
+}
 
 auto get_jump_over_tile_state( const player &p,
                                const tripoint_bub_ms &examp_bub ) -> jump_over_tile_state
@@ -5629,21 +5653,29 @@ auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
         return false;
     }
 
-    if( p.get_str() < 4 ) {
-        if( show_messages ) {
-            add_msg( m_warning, _( "You are too weak to jump over an obstacle." ) );
-        }
-        return false;
-    }
-
-    if( 100 * p.weight_carried() / p.weight_capacity() > 25 ) {
-        if( show_messages ) {
-            add_msg( m_warning, _( "You are too burdened to jump over an obstacle." ) );
-        }
+    if( !iexamine::can_start_jump_over_tile( p, show_messages ) ) {
         return false;
     }
 
     auto &buffer = p.get_mapbuffer();
+    const auto tile_reader = buffer.make_abs_tile_reader();
+    const auto jumped_tile = tile_reader.get_tile( jump_state.examp );
+    if( jumped_tile && jumped_tile->get_furn() != f_null && jumped_tile->get_furn_t().movecost < 0 ) {
+        if( show_messages ) {
+            add_msg( m_warning, _( "You cannot jump over that piece of furniture." ) );
+        }
+        return false;
+    }
+
+    if( const auto blocking_creature = buffer.creature_at( jump_state.examp ) ) {
+        if( blocking_creature->get_size() >= p.get_size() ) {
+            if( show_messages ) {
+                add_msg( m_warning, _( "You cannot jump over %s." ), blocking_creature->disp_name() );
+            }
+            return false;
+        }
+    }
+
     if( !buffer.valid_move( jump_state.examp, jump_state.dest, { .flying = true } ) ) {
         if( show_messages ) {
             add_msg( m_warning, _( "You cannot jump over an obstacle - something is blocking the way." ) );
@@ -5663,6 +5695,18 @@ auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
 }
 
 } // namespace
+
+auto iexamine::can_start_jump_over_tile( const player &p, const bool show_messages ) -> bool
+{
+    if( p.get_str() < jump_over_tile_min_strength ) {
+        if( show_messages ) {
+            add_msg( m_warning, _( "You are too weak to jump over an obstacle." ) );
+        }
+        return false;
+    }
+
+    return true;
+}
 
 auto iexamine::can_jump_over_tile( const player &p, const tripoint_bub_ms &examp ) -> bool
 {
@@ -5685,9 +5729,10 @@ auto iexamine::jump_over_tile( player &p, const tripoint_bub_ms &examp ) -> bool
 
     const auto jump_state = get_jump_over_tile_state( p, examp );
     const auto move_cost = p.run_cost( jump_over_tile_base_move_cost );
+    const auto stamina_cost = jump_over_tile_stamina_cost( p, move_cost );
     add_msg( m_info, _( "You jump over an obstacle." ) );
     p.mod_moves( -move_cost );
-    p.burn_move_stamina( move_cost );
+    p.mod_stamina( -stamina_cost, false );
     p.setpos( jump_state.dest );
     get_map().creature_on_trap( p, false );
     return true;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5609,6 +5609,8 @@ struct jump_over_tile_state {
 static constexpr auto jump_over_tile_base_move_cost = 200;
 static constexpr auto jump_over_tile_min_strength = 4;
 static constexpr auto jump_over_tile_stamina_burn_ratio = 7;
+static const auto dashing_effect = efftype_id( "dashing" );
+static const auto effect_downed = efftype_id( "downed" );
 
 auto jump_over_tile_carried_weight_percentage( const player &p ) -> int
 {
@@ -5643,6 +5645,55 @@ auto get_jump_over_tile_state( const player &p,
     };
 }
 
+auto is_jumpable_window_terrain( const ter_id &terrain ) -> bool
+{
+    static const auto jumpable_window_terrains = std::array{
+        t_window, t_window_taped, t_window_domestic, t_window_domestic_taped,
+        t_window_open, t_window_alarm, t_window_alarm_taped,
+        t_window_no_curtains, t_window_no_curtains_open, t_window_no_curtains_taped,
+        t_window_stained_green, t_window_stained_red, t_window_stained_blue
+    };
+    namespace ranges = std::ranges;
+    return ranges::contains( jumpable_window_terrains, terrain );
+}
+
+auto jump_over_tile_has_stumble_risk( const map &here,
+                                      const tripoint_bub_ms &jumped_tile ) -> bool
+{
+    return is_jumpable_window_terrain( here.ter( jumped_tile ) ) || here.has_furn( jumped_tile );
+}
+
+auto jump_over_tile_stumble_roll( const player &p ) -> bool
+{
+    auto climb = p.dex_cur;
+    if( p.has_trait( trait_BADKNEES ) ) {
+        climb /= 2;
+    }
+    if( p.mutation_value( "movecost_obstacle_modifier" ) != 0.0f ) {
+        climb = static_cast<int>( climb / p.mutation_value( "movecost_obstacle_modifier" ) );
+    }
+    return one_in( std::max( climb, 1 ) );
+}
+
+auto confirm_dangerous_jump_landing( const player &p,
+                                     const tripoint_abs_ms &dest ) -> bool
+{
+    if( !p.is_avatar() ) {
+        return true;
+    }
+
+    if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "IGNORE" ) {
+        return true;
+    }
+
+    const auto harmful_stuff = g->get_dangerous_tile( abs_to_bub( dest ) );
+    if( harmful_stuff.empty() || p.has_effect( dashing_effect ) ) {
+        return true;
+    }
+
+    return query_yn( _( "Really jump into %s?" ), enumerate_as_string( harmful_stuff ) );
+}
+
 auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
                               const bool show_messages ) -> bool
 {
@@ -5658,11 +5709,13 @@ auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
     }
 
     auto &buffer = p.get_mapbuffer();
-    const auto tile_reader = buffer.make_abs_tile_reader();
-    const auto jumped_tile = tile_reader.get_tile( jump_state.examp );
-    if( jumped_tile && jumped_tile->get_furn() != f_null && jumped_tile->get_furn_t().movecost < 0 ) {
+    auto &here = get_map();
+    const auto jumped_tile = abs_to_bub( jump_state.examp );
+    if( here.impassable( jumped_tile ) &&
+        !is_jumpable_window_terrain( here.ter( jumped_tile ) ) ) {
         if( show_messages ) {
-            add_msg( m_warning, _( "You cannot jump over that piece of furniture." ) );
+            add_msg( m_warning, _( "You cannot jump through the %s." ),
+                     here.obstacle_name( jumped_tile ) );
         }
         return false;
     }
@@ -5676,9 +5729,11 @@ auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
         }
     }
 
-    if( !buffer.valid_move( jump_state.examp, jump_state.dest, { .flying = true } ) ) {
+    const auto landing_tile = abs_to_bub( jump_state.dest );
+    if( here.impassable( landing_tile ) ) {
         if( show_messages ) {
-            add_msg( m_warning, _( "You cannot jump over an obstacle - something is blocking the way." ) );
+            add_msg( m_warning, _( "You cannot land there - the %s is blocking the way." ),
+                     here.obstacle_name( landing_tile ) );
         }
         return false;
     }
@@ -5720,7 +5775,6 @@ auto iexamine::jump_over_tile( player &p, const tripoint_bub_ms &examp ) -> bool
             !query_yn( _( "Do you really want to jump off the vehicle?" ) ) ) {
             return false;
         }
-        get_map().unboard_vehicle( p.bub_pos() );
     }
 
     if( !can_jump_over_tile_impl( p, examp, true ) ) {
@@ -5728,13 +5782,30 @@ auto iexamine::jump_over_tile( player &p, const tripoint_bub_ms &examp ) -> bool
     }
 
     const auto jump_state = get_jump_over_tile_state( p, examp );
+    if( !confirm_dangerous_jump_landing( p, jump_state.dest ) ) {
+        return false;
+    }
+
+    if( p.in_vehicle ) {
+        get_map().unboard_vehicle( p.bub_pos() );
+    }
+
     const auto move_cost = p.run_cost( jump_over_tile_base_move_cost );
     const auto stamina_cost = jump_over_tile_stamina_cost( p, move_cost );
-    add_msg( m_info, _( "You jump over an obstacle." ) );
+    auto &here = get_map();
+    const auto jumped_tile = abs_to_bub( jump_state.examp );
+    const auto stumbled = jump_over_tile_has_stumble_risk( here, jumped_tile ) &&
+                          jump_over_tile_stumble_roll( p );
+    add_msg( m_info, _( "You leap across." ) );
     p.mod_moves( -move_cost );
     p.mod_stamina( -stamina_cost, false );
     p.setpos( jump_state.dest );
-    get_map().creature_on_trap( p, false );
+    if( stumbled ) {
+        add_msg( m_bad, _( "You misjudge the leap past %s and crash to the ground." ),
+                 here.name( jumped_tile ) );
+        p.add_effect( effect_downed, 2_turns, bodypart_str_id::NULL_ID(), 0, true );
+    }
+    here.creature_on_trap( p, false );
     return true;
 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5697,10 +5697,10 @@ auto jump_over_tile_window_cut_bodyparts( const player &p ) -> std::vector<bodyp
     using namespace std::views;
 
     return risky_bodyparts
-           | filter( [&p]( const bodypart_id &bp ) {
-               return !p.wearing_something_on( bp );
-           } )
-           | ranges::to<std::vector>();
+    | filter( [&p]( const bodypart_id & bp ) {
+        return !p.wearing_something_on( bp );
+    } )
+    | ranges::to<std::vector>();
 }
 
 auto maybe_cut_from_smashing_window( player &p,

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5613,7 +5613,7 @@ static constexpr auto jump_over_tile_stamina_burn_ratio = 7;
 auto jump_over_tile_carried_weight_percentage( const player &p ) -> int
 {
     const auto carried_weight_grams = units::to_gram( p.weight_carried() );
-    const auto carry_capacity_grams = std::max( units::to_gram( p.weight_capacity() ), 1L );
+    const auto carry_capacity_grams = units::to_gram( std::max( p.weight_capacity(), 1_gram ) );
     return std::clamp( static_cast<int>( carried_weight_grams * 100 / carry_capacity_grams ), 0, 100 );
 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5670,6 +5670,13 @@ auto jump_over_tile_bashes_window( const map &here, const player &p,
            here.bash_rating( p.get_str(), jumped_tile ) > 0;
 }
 
+auto jump_over_tile_can_cross_impassable( const map &here, const player &p,
+        const tripoint_bub_ms &jumped_tile ) -> bool
+{
+    return here.has_flag( flag_CLIMB_SIMPLE, jumped_tile ) ||
+           jump_over_tile_bashes_window( here, p, jumped_tile );
+}
+
 auto bash_window_for_jump( map &here, const player &p,
                            const tripoint_bub_ms &jumped_tile ) -> bool
 {
@@ -5788,7 +5795,7 @@ auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
     auto &here = get_map();
     const auto jumped_tile = abs_to_bub( jump_state.examp );
     if( here.impassable( jumped_tile ) &&
-        !jump_over_tile_bashes_window( here, p, jumped_tile ) ) {
+        !jump_over_tile_can_cross_impassable( here, p, jumped_tile ) ) {
         if( show_messages ) {
             add_msg( m_warning, _( "You cannot jump through the %s." ),
                      here.obstacle_name( jumped_tile ) );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5751,7 +5751,8 @@ auto maybe_cut_from_sharp_jump_terrain( player &p, map &here,
     if( p.deal_damage( nullptr, bp, damage_instance( DT_CUT, rng( 1, 10 ) ) ).total_damage() > 0 ) {
         add_msg( m_bad, _( "You cut your %1$s on the %2$s as you leap over it!" ),
                  body_part_name_accusative( damaged_bp ),
-                 here.has_flag_ter( "SHARP", sharp_tile ) ? here.tername( sharp_tile ) : here.furnname( sharp_tile ) );
+                 here.has_flag_ter( "SHARP", sharp_tile ) ? here.tername( sharp_tile ) : here.furnname(
+                     sharp_tile ) );
         if( one_in( 2 ) && !p.is_immune_effect( effect_bleed ) ) {
             p.add_effect( effect_bleed, rng( 2_minutes, 5_minutes ), bp.id() );
         }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5608,7 +5608,7 @@ struct jump_over_tile_state {
 
 static constexpr auto jump_over_tile_base_move_cost = 200;
 static constexpr auto jump_over_tile_min_strength = 4;
-static constexpr auto jump_over_tile_stamina_burn_ratio = 7;
+static constexpr auto jump_over_tile_stamina_burn_ratio = 14;
 static const auto dashing_effect = efftype_id( "dashing" );
 static const auto effect_downed = efftype_id( "downed" );
 
@@ -5726,9 +5726,35 @@ auto maybe_cut_from_smashing_window( player &p,
     }
 
     const auto bp = random_entry( exposed_bodyparts );
+    const auto damaged_bp = bp->main_part.id();
     if( p.deal_damage( nullptr, bp, damage_instance( DT_CUT, rng( 1, 10 ) ) ).total_damage() > 0 ) {
         add_msg( m_bad, _( "You smash through the %1$s and cut your %2$s on the broken glass!" ),
-                 obstacle_name, body_part_name_accusative( bp ) );
+                 obstacle_name, body_part_name_accusative( damaged_bp ) );
+    }
+}
+
+auto maybe_cut_from_sharp_jump_terrain( player &p, map &here,
+                                        const tripoint_bub_ms &sharp_tile ) -> void
+{
+    if( !here.has_flag( "SHARP", sharp_tile ) || here.veh_at( sharp_tile ) ) {
+        return;
+    }
+
+    if( one_in( 3 ) || x_in_y( 1 + p.dex_cur / 2.0, 40 ) ||
+        ( p.mutation_value( "movecost_obstacle_modifier" ) <= 0.5f && !one_in( 4 ) ) ||
+        ( p.has_trait( trait_id( "THICKSKIN" ) ) && one_in( 8 ) ) ) {
+        return;
+    }
+
+    const auto bp = p.get_random_body_part();
+    const auto damaged_bp = bp->main_part.id();
+    if( p.deal_damage( nullptr, bp, damage_instance( DT_CUT, rng( 1, 10 ) ) ).total_damage() > 0 ) {
+        add_msg( m_bad, _( "You cut your %1$s on the %2$s as you leap over it!" ),
+                 body_part_name_accusative( damaged_bp ),
+                 here.has_flag_ter( "SHARP", sharp_tile ) ? here.tername( sharp_tile ) : here.furnname( sharp_tile ) );
+        if( one_in( 2 ) && !p.is_immune_effect( effect_bleed ) ) {
+            p.add_effect( effect_bleed, rng( 2_minutes, 5_minutes ), bp.id() );
+        }
     }
 }
 
@@ -5748,6 +5774,18 @@ auto jump_over_tile_stumble_roll( const player &p ) -> bool
     return one_in( std::max( climb, 1 ) );
 }
 
+auto apply_jump_stumble_fall_damage( player &p ) -> void
+{
+    static const auto stumble_bps = std::array{
+        bodypart_id( "hand_l" ), bodypart_id( "hand_r" ),
+        bodypart_id( "leg_l" ), bodypart_id( "leg_r" ),
+    };
+
+    for( const auto &bp : stumble_bps ) {
+        p.deal_damage( nullptr, bp, damage_instance( DT_BASH, rng( 1, 2 ) ) );
+    }
+}
+
 auto confirm_dangerous_jump_landing( const player &p,
                                      const tripoint_abs_ms &dest ) -> bool
 {
@@ -5755,16 +5793,7 @@ auto confirm_dangerous_jump_landing( const player &p,
         return true;
     }
 
-    if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "IGNORE" ) {
-        return true;
-    }
-
-    const auto harmful_stuff = g->get_dangerous_tile( abs_to_bub( dest ) );
-    if( harmful_stuff.empty() || p.has_effect( dashing_effect ) ) {
-        return true;
-    }
-
-    return query_yn( _( "Really jump into %s?" ), enumerate_as_string( harmful_stuff ) );
+    return g->prompt_dangerous_tile( abs_to_bub( dest ), _( "Really jump into %s?" ), false );
 }
 
 auto confirm_crash_through_window( const player &p,
@@ -5895,12 +5924,14 @@ auto iexamine::jump_over_tile( player &p, const tripoint_bub_ms &examp ) -> bool
         maybe_cut_from_smashing_window( p, jumped_obstacle_name );
     } else {
         add_msg( m_info, _( "You leap across." ) );
+        maybe_cut_from_sharp_jump_terrain( p, here, jumped_tile );
     }
     p.setpos( jump_state.dest );
     if( stumbled ) {
         add_msg( m_bad, _( "You misjudge the leap past %s and crash to the ground." ),
                  jumped_obstacle_name );
-        p.add_effect( effect_downed, 2_turns, bodypart_str_id::NULL_ID(), 0, true );
+        apply_jump_stumble_fall_damage( p );
+        p.add_effect( effect_downed, rng( 2_turns, 3_turns ), bodypart_str_id::NULL_ID(), 0, true );
     }
     here.creature_on_trap( p, false );
     return true;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5645,22 +5645,10 @@ auto get_jump_over_tile_state( const player &p,
     };
 }
 
-auto is_jumpable_window_terrain( const ter_id &terrain ) -> bool
-{
-    static const auto jumpable_window_terrains = std::array{
-        t_window, t_window_taped, t_window_domestic, t_window_domestic_taped,
-        t_window_open, t_window_alarm, t_window_alarm_taped,
-        t_window_no_curtains, t_window_no_curtains_open, t_window_no_curtains_taped,
-        t_window_stained_green, t_window_stained_red, t_window_stained_blue
-    };
-    namespace ranges = std::ranges;
-    return ranges::contains( jumpable_window_terrains, terrain );
-}
-
 auto jump_over_tile_has_stumble_risk( const map &here,
                                       const tripoint_bub_ms &jumped_tile ) -> bool
 {
-    return is_jumpable_window_terrain( here.ter( jumped_tile ) ) || here.has_furn( jumped_tile );
+    return here.has_flag( "WINDOW", jumped_tile ) || here.has_furn( jumped_tile );
 }
 
 auto jump_over_tile_stumble_roll( const player &p ) -> bool
@@ -5711,8 +5699,7 @@ auto can_jump_over_tile_impl( const player &p, const tripoint_bub_ms &examp_bub,
     auto &buffer = p.get_mapbuffer();
     auto &here = get_map();
     const auto jumped_tile = abs_to_bub( jump_state.examp );
-    if( here.impassable( jumped_tile ) &&
-        !is_jumpable_window_terrain( here.ter( jumped_tile ) ) ) {
+    if( here.impassable( jumped_tile ) ) {
         if( show_messages ) {
             add_msg( m_warning, _( "You cannot jump through the %s." ),
                      here.obstacle_name( jumped_tile ) );

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -104,6 +104,8 @@ void curtains( player &p, const tripoint_bub_ms &examp );
 void sign( player &p, const tripoint_bub_ms &examp );
 void pay_gas( player &p, const tripoint_bub_ms &examp );
 void ledge( player &p, const tripoint_bub_ms &examp );
+auto can_jump_over_tile( const player &p, const tripoint_bub_ms &examp ) -> bool;
+auto jump_over_tile( player &p, const tripoint_bub_ms &examp ) -> bool;
 void autodoc( player &p, const tripoint_bub_ms &examp );
 void translocator( player &p, const tripoint_bub_ms &examp );
 void on_smoke_out( const tripoint_bub_ms &examp,

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -104,6 +104,7 @@ void curtains( player &p, const tripoint_bub_ms &examp );
 void sign( player &p, const tripoint_bub_ms &examp );
 void pay_gas( player &p, const tripoint_bub_ms &examp );
 void ledge( player &p, const tripoint_bub_ms &examp );
+auto can_start_jump_over_tile( const player &p, const bool show_messages = false ) -> bool;
 auto can_jump_over_tile( const player &p, const tripoint_bub_ms &examp ) -> bool;
 auto jump_over_tile( player &p, const tripoint_bub_ms &examp ) -> bool;
 void autodoc( player &p, const tripoint_bub_ms &examp );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -17,13 +17,16 @@
 #include "mapbuffer.h"
 #include "mapbuffer_registry.h"
 #include "mapgen_constructor.h"
+#include "messages.h"
 #include "monster.h"
 #include "npc.h"
 #include "options_helpers.h"
+#include "player_helpers.h"
 #include "state_helpers.h"
 #include "submap.h"
 #include "submap_load_manager.h"
 #include "type_id.h"
+#include "units.h"
 #include "vehicle.h"
 
 #include <memory>
@@ -33,6 +36,16 @@ namespace {
 
 static const auto effect_in_pit = efftype_id("in_pit");
 static const auto skill_dodge = skill_id("dodge");
+
+auto burden_jumping_player( avatar &you, const float burden_proportion ) -> void
+{
+    const auto target_weight_grams = static_cast<int>( you.weight_capacity() * burden_proportion / 1_gram );
+    const auto current_weight_grams = static_cast<int>( you.weight_carried() / 1_gram );
+    const auto weight_to_add = std::max( 0, target_weight_grams - current_weight_grams );
+    if( weight_to_add > 0 ) {
+        you.i_add( item::spawn( "test_platinum_bit", calendar::turn, weight_to_add ) );
+    }
+}
 
 struct adjacent_pit_move {
     tripoint_bub_ms origin;
@@ -203,7 +216,17 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
     g->u.str_cur = 8;
     g->u.moves = 1000;
 
-    SECTION("can vault a normal adjacent tile") {
+    SECTION("can jump across clear adjacent ground") {
+        const auto moves_before = g->u.moves;
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
+        CHECK(g->u.moves < moves_before);
+    }
+
+    SECTION("can jump over a low obstacle") {
+        here.ter_set( middle, ter_id( "t_railing" ) );
+
         const auto moves_before = g->u.moves;
         CHECK(iexamine::can_jump_over_tile(g->u, middle));
         REQUIRE(iexamine::jump_over_tile(g->u, middle));
@@ -218,6 +241,75 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
         REQUIRE(iexamine::jump_over_tile(g->u, middle));
         CHECK(g->u.bub_pos() == landing_below);
         CHECK(g->u.moves < moves_before);
+    }
+
+    SECTION("cannot jump over impassable furniture") {
+        here.furn_set( middle, furn_id( "f_bookcase" ) );
+
+        CHECK_FALSE( iexamine::can_jump_over_tile( g->u, middle ) );
+        CHECK_FALSE( iexamine::jump_over_tile( g->u, middle ) );
+        CHECK( g->u.bub_pos() == origin );
+    }
+
+    SECTION("cannot jump over creatures our size or larger") {
+        here.ter_set( middle, ter_id( "t_floor" ) );
+        auto &blocking_creature = spawn_test_monster( "mon_zombie", middle );
+        REQUIRE( blocking_creature.get_size() >= g->u.get_size() );
+
+        CHECK_FALSE( iexamine::can_jump_over_tile( g->u, middle ) );
+        CHECK_FALSE( iexamine::jump_over_tile( g->u, middle ) );
+        CHECK( g->u.bub_pos() == origin );
+    }
+
+    SECTION("can jump over creatures smaller than us") {
+        here.ter_set( middle, ter_id( "t_floor" ) );
+        auto &blocking_creature = spawn_test_monster( "mon_dog", middle );
+        REQUIRE( blocking_creature.get_size() < g->u.get_size() );
+
+        CHECK( iexamine::can_jump_over_tile( g->u, middle ) );
+        REQUIRE( iexamine::jump_over_tile( g->u, middle ) );
+        CHECK( g->u.bub_pos() == landing );
+    }
+
+    SECTION("can jump while carrying more than a quarter of capacity") {
+        burden_jumping_player( g->u, 0.3f );
+
+        CHECK( iexamine::can_jump_over_tile( g->u, middle ) );
+        REQUIRE( iexamine::jump_over_tile( g->u, middle ) );
+        CHECK( g->u.bub_pos() == landing );
+    }
+
+    SECTION("jumping burns stamina and heavier carried loads burn more") {
+        const auto jump_stamina_burn = [&]( const float burden_proportion ) {
+            clear_character( g->u, false );
+            g->u.setpos( origin );
+            g->u.str_cur = 8;
+            g->u.moves = 1000;
+            g->u.set_stamina( g->u.get_stamina_max() );
+            burden_jumping_player( g->u, burden_proportion );
+
+            const auto stamina_before = g->u.get_stamina();
+            CHECK( iexamine::can_jump_over_tile( g->u, middle ) );
+            REQUIRE( iexamine::jump_over_tile( g->u, middle ) );
+            return stamina_before - g->u.get_stamina();
+        };
+
+        const auto unburdened_burn = jump_stamina_burn( 0.0f );
+        const auto burdened_burn = jump_stamina_burn( 0.2f );
+
+        CHECK( unburdened_burn > 0 );
+        CHECK( burdened_burn > unburdened_burn );
+    }
+
+    SECTION("warns when too weak to jump") {
+        g->u.str_cur = 3;
+        Messages::clear_messages();
+
+        CHECK_FALSE( iexamine::can_start_jump_over_tile( g->u, true ) );
+
+        const auto recent_messages = Messages::recent_messages( 1 );
+        REQUIRE( recent_messages.size() == 1 );
+        CHECK( recent_messages.front().second == "You are too weak to jump over an obstacle." );
     }
 }
 

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -49,19 +49,18 @@ auto burden_jumping_player(avatar& you, const float burden_proportion) -> void {
     }
 }
 
-auto reset_jumping_avatar( avatar &you, const tripoint_bub_ms &origin,
-                           const int dexterity ) -> void {
-    clear_character( you, false );
-    you.setpos( origin );
+auto reset_jumping_avatar(avatar& you, const tripoint_bub_ms& origin, const int dexterity) -> void {
+    clear_character(you, false);
+    you.setpos(origin);
     you.str_cur = 8;
     you.dex_cur = dexterity;
     you.moves = 1000;
 }
 
-auto equip_window_jump_protection( avatar &you ) -> void {
-    REQUIRE_FALSE( you.wear_item( item::spawn( "gloves_work" ), false ) );
-    REQUIRE_FALSE( you.wear_item( item::spawn( "longshirt" ), false ) );
-    REQUIRE_FALSE( you.wear_item( item::spawn( "jeans" ), false ) );
+auto equip_window_jump_protection(avatar& you) -> void {
+    REQUIRE_FALSE(you.wear_item(item::spawn("gloves_work"), false));
+    REQUIRE_FALSE(you.wear_item(item::spawn("longshirt"), false));
+    REQUIRE_FALSE(you.wear_item(item::spawn("jeans"), false));
 }
 
 struct adjacent_pit_move {
@@ -297,15 +296,15 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
 
     SECTION("jumping through a closed window can cut exposed body parts") {
         auto took_damage = false;
-        for( const auto attempt : std::views::iota( 0, 16 ) ) {
-            ( void )attempt;
+        for (const auto attempt : std::views::iota(0, 16)) {
+            (void)attempt;
             here.ter_set(middle, ter_id("t_window"));
             reset_jumping_avatar(g->u, origin, 2);
 
             const auto hp_before = g->u.get_hp();
             CHECK(iexamine::can_jump_over_tile(g->u, middle));
             REQUIRE(iexamine::jump_over_tile(g->u, middle));
-            if( g->u.get_hp() < hp_before ) {
+            if (g->u.get_hp() < hp_before) {
                 took_damage = true;
                 break;
             }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -10,6 +10,7 @@
 #include "field_type.h"
 #include "game.h"
 #include "game_constants.h"
+#include "iexamine.h"
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -179,6 +180,44 @@ TEST_CASE("moving_between_adjacent_pit_traps") {
         g->u.add_known_trap(positions.destination, here.tr_at(positions.destination));
 
         CHECK_FALSE(g->get_dangerous_tile(positions.destination).empty());
+    }
+}
+
+TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][movement][jump]") {
+    clear_all_state();
+
+    auto& here = get_map();
+    const auto origin = tripoint_bub_ms(60, 60, 1);
+    const auto middle = origin + tripoint_rel_ms::east();
+    const auto landing = middle + tripoint_rel_ms::east();
+    const auto landing_below = landing + tripoint_rel_ms::below();
+    for (const auto& pos : here.points_in_radius(origin, 2)) {
+        here.ter_set(pos, ter_id("t_floor"));
+        here.furn_set(pos, furn_id("f_null"));
+        const auto below = pos + tripoint_rel_ms::below();
+        here.ter_set(below, ter_id("t_floor"));
+        here.furn_set(below, furn_id("f_null"));
+    }
+
+    g->place_player(origin);
+    g->u.str_cur = 8;
+    g->u.moves = 1000;
+
+    SECTION("can vault a normal adjacent tile") {
+        const auto moves_before = g->u.moves;
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
+        CHECK(g->u.moves < moves_before);
+    }
+
+    SECTION("can jump into open air and immediately resolve the ledge fall") {
+        here.ter_set(landing, ter_id("t_open_air"));
+        const auto moves_before = g->u.moves;
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing_below);
+        CHECK(g->u.moves < moves_before);
     }
 }
 

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -37,13 +37,13 @@ namespace {
 static const auto effect_in_pit = efftype_id("in_pit");
 static const auto skill_dodge = skill_id("dodge");
 
-auto burden_jumping_player( avatar &you, const float burden_proportion ) -> void
-{
-    const auto target_weight_grams = static_cast<int>( you.weight_capacity() * burden_proportion / 1_gram );
-    const auto current_weight_grams = static_cast<int>( you.weight_carried() / 1_gram );
-    const auto weight_to_add = std::max( 0, target_weight_grams - current_weight_grams );
-    if( weight_to_add > 0 ) {
-        you.i_add( item::spawn( "test_platinum_bit", calendar::turn, weight_to_add ) );
+auto burden_jumping_player(avatar& you, const float burden_proportion) -> void {
+    const auto target_weight_grams = static_cast<int>(
+        you.weight_capacity() * burden_proportion / 1_gram);
+    const auto current_weight_grams = static_cast<int>(you.weight_carried() / 1_gram);
+    const auto weight_to_add = std::max(0, target_weight_grams - current_weight_grams);
+    if (weight_to_add > 0) {
+        you.i_add(item::spawn("test_platinum_bit", calendar::turn, weight_to_add));
     }
 }
 
@@ -225,7 +225,7 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
     }
 
     SECTION("can jump over a low obstacle") {
-        here.ter_set( middle, ter_id( "t_railing" ) );
+        here.ter_set(middle, ter_id("t_railing"));
 
         const auto moves_before = g->u.moves;
         CHECK(iexamine::can_jump_over_tile(g->u, middle));
@@ -244,72 +244,72 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
     }
 
     SECTION("cannot jump over impassable furniture") {
-        here.furn_set( middle, furn_id( "f_bookcase" ) );
+        here.furn_set(middle, furn_id("f_bookcase"));
 
-        CHECK_FALSE( iexamine::can_jump_over_tile( g->u, middle ) );
-        CHECK_FALSE( iexamine::jump_over_tile( g->u, middle ) );
-        CHECK( g->u.bub_pos() == origin );
+        CHECK_FALSE(iexamine::can_jump_over_tile(g->u, middle));
+        CHECK_FALSE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == origin);
     }
 
     SECTION("cannot jump over creatures our size or larger") {
-        here.ter_set( middle, ter_id( "t_floor" ) );
-        auto &blocking_creature = spawn_test_monster( "mon_zombie", middle );
-        REQUIRE( blocking_creature.get_size() >= g->u.get_size() );
+        here.ter_set(middle, ter_id("t_floor"));
+        auto& blocking_creature = spawn_test_monster("mon_zombie", middle);
+        REQUIRE(blocking_creature.get_size() >= g->u.get_size());
 
-        CHECK_FALSE( iexamine::can_jump_over_tile( g->u, middle ) );
-        CHECK_FALSE( iexamine::jump_over_tile( g->u, middle ) );
-        CHECK( g->u.bub_pos() == origin );
+        CHECK_FALSE(iexamine::can_jump_over_tile(g->u, middle));
+        CHECK_FALSE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == origin);
     }
 
     SECTION("can jump over creatures smaller than us") {
-        here.ter_set( middle, ter_id( "t_floor" ) );
-        auto &blocking_creature = spawn_test_monster( "mon_dog", middle );
-        REQUIRE( blocking_creature.get_size() < g->u.get_size() );
+        here.ter_set(middle, ter_id("t_floor"));
+        auto& blocking_creature = spawn_test_monster("mon_dog", middle);
+        REQUIRE(blocking_creature.get_size() < g->u.get_size());
 
-        CHECK( iexamine::can_jump_over_tile( g->u, middle ) );
-        REQUIRE( iexamine::jump_over_tile( g->u, middle ) );
-        CHECK( g->u.bub_pos() == landing );
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
     }
 
     SECTION("can jump while carrying more than a quarter of capacity") {
-        burden_jumping_player( g->u, 0.3f );
+        burden_jumping_player(g->u, 0.3f);
 
-        CHECK( iexamine::can_jump_over_tile( g->u, middle ) );
-        REQUIRE( iexamine::jump_over_tile( g->u, middle ) );
-        CHECK( g->u.bub_pos() == landing );
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
     }
 
     SECTION("jumping burns stamina and heavier carried loads burn more") {
-        const auto jump_stamina_burn = [&]( const float burden_proportion ) {
-            clear_character( g->u, false );
-            g->u.setpos( origin );
+        const auto jump_stamina_burn = [&](const float burden_proportion) {
+            clear_character(g->u, false);
+            g->u.setpos(origin);
             g->u.str_cur = 8;
             g->u.moves = 1000;
-            g->u.set_stamina( g->u.get_stamina_max() );
-            burden_jumping_player( g->u, burden_proportion );
+            g->u.set_stamina(g->u.get_stamina_max());
+            burden_jumping_player(g->u, burden_proportion);
 
             const auto stamina_before = g->u.get_stamina();
-            CHECK( iexamine::can_jump_over_tile( g->u, middle ) );
-            REQUIRE( iexamine::jump_over_tile( g->u, middle ) );
+            CHECK(iexamine::can_jump_over_tile(g->u, middle));
+            REQUIRE(iexamine::jump_over_tile(g->u, middle));
             return stamina_before - g->u.get_stamina();
         };
 
-        const auto unburdened_burn = jump_stamina_burn( 0.0f );
-        const auto burdened_burn = jump_stamina_burn( 0.2f );
+        const auto unburdened_burn = jump_stamina_burn(0.0f);
+        const auto burdened_burn = jump_stamina_burn(0.2f);
 
-        CHECK( unburdened_burn > 0 );
-        CHECK( burdened_burn > unburdened_burn );
+        CHECK(unburdened_burn > 0);
+        CHECK(burdened_burn > unburdened_burn);
     }
 
     SECTION("warns when too weak to jump") {
         g->u.str_cur = 3;
         Messages::clear_messages();
 
-        CHECK_FALSE( iexamine::can_start_jump_over_tile( g->u, true ) );
+        CHECK_FALSE(iexamine::can_start_jump_over_tile(g->u, true));
 
-        const auto recent_messages = Messages::recent_messages( 1 );
-        REQUIRE( recent_messages.size() == 1 );
-        CHECK( recent_messages.front().second == "You are too weak to jump over an obstacle." );
+        const auto recent_messages = Messages::recent_messages(1);
+        REQUIRE(recent_messages.size() == 1);
+        CHECK(recent_messages.front().second == "You are too weak to jump over an obstacle.");
     }
 }
 

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -35,6 +35,7 @@
 namespace {
 
 static const auto effect_in_pit = efftype_id("in_pit");
+static const auto effect_downed = efftype_id("downed");
 static const auto skill_dodge = skill_id("dodge");
 
 auto burden_jumping_player(avatar& you, const float burden_proportion) -> void {
@@ -235,6 +236,7 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
     }
 
     SECTION("can jump into open air and immediately resolve the ledge fall") {
+        const auto dangerous_prompt = override_option("DANGEROUS_TERRAIN_WARNING_PROMPT", "IGNORE");
         here.ter_set(landing, ter_id("t_open_air"));
         const auto moves_before = g->u.moves;
         CHECK(iexamine::can_jump_over_tile(g->u, middle));
@@ -249,6 +251,42 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
         CHECK_FALSE(iexamine::can_jump_over_tile(g->u, middle));
         CHECK_FALSE(iexamine::jump_over_tile(g->u, middle));
         CHECK(g->u.bub_pos() == origin);
+    }
+
+    SECTION("cannot jump through walls") {
+        here.ter_set(middle, ter_id("t_wall"));
+
+        CHECK_FALSE(iexamine::can_jump_over_tile(g->u, middle));
+        CHECK_FALSE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == origin);
+    }
+
+    SECTION("cannot jump through trees") {
+        here.ter_set(middle, ter_id("t_tree"));
+
+        CHECK_FALSE(iexamine::can_jump_over_tile(g->u, middle));
+        CHECK_FALSE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == origin);
+    }
+
+    SECTION("can jump through a window but may end up downed") {
+        here.ter_set(middle, ter_id("t_window"));
+        g->u.dex_cur = 1;
+
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
+        CHECK(g->u.has_effect(effect_downed));
+    }
+
+    SECTION("can trip and end up downed when jumping over furniture") {
+        here.furn_set(middle, furn_id("f_chair"));
+        g->u.dex_cur = 1;
+
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
+        CHECK(g->u.has_effect(effect_downed));
     }
 
     SECTION("cannot jump over creatures our size or larger") {

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -20,6 +20,7 @@
 #include "messages.h"
 #include "monster.h"
 #include "npc.h"
+#include "options.h"
 #include "options_helpers.h"
 #include "player_helpers.h"
 #include "state_helpers.h"
@@ -36,6 +37,7 @@
 namespace {
 
 static const auto effect_in_pit = efftype_id("in_pit");
+static const auto effect_bleed = efftype_id("bleed");
 static const auto effect_downed = efftype_id("downed");
 static const auto skill_dodge = skill_id("dodge");
 
@@ -212,6 +214,33 @@ TEST_CASE("moving_between_adjacent_pit_traps") {
     }
 }
 
+TEST_CASE("moving through a sharp window frame can cause bleeding") {
+    clear_all_state();
+
+    auto& here = get_map();
+    const auto origin = tripoint_bub_ms(60, 60, 0);
+    const auto destination = origin + tripoint_rel_ms::east();
+    const auto dangerous_prompt = override_option("DANGEROUS_TERRAIN_WARNING_PROMPT", "IGNORE");
+    here.ter_set(origin, ter_id("t_floor"));
+    here.furn_set(origin, furn_id("f_null"));
+    here.ter_set(destination, ter_id("t_window_frame"));
+    here.furn_set(destination, furn_id("f_null"));
+
+    auto started_bleeding = false;
+    for (const auto attempt : std::views::iota(0, 64)) {
+        (void)attempt;
+        reset_jumping_avatar(g->u, origin, 2);
+
+        REQUIRE(g->walk_move(destination, false));
+        if (g->u.has_effect(effect_bleed)) {
+            started_bleeding = true;
+            break;
+        }
+    }
+
+    CHECK(started_bleeding);
+}
+
 TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][movement][jump]") {
     clear_all_state();
 
@@ -330,6 +359,67 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
         CHECK(took_damage);
     }
 
+    SECTION("jumping over sharp terrain can cut exposed body parts") {
+        auto took_damage = false;
+        for (const auto attempt : std::views::iota(0, 16)) {
+            (void)attempt;
+            here.ter_set(middle, ter_id("t_fence_barbed"));
+            reset_jumping_avatar(g->u, origin, 2);
+
+            const auto hp_before = g->u.get_hp();
+            CHECK(iexamine::can_jump_over_tile(g->u, middle));
+            REQUIRE(iexamine::jump_over_tile(g->u, middle));
+            if (g->u.get_hp() < hp_before) {
+                took_damage = true;
+                break;
+            }
+        }
+
+        CHECK(took_damage);
+    }
+
+    SECTION("jumping over sharp terrain can cause bleeding") {
+        auto started_bleeding = false;
+        for (const auto attempt : std::views::iota(0, 32)) {
+            (void)attempt;
+            here.ter_set(middle, ter_id("t_fence_barbed"));
+            reset_jumping_avatar(g->u, origin, 2);
+
+            CHECK(iexamine::can_jump_over_tile(g->u, middle));
+            REQUIRE(iexamine::jump_over_tile(g->u, middle));
+            if (g->u.has_effect(effect_bleed)) {
+                started_bleeding = true;
+                break;
+            }
+        }
+
+        CHECK(started_bleeding);
+    }
+
+    SECTION("jumping through a closed window with only hands exposed damages an arm") {
+        auto took_arm_damage = false;
+        for (const auto attempt : std::views::iota(0, 16)) {
+            (void)attempt;
+            here.ter_set(middle, ter_id("t_window"));
+            reset_jumping_avatar(g->u, origin, 2);
+            REQUIRE_FALSE(g->u.wear_item(item::spawn("longshirt"), false));
+            REQUIRE_FALSE(g->u.wear_item(item::spawn("jeans"), false));
+
+            const auto arm_hp_before = g->u.get_part_hp_cur(bodypart_id("arm_l")) +
+                                       g->u.get_part_hp_cur(bodypart_id("arm_r"));
+            CHECK(iexamine::can_jump_over_tile(g->u, middle));
+            REQUIRE(iexamine::jump_over_tile(g->u, middle));
+            const auto arm_hp_after = g->u.get_part_hp_cur(bodypart_id("arm_l")) +
+                                      g->u.get_part_hp_cur(bodypart_id("arm_r"));
+            if (arm_hp_after < arm_hp_before) {
+                took_arm_damage = true;
+                break;
+            }
+        }
+
+        CHECK(took_arm_damage);
+    }
+
     SECTION("jumping through a closed window is safe when covered") {
         here.ter_set(middle, ter_id("t_window"));
         reset_jumping_avatar(g->u, origin, 2);
@@ -357,11 +447,23 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
     SECTION("can trip and end up downed when jumping over furniture") {
         here.furn_set(middle, furn_id("f_chair"));
         g->u.dex_cur = 1;
+        const auto limb_hp_before = g->u.get_part_hp_cur(bodypart_id("arm_l")) +
+                                    g->u.get_part_hp_cur(bodypart_id("arm_r")) +
+                                    g->u.get_part_hp_cur(bodypart_id("leg_l")) +
+                                    g->u.get_part_hp_cur(bodypart_id("leg_r"));
 
         CHECK(iexamine::can_jump_over_tile(g->u, middle));
         REQUIRE(iexamine::jump_over_tile(g->u, middle));
         CHECK(g->u.bub_pos() == landing);
         CHECK(g->u.has_effect(effect_downed));
+        const auto limb_hp_after = g->u.get_part_hp_cur(bodypart_id("arm_l")) +
+                                   g->u.get_part_hp_cur(bodypart_id("arm_r")) +
+                                   g->u.get_part_hp_cur(bodypart_id("leg_l")) +
+                                   g->u.get_part_hp_cur(bodypart_id("leg_r"));
+        CHECK(limb_hp_after < limb_hp_before);
+        const auto downed_duration = g->u.get_effect(effect_downed).get_duration();
+        CHECK(downed_duration >= 2_turns);
+        CHECK(downed_duration <= 3_turns);
     }
 
     SECTION("cannot jump over creatures our size or larger") {
@@ -393,6 +495,11 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
     }
 
     SECTION("jumping burns stamina and heavier carried loads burn more") {
+        struct jump_stamina_result {
+            int actual_burn;
+            int expected_burn;
+        };
+
         const auto jump_stamina_burn = [&](const float burden_proportion) {
             clear_character(g->u, false);
             g->u.setpos(origin);
@@ -401,17 +508,29 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
             g->u.set_stamina(g->u.get_stamina_max());
             burden_jumping_player(g->u, burden_proportion);
 
+            const auto move_cost = g->u.run_cost(200);
+            const auto base_stamina_burn = divide_round_up(
+                                               get_option<int>("PLAYER_BASE_STAMINA_BURN_RATE") * move_cost * 14, 100);
+            const auto carried_weight_grams = units::to_gram(g->u.weight_carried());
+            const auto carry_capacity_grams = units::to_gram(std::max(g->u.weight_capacity(), 1_gram));
+            const auto carried_weight_percentage = std::clamp(
+                                                       static_cast<int>(carried_weight_grams * 100 / carry_capacity_grams), 0, 100);
             const auto stamina_before = g->u.get_stamina();
             CHECK(iexamine::can_jump_over_tile(g->u, middle));
             REQUIRE(iexamine::jump_over_tile(g->u, middle));
-            return stamina_before - g->u.get_stamina();
+            return jump_stamina_result{
+                .actual_burn = stamina_before - g->u.get_stamina(),
+                .expected_burn = divide_round_up(base_stamina_burn * (100 + carried_weight_percentage), 100),
+            };
         };
 
         const auto unburdened_burn = jump_stamina_burn(0.0f);
         const auto burdened_burn = jump_stamina_burn(0.2f);
 
-        CHECK(unburdened_burn > 0);
-        CHECK(burdened_burn > unburdened_burn);
+        CHECK(unburdened_burn.actual_burn == unburdened_burn.expected_burn);
+        CHECK(burdened_burn.actual_burn == burdened_burn.expected_burn);
+        CHECK(unburdened_burn.actual_burn > 0);
+        CHECK(burdened_burn.actual_burn > unburdened_burn.actual_burn);
     }
 
     SECTION("warns when too weak to jump") {

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -269,14 +269,12 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
         CHECK(g->u.bub_pos() == origin);
     }
 
-    SECTION("can jump through a window but may end up downed") {
+    SECTION("cannot jump through a closed window") {
         here.ter_set(middle, ter_id("t_window"));
-        g->u.dex_cur = 1;
 
-        CHECK(iexamine::can_jump_over_tile(g->u, middle));
-        REQUIRE(iexamine::jump_over_tile(g->u, middle));
-        CHECK(g->u.bub_pos() == landing);
-        CHECK(g->u.has_effect(effect_downed));
+        CHECK_FALSE(iexamine::can_jump_over_tile(g->u, middle));
+        CHECK_FALSE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == origin);
     }
 
     SECTION("can trip and end up downed when jumping over furniture") {

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -30,6 +30,7 @@
 #include "vehicle.h"
 
 #include <memory>
+#include <ranges>
 #include <vector>
 
 namespace {
@@ -46,6 +47,21 @@ auto burden_jumping_player(avatar& you, const float burden_proportion) -> void {
     if (weight_to_add > 0) {
         you.i_add(item::spawn("test_platinum_bit", calendar::turn, weight_to_add));
     }
+}
+
+auto reset_jumping_avatar( avatar &you, const tripoint_bub_ms &origin,
+                           const int dexterity ) -> void {
+    clear_character( you, false );
+    you.setpos( origin );
+    you.str_cur = 8;
+    you.dex_cur = dexterity;
+    you.moves = 1000;
+}
+
+auto equip_window_jump_protection( avatar &you ) -> void {
+    REQUIRE_FALSE( you.wear_item( item::spawn( "gloves_work" ), false ) );
+    REQUIRE_FALSE( you.wear_item( item::spawn( "longshirt" ), false ) );
+    REQUIRE_FALSE( you.wear_item( item::spawn( "jeans" ), false ) );
 }
 
 struct adjacent_pit_move {
@@ -269,12 +285,57 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
         CHECK(g->u.bub_pos() == origin);
     }
 
-    SECTION("cannot jump through a closed window") {
+    SECTION("can jump through a closed window and bash it out") {
         here.ter_set(middle, ter_id("t_window"));
+        reset_jumping_avatar(g->u, origin, 8);
 
-        CHECK_FALSE(iexamine::can_jump_over_tile(g->u, middle));
-        CHECK_FALSE(iexamine::jump_over_tile(g->u, middle));
-        CHECK(g->u.bub_pos() == origin);
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
+        CHECK(here.ter(middle) == ter_id("t_window_frame"));
+    }
+
+    SECTION("jumping through a closed window can cut exposed body parts") {
+        auto took_damage = false;
+        for( const auto attempt : std::views::iota( 0, 16 ) ) {
+            ( void )attempt;
+            here.ter_set(middle, ter_id("t_window"));
+            reset_jumping_avatar(g->u, origin, 2);
+
+            const auto hp_before = g->u.get_hp();
+            CHECK(iexamine::can_jump_over_tile(g->u, middle));
+            REQUIRE(iexamine::jump_over_tile(g->u, middle));
+            if( g->u.get_hp() < hp_before ) {
+                took_damage = true;
+                break;
+            }
+        }
+
+        CHECK(took_damage);
+    }
+
+    SECTION("jumping through a closed window is safe when covered") {
+        here.ter_set(middle, ter_id("t_window"));
+        reset_jumping_avatar(g->u, origin, 2);
+        equip_window_jump_protection(g->u);
+
+        const auto hp_before = g->u.get_hp();
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
+        CHECK(g->u.get_hp() == hp_before);
+    }
+
+    SECTION("parkour experts never trip while jumping obstacles") {
+        here.ter_set(middle, ter_id("t_window"));
+        reset_jumping_avatar(g->u, origin, 1);
+        equip_window_jump_protection(g->u);
+        g->u.toggle_trait(trait_id("PARKOUR"));
+
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
+        CHECK_FALSE(g->u.has_effect(effect_downed));
     }
 
     SECTION("can trip and end up downed when jumping over furniture") {

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -294,6 +294,15 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
         CHECK(here.ter(middle) == ter_id("t_window_frame"));
     }
 
+    SECTION("cannot jump through reinforced boarded windows") {
+        here.ter_set(middle, ter_id("t_window_reinforced"));
+        reset_jumping_avatar(g->u, origin, 20);
+
+        CHECK_FALSE(iexamine::can_jump_over_tile(g->u, middle));
+        CHECK_FALSE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == origin);
+    }
+
     SECTION("jumping through a closed window can cut exposed body parts") {
         auto took_damage = false;
         for (const auto attempt : std::views::iota(0, 16)) {

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -405,12 +405,14 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
             REQUIRE_FALSE(g->u.wear_item(item::spawn("longshirt"), false));
             REQUIRE_FALSE(g->u.wear_item(item::spawn("jeans"), false));
 
-            const auto arm_hp_before = g->u.get_part_hp_cur(bodypart_id("arm_l")) +
-                                       g->u.get_part_hp_cur(bodypart_id("arm_r"));
+            const auto arm_hp_before =
+                g->u.get_part_hp_cur(bodypart_id("arm_l"))
+                + g->u.get_part_hp_cur(bodypart_id("arm_r"));
             CHECK(iexamine::can_jump_over_tile(g->u, middle));
             REQUIRE(iexamine::jump_over_tile(g->u, middle));
-            const auto arm_hp_after = g->u.get_part_hp_cur(bodypart_id("arm_l")) +
-                                      g->u.get_part_hp_cur(bodypart_id("arm_r"));
+            const auto arm_hp_after =
+                g->u.get_part_hp_cur(bodypart_id("arm_l"))
+                + g->u.get_part_hp_cur(bodypart_id("arm_r"));
             if (arm_hp_after < arm_hp_before) {
                 took_arm_damage = true;
                 break;
@@ -447,19 +449,19 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
     SECTION("can trip and end up downed when jumping over furniture") {
         here.furn_set(middle, furn_id("f_chair"));
         g->u.dex_cur = 1;
-        const auto limb_hp_before = g->u.get_part_hp_cur(bodypart_id("arm_l")) +
-                                    g->u.get_part_hp_cur(bodypart_id("arm_r")) +
-                                    g->u.get_part_hp_cur(bodypart_id("leg_l")) +
-                                    g->u.get_part_hp_cur(bodypart_id("leg_r"));
+        const auto limb_hp_before =
+            g->u.get_part_hp_cur(bodypart_id("arm_l")) + g->u.get_part_hp_cur(bodypart_id("arm_r"))
+            + g->u.get_part_hp_cur(bodypart_id("leg_l"))
+            + g->u.get_part_hp_cur(bodypart_id("leg_r"));
 
         CHECK(iexamine::can_jump_over_tile(g->u, middle));
         REQUIRE(iexamine::jump_over_tile(g->u, middle));
         CHECK(g->u.bub_pos() == landing);
         CHECK(g->u.has_effect(effect_downed));
-        const auto limb_hp_after = g->u.get_part_hp_cur(bodypart_id("arm_l")) +
-                                   g->u.get_part_hp_cur(bodypart_id("arm_r")) +
-                                   g->u.get_part_hp_cur(bodypart_id("leg_l")) +
-                                   g->u.get_part_hp_cur(bodypart_id("leg_r"));
+        const auto limb_hp_after =
+            g->u.get_part_hp_cur(bodypart_id("arm_l")) + g->u.get_part_hp_cur(bodypart_id("arm_r"))
+            + g->u.get_part_hp_cur(bodypart_id("leg_l"))
+            + g->u.get_part_hp_cur(bodypart_id("leg_r"));
         CHECK(limb_hp_after < limb_hp_before);
         const auto downed_duration = g->u.get_effect(effect_downed).get_duration();
         CHECK(downed_duration >= 2_turns);
@@ -510,17 +512,19 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
 
             const auto move_cost = g->u.run_cost(200);
             const auto base_stamina_burn = divide_round_up(
-                                               get_option<int>("PLAYER_BASE_STAMINA_BURN_RATE") * move_cost * 14, 100);
+                get_option<int>("PLAYER_BASE_STAMINA_BURN_RATE") * move_cost * 14, 100);
             const auto carried_weight_grams = units::to_gram(g->u.weight_carried());
-            const auto carry_capacity_grams = units::to_gram(std::max(g->u.weight_capacity(), 1_gram));
-            const auto carried_weight_percentage = std::clamp(
-                                                       static_cast<int>(carried_weight_grams * 100 / carry_capacity_grams), 0, 100);
+            const auto carry_capacity_grams = units::to_gram(
+                std::max(g->u.weight_capacity(), 1_gram));
+            const auto carried_weight_percentage = std::
+                clamp(static_cast<int>(carried_weight_grams * 100 / carry_capacity_grams), 0, 100);
             const auto stamina_before = g->u.get_stamina();
             CHECK(iexamine::can_jump_over_tile(g->u, middle));
             REQUIRE(iexamine::jump_over_tile(g->u, middle));
             return jump_stamina_result{
                 .actual_burn = stamina_before - g->u.get_stamina(),
-                .expected_burn = divide_round_up(base_stamina_burn * (100 + carried_weight_percentage), 100),
+                .expected_burn =
+                    divide_round_up(base_stamina_burn * (100 + carried_weight_percentage), 100),
             };
         };
 

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -268,6 +268,14 @@ TEST_CASE("jump_over_tile_is_generic_but_reuses_ledge_landing_rules", "[map][mov
         CHECK(g->u.bub_pos() == origin);
     }
 
+    SECTION("can jump over CLIMB_SIMPLE furniture") {
+        here.furn_set(middle, furn_id("f_barricade_road"));
+
+        CHECK(iexamine::can_jump_over_tile(g->u, middle));
+        REQUIRE(iexamine::jump_over_tile(g->u, middle));
+        CHECK(g->u.bub_pos() == landing);
+    }
+
     SECTION("cannot jump through walls") {
         here.ter_set(middle, ter_id("t_wall"));
 


### PR DESCRIPTION
## Purpose of change (The Why)
Requested in the discord, I'm always up for expanding movement options & making the character feel more maneuverable/grounded in the world.
## Describe the solution (The How)
Adds an unbound by default action in the action menu to jump over a nearby tile, costing 200 move points. This functions basically exactly the same way the ledge jump does, but without a check for empty air so it's possible to jump off buildings. Can also be used to crash through windows, smashing them in the process and potentially injuring yourself.

In addition to the usual rules, you can't jump over creatures your size or larger as well as furniture that's impassible.
## Describe alternatives you've considered
Not adding the jump
## Testing
Jumped over terrain and traps. Ensured I jumped over it properly and didn't activate the trap. Put a fridge in a door to block it, ensured I couldn't jump through the newly created wall.
## Additional context
Maybe we should check a flag to ensure the furniture in the tile we are jumping over is small enough? Probably shouldn't be able to jump THROUGH terrain...

## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [X] This PR used AI assistance.
  - [X] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e11c99b](https://github.com/cataclysmbn/Cataclysm-BN/commit/e11c99bf3a0b604dc4013f36e24176086dfe167b) (Apply suggestion from @chaosvolt) on 2026-08-18 09:16:26

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32107992984/artifacts/9317231025)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32107992984)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32107992984/artifacts/9314801957)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32107992984/artifacts/9317051829)
<!-- END artifact comment -->