### PR TITLE
perf: batch distribution grid update

### DIFF
--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -791,11 +791,18 @@ std::string grid_furn_transform_queue::to_string() const
 
 void distribution_grid_tracker::update( time_point to )
 {
-    ZoneScoped;
-    flush_dirty_omts();
+    ZoneScopedN( "all_distribution_grid_update" );
+    {
+        ZoneScopedN( "flush_dirty_omt_distribution_grid_update" );
+        flush_dirty_omts();
+    }
     for( const shared_ptr_fast<distribution_grid> &grid : grids_requiring_updates ) {
+        ZoneScopedN( "individual_grid_update" );
         grid->update( to );
     }
-    transform_queue.apply( mb, *this, get_player_character(), get_map() );
-    transform_queue.clear();
+    {
+        ZoneScopedN( "apply_transformation_queue" );
+        transform_queue.apply( mb, *this, get_player_character(), get_map() );
+        transform_queue.clear();
+    }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2740,15 +2740,9 @@ auto game::execute_activity_fixed_window_skip( const time_duration &duration ) -
         if( m.has_field_at( u.bub_pos() ) ) {
             m.creature_in_field( u );
         }
-        for( auto &[dim_id, tracker_ptr] : grid_trackers_ ) {
-            if( tracker_ptr ) {
-                tracker_ptr->update( calendar::turn );
-            }
-        }
         tick_portal_links();
         tick_temporary_pocket_dimensions();
         tick_vehicle_portal_taps();
-        fluid_grid::update( calendar::turn );
 
         const auto has_active_npcs = std::ranges::any_of( active_npc,
         []( const shared_ptr_fast<npc> &guy ) {
@@ -2822,6 +2816,19 @@ auto game::run_activity_skip_batch_turns( const int skipped_turns ) -> void
     {
         ZoneScopedN( "do_map_process_items" );
         m.process_items( skipped_turns );
+    }
+
+    {
+        ZoneScopedN( "activity_fixed_window_distribution_grid_update" );
+        for( auto &[dim_id, tracker_ptr] : grid_trackers_ ) {
+            if( tracker_ptr ) {
+                tracker_ptr->update( calendar::turn );
+            }
+        }
+    }
+    {
+        ZoneScopedN( "activity_fixed_window_fluid_grid_update" );
+        fluid_grid::update( calendar::turn );
     }
 
     explosion_handler::get_explosion_queue().execute();


### PR DESCRIPTION
## Purpose of change (The Why)
I believe this closes #9657 ( opened #10121 for the relatively minor remaining issue )

Behold when there was massive slowdown ( after running around a large city )
<img width="1920" height="1080" alt="Aug22::082617" src="https://github.com/user-attachments/assets/6e019c2d-349e-43fd-bc7f-1195184f5b65" />

Power grids were 90% of the time

## Describe the solution (The How)
Distribution grids support autocatchup, meaning we only need to call it once per tick ( 5 minute increments ), not 300 times per tick

## Describe alternatives you've considered
Figure out how to solve #10121 fully instead of just removing most of the perf cost

## Testing
Loaded, ran around big city, went back -> Perf wasn't slow as a slug
Loaded, waited at evac shelter, battery slowly charged

## Additional context
Result afterwards
<img width="1920" height="1080" alt="Aug22::082921" src="https://github.com/user-attachments/assets/6f871b14-1de8-4380-9faa-0fafccee2466" />

Note: Fresh load is as such
<img width="1920" height="1080" alt="Aug22::084909" src="https://github.com/user-attachments/assets/2db73723-8775-433f-8b79-f3c5e708aefb" />


## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [be55aa1](https://github.com/cataclysmbn/Cataclysm-BN/commit/be55aa143861728c52cd8bbd4bb756e62d2ada1c) (perf: batch distribution grid update) on 2026-08-22 17:09:42

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32582490381/artifacts/9478960307)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32582490381/artifacts/9479241551)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32582490381/artifacts/9478310438)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32582490381/artifacts/9478375407)
<!-- END artifact comment -->