### PR TITLE
feat(balance): increase variety of military item/monsterdrop spawns, rebalance 6.8mm ammo, fixes for empty MBR vest and tactical outfit

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -111,6 +111,26 @@
     ]
   },
   {
+    "id": "clothing_military_bioop",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "Used by bio-operators, replaces the standard blouse and pants with tactical version.",
+    "items": [
+      { "group": "clothing_soldier_shirt" },
+      { "item": "jacket_tacticool" },
+      { "item": "pants_tacticool" },
+      { "item": "webbing_belt" },
+      { "distribution": [ { "item": "socks", "prob": 95 }, { "item": "socks_wool", "prob": 5 } ] },
+      { "item": "boots_combat" },
+      {
+        "distribution": [
+          { "collection": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] },
+          { "distribution": [ { "item": "briefs" }, { "item": "boxer_briefs" }, { "item": "boxer_shorts" } ] }
+        ]
+      }
+    ]
+  },
+  {
     "id": "clothing_military_distribution",
     "type": "item_group",
     "subtype": "distribution",
@@ -243,6 +263,124 @@
           { "item": "goggles_ir", "prob": 5 }
         ],
         "prob": 20
+      },
+      { "group": "clothing_watch", "prob": 5 }
+    ]
+  },
+  {
+    "id": "clothing_soldier_set_elite",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "Standard (non-winter) set of clothes and combat gear worn by elite soldiers and paramilitary forces.",
+    "items": [
+      { "distribution": [ { "group": "clothing_military", "prob": 80 }, { "group": "clothing_military_bioop", "prob": 20 } ] },
+      { "item": "elbow_pads", "prob": 10 },
+      { "item": "knee_pads", "prob": 85 },
+      {
+        "distribution": [
+          { "item": "beret", "prob": 25 },
+          { "collection": [ { "item": "helmet_army" }, { "item": "mask_bal", "prob": 25 } ], "prob": 50 },
+          { "collection": [ { "item": "tac_helmet" }, { "item": "mask_bal", "prob": 25 } ], "prob": 15 },
+          { "item": "tac_fullhelmet", "prob": 10 }
+        ],
+        "prob": 80
+      },
+      { "item": "gloves_tactical", "prob": 60 },
+      {
+        "distribution": [
+          { "item": "modularvestceramic", "prob": 25 },
+          { "item": "modularvest", "prob": 10 },
+          { "item": "modularveststeel", "prob": 5 },
+          { "item": "modularvesthard", "prob": 5 },
+          { "item": "modularvestsuper", "prob": 5 },
+          { "item": "dragonskin", "prob": 15 },
+          { "item": "dragonskinempty", "prob": 5 },
+          { "item": "exosuit_military", "prob": 5 }
+        ],
+        "prob": 90
+      },
+      {
+        "distribution": [ { "item": "nature_ghillie", "prob": 50 }, { "item": "urban_ghillie", "prob": 50 } ],
+        "prob": 10
+      },
+      { "distribution": [ { "item": "molle_pack", "prob": 75 }, { "item": "rucksack", "prob": 25 } ], "prob": 85 },
+      { "group": "clothing_tactical_leg", "prob": 15 },
+      {
+        "distribution": [
+          { "group": "clothing_glasses", "prob": 50 },
+          { "item": "glasses_bal", "prob": 25 },
+          { "item": "mil_scouter", "prob": 10 },
+          { "item": "goggles_nv", "prob": 5 },
+          { "item": "goggles_nv_enhanced", "prob": 5 },
+          { "item": "goggles_ir", "prob": 5 }
+        ],
+        "prob": 30
+      },
+      { "group": "clothing_watch", "prob": 5 }
+    ]
+  },
+  {
+    "id": "clothing_soldier_winter_set_elite",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "Winter set of clothes and combat gear worn by elite soldiers and paramilitary forces.",
+    "items": [
+      {
+        "distribution": [ { "group": "clothing_military_winter", "prob": 80 }, { "group": "clothing_military_bioop", "prob": 20 } ]
+      },
+      { "item": "elbow_pads", "prob": 10 },
+      { "item": "knee_pads", "prob": 85 },
+      {
+        "distribution": [
+          { "item": "beret_wool", "prob": 25 },
+          {
+            "collection": [ { "item": "helmet_army" }, { "item": "helmet_liner" }, { "item": "mask_bal", "prob": 25 } ],
+            "prob": 50
+          },
+          {
+            "collection": [ { "item": "tac_helmet" }, { "item": "helmet_liner" }, { "item": "mask_bal", "prob": 25 } ],
+            "prob": 15
+          },
+          { "collection": [ { "item": "tac_fullhelmet" }, { "item": "helmet_liner" } ], "prob": 10 }
+        ],
+        "prob": 80
+      },
+      {
+        "collection": [
+          { "distribution": [ { "item": "gloves_liner", "prob": 75 }, { "item": "gloves_liner_wool", "prob": 25 } ], "prob": 60 },
+          { "item": "winter_gloves_army" }
+        ],
+        "prob": 80
+      },
+      {
+        "distribution": [ { "item": "nature_ghillie", "prob": 50 }, { "item": "urban_ghillie", "prob": 50 } ],
+        "prob": 10
+      },
+      {
+        "distribution": [
+          { "item": "modularvestceramic", "prob": 25 },
+          { "item": "modularvest", "prob": 10 },
+          { "item": "modularveststeel", "prob": 5 },
+          { "item": "modularvesthard", "prob": 5 },
+          { "item": "modularvestsuper", "prob": 5 },
+          { "item": "dragonskin", "prob": 15 },
+          { "item": "dragonskinempty", "prob": 5 },
+          { "item": "exosuit_military", "prob": 5 }
+        ],
+        "prob": 90
+      },
+      { "distribution": [ { "item": "molle_pack", "prob": 75 }, { "item": "rucksack", "prob": 25 } ], "prob": 85 },
+      { "group": "clothing_tactical_leg", "prob": 15 },
+      {
+        "distribution": [
+          { "group": "clothing_glasses", "prob": 50 },
+          { "item": "glasses_bal", "prob": 25 },
+          { "item": "mil_scouter", "prob": 10 },
+          { "item": "goggles_nv", "prob": 5 },
+          { "item": "goggles_nv_enhanced", "prob": 5 },
+          { "item": "goggles_ir", "prob": 5 }
+        ],
+        "prob": 30
       },
       { "group": "clothing_watch", "prob": 5 }
     ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -1097,6 +1097,23 @@
     ]
   },
   {
+    "id": "everyday_hk417_13_grenadier",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
+    "subtype": "collection",
+    "entries": [
+      {
+        "item": "hk417_13",
+        "ammo-group": "on_hand_308",
+        "charges": [ 0, 30 ],
+        "contents-group": "military_accessories_grenadier"
+      },
+      { "group": "nested_hk417_13_mag", "charges-min": 0, "prob": 80 },
+      { "group": "nested_hk417_13_mag", "charges-min": 0, "prob": 50 },
+      { "group": "on_hand_308", "prob": 25, "charges": [ 10, 20 ], "count": [ 1, 2 ] }
+    ]
+  },
+  {
     "id": "everyday_iwi_tavor_x95_300blk",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
@@ -1363,6 +1380,18 @@
     "subtype": "collection",
     "entries": [
       { "item": "m7", "ammo-group": "on_hand_277", "charges": [ 0, 20 ] },
+      { "group": "nested_m7_mag", "charges-min": 0, "prob": 80 },
+      { "group": "nested_m7_mag", "charges-min": 0, "prob": 50 },
+      { "group": "on_hand_277", "prob": 25, "charges": [ 10, 20 ], "count": [ 1, 2 ] }
+    ]
+  },
+  {
+    "id": "everyday_m7_grenadier",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
+    "subtype": "collection",
+    "entries": [
+      { "item": "m7", "ammo-group": "on_hand_277", "charges": [ 0, 30 ], "contents-group": "military_accessories_grenadier" },
       { "group": "nested_m7_mag", "charges-min": 0, "prob": 80 },
       { "group": "nested_m7_mag", "charges-min": 0, "prob": 50 },
       { "group": "on_hand_277", "prob": 25, "charges": [ 10, 20 ], "count": [ 1, 2 ] }

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -84,11 +84,13 @@
     "//": "Mainly the standard rifles that an Army/Marine rifleman, Army TL, or Marine assistant automatic rifleman would use, but allow a handful of Ranger and Delta Force rifles",
     "subtype": "distribution",
     "entries": [
-      { "group": "everyday_m4a1_military", "prob": 75, "charges": [ 0, 30 ] },
+      { "group": "everyday_m4a1_military", "prob": 65, "charges": [ 0, 30 ] },
+      { "item": "m16a4", "prob": 5, "charges": [ 0, 30 ], "contents-group": "military_accessories_standard" },
       { "group": "everyday_m27iar_military", "prob": 10, "charges": [ 0, 30 ] },
       { "group": "everyday_h&k416a5_military", "prob": 5, "charges": [ 0, 30 ] },
+      { "group": "everyday_hk417_13", "prob": 5, "charges": [ 0, 30 ] },
       { "group": "everyday_scar_h_military", "prob": 5, "charges": [ 0, 30 ] },
-      { "item": "m16a4", "prob": 5, "charges": [ 0, 30 ], "contents-group": "military_accessories_standard" }
+      { "group": "everyday_m7", "prob": 5, "charges": [ 0, 30 ] }
     ]
   },
   {
@@ -101,11 +103,13 @@
         "collection": [
           {
             "distribution": [
-              { "group": "everyday_m4a1_grenadier", "prob": 75, "charges": [ 0, 30 ] },
+              { "group": "everyday_m4a1_grenadier", "prob": 65, "charges": [ 0, 30 ] },
+              { "item": "m16a4", "prob": 5, "charges": [ 0, 30 ], "contents-group": "military_accessories_grenadier" },
               { "group": "everyday_m27iar_grenadier", "prob": 10, "charges": [ 0, 30 ] },
               { "group": "everyday_h&k416a5_grenadier", "prob": 5, "charges": [ 0, 30 ] },
+              { "group": "everyday_hk417_13_grenadier", "prob": 5, "charges": [ 0, 30 ] },
               { "group": "everyday_scar_h_grenadier", "prob": 5, "charges": [ 0, 30 ] },
-              { "item": "m16a4", "prob": 5, "charges": [ 0, 30 ], "contents-group": "military_accessories_grenadier" }
+              { "group": "everyday_m7_grenadier", "prob": 5, "charges": [ 0, 30 ] }
             ]
           },
           { "group": "on_hand_40x46mm" }
@@ -151,9 +155,10 @@
     "//": "Mostly LMGs but allows the occasional GPMG too",
     "subtype": "distribution",
     "entries": [
-      { "group": "everyday_m249_military", "prob": 75, "charges": [ 0, 100 ] },
+      { "group": "everyday_m249_military", "prob": 70, "charges": [ 0, 100 ] },
       { "group": "everyday_m27iar_fire_support", "prob": 15, "charges": [ 0, 100 ] },
-      { "group": "everyday_m240_military", "prob": 10, "charges": [ 0, 100 ] }
+      { "group": "everyday_m240_military", "prob": 10, "charges": [ 0, 100 ] },
+      { "group": "everyday_m250", "prob": 5, "charges": [ 0, 100 ] }
     ]
   },
   {
@@ -162,9 +167,10 @@
     "subtype": "distribution",
     "entries": [
       { "group": "everyday_m9", "prob": 30, "charges": [ 0, 15 ] },
-      { "group": "everyday_m17", "prob": 65, "charges": [ 0, 17 ] },
-      { "group": "everyday_glock_19", "prob": 3, "charges": [ 0, 15 ] },
-      { "group": "everyday_m1911_MEU", "prob": 2, "charges": [ 0, 7 ] }
+      { "group": "everyday_m17", "prob": 50, "charges": [ 0, 17 ] },
+      { "group": "everyday_glock_19", "prob": 5, "charges": [ 0, 15 ] },
+      { "group": "everyday_m1911_MEU", "prob": 10, "charges": [ 0, 7 ] },
+      { "group": "everyday_mk23", "prob": 5, "charges": [ 0, 12 ] }
     ]
   },
   {
@@ -191,9 +197,31 @@
     "entries": [
       { "item": "e_tool", "prob": 50 },
       { "item": "mask_gas", "prob": 20 },
-      { "item": "two_way_radio", "prob": 60 },
-      { "item": "army_powered_earmuffs", "prob": 25 },
+      {
+        "distribution": [
+          { "collection": [ { "item": "two_way_radio" }, { "item": "ear_plugs", "prob": 50 } ], "prob": 50 },
+          { "item": "army_powered_earmuffs", "prob": 50 }
+        ],
+        "prob": 75
+      },
       { "item": "sheath", "contents-item": "knife_combat", "prob": 80 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "infantry_elite_gear",
+    "subtype": "collection",
+    "entries": [
+      { "item": "e_tool", "prob": 50 },
+      { "item": "mask_gas", "prob": 20 },
+      { "item": "army_powered_earmuffs", "prob": 75 },
+      {
+        "collection": [
+          { "item": "sheath", "contents-item": "knife_combat", "prob": 80 },
+          { "item": "sheath", "contents-item": "knife_rm42", "prob": 20 }
+        ],
+        "prob": 80
+      }
     ]
   },
   {

--- a/data/json/items/ammo/277.json
+++ b/data/json/items/ammo/277.json
@@ -17,7 +17,7 @@
     "ammo_type": "277",
     "casing": "277_casing",
     "range": 65,
-    "damage": { "damage_type": "bullet", "amount": 45, "armor_penetration": 27 },
+    "damage": { "damage_type": "bullet", "amount": 59, "armor_penetration": 26 },
     "dispersion": 15,
     "recoil": 2500,
     "loudness": 164,
@@ -32,9 +32,10 @@
     "casing": "277_casing",
     "loudness": 166,
     "speed": 980,
-    "description": "A rimless cartridge that was planned to be adopted by the US military to combat advances in modern body armor, but was quietly abandoned soon after the development of caseless. These full-power Hybrid rounds offer significant armor penetration but greatly increase recoil.",
-    "relative": { "damage": { "damage_type": "bullet", "amount": 25, "armor_penetration": 30 } },
-    "proportional": { "recoil": 1.3 }
+    "description": "A rimless cartridge that was planned to be adopted by the US military to combat advances in modern body armor, but was quietly abandoned soon after the development of caseless ammo.  These full-power Hybrid rounds offer significant armor penetration but greatly increased recoil and reduced accuracy.",
+    "//": "Balanced as +p instead of AP, giving it a total damage+arpen on par with .30-06 AP but weighted more towards raw damage.",
+    "relative": { "damage": { "damage_type": "bullet", "amount": 15 } },
+    "proportional": { "dispersion": 1.25, "recoil": 1.5 }
   },
   {
     "id": "bp_277_fmj",

--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -87,7 +87,7 @@
     "color": "light_gray",
     "covers": [ "torso" ],
     "coverage": 85,
-    "encumbrance": 10,
+    "encumbrance": 15,
     "storage": "2500 ml",
     "warmth": 15,
     "material_thickness": 7,
@@ -237,7 +237,7 @@
     "resistance": { "bullet": 90 },
     "extend": { "flags": [ "NO_REPAIR" ] },
     "delete": { "flags": [ "STURDY" ] },
-    "relative": { "weight": "6 kg", "encumbrance": 15, "material_thickness": 3 },
+    "relative": { "weight": "6 kg", "encumbrance": 10, "material_thickness": 3 },
     "proportional": { "price": 1.5, "price_postapoc": 1.5, "storage": 0.4 }
   },
   {
@@ -251,7 +251,7 @@
     "material": [ "kevlar", "hardsteel" ],
     "resistance": { "bullet": 90 },
     "extend": { "flags": [ "NO_REPAIR" ] },
-    "relative": { "weight": "18 kg", "encumbrance": 20, "material_thickness": 3 },
+    "relative": { "weight": "18 kg", "encumbrance": 15, "material_thickness": 3 },
     "proportional": { "price": 1.5, "price_postapoc": 1.5, "storage": 0.4 }
   },
   {
@@ -265,7 +265,7 @@
     "material": [ "kevlar", "steel" ],
     "resistance": { "bullet": 70 },
     "extend": { "flags": [ "NO_REPAIR" ] },
-    "relative": { "weight": "12 kg", "encumbrance": 15, "material_thickness": 3 },
+    "relative": { "weight": "12 kg", "encumbrance": 10, "material_thickness": 3 },
     "proportional": { "price": 1.5, "price_postapoc": 1.5, "storage": 0.4 }
   },
   {
@@ -279,7 +279,7 @@
     "material": [ "kevlar", "superalloy" ],
     "resistance": { "bullet": 70 },
     "extend": { "flags": [ "NO_REPAIR" ] },
-    "relative": { "weight": "10800 g", "encumbrance": 10, "material_thickness": 3 },
+    "relative": { "weight": "10800 g", "encumbrance": 5, "material_thickness": 3 },
     "proportional": { "price": 1.5, "price_postapoc": 1.5, "storage": 0.4 }
   },
   {

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -434,7 +434,7 @@
     "repairs_like": "trenchcoat",
     "type": "ARMOR",
     "name": { "str_sp": "multicam black tactical shirt" },
-    "description": "I beat the government spook squad and all I got was this lousy shirt...",
+    "description": "A tough army blouse with lots of pockets, in a not-very-stealthy black camo pattern.",
     "weight": "780 g",
     "volume": "3 L",
     "price": "35 USD",

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -371,7 +371,7 @@
     "repairs_like": "jeans",
     "type": "ARMOR",
     "name": { "str_sp": "multicam black tactical pants" },
-    "description": "I beat the government spook squad and all I got were these lousy pants...",
+    "description": "A tough set of army pants lined with pockets, in a not-very-stealthy black camo pattern.",
     "weight": "720 g",
     "volume": "2500 ml",
     "price": "35 USD",

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -73,11 +73,11 @@
     "entries": [
       {
         "distribution": [
-          { "group": "clothing_soldier_set", "prob": 65, "damage": [ 1, 4 ] },
-          { "group": "clothing_soldier_winter_set", "prob": 35, "damage": [ 1, 4 ] }
+          { "group": "clothing_soldier_set_elite", "prob": 65, "damage": [ 1, 4 ] },
+          { "group": "clothing_soldier_winter_set_elite", "prob": 35, "damage": [ 1, 4 ] }
         ]
       },
-      { "group": "infantry_common_gear" },
+      { "group": "infantry_elite_gear" },
       { "group": "military_specops_guns", "prob": 40, "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ] },
       { "item": "holster" },
       { "group": "carried_guns_pistol_milspec", "prob": 100, "damage": [ 0, 2 ], "dirt": [ 0, 1500 ] },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Increases variety of items in military itemgroups to reduce the eternal dominance of 5.56mm and 9mm, and an assortment of corrections and sanity-checking involving military stuff.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Increased encumbrance of empty MBR vest from 10 to 15. Bit weird that it's more protective than a kevlar vest for the same encumbrance plus when I did the earlier rebalancing I clearly overlooked it given I set superalloy (which you'd expect to be the lighested filled vest but still be a step more encumbering than when empty) to 20 encumbrance.
2. Adjusted `relative` encumbrance modifiers of filled IOTV suits accordingly.
3. Sanity-checked 6.8x51mm ammo because holy balls it was goofy as hell, with hybrid ammo outperforming .30-06 AP in terms of combined damaged+arpen. Baseline FMJ ammo was bumped up in damage from 45 to 58, putting it in between .308 and .30-06 ammo, while its arpen was reduced to 26 to keep it consistent with standard FMJ ratios. Hybrid ammo meanwhile was balanced as +p ammo, which comes out to more combined damage+arpen pushing it to being competitive with .30-06 AP but with more weight towards damage than arpen (also compare 8x40mm caseless hitting a similar benchmark but slanted more towards arpen and less damage). In exchange their drawbacks were increased from an inconsequential 30% more recoil to 25% more dispersion and 50% more recoil.
4. Added a chance for the M7 and M250 to show up in `military_standard_assault_rifles`, `military_standard_grenadier`, and `military_standard_lmgs` along with adding a bit more potential chance to see 7.62x51mm guns show up in them.
5. Increased chance of .45 ACP guns showing up in `military_standard_pistols` to again make the variety more interesting, with a rare chance to see the mk. 23 from implied SOCOM usage.
6. Added two new collections as variations of `clothing_soldier_set` and `clothing_soldier_winter_set` for bio-operators and other elite soldier monsterdrops, which expands the variety of supplemental gear considerably, also set it so they get a variant of `infantry_common_gear` that spawns a headset more consistently and picks between a regular combat knife and an RM42 knife at random.
7. Misc: `infantry_common_gear` tweaked a lil so it spawns either a two-way radio OR a headset instead of rolling for both, and if it picks the former it has a chance to spawn ear plugs alongside it.
8. Sanity-checked the tactical pants and jacket descriptions because I specifically vetoed this goofy item being a unique boss reward due to how incredibly pointless it is and yet it got snuck into the game anyway.
9. Likewise ruining dedmem's fun by giving bio-operators a 20% chance to drop them instead of normal military clothes.

## Describe alternatives you've considered

Removing the tacticool clothes because I EXPLICITLY SAID DON'T DO THAT

<img width="880" height="732" alt="image" src="https://github.com/user-attachments/assets/de4b69ab-dc41-41e3-960c-15acd8cb45e2" />

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Debug spawned and killed a bunch of bio-operators, equipment variety seemed to be correct.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Mall ninja nonsense was snuck into https://github.com/cataclysmbn/Cataclysm-BN/pull/9852 which I failed to notice or I would've vetoed it, given we already had that discussion about making black multicam a unique boss reward purely for flavor and I said it was a dumb idea.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [446619a](https://github.com/cataclysmbn/Cataclysm-BN/commit/446619ab0dcd8b6a9b79a7321885a2b68a3c21f8) (feat (balance): increase variety of military item/monsterdrop spawns, rebalance 6.8mm ammo, fixes for empty MBR vest and tactical outfit) on 2026-08-20 10:31:12

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32353649121/artifacts/9402618920)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32353649121/artifacts/9402094256)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32353649121/artifacts/9402087636)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32353649121/artifacts/9401337267)
<!-- END artifact comment -->