### PR TITLE
feat(balance): overhaul and sanity-check jabberwock mission chain

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -445,10 +445,9 @@
     "monster_kill_goal": 100,
     "difficulty": 5,
     "value": 250000,
-    "start": { "effect": "follow_only" },
-    "end": { "effect": "stop_following" },
+    "start": { "effect": "follow" },
     "origins": [ "ORIGIN_SECONDARY" ],
-    "followup": "MISSION_KILL_HORDE_MASTER",
+    "followup": "MISSION_RECRUIT_TRACKER",
     "dialogue": {
       "describe": "You seem to know this new world better than most…",
       "offer": "You're kitted out better than most… would you be interested in making this world a little better for the rest of us?  The towns have enough supplies for us survivors to start securing a foothold but we don't have anyone with the skills and equipment to thin the masses of undead.  I'll lend you a hand to the best of my ability but you really showed promise taking out that other beast.  You, I, and a 100 zombies laid to rest, what do you say?",
@@ -462,6 +461,32 @@
     }
   },
   {
+    "id": "MISSION_RECRUIT_TRACKER",
+    "type": "mission_definition",
+    "name": { "str": "Recruit Tracker" },
+    "goal": "MGOAL_RECRUIT_NPC",
+    "difficulty": 5,
+    "value": 70000,
+    "start": {
+      "assign_mission_target": { "om_terrain": "cabin", "reveal_radius": 2, "z": 0 },
+      "effect": "follow",
+      "update_mapgen": { "place_npcs": [ { "class": "tracker_gunslinger", "x": 11, "y": 11, "target": true } ] }
+    },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "followup": "MISSION_KILL_HORDE_MASTER",
+    "dialogue": {
+      "describe": "You seem to know this new world better than most…",
+      "offer": "We've got another problem to deal with but I don't think we can handle it on our own.  So, I sent word out and found us a volunteer… of sorts.  He's vain as hell but has a little skill with firearms.  He was supposed to collect whatever he had of value and is going to meet us at a cabin in the woods.  Wasn't sure how long we were going to be so I told him to just camp there until we picked him up.",
+      "accepted": "Rodger, if he's a no-show then any other gunslinger will do… but I doubt he'll quit before we even begin.",
+      "rejected": "Hey, I know I wouldn't volunteer for it either… but then I remember that most of us survivors won't make it unless someone decides to take the initiative.",
+      "advice": "I hope the bastard is packing heat… else we'll need to grab him a gun before we hit our next target.",
+      "inquire": "Found a gunslinger?",
+      "success": "Great, just let me know when you are ready to wade knee-deep in an ocean of blood.",
+      "success_lie": "I don't think so…",
+      "failure": "Quitting already?"
+    }
+  },
+  {
     "id": "MISSION_KILL_HORDE_MASTER",
     "type": "mission_definition",
     "name": { "str": "Kill Horde Master" },
@@ -469,16 +494,24 @@
     "difficulty": 5,
     "value": 250000,
     "urgent": true,
-    "start": "kill_horde_master",
-    "end": { "effect": "stop_following" },
+    "start": {
+      "assign_mission_target": { "om_terrain": "forest", "random": true, "search_range": 60, "reveal_radius": 1, "min_distance": 10, "z": 0 },
+      "effect": "follow",
+      "update_mapgen": {
+        "place_monster": [
+          { "monster": "mon_zombie_master", "name": "Demonic Soul", "x": [ 11, 12 ], "y": [ 11, 12 ], "target": true },
+          { "group": "GROUP_ZOMBIE_BRUTE", "x": [ 9, 14 ], "y": [ 9, 14 ], "repeat": [ 3, 6 ] },
+          { "group": "GROUP_BLACK_ROAD", "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 30, 60 ] }
+        ]
+      }
+    },
     "origins": [ "ORIGIN_SECONDARY" ],
-    "followup": "MISSION_RECRUIT_TRACKER",
     "dialogue": {
       "describe": "I've heard some bad rumors so I hope you are up for another challenge…",
-      "offer": "Apparently one of the other survivors picked up on an unusually dense horde of undead moving into the area.  At the center of this throng there was a 'leader' of some sort.  The short of it is, kill the son of a bitch.  We don't know what it is capable of or why it is surrounded by other zombies but this thing reeks of trouble.  Do whatever it takes but we can't risk it getting away.",
+      "offer": "From what I overheard from your new deputy, an unusually dense horde of undead recently moving into the area.  At the center of this throng there was a 'leader' of some sort.  The short of it is, kill the son of a bitch.  We don't know what it is capable of or why it is surrounded by other zombies but this thing reeks of trouble.  Do whatever it takes but we can't risk it getting away.",
       "accepted": "I'll lend you a hand but I'd try and recruit another gunslinger if you can.",
       "rejected": "What's the use of walking away, they'll track you down eventually.",
-      "advice": "Don't risk torching the building it may be hiding in if it has a basement.  The sucker may still be alive under the rubble and ash.",
+      "advice": "Don't risk torching the area it may be hiding in.  The sucker may still be alive under the rubble and ash.",
       "inquire": "Got this knocked out?",
       "success": "May that bastard never get up again.",
       "success_lie": "I don't think we got it yet.",
@@ -669,31 +702,6 @@
       "success": "Thank you, a diary is exactly what I was looking for.",
       "success_lie": "What good does this do us?",
       "failure": "It was a lost cause anyways…"
-    }
-  },
-  {
-    "id": "MISSION_RECRUIT_TRACKER",
-    "type": "mission_definition",
-    "name": { "str": "Recruit Tracker" },
-    "goal": "MGOAL_RECRUIT_NPC",
-    "difficulty": 5,
-    "value": 70000,
-    "start": {
-      "assign_mission_target": { "om_terrain": "cabin", "reveal_radius": 2, "random": true, "search_range": 80, "z": 0 },
-      "effect": "follow",
-      "update_mapgen": { "place_npcs": [ { "class": "tracker_gunslinger", "x": 11, "y": 11, "target": true } ] }
-    },
-    "origins": [ "ORIGIN_SECONDARY" ],
-    "dialogue": {
-      "describe": "You seem to know this new world better than most…",
-      "offer": "We've got another problem to deal with but I don't think we can handle it on our own.  So, I sent word out and found us a volunteer… of sorts.  He's vain as hell but has a little skill with firearms.  He was supposed to collect whatever he had of value and is going to meet us at a cabin in the woods.  Wasn't sure how long we were going to be so I told him to just camp there until we picked him up.",
-      "accepted": "Rodger, if he's a no-show then any other gunslinger will do… but I doubt he'll quit before we even begin.",
-      "rejected": "Hey, I know I wouldn't volunteer for it either… but then I remember that most of us survivors won't make it unless someone decides to take the initiative.",
-      "advice": "I hope the bastard is packing heat… else we'll need to grab him a gun before we hit our next target.",
-      "inquire": "Found a gunslinger?",
-      "success": "Great, just let me know when you are ready to wade knee-deep in an ocean of blood.",
-      "success_lie": "I don't think so…",
-      "failure": "Quitting already?"
     }
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

<img width="862" height="482" alt="image" src="https://github.com/user-attachments/assets/b0e4b09c-16d5-4f01-9c10-9d2003f1e49d" />

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Changed `MISSION_KILL_HORDE_MASTER` from using a hardcoded mission start effect to a JSONized one. Instead of a lame hardcoded selection of mostly basic zeds since it was clearly designed under the assumption that the master can force-evolve stuff, instead it now uses `GROUP_BLACK_ROAD` for the random fodder zeds and `GROUP_ZOMBIE_BRUTE` for the brute-tier enemies, and moreover set it spawn an actual proper HORDE because this is mission three in a chain where you start off fighting a fucking jabberwock and mission two demanded you to kill 100 zombies.

One loss is it will now always pick a forest instead of sometimes a hotel or office tower, but such is life plus needed to ensure it won't break in a zero-city-size world.

In addition, `MISSION_RECRUIT_TRACKER` implies there's a big mission coming afterward but it's the end of the chain, so I swapped places with the horde master mission so the giant horde fight actually comes as the climax to the mission chain, plus finding the tracker helps to better justify why your follower NPC who may have never seen another NPC during your travels has rumors about a horde from other survivors, instead it can be implied that the tracker told them. Also set it to search for the closest cabin instead of a random one within 80 tiles so it won't randomly fail.

Lastly, changed up the mission chain to not forcibly de-recruit the NPC every time because that's fucking dumb, just let them stay a follower.

## Describe alternatives you've considered

1. Picking a different mission location instead.
2. Picking a different monstergroup to use.
3. Also making the opening mission less of a "go fuck yourself newbie" vibe check by making it spawn an unevolved flesh golem instead of a jabberwock.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Gave starter NPC the "find tracker" mission and accepted it.
3. Was correctly able to go recruit the tracker NPC and get the horde mission from the first NPC.
4. Warped over to location, appropriate amount of goons.
5. Repeated test of horde mission after first advancing time forward a year, the horde is appropriately even spicier.

Mission on day one:
<img width="1595" height="955" alt="image" src="https://github.com/user-attachments/assets/6d687b6e-aeb7-490b-a221-3fd65adaf656" />

Taken a year later:
<img width="1589" height="949" alt="image" src="https://github.com/user-attachments/assets/10564e76-50c8-478f-b62b-97e346314da3" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6cd572f](https://github.com/cataclysmbn/Cataclysm-BN/commit/6cd572fdb7e3bb48d3675a4c2bfdbff99b657dc2) (feat(balance): overhaul and sanity-check jabberwock mission chain) on 2026-08-17 23:23:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32074201860/artifacts/9304448972)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32074201860/artifacts/9303914893)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32074201860/artifacts/9303496890)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32074201860/artifacts/9303311423)
<!-- END artifact comment -->