### PR TITLE
perf: improve vehicle batched turn skip and improve sleep skip rules

### DIFF
--- a/src/batch_turns.cpp
+++ b/src/batch_turns.cpp
@@ -149,7 +149,7 @@ void run_submap_batch_turns( submap &sm, int n )
     // batch_turns_items( sm, n );
     for( const auto &veh_ptr : sm.vehicles ) {
         if( veh_ptr ) {
-            veh_ptr->update_time( calendar::turn );
+            veh_ptr->update_time( calendar::turn, true );
         }
     }
 }

--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -5,6 +5,7 @@
 bool test_mode = false;
 bool debug_mode = false;
 bool json_report_strict = true;
+bool log_activity_skip_state = false;
 bool use_tiles = false;
 bool colored_lighting = false;
 bool use_pinyin_search = false;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -100,6 +100,8 @@ extern int PICKUP_RANGE;
  */
 extern bool dont_debugmsg;
 
+// If true, add messages for why activities aren't entering skip state.
+extern bool log_activity_skip_state;
 
 /** Monster LOD (level-of-detail) options. */
 extern bool monster_lod_enabled;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2563,12 +2563,32 @@ auto game::has_activity_skip_relevant_vehicle() -> bool
 {
     return std::ranges::any_of( m.get_vehicles(), []( const wrapped_vehicle & wrapped ) {
         const vehicle *veh = wrapped.v;
-        return veh != nullptr &&
-               ( veh->is_moving() || veh->vertical_velocity != 0 || veh->skidding ||
-                 veh->is_falling || veh->engine_on || veh->is_autodriving ||
-                 veh->is_following || veh->is_patrolling || veh->autopilot_on ||
-                 veh->is_alarm_on || veh->check_environmental_effects ||
-                 veh->total_accessory_epower_w() < 0 );
+        if( !log_activity_skip_state ) {
+            return veh != nullptr &&
+                   ( veh->is_moving() || veh->vertical_velocity != 0 || veh->skidding ||
+                     veh->is_falling || veh->is_autodriving || veh->is_following ||
+                     veh->is_patrolling || veh->autopilot_on || veh->is_alarm_on );
+        }
+        if( veh == nullptr ) {
+            return false;
+        }
+        if( veh->is_moving() || veh->vertical_velocity != 0 || veh->is_falling ) {
+            add_msg( "Vehicles are actively moving, cannot skip time" );
+            return true;
+        }
+        if( veh->skidding ) {
+            add_msg( "Vehicles are skidding, cannot skip time" );
+            return true;
+        }
+        if( veh->is_autodriving || veh->is_following || veh->is_patrolling || veh->autopilot_on ) {
+            add_msg( "Vehicles are autodriving, cannot skip time" );
+            return true;
+        }
+        if( veh->is_alarm_on ) {
+            add_msg( "Vehicle alarm is actively going off..." );
+            return true;
+        }
+        return false;
     } );
 }
 
