### PR TITLE
perf: cache `has_any_vehicle_floor`

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9536,6 +9536,7 @@ static void vehicle_caching_internal_above( level_cache &zch_above, const vpart_
         const tripoint_bub_ms &part_pos = v->bub_part_location( vp.part() );
         const int tile_idx = zch_above.idx( part_pos.x(), part_pos.y() );
         zch_above.vehicle_floor_cache[tile_idx] = true;
+        zch_above.has_any_vehicle_floor = true;
     }
 }
 
@@ -9599,9 +9600,8 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         levels.erase( std::ranges::unique( levels ).begin(), levels.end() );
     };
     auto level_has_vehicle_floor = []( const level_cache & ch ) {
-        return std::ranges::any_of( ch.vehicle_floor_cache, []( const char c ) {
-            return c != '\0';
-        } );
+        ZoneScopedN( "Level_Has_Vehicle_Floor" );
+        return ch.has_any_vehicle_floor;
     };
 
     // Refresh the shared weather-transparency lookup table once, serially,
@@ -9667,6 +9667,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
                 // vehicle_caching_internal_above), so it must be cleared unconditionally —
                 // not gated on veh_in_active_range — to prevent stale entries after shifts.
                 std::fill( ch.vehicle_floor_cache.begin(), ch.vehicle_floor_cache.end(), '\0' );
+                ch.has_any_vehicle_floor = false;
                 if( ch.veh_in_active_range ) {
                     const diagonal_blocks fill = {false, false};
                     std::fill( ch.vehicle_obscured_cache.begin(), ch.vehicle_obscured_cache.end(), fill );
@@ -9696,6 +9697,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
                 // vehicle_caching_internal_above), so it must be cleared unconditionally —
                 // not gated on veh_in_active_range — to prevent stale entries after shifts.
                 std::fill( ch.vehicle_floor_cache.begin(), ch.vehicle_floor_cache.end(), '\0' );
+                ch.has_any_vehicle_floor = false;
                 if( ch.veh_in_active_range ) {
                     const diagonal_blocks fill = {false, false};
                     std::fill( ch.vehicle_obscured_cache.begin(), ch.vehicle_obscured_cache.end(), fill );
@@ -9731,6 +9733,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         // otherwise such changes might be overwritten by main cache-building logic.
         // This pass must remain serial: do_vehicle_caching() writes to neighbor z-level caches.
         auto const mark_vehicle_gpu_structural_levels = [&]( const vehicle * const veh ) {
+            ZoneScopedN( "Phase3_vehicles_structural" );
             if( veh == nullptr ) {
                 return;
             }
@@ -9750,14 +9753,20 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
                 for( const vehicle *const veh : get_cache( z ).vehicle_list ) {
                     mark_vehicle_gpu_structural_levels( veh );
                 }
-                do_vehicle_caching( z );
+                {
+                    ZoneScopedN( "Phase3_vehicles_cache" );
+                    do_vehicle_caching( z );
+                }
             }
         }
-        std::ranges::for_each( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ), [&]( const int z ) {
-            if( level_has_vehicle_floor( get_cache_ref( z ) ) ) {
-                add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
-            }
-        } );
+        {
+            ZoneScopedN( "Phase3_vehicles_redirty" );
+            std::ranges::for_each( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ), [&]( const int z ) {
+                if( level_has_vehicle_floor( get_cache_ref( z ) ) ) {
+                    add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
+                }
+            } );
+        }
     }
 
     normalize_gpu_dirty_levels( gpu_transparency_dirty_levels );

--- a/src/map.h
+++ b/src/map.h
@@ -382,6 +382,7 @@ struct level_cache {
     bool visibility_cache_dirty = true;
     // Set by build_floor_cache; true when at least one tile has a floor.
     bool has_any_floor = true;
+    bool has_any_vehicle_floor = false;
     bool suspension_cache_initialized = false;
     bool suspension_cache_dirty = false;
     std::list<point_abs_ms> suspension_cache;


### PR DESCRIPTION
## Purpose of change (The Why)
I got tracy working
~~After changing the version locally~~
And I came across this:
<img width="1920" height="1080" alt="Aug20::142211" src="https://github.com/user-attachments/assets/bd17def9-bd2b-4a57-b3ef-0285e6292b15" />
Phase 3 Vehicles looked suspicious at first
Dirty Round 2? was a loop over the world checking for the first vehicle floor it could find
I added it during testing to determine what was causing the giant block of time

## Describe the solution (The How)
When initialing `vehicle_floor_cache` set new variable `has_any_vehicle_floor` to true
Reference that instead of looping over `vehicle_floor_cache`

## Describe alternatives you've considered

## Testing
Before
<img width="1920" height="1080" alt="Aug20::142211" src="https://github.com/user-attachments/assets/bd17def9-bd2b-4a57-b3ef-0285e6292b15" />
After
<img width="1920" height="1080" alt="Aug20::151637" src="https://github.com/user-attachments/assets/3ea92143-acb6-4092-81b8-b53289d6d147" />

Hour timer seemed too good, it claimed to be 2500 -> 1500 per hour....
I dont know if I trust it...

Blimp in the sky still eventually makes a shadow

## Additional context
Duck the attempter at perf returns :P

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c45d479](https://github.com/cataclysmbn/Cataclysm-BN/commit/c45d479f93bb5fa22df090ae889cab91af97e449) (perf: cache `has_any_vehicle_floor`) on 2026-08-20 23:57:13

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32424900595/artifacts/9428557734)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32424900595/artifacts/9428939960)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32424900595/artifacts/9428056793)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32424900595/artifacts/9427952083)
<!-- END artifact comment -->