### PR TITLE
feat: add overmap_origin for specifying specific locations for specials

### DIFF
--- a/data/mods/TEST_DATA/overmap_specials.json
+++ b/data/mods/TEST_DATA/overmap_specials.json
@@ -95,5 +95,30 @@
     },
     "root": "crater_all",
     "phases": [ [ { "overmap": "crater_all", "max": { "poisson": 5 } } ], [ { "overmap": "crater_edge", "weight": 1 } ] ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "test_exact_origin",
+    "locations": [ "land" ],
+    "overmap_origin": [ 10, 20, 0 ],
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "field" } ],
+    "city_distance": [ 0, -1 ],
+    "occurrences": [ 0, 1 ],
+    "flags": [ "CLASSIC" ],
+    "rotate": false
+  },
+  {
+    "type": "overmap_special",
+    "id": "test_origin_range",
+    "locations": [ "land" ],
+    "overmap_origin": {
+      "from": [ 30, 40, 0 ],
+      "to": [ 32, 41, 0 ]
+    },
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "field" } ],
+    "city_distance": [ 0, -1 ],
+    "occurrences": [ 0, 1 ],
+    "flags": [ "CLASSIC" ],
+    "rotate": false
   }
 ]

--- a/data/mods/TEST_DATA/overmap_specials.json
+++ b/data/mods/TEST_DATA/overmap_specials.json
@@ -111,10 +111,7 @@
     "type": "overmap_special",
     "id": "test_origin_range",
     "locations": [ "land" ],
-    "overmap_origin": {
-      "from": [ 30, 40, 0 ],
-      "to": [ 32, 41, 0 ]
-    },
+    "overmap_origin": { "from": [ 30, 40, 0 ], "to": [ 32, 41, 0 ] },
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "field" } ],
     "city_distance": [ 0, -1 ],
     "occurrences": [ 0, 1 ],

--- a/docs/en/mod/json/reference/map/overmap.md
+++ b/docs/en/mod/json/reference/map/overmap.md
@@ -305,20 +305,20 @@ level value and then only specify it for individual entries that differ.
 
 ### Fields
 
