### PR TITLE
fix: restore editmap overmap functionality

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1749,9 +1749,6 @@ void editmap::mapgen_preview( const point_abs_ms &tc, uilist &gmenu )
 
                 submap::swap( *destsm,  *srcsm );
 
-                if( !destsm->spawns.empty() ) {                              // trigger spawnpoints
-                    here.spawn_monsters( true );
-                }
             }
         }
     };
@@ -1866,6 +1863,9 @@ void editmap::mapgen_preview( const point_abs_ms &tc, uilist &gmenu )
             con.rotate( 1 );
             swap_buffers();
             invalidate_cache();
+        } else if( gpmenu.ret == 2 ) {
+            // Trigger spawns now, they are dependent on the map so only can be added at this point
+            here.spawn_monsters( true );
         } else if( gpmenu.ret == 3 ) {
             popup( _( "Changed oter_id from '%s' (%s) to '%s' (%s)" ),
                    orig_oters->get_name(), orig_oters.id().str(),

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -606,91 +606,6 @@ void editmap::draw_main_ui_overlay()
         mvwputch( g->w_terrain, point( mp.x, 1 ), c_yellow, '^' );
         mvwputch( g->w_terrain, point( mp.x, tmax.y - 1 ), c_yellow, 'v' );
     }
-
-    if( tmpmap_ptr ) {
-        map &tmpmap = *tmpmap_ptr;
-#ifdef TILES
-        if( use_tiles ) {
-            const auto origin_p = target.xy() + point( 1 - SEEX, 1 - SEEY );
-            for( int x = 0; x < SEEX * 2; x++ ) {
-                for( int y = 0; y < SEEY * 2; y++ ) {
-                    const tripoint_bub_ms tmp_p( x, y, target.z() );
-                    const auto map_p = tmp_p + origin_p.raw();
-                    g->draw_radiation_override( map_p, tmpmap.get_radiation( tmp_p ) );
-                    // scent is managed in `game` instead of `map`, so there's no override for it
-                    // temperature is managed in `game` instead of `map`, so there's no override for it
-                    // TODO: visibility could be affected by both the actual map and the preview map,
-                    // which complicates calculation, so there's no override for it (yet)
-                    g->draw_terrain_override( map_p, tmpmap.ter( tmp_p ) );
-                    g->draw_furniture_override( map_p, tmpmap.furn( tmp_p ) );
-                    g->draw_graffiti_override( map_p, tmpmap.has_graffiti_at( tmp_p ) );
-                    g->draw_trap_override( map_p, tmpmap.tr_at( tmp_p ).loadid );
-                    g->draw_field_override( map_p, tmpmap.field_at( tmp_p ).displayed_field_type() );
-                    const maptile &tile = tmpmap.maptile_at( tripoint_bub_ms( tmp_p ) );
-                    if( tmpmap.sees_some_items( tmp_p, g->u.bub_pos() - origin_p.raw() ) ) {
-                        const item &itm = tile.get_uppermost_item();
-                        const mtype *const mon = itm.get_mtype();
-                        g->draw_item_override( map_p, itm.typeId(), mon ? mon->id : mtype_id::NULL_ID(),
-                                               tile.get_item_count() > 1 );
-                    } else {
-                        g->draw_item_override( map_p, itype_id::NULL_ID(), mtype_id::NULL_ID(),
-                                               false );
-                    }
-                    const optional_vpart_position vp = tmpmap.veh_at( tmp_p );
-                    if( vp ) {
-                        const vehicle &veh = vp->vehicle();
-                        const int veh_part = vp->part_index();
-                        char part_mod = 0;
-                        const vpart_id &vp_id = veh.part_id_string( veh_part, false, part_mod );
-                        const std::optional<vpart_reference> cargopart = vp.part_with_feature( "CARGO", true );
-                        bool draw_highlight = cargopart && !veh.get_items( cargopart->part_index() ).empty();
-                        units::angle veh_dir = veh.face.dir();
-                        g->draw_vpart_override( map_p, vp_id, part_mod, veh_dir, draw_highlight, vp->mount() );
-                    } else {
-                        g->draw_vpart_override( map_p, vpart_id::NULL_ID(), 0, 0_degrees, false,
-                        { 0, 0, 0 } );
-                    }
-                    g->draw_below_override( map_p, tmpmap.ter( tmp_p ).obj().has_flag( TFLAG_NO_FLOOR ) );
-                }
-            }
-            // int: count, bool: more than 1 spawn data
-            std::map<tripoint_bub_ms, std::tuple<mtype_id, int, bool, Attitude>> spawns;
-            for( int x = 0; x < 2; x++ ) {
-                for( int y = 0; y < 2; y++ ) {
-                    const auto sm_pos = tripoint_bub_sm{ x, y, target.z() };
-                    submap *sm = tmpmap.get_mapbuffer().lookup_submap_in_memory(
-                                     map_local_to_abs( tmpmap, sm_pos ) );
-                    if( sm ) {
-                        const auto sm_origin = project_to<coords::ms>( sm_pos ) + origin_p.raw();
-                        for( const auto &sp : sm->spawns ) {
-                            const auto spawn_p = sm_origin + sp.pos.raw();
-                            const auto spawn_it = spawns.find( spawn_p );
-                            if( spawn_it == spawns.end() ) {
-                                const Attitude att = sp.is_friendly() ? Attitude::A_FRIENDLY : Attitude::A_ANY;
-                                spawns.emplace( spawn_p.raw(), std::make_tuple( sp.type, sp.count, false, att ) );
-                            } else {
-                                std::get<2>( spawn_it->second ) = true;
-                            }
-                        }
-                    }
-                }
-            }
-            for( const auto &it : spawns ) {
-                g->draw_monster_override( it.first, std::get<0>( it.second ), std::get<1>( it.second ),
-                                          std::get<2>( it.second ), std::get<3>( it.second ) );
-            }
-        } else {
-#endif
-            hilights["mapgentgt"].draw( *this, true );
-            tmpmap.reset_vehicle_cache( );
-            drawsq_params params = drawsq_params().center( tripoint_bub_ms( SEEX - 1, SEEY - 1, target.z() ) );
-            for( const tripoint_bub_ms &p : tmpmap.points_on_zlevel() ) {
-                tmpmap.drawsq( g->w_terrain, p, params );
-            }
-#ifdef TILES
-        }
-#endif
-    }
 }
 
 void editmap::update_view_with_help( const std::string &txt, const std::string &title )