@@ -2611,33 +2631,59 @@ auto game::has_activity_skip_active_fire() -> bool
 auto game::can_activity_fixed_window_skip( const time_duration &duration ) -> bool
 {
     if( new_game || queue_screenshot || uquit == QUIT_WATCH ) {
+        if( log_activity_skip_state ) {
+            add_msg( "Preparing quitting or screenshot, skip state impossible" );
+        }
         return false;
     }
     if( duration <= 0_turns || !get_weather().weather_id ||
         get_weather().nextweather <= calendar::turn ) {
+        if( log_activity_skip_state ) {
+            add_msg( "Need to process weather" );
+        }
         return false;
     }
     if( debug_infinite_speed_can_freeze_time() ) {
+        if( log_activity_skip_state ) {
+            add_msg( "Time is frozen" );
+        }
         return false;
     }
     if( !u.in_sleep_state() ) {
         if( !u.activity || !*u.activity || u.activity->complete() || u.has_destination() ||
             u.is_mounted() ) {
+            if( log_activity_skip_state ) {
+                if( !u.activity || !*u.activity || u.activity->complete() ) {
+                    add_msg( "Activity is null" );
+                }
+                if( u.has_destination() ) {
+                    add_msg( "You have autowalk target" );
+                }
+                if( u.is_mounted() ) {
+                    add_msg( "You are currently mounted on something" );
+                }
+            }
             return false;
         }
         if( u.activity->id() == ACT_AUTODRIVE || !u.activity->rooted() ||
             !u.activity->has_idle_bubble_effect() || u.activity->has_special_turns() ||
             !u.activity->assistants().empty() ) {
+            if( log_activity_skip_state ) {
+                add_msg( "The activity does not support skip state, or you have assistants" );
+            }
             return false;
         }
     }
     if( u.in_vehicle && u.controlling_vehicle ) {
-        return false;
-    }
-    if( m.field_at( u.bub_pos() ).field_count() > 0 ) {
+        if( log_activity_skip_state ) {
+            add_msg( "You are controlling a vehicle" );
+        }
         return false;
     }
     if( has_activity_skip_active_fire() ) {
+        if( log_activity_skip_state ) {
+            add_msg( "Fire is being processed, cannot skip time" );
+        }
         return false;
     }
     if( has_activity_skip_relevant_vehicle() ) {
@@ -2645,9 +2691,15 @@ auto game::can_activity_fixed_window_skip( const time_duration &duration ) -> bo
     }
     if( const std::optional<time_point> event_time = timed_events.next_event_time();
         event_time && *event_time <= calendar::turn + duration ) {
+        if( log_activity_skip_state ) {
+            add_msg( "Upcoming timed event, cannot skip time" );
+        }
         return false;
     }
     if( has_activity_skip_blocking_npc_state() ) {
+        if( log_activity_skip_state ) {
+            add_msg( "New NPCs generated, cannot skip time" );
+        }
         return false;
     }
     return true;
@@ -2682,6 +2734,9 @@ auto game::execute_activity_fixed_window_skip( const time_duration &duration ) -
     const auto requested_turns = to_turns<int>( duration );
     while( skipped_turns < requested_turns ) {
         if( is_game_over() || ( ( !u.activity || !*u.activity ) && !u.in_sleep_state() ) ) {
+            if( log_activity_skip_state ) {
+                add_msg( "Activity lost, cannot skip time" );
+            }
             break;
         }
 
@@ -2721,21 +2776,33 @@ auto game::execute_activity_fixed_window_skip( const time_duration &duration ) -
         perhaps_add_random_npc();
         if( npcs_dirty || critter_tracker->size() != monster_count ) {
             activity_fixed_window_force_normal_turn_ = true;
+            if( log_activity_skip_state ) {
+                add_msg( "NPC added, cannot skip time" );
+            }
             break;
         }
 
         debug_hour_timer.print_time();
         process_voluntary_act_interrupt();
         if( ( ( !u.activity || !*u.activity ) && !u.in_sleep_state() ) ) {
+            if( log_activity_skip_state ) {
+                add_msg( "Lost activity, cannot skip time" );
+            }
             break;
         }
 
         process_activity();
         if( is_game_over() ) {
+            if( log_activity_skip_state ) {
+                add_msg( "You died, cannot skip time" );
+            }
             break;
         }
         if( npcs_dirty || critter_tracker->size() != monster_count ) {
             activity_fixed_window_force_normal_turn_ = true;
+            if( log_activity_skip_state ) {
+                add_msg( "NPC or monster added, cannot skip time" );
+            }
             break;
         }
         const auto activity_continues = ( u.activity && *u.activity &&
@@ -2760,6 +2827,9 @@ auto game::execute_activity_fixed_window_skip( const time_duration &duration ) -
                 monmove( monster_activity_ai_mode::activity_skip, &activity_monsters );
                 if( critter_tracker->size() != monster_count ) {
                     activity_fixed_window_force_normal_turn_ = true;
+                    if( log_activity_skip_state ) {
+                        add_msg( "Monster added, cannot skip time" );
+                    }
                     break;
                 }
             }
@@ -2767,6 +2837,9 @@ auto game::execute_activity_fixed_window_skip( const time_duration &duration ) -
                 npcmove();
                 if( npcs_dirty || critter_tracker->size() != monster_count ) {
                     activity_fixed_window_force_normal_turn_ = true;
+                    if( log_activity_skip_state ) {
+                        add_msg( "NPC or monster added, cannot skip time" );
+                    }
                     break;
                 }
             }
@@ -2872,12 +2945,23 @@ auto game::try_activity_fixed_window_skip() -> bool
     ZoneScopedN( "activity_fixed_window_try" );
     if( activity_fixed_window_force_normal_turn_ ) {
         activity_fixed_window_force_normal_turn_ = false;
+        if( log_activity_skip_state ) {
+            add_msg( "Forced Normal Turn" );
+        }
         return false;
     }
     if( ( !u.activity || !*u.activity ) && !u.in_sleep_state() ) {
+        if( log_activity_skip_state ) {
+            add_msg( "No Activity" );
+        }
         return false;
     }
     if( calendar::turn < next_activity_fixed_window_check_ ) {
+        if( log_activity_skip_state ) {
+            add_msg(
+                string_format( "Before Next Fixed Window Check in %s turns",
+                               ( next_activity_fixed_window_check_ - calendar::turn ) / 1_turns ) );
+        }
         return false;
     }
     const auto duration = activity_fixed_window_duration();
@@ -2888,6 +2972,9 @@ auto game::try_activity_fixed_window_skip() -> bool
     const auto skipped_turns = execute_activity_fixed_window_skip( duration );
     if( skipped_turns <= 0 ) {
         next_activity_fixed_window_check_ = calendar::turn + 1_minutes;
+        if( log_activity_skip_state ) {
+            add_msg( "No Turns Were Skipped" );
+        }
         return false;
     }
     TracyPlot( "Activity Fixed Window Skipped Turns", int64_t{ skipped_turns } );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2749,6 +2749,9 @@ void options_manager::add_options_debug()
          false
        );
 
