### PR TITLE
fix(lua): ebook_lua uses positional string format specifiers which lua does not support

### DIFF
--- a/data/mods/ebook_lua/main.lua
+++ b/data/mods/ebook_lua/main.lua
@@ -457,7 +457,7 @@ mod.mc_io = function(reader, device)
             ui.query_any_key(string.format(locale.gettext("%s has nothing new books."), that_mc:tname(1, false, 0)))
           else
             ui.query_any_key(
-              string.format(locale.gettext("%1$d books downloaded from %2$s."), dl_count, that_mc:tname(1, false, 0))
+              string.format(locale.gettext("%d books downloaded from %s."), dl_count, that_mc:tname(1, false, 0))
             )
           end
         elseif ans_mc_menu == 2 then --Upload
@@ -475,7 +475,7 @@ mod.mc_io = function(reader, device)
           else
             ui.query_any_key(
               string.format(
-                locale.gettext("%1$d books uploaded on %2$s.\nNaming the card is recommended."),
+                locale.gettext("%d books uploaded on %s.\nNaming the card is recommended."),
                 ul_count,
                 that_mc:tname(1, false, 0)
               )


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

If you download or upload a book to an SD card on an e-paper tablet using the ebook_lua mod, you get a lua error: `ERROR: Failed to run iuse_function k='LUA_EBOOK': Script runtime error: data/mods/ebook_lua/main.lua:477: invalid option '%$' to 'format'`

The [Lua string formatter](https://www.luadocs.com/docs/functions/string/format) does not support positional specifiers.

There are only 2 strings in *all* lua files that use positional specifiers like this. This PR fixes them both.

## Describe the solution (The How)

I dropped the positionality from the format specifiers, so they will work with the lua formatter.

I understand why they wanted to use positional specifiers, it's so they could be translated and used in a different order from the english string. The translators will need to be creative and work with the original english order in the format string (sorry).

## Describe alternatives you've considered

Adding a positional formatter to lua. I haven't looked around for a library that does this, but it seems a bit much for 2 inconvenient strings.

## Testing

Spawn an empty SD card, 2 e-book readers and a book. Scan the book with the reader. Open the Info... menu on the e-reader and choose 'Upload book data'. Then also choose 'Download book data' *on the other reader* for the other string.

Unfortunately, the "Reset library" menu option does not work. Together with https://github.com/cataclysmbn/Cataclysm-BN/issues/10015 , it might be a reason to drop the mod from being loaded by default on new worlds for now, cool as it is.

## Checklist
### Mandatory

- [X] I linked any relevant issues. There was no issue for this problem yet.

- [X] This PR modifies lua scripts or the lua API.
  - [X] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5781f5d](https://github.com/cataclysmbn/Cataclysm-BN/commit/5781f5dbf8deeeb38fbe0ffc98aacae2e4960250) (Removed positional string formatting, lua does not support it.) on 2026-08-21 23:45:52

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32532401725/artifacts/9464529448)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32532401725/artifacts/9466025825)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32532401725/artifacts/9464685096)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32532401725/artifacts/9464644924)
<!-- END artifact comment -->