### PR TITLE
feat(balance): reimplement mininuke recipe

### DIFF
--- a/data/json/obsoletion/recipes.json
+++ b/data/json/obsoletion/recipes.json
@@ -648,11 +648,6 @@
   },
   {
     "type": "recipe",
-    "result": "mininuke",
-    "obsolete": true
-  },
-  {
-    "type": "recipe",
     "result": "mirrorfrom_steel",
     "obsolete": true
   },

--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -441,5 +441,29 @@
     "using": [ [ "steel_standard", 10 ], [ "welding_standard", 10 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 }, { "id": "DRILL", "level": 2 } ],
     "components": [ [ [ "military_explosive", 3500, "LIST" ] ], [ [ "impact_fuze", 1 ] ], [ [ "steel_plate", 5 ] ] ]
+  },
+  {
+    "result": "mininuke",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_EXPLOSIVE",
+    "skill_used": "electronics",
+    "skills_required": [ [ "fabrication", 6 ], [ "mechanics", 8 ] ],
+    "difficulty": 10,
+    "time": "1 h 30 m",
+    "book_learn": [ [ "recipe_lab_elec", 7 ], [ "recipe_mininuke_launch", 9 ] ],
+    "reversible": true,
+    "decomp_learn": 8,
+    "using": [ [ "soldering_standard", 50 ], [ "welding_standard", 10 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
+    "components": [
+      [ [ "cable", 12 ] ],
+      [ [ "military_explosive", 25, "LIST" ] ],
+      [ [ "circuit", 6 ] ],
+      [ [ "plut_cell", 10 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "sheet_metal_small", 48 ], [ "sheet_metal", 2 ] ],
+      [ [ "small_storage_battery", 2 ] ]
+    ]
   }
 ]

--- a/data/json/uncraft/cbm/cbm.json
+++ b/data/json/uncraft/cbm/cbm.json
@@ -18,6 +18,22 @@
   },
   {
     "type": "uncraft",
+    "result": "afs_bio_missiles",
+    "skill_used": "electronics",
+    "difficulty": 10,
+    "time": "50 m",
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
+    "components": [
+      [ [ "mininuke", 1 ] ],
+      [ [ "processor", 1 ] ],
+      [ [ "self_monitoring_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "cable", 4 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
     "result": "bio_armor_arms",
     "skill_used": "electronics",
     "difficulty": 6,

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -2562,32 +2562,6 @@
     "flags": [ "BLIND_NO_EFFECT" ]
   },
   {
-    "result": "mininuke",
-    "type": "uncraft",
-    "time": "3 h",
-    "skill_used": "electronics",
-    "difficulty": 8,
-    "skills_required": [ [ "fabrication", 4 ], [ "mechanics", 6 ] ],
-    "using": [ [ "soldering_standard", 150 ], [ "welding_standard", 6 ] ],
-    "qualities": [
-      { "id": "SCREW", "level": 1 },
-      { "id": "SCREW_FINE", "level": 1 },
-      { "id": "WRENCH", "level": 2 },
-      { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "SAW_M", "level": 2 },
-      { "id": "SAW_M_FINE", "level": 1 }
-    ],
-    "components": [
-      [ [ "cable", 12 ] ],
-      [ [ "chem_rdx", 20 ] ],
-      [ [ "circuit", 6 ] ],
-      [ [ "plut_cell", 6 ] ],
-      [ [ "power_supply", 1 ] ],
-      [ [ "scrap", 200 ] ],
-      [ [ "small_storage_battery", 2 ] ]
-    ]
-  },
-  {
     "result": "money_bundle",
     "type": "uncraft",
     "time": "30 s",

--- a/data/mods/Aftershock/recipes/recipes.json
+++ b/data/mods/Aftershock/recipes/recipes.json
@@ -17,29 +17,6 @@
     ]
   },
   {
-    "result": "mininuke",
-    "type": "recipe",
-    "category": "CC_WEAPON",
-    "subcategory": "CSC_WEAPON_EXPLOSIVE",
-    "skill_used": "mechanics",
-    "skills_required": [ "electronics", 5 ],
-    "difficulty": 10,
-    "time": 360000,
-    "reversible": true,
-    "decomp_learn": 10,
-    "book_learn": [ [ "textbook_atomic_lab", 5 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
-    "components": [
-      [ [ "canister_empty", 1 ] ],
-      [ [ "grenade", 1 ], [ "40x46mm_m433", 2 ] ],
-      [ [ "plut_cell", 6 ] ],
-      [ [ "amplifier", 3 ] ],
-      [ [ "power_supply", 1 ] ],
-      [ [ "clockworks", 1 ] ],
-      [ [ "cable", 15 ] ]
-    ]
-  },
-  {
     "result": "light_battery_cell",
     "id_suffix": "afs_plutonium_battery",
     "type": "recipe",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Me want big boom and big boom accessories.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Revived ye olde recipe for mininukes, based it off the disassembly recipe but with some changes:
 * Difficulty bumped up by 2 levels overall, making it require 10 electronics, 6 fabrication, and 8 mechanics (compare the original recipe requiring 10 mechanics and 5 electronics).
 * Time requirement cut in half from 3 hours to an hour and a half.
 * Added booklearns, `recipe_lab_elec` was kept as with the original recipe but also added `recipe_mininuke_launch` like the booklearns for modified mininukes, level requirements set to level 6 for `recipe_lab_elec` (2 higher than its original incarnation), 9 for `recipe_mininuke_launch` (de-facto inverting the relationship the books have for modified miniukes where the launcher book is the better source for the recipe).
 * Set to be `reversible` with a `decomp_learn` of 8.
 * Lowered required `soldering_standard` from a downright goofy 150 to just 50, but in exchange increased required `welding_standard` from 6 to 10.
 * Sanity-checked tool qualities needed to just use fine versions of the qualities called for.
 * Instead of only 20 RDX it uses the same amount of `military_explosive` used by a frag grenade plus a timed fuze (in reference to its original recipe where a grenade was one of the main options for the explosive), the number of plutonium cells was increased from 6 to 10, and the 200 scrap metal was replaced with 2 sheet metal or 48 small metal sheets (slight increase in material, as 40 small sheets would equal 200 scrap).
2. Accordingly removed the now-unneeded uncraft for mininukes and old obsoletion entry for mininuke recipe.
3. Remove old copy of recipe from Aftershock.
4. Bonus fun: added an uncraft for minirose CBM that yields a mininuke, since it's also useful to have if you find one and don't need to commit sudoku except with city blocks as the grid squares.

## Describe alternatives you've considered

<img width="400" height="214" alt="tumblr_aa0a89c71481f2455452e89df0048f22_6df3e0a4_400" src="https://github.com/user-attachments/assets/0bc432c7-5592-4ef7-a328-4e30cc2f79aa" />

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Relevant PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/25115

<img width="236" height="237" alt="image" src="https://github.com/user-attachments/assets/effb9ee9-7bdd-4898-99bd-c95214191259" />

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9abf9e1](https://github.com/cataclysmbn/Cataclysm-BN/commit/9abf9e18a38c42e808604301ae2c8254f335c43a) (feat(balance): reimplement mininuke recipe) on 2026-08-20 07:39:28

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32339489708/artifacts/9396098380)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32339489708/artifacts/9397644065)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32339489708/artifacts/9396110721)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32339489708/artifacts/9396247823)
<!-- END artifact comment -->