-| Identifier      | Description                                                                                           |
-| --------------- | ----------------------------------------------------------------------------------------------------- |
-| `type`          | Must be `"overmap_special"`.                                                                          |
-| `id`            | Unique id.                                                                                            |
-| `connections`   | List of overmap connections and their relative `[ x, y, z ]` location within the special.             |
-| `place_nested`  | Array of `{ "point": [x, y, z], "special": id }` with nested specials, relative to this one.          |
-| `subtype`       | Either `"fixed"` or `"mutable"`. Defaults to `"fixed"` if not specified.                              |
-| `locations`     | List of `overmap_location` ids that the special may be placed on.                                     |
+| Identifier       | Description                                                                                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`           | Must be `"overmap_special"`.                                                                                                                                   |
+| `id`             | Unique id.                                                                                                                                                     |
+| `connections`    | List of overmap connections and their relative `[ x, y, z ]` location within the special.                                                                      |
+| `place_nested`   | Array of `{ "point": [x, y, z], "special": id }` with nested specials, relative to this one.                                                                   |
+| `subtype`        | Either `"fixed"` or `"mutable"`. Defaults to `"fixed"` if not specified.                                                                                       |
+| `locations`      | List of `overmap_location` ids that the special may be placed on.                                                                                              |
 | `overmap_origin` | Exact origin `[ x, y, z ]` or inclusive origin range object `{ "from": [ ... ], "to": [ ... ] }` within the current overmap that the special may be placed at. |
-| `city_distance` | Min/max distance from a city that the special may be placed. Use -1 for unbounded.                    |
-| `city_sizes`    | Min/max city size for a city that the special may be placed near. Use -1 for unbounded.               |
-| `occurrences`   | Min/max number of occurrences when placing the special. If UNIQUE flag is set, becomes X of Y chance. |
-| `flags`         | See `Overmap specials` in [json_flags.md](../json_flags).                                             |
-| `rotate`        | Whether the special can rotate. True if not specified.                                                |
+| `city_distance`  | Min/max distance from a city that the special may be placed. Use -1 for unbounded.                                                                             |
+| `city_sizes`     | Min/max city size for a city that the special may be placed near. Use -1 for unbounded.                                                                        |
+| `occurrences`    | Min/max number of occurrences when placing the special. If UNIQUE flag is set, becomes X of Y chance.                                                          |
+| `flags`          | See `Overmap specials` in [json_flags.md](../json_flags).                                                                                                      |
+| `rotate`         | Whether the special can rotate. True if not specified.                                                                                                         |
 
 Depending on the subtype, there are further relevant fields:
 
@@ -354,7 +354,7 @@ Depending on the subtype, there are further relevant fields:
     ],
     "connections": [{ "point": [1, -1, 0], "connection": "local_road", "from": [1, 0, 0] }],
     "locations": ["forest"],
-    "overmap_origin": { "from": [ 10, 20, 0 ], "to": [ 14, 24, 0 ] },
+    "overmap_origin": { "from": [10, 20, 0], "to": [14, 24, 0] },
     "city_distance": [10, -1],
     "city_sizes": [3, 12],
     "occurrences": [0, 5],

--- a/docs/en/mod/json/reference/map/overmap.md
+++ b/docs/en/mod/json/reference/map/overmap.md
@@ -313,6 +313,7 @@ level value and then only specify it for individual entries that differ.
 | `place_nested`  | Array of `{ "point": [x, y, z], "special": id }` with nested specials, relative to this one.          |
 | `subtype`       | Either `"fixed"` or `"mutable"`. Defaults to `"fixed"` if not specified.                              |
 | `locations`     | List of `overmap_location` ids that the special may be placed on.                                     |
+| `overmap_origin` | Exact origin `[ x, y, z ]` or inclusive origin range object `{ "from": [ ... ], "to": [ ... ] }` within the current overmap that the special may be placed at. |
 | `city_distance` | Min/max distance from a city that the special may be placed. Use -1 for unbounded.                    |
 | `city_sizes`    | Min/max city size for a city that the special may be placed near. Use -1 for unbounded.               |
 | `occurrences`   | Min/max number of occurrences when placing the special. If UNIQUE flag is set, becomes X of Y chance. |
@@ -353,6 +354,7 @@ Depending on the subtype, there are further relevant fields:
     ],
     "connections": [{ "point": [1, -1, 0], "connection": "local_road", "from": [1, 0, 0] }],
     "locations": ["forest"],
+    "overmap_origin": { "from": [ 10, 20, 0 ], "to": [ 14, 24, 0 ] },
     "city_distance": [10, -1],
     "city_sizes": [3, 12],
     "occurrences": [0, 5],

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1776,7 +1776,7 @@ struct mutable_overmap_placement_rule {
 };
 
 auto normalize_overmap_origin_range( inclusive_cuboid<tripoint_om_omt> range )
--> inclusive_cuboid<tripoint_om_omt>
+- > inclusive_cuboid<tripoint_om_omt>
 {
     if( range.p_min.x() > range.p_max.x() ) {
         std::swap( range.p_min.x(), range.p_max.x() );
@@ -1791,7 +1791,7 @@ auto normalize_overmap_origin_range( inclusive_cuboid<tripoint_om_omt> range )
 }
 
 auto load_overmap_origin_range( const JsonValue &value )
--> inclusive_cuboid<tripoint_om_omt>
+- > inclusive_cuboid<tripoint_om_omt>
 {
     if( value.test_array() ) {
         auto point = tripoint_om_omt();
@@ -1806,7 +1806,8 @@ auto load_overmap_origin_range( const JsonValue &value )
         return normalize_overmap_origin_range( range );
     }
 
-    value.throw_error( R"(overmap_origin must be a point [x, y, z] or an object with "from" and "to")" );
+    value.throw_error(
+        R"(overmap_origin must be a point [x, y, z] or an object with "from" and "to")" );
 }
 
 struct mutable_overmap_placement_rule_remainder {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1775,6 +1775,40 @@ struct mutable_overmap_placement_rule {
     }
 };
 
+auto normalize_overmap_origin_range( inclusive_cuboid<tripoint_om_omt> range )
+-> inclusive_cuboid<tripoint_om_omt>
+{
+    if( range.p_min.x() > range.p_max.x() ) {
+        std::swap( range.p_min.x(), range.p_max.x() );
+    }
+    if( range.p_min.y() > range.p_max.y() ) {
+        std::swap( range.p_min.y(), range.p_max.y() );
+    }
+    if( range.p_min.z() > range.p_max.z() ) {
+        std::swap( range.p_min.z(), range.p_max.z() );
+    }
+    return range;
+}
+
+auto load_overmap_origin_range( const JsonValue &value )
+-> inclusive_cuboid<tripoint_om_omt>
+{
+    if( value.test_array() ) {
+        auto point = tripoint_om_omt();
+        value.read( point, true );
+        return inclusive_cuboid<tripoint_om_omt>( point, point );
+    }
+    if( value.test_object() ) {
+        auto jo = value.get_object();
+        auto range = inclusive_cuboid<tripoint_om_omt>();
+        mandatory( jo, false, "from", range.p_min );
+        mandatory( jo, false, "to", range.p_max );
+        return normalize_overmap_origin_range( range );
+    }
+
+    value.throw_error( R"(overmap_origin must be a point [x, y, z] or an object with "from" and "to")" );
+}
+
 struct mutable_overmap_placement_rule_remainder {
     const mutable_overmap_placement_rule *parent;
     int max = INT_MAX;
@@ -2870,6 +2904,11 @@ void overmap_special::load( const JsonObject &jo, const std::string &src )
 
         assign( jo, "city_sizes", constraints_.city_size, strict );
         assign( jo, "city_distance", constraints_.city_distance, strict );
+        if( jo.has_member( "overmap_origin" ) ) {
+            constraints_.overmap_origin = load_overmap_origin_range( jo.get_member( "overmap_origin" ) );
+        } else if( !was_loaded ) {
+            constraints_.overmap_origin.reset();
+        }
     }
 
     assign( jo, "spawns", monster_spawns_, strict );
@@ -6875,6 +6914,11 @@ int overmap::place_special_attempt( const overmap_special &special, const int ma
 
     int placed = 0;
     for( auto p = points.begin(); p != points.end(); ) {
+        if( !special.get_constraints().allows_origin( *p ) ) {
+            ++p;
+            continue;
+        }
+
         const city &nearest_city = get_nearest_city( *p );
 
         // City check is the fastest => it goes first.

--- a/src/overmap_special.h
+++ b/src/overmap_special.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <bitset>
 #include <list>
+#include <optional>
 #include <set>
 #include <vector>
 #include <array>
@@ -12,6 +13,7 @@
 
 #include "coordinates.h"
 #include "cube_direction.h"
+#include "cuboid_rectangle.h"
 #include "flat_set.h"
 #include "memory_fast.h"
 #include "omdata.h"
@@ -89,6 +91,11 @@ struct overmap_special_placement_constraints {
     numeric_interval<int> city_size{ 0, INT_MAX };
     numeric_interval<int> city_distance{ 0, INT_MAX };
     numeric_interval<int> occurrences;
+    std::optional<inclusive_cuboid<tripoint_om_omt>> overmap_origin;
+
+    auto allows_origin( const tripoint_om_omt &p ) const -> bool {
+        return !overmap_origin || overmap_origin->contains( p );
+    }
 };
 
 enum class overmap_special_subtype {
@@ -262,4 +269,3 @@ class overmap_special_batch
         std::vector<overmap_special_placement> placements;
         point_abs_om origin_overmap;
 };
-

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -202,8 +202,8 @@ TEST_CASE("overmap_special_exact_origin_restricts_placement", "[overmap]") {
 
     CHECK_FALSE(ACTIVE_OVERMAP_BUFFER.place_special(
         special.id, project_combine(point_abs_om::zero(), blocked_a), 0, 0));
-    CHECK(ACTIVE_OVERMAP_BUFFER.place_special(
-        special.id, project_combine(point_abs_om::zero(), allowed), 0, 0));
+    CHECK(ACTIVE_OVERMAP_BUFFER
+              .place_special(special.id, project_combine(point_abs_om::zero(), allowed), 0, 0));
     CHECK(om.check_overmap_special_type(special.id, allowed));
     CHECK_FALSE(om.check_overmap_special_type(special.id, blocked_a));
 }
@@ -220,8 +220,8 @@ TEST_CASE("overmap_special_origin_range_restricts_placement", "[overmap]") {
 
     CHECK_FALSE(ACTIVE_OVERMAP_BUFFER.place_special(
         special.id, project_combine(point_abs_om::zero(), blocked), 0, 0));
-    CHECK(ACTIVE_OVERMAP_BUFFER.place_special(
-        special.id, project_combine(point_abs_om::zero(), allowed), 0, 0));
+    CHECK(ACTIVE_OVERMAP_BUFFER
+              .place_special(special.id, project_combine(point_abs_om::zero(), allowed), 0, 0));
     CHECK(om.check_overmap_special_type(special.id, allowed));
     CHECK_FALSE(om.check_overmap_special_type(special.id, blocked));
 }

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -190,6 +190,42 @@ TEST_CASE("mutable_overmap_placement", "[overmap][slow]") {
     }
 }
 
+TEST_CASE("overmap_special_exact_origin_restricts_placement", "[overmap]") {
+    clear_all_state();
+    const auto& special = *overmap_special_id("test_exact_origin");
+    auto& om = ACTIVE_OVERMAP_BUFFER.get(point_abs_om::zero());
+
+    const auto blocked_a = tripoint_om_omt(7, 20, 0);
+    const auto allowed = tripoint_om_omt(10, 20, 0);
+    om.ter_set(blocked_a, oter_id("field"));
+    om.ter_set(allowed, oter_id("field"));
+
+    CHECK_FALSE(ACTIVE_OVERMAP_BUFFER.place_special(
+        special.id, project_combine(point_abs_om::zero(), blocked_a), 0, 0));
+    CHECK(ACTIVE_OVERMAP_BUFFER.place_special(
+        special.id, project_combine(point_abs_om::zero(), allowed), 0, 0));
+    CHECK(om.check_overmap_special_type(special.id, allowed));
+    CHECK_FALSE(om.check_overmap_special_type(special.id, blocked_a));
+}
+
+TEST_CASE("overmap_special_origin_range_restricts_placement", "[overmap]") {
+    clear_all_state();
+    const auto& special = *overmap_special_id("test_origin_range");
+    auto& om = ACTIVE_OVERMAP_BUFFER.get(point_abs_om::zero());
+
+    const auto blocked = tripoint_om_omt(28, 40, 0);
+    const auto allowed = tripoint_om_omt(30, 40, 0);
+    om.ter_set(blocked, oter_id("field"));
+    om.ter_set(allowed, oter_id("field"));
+
+    CHECK_FALSE(ACTIVE_OVERMAP_BUFFER.place_special(
+        special.id, project_combine(point_abs_om::zero(), blocked), 0, 0));
+    CHECK(ACTIVE_OVERMAP_BUFFER.place_special(
+        special.id, project_combine(point_abs_om::zero(), allowed), 0, 0));
+    CHECK(om.check_overmap_special_type(special.id, allowed));
+    CHECK_FALSE(om.check_overmap_special_type(special.id, blocked));
+}
+
 #if defined(TILES)
 
 // Regression tests for issue #9688: the main view and the (possibly shared) overmap


### PR DESCRIPTION
## Purpose of change (The Why)
No way to specify an exact location for a special currently.

## Describe the solution (The How)
Adds `overmap_origin` which allows mod makers to specify exact coordinates or coordinate ranges for their specials to spawn. This enables mods to do things similar to the Massachusetts mod, where specific locations will always spawn in the same direction/relative location on the world map.

## Describe alternatives you've considered

## Testing
Changed a special to spawn at 0, 0. Spawned in a new world and teleported there, ensured it spawned in the correct place.
## Additional context

## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [X] This PR used AI assistance.
  - [X] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).<!-- BEGIN docs comment -->

## Translations

| post                              | changed | stale | missing |
| --------------------------------- | ------- | ----- | ------- |
| mod/json/reference/map/overmap.md | en      | ko    | ja      |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b4c6188](https://github.com/cataclysmbn/Cataclysm-BN/commit/b4c618863526615a18ebc682fe4fb8137ee2b251) (style(autofix.ci): automated formatting) on 2026-08-18 00:43:40

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32080229570)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32080229570)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32080229570)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32080229570)
<!-- END artifact comment -->