### PR TITLE
feat(lua): improve item accessing and requirement consumption

### DIFF
--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -21,6 +21,8 @@
 #include "catalua_luna_doc.h"
 #include "catalua_serde.h"
 #include "character.h"
+#include "crafting.h"
+#include "craft_command.h"
 #include "creature.h"
 #include "damage.h"
 #include "disease.h"
@@ -1304,6 +1306,23 @@ void cata::detail::reg_character( sol::state &lua )
 
         DOC( "Invalidates the cached crafting inventory" );
         SET_FX_T( invalidate_crafting_inventory, void() );
+
+        DOC( "Consumes a requirement's items from the inventory" );
+        luna::set_fx( ut, "consume_requirement", []( UT_CLASS & ch, const requirement_data & req, const sol::table & opts ) -> bool {
+            int range = opts.get_or( "range", PICKUP_RANGE );
+            int size = opts.get_or( "count", 1 );
+            inventory map_inv;
+            map_inv.form_from_map( ch.bub_pos(), range );
+            for( const auto &it : req.get_components() )
+            {
+                auto chosen = ch.select_item_component( it, size, map_inv, true );
+                if( chosen.use_from == usage_from::cancel ) {
+                    return false;
+                }
+                ch.consume_items( chosen, size );
+            }
+            return true;
+        } );
 
         DOC( "Consumes items from inventory based on item component list" );
         luna::set_fx( ut, "consume_items", []( UT_CLASS & ch, const std::vector<item_comp> &components ) -> void {

--- a/src/catalua_bindings_game.cpp
+++ b/src/catalua_bindings_game.cpp
@@ -1,3 +1,4 @@
+#include "cached_options.h"
 #include "catalua_bindings.h"
 #include "catalua_coord.h"
 #include "catalua_bindings_utils.h"
@@ -14,6 +15,7 @@
 #include "avatar.h"
 #include "creature_tracker.h"
 #include "distribution_grid.h"
+#include "init.h"
 #include "game.h"
 #include "iexamine.h"
 #include "lightmap.h"
@@ -23,6 +25,7 @@
 #include "npc.h"
 #include "monster.h"
 #include "overmapbuffer.h"
+#include "sol/forward.hpp"
 #include "weather.h"
 #include "line.h"
 #include "lua_action_menu.h"
@@ -276,6 +279,28 @@ void cata::detail::reg_game_api( sol::state &lua )
 
     luna::set_fx( lib, "add_npc_follower", []( npc & p ) { g->add_npc_follower( p.getID() ); } );
     luna::set_fx( lib, "remove_npc_follower", []( npc & p ) { g->remove_npc_follower( p.getID() ); } );
+
+    DOC( "Register a Lua-defined action menu entry in the in-game action menu." );
+    luna::set_fx( lib, "inv_map_splice", []( sol::table opts ) -> item* {
+        auto title = opts.get<std::string>( "title" );
+        auto failure = opts.get<std::string>( "failure" );
+        auto radius = opts.get_or<int>( "radius", PICKUP_RANGE );
+        auto fn = opts.get<sol::protected_function>( "check" );
+        auto &state = *DynamicDataLoader::get_instance().lua.get();
+        return g->inv_map_splice( [&]( const item & e )
+        {
+            auto params = state.lua.create_table();
+            params["item"] = &e;
+            sol::protected_function_result res = fn( params );
+
+            check_func_result( res );
+            if( res.get_type() != sol::type::boolean ) {
+                debugmsg( "Expected boolean result in `inv_map_splice` lua callback. Defaulting to false" );
+                return false;
+            }
+            return res.get<bool>();
+        }, title, radius, failure );
+    } );
 
     reg_game_api_creature_queries( lib );
     reg_game_api_world_helpers( lib );


### PR DESCRIPTION
## Purpose of change (The Why)
Needed for <https://github.com/WishDuck/Cataclysm-BN-Mods/tree/master/FilthyClothing>

## Describe the solution (The How)
Add `consume_requirements`: hand it a requirement, the count and range, it will consume them without any more issues
Add `inv_map_splice`: Give it a title, failure, radius and check function, it returns an item or nil from player selection.

## Describe alternatives you've considered
None

## Testing
Activated my sponge to clean some clothes
It worky

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [49779a9](https://github.com/cataclysmbn/Cataclysm-BN/commit/49779a950b13d7e9735878cc45bc3b50e012f6a4) (feat(lua): add 2 lua functions for consuming requirements and selecting an item from the map in range) on 2026-08-25 23:29:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32907755233/artifacts/9585721392)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32907755233/artifacts/9586458891)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32907755233/artifacts/9585803530)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/32907755233/artifacts/9585867166)
<!-- END artifact comment -->