### PR TITLE
fix: fix dp-12 segfault when primary magazine is empty

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1256,7 +1256,7 @@ static int calc_gun_volume( const item &gun )
     int speed = parent.gun_speed( am_dat );
     bool suppressed = false;
     if( am_dat ) {
-        noise = parent.ammo_data()->ammo->loudness;
+        noise = gun.ammo_data()->ammo->loudness;
         // Speed of sound at sea level is around 343 meters per second.
         // While it would be ideal to be based on speed of sound
         // EVERYTHING flies faster then the speed of sound so using that to force loud sounds makes little sense in the current state of affairs


### PR DESCRIPTION
## Purpose of change (The Why)
A crash reported when firing dp-12 secondary magazine with primary magazine empty

## Describe the solution (The How)
Feex it by referencing the right ammo data for gun noise

## Describe alternatives you've considered
None

## Testing
Do so, no splode

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [53f0e2d](https://github.com/cataclysmbn/Cataclysm-BN/commit/53f0e2d552be9d68f044e20b2e11309564c56c04) (fix: fix dp-12 segfault when primary magazine is empty) on 2026-08-27 21:44:13

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33115498504/artifacts/9664826124)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33115498504/artifacts/9665792483)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33115498504/artifacts/9665348847)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33115498504/artifacts/9664884698)
<!-- END artifact comment -->