### PR TITLE
feat: make small office building enemy spawns make sense

### DIFF
--- a/data/json/mapgen/office_small.json
+++ b/data/json/mapgen/office_small.json
@@ -93,8 +93,8 @@
         { "item": "kitchen", "x": [ 2, 3 ], "y": 9, "chance": 50 }
       ],
       "place_monsters": [
-        { "monster": "GROUP_PUBLICWORKERS", "x": 5, "y": 18, "chance": 2 },
-        { "monster": "GROUP_PUBLICWORKERS", "x": 20, "y": 6, "chance": 2 }
+        { "monster": "GROUP_OFFICE_TOWER_2", "x": 5, "y": 18, "chance": 2 },
+        { "monster": "GROUP_OFFICE_TOWER_2", "x": 20, "y": 6, "chance": 2 }
       ]
     }
   },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -857,7 +857,8 @@
     "copy-from": "generic_city_building",
     "name": "small office",
     "sym": "o",
-    "color": "brown"
+    "color": "brown",
+    "spawns": { "group": "GROUP_OFFICE_TOWER_2", "population": [ 6, 9 ], "chance": 80 }
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
For some reason, the small office building spawns public workers, which are supposed to be construction workers from the public works site, which doesn't make much sense for an office building. Also, the only groups that spawn are two predefined groups that spawn in the rooms but sometimes don't?
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Changes the public workers group to the office tower group, and adds some spawns that aren't predefined.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Ram ranch in the office
## Testing
Debug teleported to some small offices, enemy types and numbers look better
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
thanks to jotofriend on discord for the "bug" report
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ca685a8](https://github.com/cataclysmbn/Cataclysm-BN/commit/ca685a8608455597eeecfb94d119bb8e5123e684) (Update overmap_terrain_commercial.json) on 2026-08-17 23:25:44

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32076445489)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32076445489/artifacts/9304846935)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32076445489/artifacts/9304684825)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32076445489/artifacts/9304308605)
<!-- END artifact comment -->