### PR TITLE
perf: visibility cache improvements

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4770,13 +4770,13 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
     bool target_is_valid = false;
     if( spell_being_cast.range() > 0 && !spell_being_cast.is_valid_target( target_none ) &&
         !spell_being_cast.has_flag( RANDOM_TARGET ) ) {
-        g->refresh_player_visibility_cache_if_needed();
+        g->refresh_player_visibility_cache_if_needed( true );
         do {
             avatar &you = *p->as_avatar();
             std::vector<tripoint_bub_ms> trajectory = target_handler::mode_spell( you, spell_being_cast,
                     no_fail,
                     no_mana );
-            g->refresh_player_visibility_cache_if_needed();
+            g->refresh_player_visibility_cache_if_needed( true );
 
             if( !trajectory.empty() ) {
                 target = trajectory.back();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2124,7 +2124,7 @@ bool game::do_turn()
     {
         ZoneScopedN( "do_turn_pre_action_updates" );
         perhaps_add_random_npc();
-        refresh_player_visibility_cache_if_needed();
+        refresh_player_visibility_cache_if_needed( m.is_map_cache_valid( u.bub_pos().z() ) );
         process_voluntary_act_interrupt();
         process_activity();
         update_performance_bubble();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2124,7 +2124,7 @@ bool game::do_turn()
     {
         ZoneScopedN( "do_turn_pre_action_updates" );
         perhaps_add_random_npc();
-        refresh_player_visibility_cache_if_needed( m.is_map_cache_valid( u.bub_pos().z() ) );
+        refresh_player_visibility_cache_if_needed( m.is_map_cache_valid( u.bub_pos().z() ), true );
         process_voluntary_act_interrupt();
         process_activity();
         update_performance_bubble();
@@ -4799,7 +4799,8 @@ auto game::visibility_cache_z() -> int
     return is_looking ? u.bub_pos().z() : ter_view_p.z();
 }
 
-auto game::refresh_player_visibility_cache_if_needed( const bool player_map_cache_current ) -> void
+auto game::refresh_player_visibility_cache_if_needed( const bool player_map_cache_current,
+        const bool skip_lightmap ) -> void
 {
 #if defined( CATA_SDL )
     ZoneScopedN( "refresh_player_visibility_cache_if_needed" );
@@ -4817,7 +4818,7 @@ auto game::refresh_player_visibility_cache_if_needed( const bool player_map_cach
     }
 
     if( !player_map_cache_current ) {
-        m.build_map_cache( zlev );
+        m.build_map_cache( zlev, skip_lightmap );
     }
     if( needs_visibility_refresh() ) {
         m.update_visibility_cache( zlev );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2124,7 +2124,11 @@ bool game::do_turn()
     {
         ZoneScopedN( "do_turn_pre_action_updates" );
         perhaps_add_random_npc();
-        refresh_player_visibility_cache_if_needed( m.is_map_cache_valid( u.bub_pos().z() ), true );
+        if( ( ( !u.activity || !*u.activity || u.activity->complete() ) && !u.in_sleep_state() ) ||
+            !get_option<bool>( "ACTIVITY_SKIP_VISIBILITY" ) ) {
+            // If map cache needs to be updated visibility cache will handle it.
+            refresh_player_visibility_cache_if_needed( true, true );
+        }
         process_voluntary_act_interrupt();
         process_activity();
         update_performance_bubble();

--- a/src/game.h
+++ b/src/game.h
@@ -232,7 +232,8 @@ class game : public submap_load_listener
         void draw_ter( bool draw_sounds = true );
         void draw_ter( const tripoint_bub_ms &center, bool looking = false, bool draw_sounds = true );
         auto visibility_cache_z() -> int;
-        auto refresh_player_visibility_cache_if_needed( bool player_map_cache_current = false ) -> void;
+        auto refresh_player_visibility_cache_if_needed( bool player_map_cache_current = false,
+                bool skip_lightmap = false ) -> void;
 
         class draw_callback_t
         {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10661,6 +10661,18 @@ bool map::check_and_set_seen_cache( const tripoint_bub_ms &p ) const
     return false;
 }
 
+bool map::is_map_cache_valid( const int zlev )
+{
+    if( inbounds_z( zlev ) ) {
+        level_cache &ch = get_cache( zlev );
+        // NOTE: Purposely excludes visibility cache, that is handled seperately in the game loop
+        return ch.floor_cache_dirty.any() || ch.transparency_cache_dirty.any() ||
+               ch.absorption_cache_dirty.any() || ch.sound_wall_cache_dirty.any() ||
+               ch.seen_cache_dirty || ch.lightmap_dirty || ch.outside_cache_dirty.any() ||
+               ch.suspension_cache_dirty;
+    }
+}
+
 void map::invalidate_map_cache( const int zlev )
 {
     if( inbounds_z( zlev ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -763,6 +763,16 @@ void map::set_floor_cache_dirty( const int zlev )
     set_absorption_cache_dirty( zlev - 1 );
 }
 
+void map::set_vehicle_cache_dirty( const int zlev )
+{
+    if( inbounds_z( zlev ) ) {
+        get_cache( zlev ).vehicle_caches_dirty = true;
+    }
+    if( inbounds_z( zlev + 1 ) ) {
+        get_cache( zlev + 1 ).vehicle_floor_cache_dirty = true;
+    }
+}
+
 void map::set_floor_cache_dirty( const tripoint_bub_ms &p )
 {
     if( !inbounds( p ) ) {
@@ -941,6 +951,7 @@ void map::add_vehicle_to_cache( vehicle *veh )
         }
         level_cache &ch = get_cache( p.z() );
         ch.veh_in_active_range = true;
+        ch.vehicle_caches_dirty = true;
 
         if( !ch.veh_cached_parts.contains( p ) ||
             !veh->part_info( vpr.part_index() ).has_flag( VPFLAG_NOCOLLIDE ) ||
@@ -963,6 +974,8 @@ void map::clear_vehicle_point_from_cache( vehicle *veh, const tripoint_bub_ms &p
     }
 
     level_cache &ch = get_cache( pt.z() );
+    ch.vehicle_floor_cache_dirty = true;
+    ch.vehicle_caches_dirty = true;
     auto it = ch.veh_cached_parts.find( pt );
     if( it != ch.veh_cached_parts.end() && it->second.first == veh ) {
         if( inbounds( pt ) ) {
@@ -1002,6 +1015,7 @@ void map::clear_vehicle_cache( )
             ch.veh_cached_parts.erase( part );
         }
         ch.veh_in_active_range = false;
+        set_vehicle_cache_dirty( zlev );
     }
     cached_veh_rope.clear();
 }
@@ -1011,6 +1025,7 @@ void map::clear_vehicle_list( const int zlev )
     auto &ch = get_cache( zlev );
     ch.vehicle_list.clear();
     ch.zone_vehicles.clear();
+    set_vehicle_cache_dirty( zlev );
 
     last_full_vehicle_list_dirty = true;
 }
@@ -1024,6 +1039,7 @@ void map::update_vehicle_list( const submap *const to, const int zlev )
     level_cache &ch = get_cache( zlev );
     for( const auto &elem : to->vehicles ) {
         ch.vehicle_list.insert( elem.get() );
+        set_vehicle_cache_dirty( zlev );
         if( !elem->loot_zones.empty() ) {
             ch.zone_vehicles.insert( elem.get() );
         }
@@ -1143,6 +1159,9 @@ void map::on_vehicle_moved( const tripoint_bub_sm &sm_min, const tripoint_bub_sm
     // cache effects.  Keep that cleanup path active even if this movement is a
     // removal of the last vehicle on the level.
     ch.veh_in_active_range = true;
+
+    // Vehicle
+    set_vehicle_cache_dirty( smz );
     invalidate_lightmap_caches();
     set_seen_cache_dirty( smz );
     mark_visibility_cache_dirty( smz );
@@ -8809,6 +8828,7 @@ void map::loadn( const tripoint_bub_sm &grid, const bool update_vehicles,
             set_seen_cache_dirty( grid.z() );
             set_pathfinding_cache_dirty( grid.z() );
             set_suspension_cache_dirty( grid.z() );
+            set_vehicle_cache_dirty( grid.z() );
         }
     }
     // Overlay boundary terrain on the edge tiles of this submap if it sits at the
@@ -9539,6 +9559,9 @@ static void vehicle_caching_internal_above( level_cache &zch_above, const vpart_
 void map::do_vehicle_caching( int z )
 {
     level_cache &ch = get_cache( z );
+    if( ch.vehicle_list.empty() && inbounds_z( z + 1 ) ) {
+        get_cache( z + 1 ).vehicle_floor_cache_dirty = false;
+    }
     for( vehicle *v : ch.vehicle_list ) {
         for( const vpart_reference &vp : v->get_all_parts() ) {
             const tripoint_bub_ms &part_pos = v->bub_part_location( vp.part() );
@@ -9547,10 +9570,13 @@ void map::do_vehicle_caching( int z )
             }
             vehicle_caching_internal( get_cache( part_pos.z() ), vp, v );
             if( part_pos.z() < OVERMAP_HEIGHT ) {
-                vehicle_caching_internal_above( get_cache( part_pos.z() + 1 ), vp, v );
+                level_cache &ch_above = get_cache( part_pos.z() + 1 );
+                vehicle_caching_internal_above( ch_above, vp, v );
+                ch_above.vehicle_floor_cache_dirty = false;
             }
         }
     }
+    ch.vehicle_caches_dirty = false;
 }
 
 void map::build_map_cache( const int zlev, bool skip_lightmap )
@@ -9573,11 +9599,17 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     bool gpu_vehicle_floor_dirty = false;
     bool gpu_vehicle_obscured_dirty = false;
     std::vector<int> dirty_seen_cache_levels;
+    dirty_seen_cache_levels.reserve( OVERMAP_HEIGHT + OVERMAP_DEPTH + 1 );
     std::vector<int> gpu_transparency_dirty_levels;
+    gpu_transparency_dirty_levels.reserve( OVERMAP_HEIGHT + OVERMAP_DEPTH + 1 );
     std::vector<int> gpu_transparency_residency_invalid_levels;
+    gpu_transparency_residency_invalid_levels.reserve( OVERMAP_HEIGHT + OVERMAP_DEPTH + 1 );
     std::vector<int> gpu_floor_dirty_levels;
+    gpu_floor_dirty_levels.reserve( OVERMAP_HEIGHT + OVERMAP_DEPTH + 1 );
     std::vector<int> gpu_vehicle_floor_dirty_levels;
+    gpu_vehicle_floor_dirty_levels.reserve( OVERMAP_HEIGHT + OVERMAP_DEPTH + 1 );
     std::vector<int> gpu_vehicle_obscured_dirty_levels;
+    gpu_vehicle_obscured_dirty_levels.reserve( OVERMAP_HEIGHT + OVERMAP_DEPTH + 1 );
 
     auto mark_lightmap_dirty = [this]( const int z ) {
         auto &cache = get_cache( z );
@@ -9654,60 +9686,58 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     {
         ZoneScopedN( "Phase1_parallel_caches" );
         // Vehicle cache clearing only — floor/outside/sheltered are already done above.
-        if( parallel_enabled && parallel_map_cache ) {
-            std::mutex dirty_mutex;
+        if( false /*parallel_enabled && parallel_map_cache*/ ) {
+            std::mutex seen_mutex;
+            std::mutex veh_mutex;
             parallel_for( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1, [&]( int z ) {
                 level_cache &ch = get_cache( z );
-                const bool vehicle_floor_was_dirty = level_has_vehicle_floor( ch );
-                // vehicle_floor_cache is written by vehicles one level below (via
-                // vehicle_caching_internal_above), so it must be cleared unconditionally —
-                // not gated on veh_in_active_range — to prevent stale entries after shifts.
-                std::fill( ch.vehicle_floor_cache.begin(), ch.vehicle_floor_cache.end(), '\0' );
-                ch.has_any_vehicle_floor = false;
-                if( ch.veh_in_active_range ) {
-                    const diagonal_blocks fill = {false, false};
-                    std::fill( ch.vehicle_obscured_cache.begin(), ch.vehicle_obscured_cache.end(), fill );
-                    std::fill( ch.vehicle_obstructed_cache.begin(), ch.vehicle_obstructed_cache.end(), fill );
-                    std::lock_guard<std::mutex> lock( dirty_mutex );
-                    add_gpu_dirty_level( gpu_vehicle_obscured_dirty_levels, z );
-                }
-
-                const bool level_seen_dirty = ch.seen_cache_dirty;
-                if( level_seen_dirty || vehicle_floor_was_dirty ) {
-                    std::lock_guard<std::mutex> lock( dirty_mutex );
-                    if( level_seen_dirty ) {
-                        seen_cache_dirty = true;
-                        dirty_seen_cache_levels.push_back( z );
-                    }
+                const bool vehicle_floor_was_dirty = ch.vehicle_floor_cache_dirty;
+                if( vehicle_floor_was_dirty || ch.vehicle_caches_dirty ) {
+                    ZoneScopedN( "veh_await_mutex" );
+                    std::lock_guard<std::mutex> lock( veh_mutex );
                     if( vehicle_floor_was_dirty ) {
+                        ZoneScopedN( "fill_veh_caches_zabove" );
+                        std::fill( ch.vehicle_floor_cache.begin(), ch.vehicle_floor_cache.end(), '\0' );
+                        ch.has_any_vehicle_floor = false;
                         add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
                     }
+                    if( ch.vehicle_caches_dirty ) {
+                        ZoneScopedN( "fill_veh_caches_thisz" );
+                        const diagonal_blocks fill = {false, false};
+                        std::fill( ch.vehicle_obscured_cache.begin(), ch.vehicle_obscured_cache.end(), fill );
+                        std::fill( ch.vehicle_obstructed_cache.begin(), ch.vehicle_obstructed_cache.end(), fill );
+                        add_gpu_dirty_level( gpu_vehicle_obscured_dirty_levels, z );
+                    }
+                }
+                const bool level_seen_dirty = ch.seen_cache_dirty;
+                if( level_seen_dirty ) {
+                    ZoneScopedN( "seen_dirty" );
+                    std::lock_guard<std::mutex> lock( seen_mutex );
+                    seen_cache_dirty = true;
+                    dirty_seen_cache_levels.push_back( z );
                 }
             } );
         } else {
             for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; ++z ) {
                 level_cache &ch = get_cache( z );
-                const bool vehicle_floor_was_dirty = level_has_vehicle_floor( ch );
 
-                // vehicle_floor_cache is written by vehicles one level below (via
-                // vehicle_caching_internal_above), so it must be cleared unconditionally —
-                // not gated on veh_in_active_range — to prevent stale entries after shifts.
-                std::fill( ch.vehicle_floor_cache.begin(), ch.vehicle_floor_cache.end(), '\0' );
-                ch.has_any_vehicle_floor = false;
-                if( ch.veh_in_active_range ) {
+                if( ch.vehicle_floor_cache_dirty ) {
+                    ZoneScopedN( "fill_veh_caches_zabove" );
+                    std::fill( ch.vehicle_floor_cache.begin(), ch.vehicle_floor_cache.end(), '\0' );
+                    ch.has_any_vehicle_floor = false;
+                    add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
+                }
+                if( ch.vehicle_caches_dirty ) {
+                    ZoneScopedN( "fill_veh_caches_thisz" );
                     const diagonal_blocks fill = {false, false};
                     std::fill( ch.vehicle_obscured_cache.begin(), ch.vehicle_obscured_cache.end(), fill );
                     std::fill( ch.vehicle_obstructed_cache.begin(), ch.vehicle_obstructed_cache.end(), fill );
                     add_gpu_dirty_level( gpu_vehicle_obscured_dirty_levels, z );
                 }
-
-                const bool level_seen_dirty = ch.seen_cache_dirty;
-                if( level_seen_dirty ) {
+                if( ch.seen_cache_dirty ) {
+                    ZoneScopedN( "seen_dirty" );
                     seen_cache_dirty = true;
                     dirty_seen_cache_levels.push_back( z );
-                }
-                if( vehicle_floor_was_dirty ) {
-                    add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
                 }
             }
         }
@@ -9725,43 +9755,22 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
 
     {
         ZoneScopedN( "Phase3_vehicles" );
-        // needs a separate pass as it changes the caches on neighbour z-levels (e.g. floor_cache);
-        // otherwise such changes might be overwritten by main cache-building logic.
-        // This pass must remain serial: do_vehicle_caching() writes to neighbor z-level caches.
-        auto const mark_vehicle_gpu_structural_levels = [&]( const vehicle * const veh ) {
-            ZoneScopedN( "Phase3_vehicles_structural" );
-            if( veh == nullptr ) {
-                return;
-            }
-            for( const vpart_reference &vp : veh->get_all_parts() ) {
-                const auto &part_pos = veh->bub_part_location( vp.part() );
-                if( !inbounds( part_pos ) || vp.part().removed ) {
-                    continue;
-                }
-                add_gpu_dirty_level( gpu_transparency_dirty_levels, part_pos.z() );
-                add_gpu_dirty_level( gpu_transparency_residency_invalid_levels, part_pos.z() );
-                add_gpu_dirty_level( gpu_floor_dirty_levels, part_pos.z() );
-                add_gpu_dirty_level( gpu_vehicle_obscured_dirty_levels, part_pos.z() );
-            }
-        };
         for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
-            if( get_cache( z ).veh_in_active_range ) {
-                for( const vehicle *const veh : get_cache( z ).vehicle_list ) {
-                    mark_vehicle_gpu_structural_levels( veh );
-                }
+            // If one cache is dirty redo the entire cache for simplicity
+            if( get_cache( z ).vehicle_caches_dirty || ( inbounds_z( z + 1 ) &&
+                    get_cache( z + 1 ).vehicle_floor_cache_dirty ) ) {
+                add_gpu_dirty_level( gpu_transparency_dirty_levels, z );
+                add_gpu_dirty_level( gpu_transparency_residency_invalid_levels, z );
+                add_gpu_dirty_level( gpu_floor_dirty_levels, z );
+                add_gpu_dirty_level( gpu_vehicle_obscured_dirty_levels, z );
                 {
                     ZoneScopedN( "Phase3_vehicles_cache" );
                     do_vehicle_caching( z );
                 }
             }
-        }
-        {
-            ZoneScopedN( "Phase3_vehicles_redirty" );
-            std::ranges::for_each( std::views::iota( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 ), [&]( const int z ) {
-                if( level_has_vehicle_floor( get_cache_ref( z ) ) ) {
-                    add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
-                }
-            } );
+            if( get_cache( z ).vehicle_floor_cache_dirty ) {
+                add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
+            }
         }
     }
 
@@ -10684,6 +10693,12 @@ void map::invalidate_map_cache( const int zlev )
         ch.seen_cache_dirty = true;
         ch.lightmap_dirty = true;
         ch.lm_cpu_cache_valid = false;
+        ch.vehicle_caches_dirty = true;
+        if( inbounds_z( zlev - 1 ) ) {
+            ch.vehicle_floor_cache_dirty = true;
+        } else {
+            ch.vehicle_floor_cache_dirty = false;
+        }
         ++ch.lm_cpu_cache_generation;
         mark_visibility_cache_dirty( zlev );
         ch.outside_cache_dirty.set();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9683,61 +9683,28 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     }
 
     {
-        ZoneScopedN( "Phase1_parallel_caches" );
+        ZoneScopedN( "Phase1_seen_and_vehicle_caches" );
         // Vehicle cache clearing only — floor/outside/sheltered are already done above.
-        if( false /*parallel_enabled && parallel_map_cache*/ ) {
-            std::mutex seen_mutex;
-            std::mutex veh_mutex;
-            parallel_for( -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1, [&]( int z ) {
-                level_cache &ch = get_cache( z );
-                const bool vehicle_floor_was_dirty = ch.vehicle_floor_cache_dirty;
-                if( vehicle_floor_was_dirty || ch.vehicle_caches_dirty ) {
-                    ZoneScopedN( "veh_await_mutex" );
-                    std::lock_guard<std::mutex> lock( veh_mutex );
-                    if( vehicle_floor_was_dirty ) {
-                        ZoneScopedN( "fill_veh_caches_zabove" );
-                        std::fill( ch.vehicle_floor_cache.begin(), ch.vehicle_floor_cache.end(), '\0' );
-                        ch.has_any_vehicle_floor = false;
-                        add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
-                    }
-                    if( ch.vehicle_caches_dirty ) {
-                        ZoneScopedN( "fill_veh_caches_thisz" );
-                        const diagonal_blocks fill = {false, false};
-                        std::fill( ch.vehicle_obscured_cache.begin(), ch.vehicle_obscured_cache.end(), fill );
-                        std::fill( ch.vehicle_obstructed_cache.begin(), ch.vehicle_obstructed_cache.end(), fill );
-                        add_gpu_dirty_level( gpu_vehicle_obscured_dirty_levels, z );
-                    }
-                }
-                const bool level_seen_dirty = ch.seen_cache_dirty;
-                if( level_seen_dirty ) {
-                    ZoneScopedN( "seen_dirty" );
-                    std::lock_guard<std::mutex> lock( seen_mutex );
-                    seen_cache_dirty = true;
-                    dirty_seen_cache_levels.push_back( z );
-                }
-            } );
-        } else {
-            for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; ++z ) {
-                level_cache &ch = get_cache( z );
+        for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; ++z ) {
+            level_cache &ch = get_cache( z );
 
-                if( ch.vehicle_floor_cache_dirty ) {
-                    ZoneScopedN( "fill_veh_caches_zabove" );
-                    std::fill( ch.vehicle_floor_cache.begin(), ch.vehicle_floor_cache.end(), '\0' );
-                    ch.has_any_vehicle_floor = false;
-                    add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
-                }
-                if( ch.vehicle_caches_dirty ) {
-                    ZoneScopedN( "fill_veh_caches_thisz" );
-                    const diagonal_blocks fill = {false, false};
-                    std::fill( ch.vehicle_obscured_cache.begin(), ch.vehicle_obscured_cache.end(), fill );
-                    std::fill( ch.vehicle_obstructed_cache.begin(), ch.vehicle_obstructed_cache.end(), fill );
-                    add_gpu_dirty_level( gpu_vehicle_obscured_dirty_levels, z );
-                }
-                if( ch.seen_cache_dirty ) {
-                    ZoneScopedN( "seen_dirty" );
-                    seen_cache_dirty = true;
-                    dirty_seen_cache_levels.push_back( z );
-                }
+            if( ch.vehicle_floor_cache_dirty ) {
+                ZoneScopedN( "fill_veh_caches_zabove" );
+                std::fill( ch.vehicle_floor_cache.begin(), ch.vehicle_floor_cache.end(), '\0' );
+                ch.has_any_vehicle_floor = false;
+                add_gpu_dirty_level( gpu_vehicle_floor_dirty_levels, z );
+            }
+            if( ch.vehicle_caches_dirty ) {
+                ZoneScopedN( "fill_veh_caches_thisz" );
+                const diagonal_blocks fill = {false, false};
+                std::fill( ch.vehicle_obscured_cache.begin(), ch.vehicle_obscured_cache.end(), fill );
+                std::fill( ch.vehicle_obstructed_cache.begin(), ch.vehicle_obstructed_cache.end(), fill );
+                add_gpu_dirty_level( gpu_vehicle_obscured_dirty_levels, z );
+            }
+            if( ch.seen_cache_dirty ) {
+                ZoneScopedN( "seen_dirty" );
+                seen_cache_dirty = true;
+                dirty_seen_cache_levels.push_back( z );
             }
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10659,12 +10659,7 @@ void map::invalidate_map_cache( const int zlev )
         ch.seen_cache_dirty = true;
         ch.lightmap_dirty = true;
         ch.lm_cpu_cache_valid = false;
-        ch.vehicle_caches_dirty = true;
-        if( inbounds_z( zlev - 1 ) ) {
-            ch.vehicle_floor_cache_dirty = true;
-        } else {
-            ch.vehicle_floor_cache_dirty = false;
-        }
+        set_vehicle_cache_dirty( zlev );
         ++ch.lm_cpu_cache_generation;
         mark_visibility_cache_dirty( zlev );
         ch.outside_cache_dirty.set();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -951,7 +951,7 @@ void map::add_vehicle_to_cache( vehicle *veh )
         }
         level_cache &ch = get_cache( p.z() );
         ch.veh_in_active_range = true;
-        ch.vehicle_caches_dirty = true;
+        set_vehicle_cache_dirty( p.z() );
 
         if( !ch.veh_cached_parts.contains( p ) ||
             !veh->part_info( vpr.part_index() ).has_flag( VPFLAG_NOCOLLIDE ) ||
@@ -974,8 +974,7 @@ void map::clear_vehicle_point_from_cache( vehicle *veh, const tripoint_bub_ms &p
     }
 
     level_cache &ch = get_cache( pt.z() );
-    ch.vehicle_floor_cache_dirty = true;
-    ch.vehicle_caches_dirty = true;
+    set_vehicle_cache_dirty( pt.z() );
     auto it = ch.veh_cached_parts.find( pt );
     if( it != ch.veh_cached_parts.end() && it->second.first == veh ) {
         if( inbounds( pt ) ) {

--- a/src/map.h
+++ b/src/map.h
@@ -845,6 +845,7 @@ class map : public submap_load_listener
         auto take_memory_seen_cache_dirty_points( int zlev ) -> std::vector<tripoint_bub_ms>;
         auto mark_memory_seen_cache_dirty_all_clean( int zlev ) -> void;
 
+        bool is_map_cache_valid( const int zlev );
         void invalidate_map_cache( const int zlev );
 
         /// Mark lightmap_dirty for every loaded z-level.

--- a/src/map.h
+++ b/src/map.h
@@ -850,7 +850,7 @@ class map : public submap_load_listener
         auto take_memory_seen_cache_dirty_points( int zlev ) -> std::vector<tripoint_bub_ms>;
         auto mark_memory_seen_cache_dirty_all_clean( int zlev ) -> void;
 
-        bool is_map_cache_valid( const int zlev );
+        auto is_map_cache_valid( const int zlev ) -> bool;
         void invalidate_map_cache( const int zlev );
 
         /// Mark lightmap_dirty for every loaded z-level.

--- a/src/map.h
+++ b/src/map.h
@@ -385,6 +385,10 @@ struct level_cache {
     bool has_any_vehicle_floor = false;
     bool suspension_cache_initialized = false;
     bool suspension_cache_dirty = false;
+    // Vehicle floor cache dirty: set when vehicle below moves
+    bool vehicle_floor_cache_dirty = false;
+    // Vehicle cache dirty: set when vehicle here moves
+    bool vehicle_caches_dirty = false;
     std::list<point_abs_ms> suspension_cache;
 
     // ---- 12 tile-coordinate arrays (size: cache_x * cache_y) ----
@@ -827,6 +831,7 @@ class map : public submap_load_listener
         void set_outside_cache_dirty( const tripoint_bub_ms &p );
 
         void set_floor_cache_dirty( const int zlev );
+        void set_vehicle_cache_dirty( const int zlev );
         // Point-level: marks only the tile's own submap (no horizontal neighbour dependency).
         void set_floor_cache_dirty( const tripoint_bub_ms &p );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2393,7 +2393,7 @@ void options_manager::add_options_performance()
     const static bool is_android = false;
 #endif
 #if defined(__ANDROID__)
-    add( "LOAD_FROM_EXTERNAL", page_id, translate_marker( "External Storage Saving" ),
+    add( "LOAD_FROM_EXTERNAL", performance, translate_marker( "External Storage Saving" ),
          translate_marker( "Save in data/catalcysm... instead of Documents/..." ),
          false );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2392,9 +2392,19 @@ void options_manager::add_options_performance()
 #else
     const static bool is_android = false;
 #endif
-    add_option_group( performance, Group( "rem_act_perf", to_translation( "Sleep Boost" ),
-                                          to_translation( "Skip expensive processing while the player sleeps." ) ),
+#if defined(__ANDROID__)
+    add( "LOAD_FROM_EXTERNAL", page_id, translate_marker( "External Storage Saving" ),
+         translate_marker( "Save in data/catalcysm... instead of Documents/..." ),
+         false );
+
+#endif
+    add_option_group( performance, Group( "rem_act_perf", to_translation( "Activity Boost" ),
+                                          to_translation( "Skip expensive processing while the player does activities ( slow path only )." ) ),
     [&]( auto & page_id ) {
+        add( "ACTIVITY_SKIP_VISIBILITY", page_id,
+             translate_marker( "Skip Activity Visibility Calculations" ),
+             translate_marker( "Turns recaclculation of visibility cache on or off during activity slow paths" ),
+             is_android ? true : false );
         add( "SLEEP_SKIP_VEH", page_id, translate_marker( "Skip Vehicle Movement" ),
              translate_marker( "Turns off vehicle movement and autodrive while sleeping" ),
              true );
@@ -2403,19 +2413,13 @@ void options_manager::add_options_performance()
              false );
         add( "SLEEP_SKIP_MON", page_id, translate_marker( "Skip Monster Movement" ),
              translate_marker( "Monsters do not move while the player is sleeping" ),
-             is_android ? false : true );
+             is_android ? true : false );
         add( "SLEEP_SKIP_NPC", page_id, translate_marker( "Skip NPC Movement" ),
              translate_marker( "NPCs are forced to sleep alongside the player, skipping movement "
                                "but still processing rest recovery (fatigue reduction, healing, etc.).  "
                                "NPCs with non-interruptible activities (e.g. surgery) are frozen "
                                "for the turn instead." ),
-             is_android ? false : true );
-#if defined(__ANDROID__)
-        add( "LOAD_FROM_EXTERNAL", page_id, translate_marker( "External Storage Saving" ),
-             translate_marker( "Save in data/catalcysm... instead of Documents/..." ),
-             false );
-
-#endif
+             is_android ? true : false );
     } );
 
     add_empty_line();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2404,7 +2404,7 @@ void options_manager::add_options_performance()
         add( "ACTIVITY_SKIP_VISIBILITY", page_id,
              translate_marker( "Skip Activity Visibility Calculations" ),
              translate_marker( "Turns recaclculation of visibility cache on or off during activity slow paths" ),
-             is_android ? true : false );
+             true );
         add( "SLEEP_SKIP_VEH", page_id, translate_marker( "Skip Vehicle Movement" ),
              translate_marker( "Turns off vehicle movement and autodrive while sleeping" ),
              true );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2971,7 +2971,7 @@ target_handler::trajectory target_ui::run()
     map &here = get_map();
     // Target lists and saved-target reacquisition use Character::sees before
     // the targeting UI gets its first redraw.
-    g->refresh_player_visibility_cache_if_needed();
+    g->refresh_player_visibility_cache_if_needed( true );
     // Load settings
     snap_to_target = get_option<bool>( "SNAP_TO_TARGET" );
     if( mode == TargetMode::Turrets ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -224,6 +224,7 @@ class DefaultRemovePartHandler : public RemovePartHandler
         }
         void set_floor_cache_dirty( const int z ) override {
             get_map().set_floor_cache_dirty( z );
+            get_map().set_vehicle_cache_dirty( z - 1 );
         }
         void removed( vehicle &veh, const int part ) override {
             avatar &player_character = get_avatar();


### PR DESCRIPTION
## Purpose of change (The Why)
The visibility cache is invalidated every turn but not updated, this caused ::sees to act wierdly as fixed by #10104
#10104 did not take into account a few things:
- Monster visibility map cache refresh refreshed floors ( and thus required lightmap update ) whenever there was a vehicle
- g->refresh_visibility_cache defaulted to itself refreshing the entire lightmap

## Describe the solution (The How)
Add vehicle dirty caches, solves point 1, as the issue was vehicle dirty caches requiring floor refresh requiring more refreshes

Set most instances of `g->refresh_player_visibility_cache_if_needed` to true -> expect cache to be up to date mid turn

Add `ACTIVITY_SKIP_VISIBILITY` this removes the changes of #10104 while doing an activity or sleeping
- This *really* shouldn't be doing anything because slow path activities should be dead.

Flip some defaults for android around ( should PC really have the "superior" sleep skip options on by default? )

As most of the path is skipped now -> remove parallel, the overhead isn't worth enough when it's mostly skipped

## Describe alternatives you've considered
Revert #10104 and ignore any complaints about ::sees messages not going through

## Testing
Use this patch for testing the slow path: [slowPathTest.patch](https://github.com/user-attachments/files/31355646/slowPathTest.patch)

Ran around a city, couldn't see anything weird with vehicles but it might still exist...

Hour timer:
( I'm not profiling the slow path sorry )
Before it was: with skip: 1000-1100 without: 2500-4000

Okay with skip: 950-1000 without: 2000-2100 ( with option: 1300 )

Compare to last PR result, map cache is smaller by a little bit.
<img width="1920" height="1080" alt="Aug23::145453" src="https://github.com/user-attachments/assets/594594fe-a952-4e5a-aeb8-c0ee1e45b9a0" />

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1a8d37f](https://github.com/cataclysmbn/Cataclysm-BN/commit/1a8d37f5b1dbfc244900af262bc5a5a50091cc2a) (fix android) on 2026-08-24 00:44:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32673632175/artifacts/9502926780)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32673632175/artifacts/9503134939)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32673632175/artifacts/9502524911)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32673632175/artifacts/9502534003)
<!-- END artifact comment -->