### PR TITLE
fix: put vehicle electric power turns multiplier parenthesis in the right spot

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5872,7 +5872,7 @@ void vehicle::power_parts( int turns )
     update_alternator_load();
     // Things that drain energy: engines and accessories.
     int engine_epower = total_engine_epower_w() * turns;
-    int epower = engine_epower + ( total_accessory_epower_w() + total_alternator_epower_w() ) * turns;
+    int epower = engine_epower + ( ( total_accessory_epower_w() + total_alternator_epower_w() ) * turns );
 
     int delta_energy_bat = power_to_energy_bat( epower, 1_turns );
     int storage_deficit_bat = std::max( 0, fuel_capacity( fuel_type_battery ) -

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5872,7 +5872,7 @@ void vehicle::power_parts( int turns )
     update_alternator_load();
     // Things that drain energy: engines and accessories.
     int engine_epower = total_engine_epower_w() * turns;
-    int epower = ( engine_epower + total_accessory_epower_w() + total_alternator_epower_w() ) * turns;
+    int epower = engine_epower + ( total_accessory_epower_w() + total_alternator_epower_w() ) * turns;
 
     int delta_energy_bat = power_to_energy_bat( epower, 1_turns );
     int storage_deficit_bat = std::max( 0, fuel_capacity( fuel_type_battery ) -

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5872,7 +5872,8 @@ void vehicle::power_parts( int turns )
     update_alternator_load();
     // Things that drain energy: engines and accessories.
     int engine_epower = total_engine_epower_w() * turns;
-    int epower = engine_epower + ( ( total_accessory_epower_w() + total_alternator_epower_w() ) * turns );
+    int epower = engine_epower + ( ( total_accessory_epower_w() + total_alternator_epower_w() ) *
+                                   turns );
 
     int delta_energy_bat = power_to_energy_bat( epower, 1_turns );
     int storage_deficit_bat = std::max( 0, fuel_capacity( fuel_type_battery ) -


### PR DESCRIPTION
## Purpose of change (The Why)
Fixes issue from comment in: #10128

## Describe the solution (The How)
Multiply only `total_accessory` and `total_alternator` epower values in the second statement

## Describe alternatives you've considered
Screm

## Testing
Eyes

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d4deb19](https://github.com/cataclysmbn/Cataclysm-BN/commit/d4deb190b8676476afe7cc3859b9b95275798799) (style(autofix.ci): automated formatting) on 2026-08-25 22:45:07

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32874004814/artifacts/9574881536)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32874004814/artifacts/9574783790)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32874004814/artifacts/9573731369)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32874004814/artifacts/9573818852)
<!-- END artifact comment -->