### PR TITLE
fix: flying no longer breaks stairs, different message on trying to ascend at max height

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -14217,8 +14217,13 @@ void game::vertical_move( int movez, bool force, bool peeking )
                         get_avatar().mutation_spend_resources( tid );
                     }
                 }
-                add_msg( m_info, _( "There is something above blocking your way." ) );
-                return;
+                if( dest.z() > OVERMAP_HEIGHT ) {
+                    add_msg( m_info, _( "It would be unsafe to try and ascend further." ) );
+                    return;
+                } else {
+                    add_msg( m_info, _( "There is something above blocking your way." ) );
+                    return;
+                }
             } else {
                 if( dest.z() > OVERMAP_HEIGHT ) {
                     add_msg( m_info, _( "Tried to move outside of zlevel world bounds." ) );
@@ -14395,7 +14400,8 @@ void game::vertical_move( int movez, bool force, bool peeking )
     // Find the corresponding staircase
     bool rope_ladder = false;
     // TODO: Remove the stairfinding, make the mapgen gen aligned maps
-    const bool special_move = climbing || swimming || can_fly;
+    // Don't check can_fly here, flight was handled earlier and doing that would just embed you in a wall instead
+    const bool special_move = climbing || swimming;
 
     if( !force && !special_move ) {
         const std::optional<tripoint_bub_ms> pnt = find_or_make_stairs( m, z_after, rope_ladder,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Fixes an issue where having wings active while going up or down stairs would embed you in the wall if the stairs aren't directly connected, and another minor lil extra improvement to flight stuff.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In game.cpp, changed `game::vertical_move` so that the definition of `special_move` ignores whether you can fly, because this section of the code is used solely for trying to find stairs and is well past the part of the code where flight is actually handled.
2. Also in `game::vertical_move`, set it so that the message that prints if you can't ascend changes to the same one when you're trying to ascend out of bounds in a vehicle if you're at max height, because "there's something blocking the way" is a weird message to print when you're at max height and implies the world has an invisible ceiling.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Used a test save with offset stairs and active bird wings, confirmed I no longer teleport into walls when I use the stairs.
3. Flew up and down repeatedly, confirmed that flight still works, as expected since the if statements that control actually flying are handled way before the edited section.
4. Confirmed that the normal message still prints if I try and fail to fly up through the roof over the stairs, while reaching max height prints the correct message instead.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c95cbd1](https://github.com/cataclysmbn/Cataclysm-BN/commit/c95cbd11d7ff275754b239352a455f9ccd8d5c8a) (fix: flying no longer breaks stairs, different message on trying to ascend at max height) on 2026-08-18 23:43:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32195518629/artifacts/9345950972)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32195518629)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32195518629/artifacts/9345988631)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32195518629/artifacts/9346056259)
<!-- END artifact comment -->