### PR TITLE
perf: process on player items and update body once per action tick

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -609,7 +609,7 @@ class Character : public Creature, public location_visitable<Character>
         /** Processes human-specific effects of an effect. */
         void process_one_effect( effect &it, bool is_new ) override;
         /** Process active items */
-        void process_items();
+        void process_items( int turns = 1 );
 
         /** Recalculates HP after a change to max strength */
         void recalc_hp();

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -221,7 +221,6 @@ void Character::process_turn()
     if( activity->targets.empty() ) {
         drop_invalid_inventory();
     }
-    process_items();
     // Didn't just pick something up
     last_item = itype_id( "null" );
 
@@ -915,12 +914,12 @@ static bool needs_elec_charges( item *it )
     }
 }
 
-void Character::process_items()
+void Character::process_items( int turns )
 {
     ZoneScoped;
 
-    auto process_item = [this]( detached_ptr<item> &&ptr ) {
-        return item::process( std::move( ptr ), as_player(), bub_pos(), false, 1 );
+    auto process_item = [this, &turns]( detached_ptr<item> &&ptr ) {
+        return item::process( std::move( ptr ), as_player(), bub_pos(), false, turns );
     };
     if( primary_weapon().needs_processing() ) {
         primary_weapon().attempt_detach( process_item );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1052,6 +1052,7 @@ bool game::start_game()
         u.add_effect( effect_feral_killed_recently, 3_days );
     }
     u.process_turn(); // process_turn adds the initial move points
+    u.process_items();
     u.set_stamina( u.get_stamina_max() );
     get_weather().update_weather();
     u.next_climate_control_check = calendar::before_time_starts; // Force recheck at startup
@@ -2341,6 +2342,7 @@ bool game::do_turn()
     {
         ZoneScopedN( "do_turn_player_process_turn" );
         u.process_turn();
+        u.process_items();
     }
 
     {
@@ -2719,7 +2721,6 @@ auto game::execute_activity_fixed_window_skip( const time_duration &duration ) -
         }
 
         debug_hour_timer.print_time();
-        u.update_body( action_time_scale::calendar_duration_this_tick() );
         process_voluntary_act_interrupt();
         if( ( ( !u.activity || !*u.activity ) && !u.in_sleep_state() ) ) {
             break;
@@ -2816,6 +2817,15 @@ auto game::run_activity_skip_batch_turns( const int skipped_turns ) -> void
     {
         ZoneScopedN( "do_map_process_items" );
         m.process_items( skipped_turns );
+    }
+
+    {
+        u.update_body( action_time_scale::calendar_duration_this_tick() * skipped_turns );
+    }
+
+    {
+        ZoneScopedN( "do_player_process_items" );
+        u.process_items( skipped_turns );
     }
 
     {
@@ -6615,6 +6625,7 @@ void game::npcmove()
             ZoneScopedN( "npc_process_turn" );
             if( !guy.has_effect( effect_npc_suspend ) ) {
                 guy.process_turn();
+                guy.process_items();
             }
         }
         while( !guy.is_dead() && guy.moves > 0 && turns < 10 &&
@@ -6716,6 +6727,7 @@ void game::sleep_skip_npc_process()
         m.creature_in_field( guy );
         if( !guy.has_effect( effect_npc_suspend ) ) {
             guy.process_turn();
+            guy.process_items();
         }
         guy.npc_update_body();
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3747,7 +3747,7 @@ void map::decay_fields_and_scent( const time_duration &amount )
         }
 
         if( to_proc > 0 ) {
-            for( const auto sm_ms : cur_submap->field_cache ) {
+            for( const auto sm_ms : submap_tiles() ) {
                 const auto ms_pos = project_combine( p, sm_ms );
 
                 field &fields = cur_submap->get_field( sm_ms );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3747,7 +3747,7 @@ void map::decay_fields_and_scent( const time_duration &amount )
         }
 
         if( to_proc > 0 ) {
-            for( const auto sm_ms : submap_tiles() ) {
+            for( const auto sm_ms : cur_submap->field_cache ) {
                 const auto ms_pos = project_combine( p, sm_ms );
 
                 field &fields = cur_submap->get_field( sm_ms );

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -199,6 +199,7 @@ TEST_CASE("microreactor_fuel_consumption", "[bionics] [reactor]") {
         REQUIRE(safety_override.powered);
 
         CHECK_NOTHROW(dummy.process_turn());
+        CHECK_NOTHROW(dummy.process_items());
         CHECK_FALSE(safety_override.powered);
     }
 
@@ -215,6 +216,7 @@ TEST_CASE("microreactor_fuel_consumption", "[bionics] [reactor]") {
         const auto power_before = dummy.get_power_level();
         const auto rad_before = dummy.get_rad();
         dummy.process_turn();
+        dummy.process_items();
 
         CHECK(safety_override.powered);
         CHECK(dummy.get_power_level() > power_before);
@@ -230,6 +232,7 @@ TEST_CASE("microreactor_fuel_consumption", "[bionics] [reactor]") {
         reactor.charge_timer = 0;
 
         CHECK_NOTHROW(dummy.process_turn());
+        CHECK_NOTHROW(dummy.process_items());
         CHECK_FALSE(reactor.powered);
     }
 
@@ -243,6 +246,7 @@ TEST_CASE("microreactor_fuel_consumption", "[bionics] [reactor]") {
         REQUIRE(safety_override.powered);
 
         CHECK_NOTHROW(dummy.process_turn());
+        CHECK_NOTHROW(dummy.process_items());
         CHECK_FALSE(safety_override.powered);
     }
 

--- a/tests/enchantment_test.cpp
+++ b/tests/enchantment_test.cpp
@@ -15,6 +15,7 @@ static efftype_id effect_debug_clairvoyance("debug_clairvoyance");
 
 static void advance_turn(Character& guy) {
     guy.process_turn();
+    guy.process_items();
     calendar::turn += 1_turns;
 }
 

--- a/tests/morale_consistency_test.cpp
+++ b/tests/morale_consistency_test.cpp
@@ -13,6 +13,7 @@ TEST_CASE("player_morale_from_effects_consistent", "[morale][effect][slow]") {
     // As in game::do_turn
     for (time_point t = start; t < end; t += tick_size) {
         dummy.process_turn();
+        dummy.process_items();
         if (to_turns<int>(t - start) % to_turns<int>(10_turns) == 0) { dummy.update_morale(); }
         if (to_turns<int>(t - start) % to_turns<int>(9_turns) == 0) {
             REQUIRE(dummy.check_and_recover_morale());

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -428,6 +428,7 @@ static void destroyed_book_test_helper(avatar& u, item* loc) {
             loc->detach();
             AND_WHEN("A turn passes for you") {
                 u.process_turn();
+                u.process_items();
                 CHECK(!u.activity->is_null());
                 process_activity(u);
                 THEN("The reading job is cancelled") { CHECK(u.activity->is_null()); }

--- a/tests/speed_test.cpp
+++ b/tests/speed_test.cpp
@@ -26,6 +26,7 @@ static const auto act_wait = activity_id("ACT_WAIT");
 
 static void advance_turn(Character& guy) {
     guy.process_turn();
+    guy.process_items();
     calendar::turn += 1_turns;
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)
Follow up to #10116 #10118 #10122

#10122 has
<img width="1920" height="1080" alt="Aug22::084909" src="https://github.com/user-attachments/assets/5a401667-8ee9-42ef-b003-8ed7954e6593" />

Update body and player items were big enough that they should be reduced

## Describe the solution (The How)
Use the fact that update body and process items takes time as parameters
Make them both use that during long ticks

NOTE: This means that `process_turn` and `process_items` are now seperate for characters and npcs.

## Describe alternatives you've considered
None

## Testing
Weilded mininuke while `.` waiting go boom
Wielded mininuke while `\` waiting go boom
Waiting drains resources and lets player go cold

NOTE: Increase from fields is due to different amounts of rain
<img width="1920" height="1080" alt="Aug22::164158" src="https://github.com/user-attachments/assets/f4bbc2fb-237f-41f2-8103-24f0e5ed4712" />

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [713603d](https://github.com/cataclysmbn/Cataclysm-BN/commit/713603df578869675cef443726a415e26d2183df) (revert field change -> needed in a followup) on 2026-08-23 02:39:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32610078481/artifacts/9485736294)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32610078481/artifacts/9486139727)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32610078481/artifacts/9485684607)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32610078481/artifacts/9485646801)
<!-- END artifact comment -->