### PR TITLE
feat: bulk craft match head powder

### DIFF
--- a/data/json/recipes/chem/other.json
+++ b/data/json/recipes/chem/other.json
@@ -91,6 +91,20 @@
     "tools": [ [ [ "matches", 1 ] ], [ [ "mortar_pestle", -1 ] ] ]
   },
   {
+    "type": "recipe",
+    "result": "chem_match_head_powder",
+    "category": "CC_CHEM",
+    "subcategory": "CC_CHEM_OTHER",
+    "id_suffix": "with food processor",
+    "skill_used": "fabrication",
+    "time": "1 m",
+    "batch_time_factors": [ 90, 2 ],
+    "charges": 5,
+    "autolearn": true,
+    "flags": [ "BLIND_EASY" ],
+    "tools": [ [ [ "matches", 5 ] ], [ [ "food_processor", 10 ] ] ]
+  },
+  {
     "result": "lye",
     "type": "recipe",
     "category": "CC_CHEM",

--- a/data/json/recipes/chem/other.json
+++ b/data/json/recipes/chem/other.json
@@ -97,12 +97,26 @@
     "subcategory": "CC_CHEM_OTHER",
     "id_suffix": "with food processor",
     "skill_used": "fabrication",
-    "time": "1 m",
+    "time": "30 s",
     "batch_time_factors": [ 90, 2 ],
-    "charges": 5,
+    "charges": 1,
     "autolearn": true,
     "flags": [ "BLIND_EASY" ],
-    "tools": [ [ [ "matches", 5 ] ], [ [ "food_processor", 10 ] ] ]
+    "tools": [ [ [ "matches", 1 ] ], [ [ "food_processor", 2 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "chem_match_head_powder",
+    "category": "CC_CHEM",
+    "subcategory": "CC_CHEM_OTHER",
+    "id_suffix": "with food processor bulk",
+    "skill_used": "fabrication",
+    "time": "1 m",
+    "batch_time_factors": [ 90, 2 ],
+    "charges": 10,
+    "autolearn": true,
+    "flags": [ "BLIND_EASY" ],
+    "tools": [ [ [ "matches", 10 ] ], [ [ "food_processor", 20 ] ] ]
   },
   {
     "result": "lye",


### PR DESCRIPTION
Adds in two new crafting recipes to craft match head powder with a food processor, one in bulk.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [221002c](https://github.com/cataclysmbn/Cataclysm-BN/commit/221002cd80f8d98c5aeb7f0368d349344ef6bc1b) (Added second non-bulk craft w/ food processor) on 2026-08-21 20:23:37

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32516624191/artifacts/9461031679)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32516624191/artifacts/9460324225)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32516624191/artifacts/9460790707)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32516624191/artifacts/9459548472)
<!-- END artifact comment -->