### PR TITLE
fix: allow `allowed_items` and `restricts_gear` to be extended and deleted

### DIFF
--- a/src/generic_readers.h
+++ b/src/generic_readers.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <vector>
+#include "bodypart.h"
 #include "calendar.h"
 #include "debug.h"
 #include "json.h"
@@ -471,5 +472,16 @@ inline bool legacy_volume_reader( const JsonObject &jo, const std::string &membe
     value = legacy_value * units::legacy_volume_factor;
     return true;
 }
+
+/**
+ * Loads string_id from JSON
+ */
+class bodypart_reader : public generic_typed_reader<bodypart_reader>
+{
+    public:
+        body_part get_next( JsonIn &jin ) const {
+            return get_body_part_token( jin.get_string() );
+        }
+};
 
 

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -1,4 +1,5 @@
 #include "mutation_data.h" // IWYU pragma: associated
+#include "generic_readers.h"
 #include "mutation.h" // IWYU pragma: associated
 
 #include <array>
@@ -459,6 +460,8 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "changes_to", replacements, trait_reader{} );
     optional( jo, was_loaded, "leads_to", additions, trait_reader{} );
     optional( jo, was_loaded, "flags", flags, auto_flags_reader<trait_flag_str_id> {} );
+    optional( jo, was_loaded, "allowed_items", allowed_items, auto_flags_reader<flag_id> {} );
+    optional( jo, was_loaded, "restricts_gear", restricts_gear, bodypart_reader{} );
     optional( jo, was_loaded, "types", types, string_reader{} );
     optional( jo, was_loaded, "enchantments", enchantments );
     if( jo.has_array( "mut_enchantments" ) ) {
@@ -534,14 +537,6 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
         std::string part_id = ec.next_string();
         int enc = ec.next_int();
         encumbrance_covered[get_body_part_token( part_id )] = enc;
-    }
-
-    for( const std::string line : jo.get_array( "restricts_gear" ) ) {
-        restricts_gear.insert( get_body_part_token( line ) );
-    }
-
-    for( const std::string line : jo.get_array( "allowed_items" ) ) {
-        allowed_items.insert( flag_id( line ) );
     }
 
     for( JsonObject ao : jo.get_array( "armor" ) ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Request from @NobleJake 

## Describe the solution (The How)
Make them use optional, which is required for `extend` and `delete` support

## Describe alternatives you've considered
None

## Testing
Everything still works as before, generic readers always support `extend` and `delete` in lists

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] The JSON loading is standard behavior so no docs are needed

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [92e6491](https://github.com/cataclysmbn/Cataclysm-BN/commit/92e64914e503ec283a77c71e1f24dd7b5a497ac8) (fix: allow `allowed_items` and `restricts_gear` to be extended and deleted) on 2026-08-19 23:43:04

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32309272290/artifacts/9387173005)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32309272290)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32309272290/artifacts/9387134649)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32309272290/artifacts/9386394224)
<!-- END artifact comment -->