### PR TITLE
feat(mods/Arcana): use climate control enchantment value where needed, related fixes

### DIFF
--- a/data/mods/Arcana_BN/effects.json
+++ b/data/mods/Arcana_BN/effects.json
@@ -242,7 +242,8 @@
     "max_duration": "120 m",
     "max_intensity": 120,
     "int_dur_factor": "1 m",
-    "flags": [ "EFFECT_COLD_IMMUNE" ]
+    "flags": [ "EFFECT_COLD_IMMUNE" ],
+    "base_enchantments": [ { "values": [ { "value": "CLIMATE_CONTROL_HEATING", "add": 5000 } ] } ]
   },
   {
     "type": "effect_type",
@@ -293,7 +294,7 @@
     "type": "effect_type",
     "id": "heat_ward",
     "name": [ "Ward Against Flame" ],
-    "desc": [ "Complete immunity to fire, and to side effectsc from heat or smoke." ],
+    "desc": [ "Complete immunity to fire, and to side effects from heat or smoke." ],
     "remove_message": "You feel a strange tingling sensation, as the ward against flame fades.",
     "removes_effects": [ "onfire", "smoke", "hot", "blisters", "hot_speed" ],
     "decay_messages": [ [ "The ward against flame is waning.", "bad" ] ],
@@ -301,7 +302,8 @@
     "max_duration": "120 m",
     "max_intensity": 120,
     "int_dur_factor": "1 m",
-    "flags": [ "EFFECT_HEAT_IMMUNE" ]
+    "flags": [ "EFFECT_HEAT_IMMUNE" ],
+    "base_enchantments": [ { "values": [ { "value": "CLIMATE_CONTROL_COOLING", "add": 5000 } ] } ]
   },
   {
     "type": "effect_type",
@@ -1202,7 +1204,7 @@
     "name": [ "Drain Life" ],
     "desc": [ "A strange radiance permeates your body, draining life from your foes with each strike." ],
     "remove_message": "You feel momentarily weak as your life-draining spell fades.",
-    "decay_messages": [ [ "You feel your lift-draining spell fading.", "bad" ] ],
+    "decay_messages": [ [ "You feel your life-draining spell fading.", "bad" ] ],
     "rating": "good",
     "max_duration": "120 m",
     "max_intensity": 120,

--- a/data/mods/Arcana_BN/items/tool_armor.json
+++ b/data/mods/Arcana_BN/items/tool_armor.json
@@ -496,7 +496,8 @@
             { "value": "ARMOR_LIGHT", "multiply": -0.5 },
             { "value": "ARMOR_DARK", "multiply": -0.5 },
             { "value": "ARMOR_PSI", "multiply": -0.5 },
-            { "value": "ARMOR_ACID", "multiply": -0.5 }
+            { "value": "ARMOR_ACID", "multiply": -0.5 },
+            { "value": "CLIMATE_CONTROL", "add": 750 }
           ]
         }
       ]
@@ -545,9 +546,6 @@
         "COMBAT_NPC_ON"
       ]
     },
-    "relic_data": {
-      "passive_effects": [ { "conditions": [ "WORN", "ACTIVE" ], "values": [ { "value": "CLIMATE_CONTROL", "add": 750 } ] } ]
-    },
     "qualities": [ [ "HV_INSULATION", 1 ] ]
   },
   {
@@ -568,11 +566,7 @@
       "passive_effects": [
         {
           "conditions": [ "WORN", "ACTIVE" ],
-          "values": [
-            { "value": "ARMOR_HEAT", "multiply": -1.0 },
-            { "value": "ARMOR_STAB", "multiply": -1.0 },
-            { "value": "ARMOR_BULLET", "multiply": -0.9 }
-          ]
+          "values": [ { "value": "ARMOR_BULLET", "multiply": -0.9 }, { "value": "CLIMATE_CONTROL_COOLING", "add": 1500 } ]
         }
       ]
     },