+    add( "LOG_ACTIVITY_SKIP_STATE", debug, translate_marker( "Log Reason for No Activity Skip State" ),
+         translate_marker( "Logs the rough reason for when activity skip state returns, used for debugging slow activities." ),
+         false );
     add_empty_line();
 
     add_option_group( debug, Group( "debug_log", to_translation( "Logging" ),
@@ -4419,6 +4422,7 @@ void options_manager::cache_to_globals()
     setDebugLogClasses( classes );
 
     json_report_strict = test_mode || ::get_option<bool>( "STRICT_JSON_CHECKS" );
+    log_activity_skip_state = ::get_option<bool>( "LOG_ACTIVITY_SKIP_STATE" );
     display_mod_source = ::get_option<bool>( "MOD_SOURCE" );
     display_object_ids = ::get_option<bool>( "SHOW_IDS" );
     trigdist = ::get_option<bool>( "CIRCLEDIST" );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1,5 +1,6 @@
 #include "vehicle.h"
 #include "detached_ptr.h"
+#include "type_id.h"
 #include "units_mass.h"
 #include "vehicle_part.h" // IWYU pragma: associated
 #include "vpart_position.h" // IWYU pragma: associated
@@ -4574,7 +4575,7 @@ int vehicle::safe_velocity( const bool fueled ) const
     }
 }
 
-bool vehicle::do_environmental_effects()
+bool vehicle::do_environmental_effects( const int turns )
 {
     bool needed = false;
     // check for smoking parts
@@ -4586,7 +4587,7 @@ bool vehicle::do_environmental_effects()
             needed = true;
             if( get_weather().weather_id->rains &&
                 get_weather().weather_id->precip != precip_class::very_light ) {
-                vp.part().blood--;
+                vp.part().blood -= std::min( vp.part().blood, turns );
             }
         }
     }
@@ -5866,12 +5867,12 @@ void vehicle::update_alternator_load()
     }
 }
 
