### PR TITLE
fix: Innawoods might start you at sloc_campsite or sloc_campground which it does not spawn

### DIFF
--- a/data/mods/innawoods/scenarios.json
+++ b/data/mods/innawoods/scenarios.json
@@ -3,6 +3,6 @@
     "type": "scenario",
     "id": "wilderness",
     "copy-from": "wilderness",
-    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_swamp", "sloc_deserted_island" ]
+    "delete": { "allowed_locs": [ "sloc_campsite", "sloc_campground" ] }
   }
 ]

--- a/data/mods/innawoods/scenarios.json
+++ b/data/mods/innawoods/scenarios.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "scenario",
+    "id": "wilderness",
+    "copy-from": "wilderness",
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_swamp", "sloc_deserted_island" ],
+  }
+]

--- a/data/mods/innawoods/scenarios.json
+++ b/data/mods/innawoods/scenarios.json
@@ -3,6 +3,6 @@
     "type": "scenario",
     "id": "wilderness",
     "copy-from": "wilderness",
-    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_swamp", "sloc_deserted_island" ],
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_swamp", "sloc_deserted_island" ]
   }
 ]


### PR DESCRIPTION

## Purpose of change (The Why)

Innawoods might start you at sloc_campsite or sloc_campground which it does not spawn. This gives you an inescapable error (Unable to generate a valid starting location) when starting a character on an innawoods world that picks them.

## Describe the solution (The How)

Innawoods (or cheesyinnawoodsfixes for that matter) do not override `scenarios.json#wilderness` to remove `sloc_campsite` and `sloc_campground`. I have made a new `/data/mods/innawoods/scenarios.json` that does so.

## Describe alternatives you've considered

None, seems like the straightforward way to fix this.

## Testing

After fixing, I have started another character on my new innawoods world and checked their list of possible starting locations. The campground and campsite did not show up in the list of possibilities anymore.

## Additional context
  
In data/mods/innawoods/scenario_blacklist.json:
```json
[
  {
    "type": "SCENARIO_BLACKLIST",
    "subtype": "whitelist",
    "scenarios": [ "wilderness" ]
  }
]
```

In data/mods/innawoods/specials.json:
```json
{
    "type": "overmap_special",
    "id": "campsite",
    "copy-from": "campsite",
    "occurrences": [ 0, 0 ]
  },
```

and

```json
{
    "type": "overmap_special",
    "id": "campground",
    "copy-from": "campground",
    "occurrences": [ 0, 0 ]
  },
```

In data/json/scenarios.json#wilderness: `"allowed_locs": [ "sloc_field", "sloc_forest", "sloc_swamp", "sloc_campsite", "sloc_campground", "sloc_deserted_island" ],`

### Mandatory

- [X] I searched for relevant issues, but could not find any.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a84f03b](https://github.com/cataclysmbn/Cataclysm-BN/commit/a84f03ba49bd19dbf850c48a11a26749bbb796ea) (Update data/mods/innawoods/scenarios.json) on 2026-08-20 18:48:37

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32398591688/artifacts/9418980110)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32398591688/artifacts/9418906090)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32398591688/artifacts/9419184231)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32398591688/artifacts/9418170147)
<!-- END artifact comment -->