@@ -613,9 +607,6 @@
     "qualities": [ [ "GLARE", 1 ] ],
     "extend": {
       "flags": [ "GAS_PROOF", "RAD_PROOF", "SUN_GLASSES", "CUT_IMMUNE", "STAB_IMMUNE", "HEAT_IMMUNE", "UNBREAKABLE", "COMBAT_NPC_ON" ]
-    },
-    "relic_data": {
-      "passive_effects": [ { "conditions": [ "WORN", "ACTIVE" ], "values": [ { "value": "CLIMATE_CONTROL", "add": 750 } ] } ]
     }
   },
   {
@@ -714,7 +705,7 @@
       "passive_effects": [
         {
           "conditions": [ "WORN", "ACTIVE" ],
-          "values": [ { "value": "ARMOR_HEAT", "multiply": -0.5 } ],
+          "values": [ { "value": "ARMOR_HEAT", "multiply": -0.5 }, { "value": "CLIMATE_CONTROL_COOLING", "add": 1500 } ],
           "ench_effects": [ { "effect": "heat_ward", "intensity": 1 } ]
         }
       ]
@@ -741,10 +732,7 @@
     "turns_per_charge": 150,
     "revert_to": "jade_wreath",
     "use_action": { "target": "jade_wreath", "msg": "The glowing carvings on the jade wreath fade.", "type": "transform" },
-    "extend": { "flags": [ "TRADER_AVOID", "NO_TAKEOFF", "COMBAT_NPC_ON" ] },
-    "relic_data": {
-      "passive_effects": [ { "conditions": [ "WORN", "ACTIVE" ], "values": [ { "value": "CLIMATE_CONTROL", "add": 750 } ] } ]
-    }
+    "extend": { "flags": [ "TRADER_AVOID", "NO_TAKEOFF", "COMBAT_NPC_ON" ] }
   },
   {
     "id": "meteoric_talisman",

--- a/data/mods/Arcana_BN/items/tools.json
+++ b/data/mods/Arcana_BN/items/tools.json
@@ -1644,7 +1644,7 @@
         },
         {
           "conditions": [ "WIELD", "ACTIVE" ],
-          "values": [ { "value": "ARMOR_COLD", "multiply": -0.5 } ],
+          "values": [ { "value": "ARMOR_COLD", "multiply": -1.0 }, { "value": "CLIMATE_CONTROL_HEATING", "add": 1500 } ],
           "ench_effects": [ { "effect": "cold_ward", "intensity": 1 } ]
         }
       ]

--- a/data/mods/Arcana_BN/mutations/mutations_dragonblood.json
+++ b/data/mods/Arcana_BN/mutations/mutations_dragonblood.json
@@ -170,7 +170,6 @@
     "id": "ARCANA_FIREAFFINITY",
     "name": { "str": "Elemental Affinity" },
     "points": 2,
-    "bodytemp_modifiers": [ -2500, 0 ],
     "description": "Your body feels abnormally comfortable around heat and flame, letting you tolerate its heat for longer, and reducing direct damage from fire.  You also no longer suffer any loss of speed from overheating, though other symptoms of heatstroke will still affect you.  In exchange however, any form of supernatural cold will be more harmful to you, including the touch of shadowy monsters from Beyond.",
     "valid": false,
     "category": [ "DRAGONBLOOD" ],

--- a/data/mods/Arcana_BN/spells/enchantments.json
+++ b/data/mods/Arcana_BN/spells/enchantments.json
@@ -16,7 +16,7 @@
     "type": "enchantment",
     "id": "ENCH_DRAGONBLOOD_ELEMENTAL_AFFINITY",
     "condition": "ALWAYS",
-    "values": [ { "value": "ARMOR_COLD", "multiply": 0.5 } ],
+    "values": [ { "value": "ARMOR_COLD", "multiply": 0.5 }, { "value": "CLIMATE_CONTROL_COOLING", "add": 2500 } ],
     "ench_effects": [ { "effect": "heat_ward_dragonblood", "intensity": 1 } ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Moar JSON modernization/fixes.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Converted Elemental Affinity to use `CLIMATE_CONTROL_COOLING` instead of bodytemp modifier hackery. Dragonfire still gains the advantage of losing its bonus heat when you're already hot.
2. Added `CLIMATE_CONTROL_HEATING` and `CLIMATE_CONTROL_COOLING` values to Flame Ward and Cold Ward respectively.
3. Removed redundant armor enchantment values from hjae hauberk, as it already grants immunity to cutting, stabbing, and heat damage via item flags.
4. Fixed several enchanted items having climate control relic data on the active state that'd get overridden by the inactive state anyway.
5. Misc: Couple smol typo fixes.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in ttest build.
3. Confirmed climate control effect cools me down in summer when I gain Elemental Affinity.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a5bdb6e](https://github.com/cataclysmbn/Cataclysm-BN/commit/a5bdb6e4c2e5bb18a0f0eacd34283e5e5682e478) (feat(mods/Arcana): use climate control enchantment value where needed, related fixes) on 2026-08-20 00:24:30

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32311632740/artifacts/9388229405)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32311632740)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32311632740/artifacts/9388082643)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32311632740/artifacts/9387133794)
<!-- END artifact comment -->