@@ -1816,20 +1731,69 @@ void editmap::mapgen_preview( const point_abs_ms &tc, uilist &gmenu )
     const oter_id orig_oters = omt_ref;
     get_overmapbuffer( get_map().get_bound_dimension() ).ter_set( omt_pos, oter_id( gmenu.ret ) );
     map tmpmap( 2 );
+    map &here = get_map();
     mapbuffer preview_buffer;
     preview_buffer.set_dimension_id( get_map().get_bound_dimension() );
-    const auto regenerate_tmpmap = [&]() {
+    const auto swap_buffers = [&]() {
+        for( int x = 0; x < 2; x++ ) {
+            for( int y = 0; y < 2; y++ ) {
+                // Apply previewed mapgen to map. Since this is a function for testing, we try avoid triggering
+                // functions that would alter the results
+                const point target_sub( target.x() / SEEX, target.y() / SEEY );
+                const auto pos = tripoint_bub_sm( x, y, target.z() ) + target_sub;
+
+                submap *destsm = here.get_mapbuffer().lookup_submap_in_memory(
+                                     map_local_to_abs( here, pos ) );
+                submap *srcsm = preview_buffer.lookup_submap_in_memory(
+                                    map_local_to_abs( here, pos ) );
+
+                submap::swap( *destsm,  *srcsm );
+
+                if( !destsm->spawns.empty() ) {                              // trigger spawnpoints
+                    here.spawn_monsters( true );
+                }
+            }
+        }
+    };
+    const auto regenerate_tmpmap = [&]( mapbuffer & buf ) {
         cleartmpmap( tmpmap );
-        preview_buffer.clear();
-        mapgen_constructor constructor( preview_buffer );
+        buf.clear();
+        mapgen_constructor constructor( buf );
         constructor.generate( omt_pos, calendar::turn );
         const auto base_sub = project_to<coords::sm>( omt_pos );
         tmpmap.set_abs_sub( base_sub.xy() );
         for( const auto offset : point_range<point_rel_sm>( point_rel_sm::zero(), point_rel_sm( 1, 1 ) ) ) {
-            preview_buffer.lookup_submap_in_memory( base_sub + offset );
+            buf.lookup_submap_in_memory( base_sub + offset );
         }
     };
-    regenerate_tmpmap();
+    const auto invalidate_cache = [&]() {
+        here.set_transparency_cache_dirty( target.z() );
+        here.set_outside_cache_dirty( target.z() );
+        here.set_floor_cache_dirty( target.z() );
+        here.set_pathfinding_cache_dirty( target.z() );
+        here.set_suspension_cache_dirty( target.z() );
+        here.set_absorption_cache_dirty( target.z() );
+
+        here.clear_vehicle_cache();
+        here.clear_vehicle_list( target.z() );
+
+        // Since we cleared the vehicle cache of the whole z-level (not just the generate map), we add it back here
+        for( int x = 0; x < here.getmapsize(); x++ ) {
+            for( int y = 0; y < here.getmapsize(); y++ ) {
+                const auto dest_pos = tripoint_bub_sm( x, y, target.z() );
+                const submap *destsm = here.get_mapbuffer().lookup_submap_in_memory(
+                                           map_local_to_abs( here, dest_pos ) );
+                here.update_vehicle_list( destsm, target.z() ); // update real map's vcaches
+            }
+        }
+
+        here.reset_vehicle_cache();
+
+        here.build_map_cache( target.z(), false );
+    };
+    regenerate_tmpmap( preview_buffer );
+    swap_buffers();
+    invalidate_cache();
 
     gmenu.border_color = c_light_gray;
     gmenu.hilight_color = c_black_white;
@@ -1863,7 +1827,6 @@ void editmap::mapgen_preview( const point_abs_ms &tc, uilist &gmenu )
     restore_on_out_of_scope<map *> map_ptr_prev( tmpmap_ptr );
     restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
     restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
-    map &here = get_map();
 
     int lastsel = gmenu.selected;
     bool showpreview = true;
@@ -1871,14 +1834,12 @@ void editmap::mapgen_preview( const point_abs_ms &tc, uilist &gmenu )
         if( gmenu.selected != lastsel ) {
             lastsel = gmenu.selected;
             get_overmapbuffer( get_map().get_bound_dimension() ).ter_set( omt_pos, oter_id( gmenu.selected ) );
-            regenerate_tmpmap();
+            swap_buffers();
+            regenerate_tmpmap( preview_buffer );
+            swap_buffers();
+            invalidate_cache();
         }
 
-        if( showpreview ) {
-            tmpmap_ptr = &tmpmap;
-        } else {
-            tmpmap_ptr = nullptr;
-        }
         input_context ctxt( gpmenu.input_category );
         // \u00A0 is the non-breaking space
         info_txt_curr = string_format( pgettext( "keybinding descriptions",
@@ -1894,58 +1855,17 @@ void editmap::mapgen_preview( const point_abs_ms &tc, uilist &gmenu )
         gpmenu.query( false, get_option<int>( "BLINK_SPEED" ) * 3 );
 
         if( gpmenu.ret == 0 ) {
-            regenerate_tmpmap();
+            swap_buffers();
+            regenerate_tmpmap( preview_buffer );
+            swap_buffers();
+            invalidate_cache();
         } else if( gpmenu.ret == 1 ) {
-            tmpmap.rotate( 1 );
-        } else if( gpmenu.ret == 2 ) {
-            const point target_sub( target.x() / SEEX, target.y() / SEEY );
-
-            here.set_transparency_cache_dirty( target.z() );
-            here.set_outside_cache_dirty( target.z() );
-            here.set_floor_cache_dirty( target.z() );
-            here.set_pathfinding_cache_dirty( target.z() );
-            here.set_suspension_cache_dirty( target.z() );
-            here.set_absorption_cache_dirty( target.z() );
-
-            here.clear_vehicle_cache();
-            here.clear_vehicle_list( target.z() );
-
-            for( int x = 0; x < 2; x++ ) {
-                for( int y = 0; y < 2; y++ ) {
-                    // Apply previewed mapgen to map. Since this is a function for testing, we try avoid triggering
-                    // functions that would alter the results
-                    const auto dest_pos = tripoint_bub_sm( x, y, target.z() ) + target_sub;
-                    const auto src_pos = tripoint_bub_sm{ x, y, target.z() };
-
-                    submap *destsm = here.get_mapbuffer().lookup_submap_in_memory(
-                                         map_local_to_abs( here, dest_pos ) );
-                    submap *srcsm = tmpmap.get_mapbuffer().lookup_submap_in_memory(
-                                        map_local_to_abs( tmpmap, src_pos ) );
-
-                    submap::swap( *destsm,  *srcsm );
-
-                    //TODO!: move this into the submap swap
-                    for( auto &veh : destsm->vehicles ) {
-                        veh->abs_sm_pos = map_local_to_abs( here, dest_pos );
-                    }
-
-                    if( !destsm->spawns.empty() ) {                              // trigger spawnpoints
-                        here.spawn_monsters( true );
-                    }
-                }
-            }
-
-            // Since we cleared the vehicle cache of the whole z-level (not just the generate map), we add it back here
-            for( int x = 0; x < here.getmapsize(); x++ ) {
-                for( int y = 0; y < here.getmapsize(); y++ ) {
-                    const auto dest_pos = tripoint_bub_sm( x, y, target.z() );
-                    const submap *destsm = here.get_mapbuffer().lookup_submap_in_memory(
-                                               map_local_to_abs( here, dest_pos ) );
-                    here.update_vehicle_list( destsm, target.z() ); // update real map's vcaches
-                }
-            }
-
-            here.reset_vehicle_cache();
+            swap_buffers();
+            mapgen_constructor con = mapgen_constructor( preview_buffer );
+            con.load( omt_pos );
+            con.rotate( 1 );
+            swap_buffers();
+            invalidate_cache();
         } else if( gpmenu.ret == 3 ) {
             popup( _( "Changed oter_id from '%s' (%s) to '%s' (%s)" ),
                    orig_oters->get_name(), orig_oters.id().str(),
@@ -1962,9 +1882,15 @@ void editmap::mapgen_preview( const point_abs_ms &tc, uilist &gmenu )
         showpreview = gpmenu.ret == UILIST_TIMEOUT ? !showpreview : true;
     } while( gpmenu.ret != 2 && gpmenu.ret != 3 && gpmenu.ret != UILIST_CANCEL );
 
-    if( gpmenu.ret != 2 &&  // we didn't apply, so restore the original om_ter
-        gpmenu.ret != 3 ) { // chose to change oter_id but not apply mapgen
-        get_overmapbuffer( get_map().get_bound_dimension() ).ter_set( omt_pos, orig_oters );
+    if( gpmenu.ret != 2 ) {
+        // we didn't apply, so restore the original map
+        swap_buffers();
+        invalidate_cache();
+        if( gpmenu.ret != 3 ) {
+            // we also didn't apply the OMT
+            get_overmapbuffer( get_map().get_bound_dimension() ).ter_set( omt_pos, orig_oters );
+
+        }
     }
     gmenu.border_color = c_magenta;
     gmenu.hilight_color = h_white;


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #10080

Completes todo:
```
// TODO: visibility could be affected by both the actual map and the preview map,
// which complicates calculation, so there's no override for it (yet)
```

## Describe the solution (The How)
1: Stop using tmpmap -> Mapbuffers are the new reality not tinymaps
2: Delete the draw overrides -> They depended on tinymaps and it would be a bunch of work to reimplement
3: Instead swap the submap buffers on generation, while generating the map put it on a temp, while displaying but the old map on temp
4: To draw, merely invalidate all caches -> this does show walls immediately but that is a nice effect, use debug clairvoyance to avoid that...
5: When exiting and not applying, restore the temp buffer, otherwise keep the old buffer
6: Only when exiting and applying apply monsters

## Describe alternatives you've considered
None

## Testing
All other editmap functions display right
Overmap sets and displays right
Exiting does indeed revert to normal

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9ef5e4d](https://github.com/cataclysmbn/Cataclysm-BN/commit/9ef5e4d1eff889cd82fdf1bb95e862c9020450d0) (fix monsters) on 2026-08-25 00:46:34

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32789360349/artifacts/9542850920)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32789360349/artifacts/9544461118)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32789360349/artifacts/9543785213)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32789360349/artifacts/9543306366)
<!-- END artifact comment -->