### PR TITLE
fix(mods/Arcana): allow deactivating rebuilt anomaly mech

### DIFF
--- a/data/mods/Arcana_BN/monsters/monsters.json
+++ b/data/mods/Arcana_BN/monsters/monsters.json
@@ -1007,7 +1007,7 @@
     "regenerates": 1,
     "mech_battery": "arcana_mech_power_cell",
     "mech_weapon": "arcana_mech_laser",
-    "revert_to_itype": "broken_mech_arcana",
+    "revert_to_itype": "bot_mech_arcana",
     "death_function": [ "BROKEN" ],
     "flags": [
       "SEES",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fix a thing pointed out in discord.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Correctly specified `bot_mech_arcana` as the revert for deployed mechs.

## Describe alternatives you've considered

Also letting you turn the boss version into a usable mech this way? It's currently intended behavior that you have to actually defeat it and recreate a version that isn't autonomous however.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

I can read :D

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1615c00](https://github.com/cataclysmbn/Cataclysm-BN/commit/1615c003c300797801f8302f0a882e2e45a1da74) (Update monsters.json) on 2026-08-18 19:20:15

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32173479432/artifacts/9338689250)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32173479432)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32173479432)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32173479432)
<!-- END artifact comment -->