-void vehicle::power_parts()
+void vehicle::power_parts( int turns )
 {
     update_alternator_load();
     // Things that drain energy: engines and accessories.
-    int engine_epower = total_engine_epower_w();
-    int epower = engine_epower + total_accessory_epower_w() + total_alternator_epower_w();
+    int engine_epower = total_engine_epower_w() * turns;
+    int epower = ( engine_epower + total_accessory_epower_w() + total_alternator_epower_w() ) * turns;
 
     int delta_energy_bat = power_to_energy_bat( epower, 1_turns );
     int storage_deficit_bat = std::max( 0, fuel_capacity( fuel_type_battery ) -
@@ -5891,7 +5892,7 @@ void vehicle::power_parts()
             // Keep track whether or not the vehicle has any reactors activated
             reactor_online = true;
             // the amount of energy the reactor generates each turn
-            const int gen_energy_bat = power_to_energy_bat( part_epower_w( elem ), 1_turns );
+            const int gen_energy_bat = power_to_energy_bat( part_epower_w( elem ), 1_turns * turns );
             if( parts[ elem ].is_unavailable() ) {
                 continue;
             } else if( parts[ elem ].info().has_flag( str_PERPETUAL ) ) {
@@ -6283,6 +6284,44 @@ void vehicle::do_engine_damage( size_t e, int strain )
     }
 }
 
+void vehicle::idle_turns( const int turns )
+{
+    power_parts( turns );
+    // Validate muscle engines - auto-disable if conditions are not met
+    validate_muscle_engines();
+    if( engine_on && total_power_w() > 0 ) {
+        bool no_electric_power = true;
+        int idle_rate = alternator_load;
+        if( idle_rate < 10 ) {
+            idle_rate = 10;    // minimum idle is 1% of full throttle
+        }
+        // Helicopters use extra power just to stay in the air
+        // 100 means 10% of power
+        /*
+            TODO: Consider different formula for idling aircraft, may need a formula to determine this
+            Possibly something like total lift / total engine power, maybe some factors for hovering efficiency of different types
+            Also consider adding a hover efficiency field
+        */
+        if( is_rotorcraft() && is_flying_in_air() ) {
+            const auto rotor_newtons = std::max( 0.0,
+                                                 to_newton( total_mass() ) - total_balloon_lift() - total_wing_lift() );
+            const auto rotor_capacity = rotor_newtons / thrust_of_rotorcraft( true );
+            idle_rate = std::max( 10, int( std::floor( 100 * rotor_capacity ) ) );
+            no_electric_power = false;
+        }
+        if( has_engine_type_not( fuel_type_muscle, true ) ) {
+            consume_fuel( idle_rate, turns, no_electric_power );
+        }
+    } else {
+        if( engine_on && g->u.sees( bub_ms_location() ) &&
+            ( has_engine_type_not( fuel_type_muscle, true ) && has_engine_type_not( fuel_type_animal, true ) &&
+              has_engine_type_not( fuel_type_wind, true ) && has_engine_type_not( fuel_type_mana, true ) ) ) {
+            add_msg( _( "The %s's engine dies!" ), name );
+        }
+        engine_on = false;
+    }
+}
+
 void vehicle::idle( bool on_map )
 {
     power_parts();
@@ -6337,7 +6376,7 @@ void vehicle::idle( bool on_map )
     if( !on_map ) {
         return;
     } else {
-        update_time( calendar::turn );
+        update_time( calendar::turn, false );
     }
 
     process_emitters();
@@ -8147,7 +8186,7 @@ static bool is_sm_tile_outside( const tripoint_abs_ms &pos )
     return m.is_outside( abs_to_bub( pos ) );
 }
 
-void vehicle::update_time( const time_point &update_to )
+void vehicle::update_time( const time_point &update_to, const bool batched )
 {
     const time_point update_from = last_update;
     if( update_to < update_from ) {
@@ -8162,6 +8201,12 @@ void vehicle::update_time( const time_point &update_to )
     }
     time_duration elapsed = update_to - last_update;
     last_update = update_to;
+    if( batched ) {
+        idle_turns( elapsed / 1_turns );
+        if( check_environmental_effects ) {
+            check_environmental_effects = do_environmental_effects( elapsed / 1_turns );
+        }
+    }
 
     if( !converters.empty() ) {
         for( int p : converters ) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -445,7 +445,7 @@ class vehicle
         void refresh();
 
         // Do stuff like clean up blood and produce smoke from broken parts. Returns false if nothing needs doing.
-        bool do_environmental_effects();
+        bool do_environmental_effects( const int turns = 1 );
 
         units::volume total_folded_volume() const;
 
@@ -983,7 +983,7 @@ class vehicle
         int max_reactor_epower_w() const;
         // Produce and consume electrical power, with excess power stored or
         // taken from batteries.
-        void power_parts();
+        void power_parts( const int turns = 1 );
 
         /**
          * Try to charge our (and, optionally, connected vehicles') batteries by the given amount.
@@ -1251,6 +1251,9 @@ class vehicle
                                         const std::set<vehicle *> &vehicle_list );
         // idle fuel consumption
         void idle( bool on_map = true );
+        // idle fuel consumption in bulk
+        // Called by update_time given the batched parameter
+        void idle_turns( const int turns );
         // continuous processing for running vehicle alarms
         void alarm();
         // leak from broken tanks
@@ -1639,7 +1642,8 @@ class vehicle
         bounding_box get_bounding_box();
         // Retroactively pass time spent outside bubble
         // Funnels, solar panels
-        void update_time( const time_point &update_to );
+        // If batched is used, it will also drain engines and batteries and use plutonium generators
+        void update_time( const time_point &update_to, const bool batched );
         // Process vehicle emitters
         void process_emitters();
 

--- a/tests/activity_fixed_window_test.cpp
+++ b/tests/activity_fixed_window_test.cpp
@@ -146,10 +146,6 @@ TEST_CASE(
     "window]") {
     const auto no_autosave = override_option("AUTOSAVE", "false");
 
-    SECTION("player tile field") {
-        expect_fixed_window_skip_blocked_by([] { g->m.add_field(g->u.bub_pos(), fd_acid, 1); });
-    }
-
     SECTION("active fire in simulated submap") {
         expect_fixed_window_skip_blocked_by([] {
             g->m.add_field(g->u.bub_pos() + point_east, fd_fire, 1);
@@ -161,7 +157,7 @@ TEST_CASE(
             auto* veh =
                 g->m.add_vehicle(vproto_id("car"), g->u.bub_pos() + tripoint_east, 0_degrees, 0, 0);
             REQUIRE(veh != nullptr);
-            veh->engine_on = true;
+            veh->is_following = true;
         });
     }
 

--- a/tests/vehicle_cargo_perf_test.cpp
+++ b/tests/vehicle_cargo_perf_test.cpp
@@ -81,7 +81,7 @@ auto make_cargo_benchmark_fixture(const cargo_benchmark_options& opts) -> cargo_
     vehicle* const veh =
         get_map().add_vehicle(vproto_id("aapc-mg"), u.bub_pos(), 0_degrees, 100, 0);
     REQUIRE(veh != nullptr);
-    veh->update_time(calendar::turn_zero);
+    veh->update_time(calendar::turn_zero, false);
 
     auto has_recharger = false;
     for (const vpart_reference& vp : veh->get_any_parts("RECHARGE")) {
@@ -130,7 +130,7 @@ auto make_solar_benchmark_fixture(const solar_benchmark_options& opts) -> solar_
         veh->part(battery_part).ammo_unset();
     }
 
-    veh->update_time(calendar::turn_zero);
+    veh->update_time(calendar::turn_zero, false);
 
     return solar_benchmark_fixture{
         .veh = veh,
@@ -210,9 +210,9 @@ TEST_CASE(
     (Catch::Benchmark::Chronometer meter) {
         meter.measure([&fixture]() {
             reset_vehicle_batteries(*fixture.veh);
-            fixture.veh->update_time(calendar::turn_zero + 1_minutes);
+            fixture.veh->update_time(calendar::turn_zero + 1_minutes, false);
             const auto stored_energy = fixture.veh->fuel_left(fuel_type_battery, false);
-            fixture.veh->update_time(calendar::turn_zero);
+            fixture.veh->update_time(calendar::turn_zero, false);
             return stored_energy;
         });
     };

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -175,7 +175,7 @@ TEST_CASE("vehicle power with reactor and solar panels", "[vehicle][power]") {
         GIVEN("it is 3 hours after sunrise, with sunny weather") {
             calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days;
             const time_point start_time = sunrise(calendar::turn) + 3_hours;
-            veh_ptr->update_time(start_time);
+            veh_ptr->update_time(start_time, false);
             get_weather().weather_override = weather_type_id("sunny");
 
             AND_GIVEN("the battery has no charge") {
@@ -183,7 +183,7 @@ TEST_CASE("vehicle power with reactor and solar panels", "[vehicle][power]") {
                 REQUIRE(veh_ptr->fuel_left(fuel_type_battery) == 0);
 
                 WHEN("30 minutes elapse") {
-                    veh_ptr->update_time(start_time + 30_minutes);
+                    veh_ptr->update_time(start_time + 30_minutes, false);
 
                     THEN("the battery should be partially charged") {
                         int charge = veh_ptr->fuel_left(fuel_type_battery) / 100;
@@ -191,7 +191,7 @@ TEST_CASE("vehicle power with reactor and solar panels", "[vehicle][power]") {
                         CHECK(charge <= 30);
 
                         AND_WHEN("another 30 minutes elapse") {
-                            veh_ptr->update_time(start_time + 2 * 30_minutes);
+                            veh_ptr->update_time(start_time + 2 * 30_minutes, false);
 
                             THEN("the battery should be further charged") {
                                 charge = veh_ptr->fuel_left(fuel_type_battery) / 100;
@@ -207,14 +207,14 @@ TEST_CASE("vehicle power with reactor and solar panels", "[vehicle][power]") {
         GIVEN("it is 3 hours after sunset, with clear weather") {
             const time_point at_night = sunset(calendar::turn) + 3_hours;
             get_weather().weather_override = weather_type_id("clear");
-            veh_ptr->update_time(at_night);
+            veh_ptr->update_time(at_night, false);
 
             AND_GIVEN("the battery has no charge") {
                 veh_ptr->discharge_battery(veh_ptr->fuel_left(fuel_type_battery));
                 REQUIRE(veh_ptr->fuel_left(fuel_type_battery) == 0);
 
                 WHEN("60 minutes elapse") {
-                    veh_ptr->update_time(at_night + 2 * 30_minutes);
+                    veh_ptr->update_time(at_night + 2 * 30_minutes, false);
 
                     THEN("the battery should still have no charge") {
                         CHECK(veh_ptr->fuel_left(fuel_type_battery) == 0);
@@ -290,7 +290,7 @@ TEST_CASE("Vehicle charging station", "[vehicle][power]") {
             g->m.add_vehicle(vproto_id("recharge_test"), vehicle_origin, 0_degrees, 100, 0);
         REQUIRE(veh_ptr != nullptr);
         REQUIRE(veh_ptr->fuel_left(fuel_type_battery) > 1000);
-        veh_ptr->update_time(calendar::turn_zero);
+        veh_ptr->update_time(calendar::turn_zero, false);
 
         auto cargo_part_index = veh_ptr->part_with_feature(tripoint_mnt_veh::zero(), "CARGO", true);
         REQUIRE(cargo_part_index >= 0);


### PR DESCRIPTION
## Purpose of change (The Why)
Should greatly reduce instances of people reaching slow activities ( when activity skip is not functional )

It fixes the following issues
- If there is *any* blood on *any* vehicle -> Slow mode
- If there is *any* engine on in *any* vehicle -> Slow mode
- If there is power draw in *any* vehicle -> Slow mode
- If there is a field ( lets say AC ) on the player -> Slow mode

## Describe the solution (The How)
1: Remove the field check -> Fields on the player were already processed, no need for it
2: Add batched engine and power updates to vehicles
3: Add batched blood cleaning updates to vehicles
4: Add `LOG_ACTIVITY_SKIP_STATE` a cached option which will spam the log with messages about why the activity is not going to skip mode, highly useful for debugging and allows players to get some clue
5: Update tests with the fact that these assumptions have changed

## Describe alternatives you've considered
None

## Testing
Make a bike have blood on it
You no longer get a massive perf drop while waiting

Turn on some heaters
You no longer get a massive perf drop while waiting

Turn on an engine
You no longer get a massive perf drop while waiting

All of the above still do roughly what you would expect

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c76c6cc](https://github.com/cataclysmbn/Cataclysm-BN/commit/c76c6cc7433c9c2677b34c7dab5697f60318a90e) (fix tests) on 2026-08-24 17:02:24

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32745647351/artifacts/9529264243)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32745647351/artifacts/9530188581)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32745647351/artifacts/9528649831)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32745647351/artifacts/9528549446)
<!-- END artifact comment -->