### PR TITLE
fix: Refilling a tank(keg?) that already has a fluid causes a detached pointer error

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4122,7 +4122,11 @@ void iexamine::keg( player &p, const tripoint_bub_ms &examp )
                 }
                 detached_ptr<item> tmp = item::spawn( drink.typeId(), calendar::turn, charges_held );
                 tmp = pour_into_keg( examp, std::move( tmp ) );
-                p.use_charges( drink.typeId(), charges_held - tmp->charges );
+                if (tmp) { // tmp->charges contains the charges left after pouring into the keg
+                    p.use_charges(drink.typeId(), charges_held - tmp->charges);
+                } else { // tmp being empty means all charges were used up
+                    p.use_charges(drink.typeId(), charges_held);
+                }
                 add_msg( _( "You fill the %1$s with %2$s." ), keg_name, drink_nname );
                 notify_contents_changed( examp );
                 p.moves -= to_moves<int>( 10_seconds );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

When you refill a standing tank you get an error under the following conditions:
The tank already has fluid in it.
All fluid in your possession is used completely.
The tank is not connected to a fluid network.

## Describe the solution (The How)

IIUC tmp is a temporary item that represents all charges in the player's posession.

`tmp = pour_into_keg( examp, std::move( tmp ) );` replaces tmp with an empty detached ptr() if it empties out this imaginary item. The next line would try to read tmp->charges on this empty pointer.

`tmp->charges` is the amount of charges *left* after filling the keg as far as possible, so in the case of the empty pointer, it should just consume all possible charges.

## Describe alternatives you've considered

Consolidating more of this code. The case where you refill an empty keg for example takes a different code path. I'm pretty new to this so I stuck to fixing the bug.

## Testing

1. Spawn a water heater.
2. Spawn 2 bottles of clean water and drop 1.
3. Examine the water heater and pick 'Refill' to fill it with 1 of the bottles
4. Pick up the other bottle and refill again.

## Context

Error log:
```
23:20:20.121 ERROR DEBUGMSG : /src/detached_ptr.cpp:57 [T *detached_ptr<item>::get() const [T = item]] (error message will follow backtrace)
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x47612c8]
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x475f3b3]
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x475d97d]
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x47b1186]
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x4aa9c20]
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x498b9e7]
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x498ae76]
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x4a5689d]
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x4957354]
    /var/home/pd/workspace/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x59afeee]
    /lib64/libc.so.6(+0x3681) [0x7ffff73e2681]
    /lib64/libc.so.6(__libc_start_main+0x88) [0x7ffff73e2798]
    xxxx/Cataclysm-BN/out/build/linux-slim/src/cataclysm-bn-tiles() [0x1b0ee85]

    Attempting to repeat stack trace using debug symbols…
    debug_write_backtrace(std::ostream&)
    …/src/debug.cpp:1358
    detail::realDebugLog(DL, DC, char const*, char const*, char const*)
    …/src/debug.cpp:1607
    detail::DebugLogGuard::operator*()
    …/src/debug.h:264
    realDebugmsg(char const*, char const*, char const*, DL, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    …/src/debug.cpp:511
    std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_data() const
    /usr/bin/../lib/gcc/x86_64-redhat-linux/16/../../../../include/c++/16/bits/basic_string.h:238
    std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_is_local() const
    /usr/bin/../lib/gcc/x86_64-redhat-linux/16/../../../../include/c++/16/bits/basic_string.h:279
    std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()
    /usr/bin/../lib/gcc/x86_64-redhat-linux/16/../../../../include/c++/16/bits/basic_string.h:297
    std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string()
    /usr/bin/../lib/gcc/x86_64-redhat-linux/16/../../../../include/c++/16/bits/basic_string.h:920
    void realDebugmsg<>(char const*, char const*, char const*, DL, char const*)
    …/src/debug.h:158
    detached_ptr<item>::get() const
    …/src/detached_ptr.cpp:57
    iexamine::keg(player&, coords::coord_point<tripoint, (coords::origin)2, (coords::scale)0> const&)
    …/src/iexamine.cpp:4125
    game::examine(coords::coord_point<tripoint, (coords::origin)2, (coords::scale)0> const&)
    …/src/game.cpp:8570
    game::examine()
    …/src/game.cpp:8403
    game::handle_action()
    …/src/handle_action.cpp:2389
    game::do_turn()
    …/src/game.cpp:2176
    main
    …/src/main.cpp:928
    ??
    ??:0
    ??
    ??:0
    _start
    ??:?
Backtrace emission took 22 seconds.
=== Lua backtrace report ===
stack traceback:
(continued from above) ERROR: Attempted to resolve invalid detached_ptr
```

### Mandatory

- [X] I linked any relevant issues. I didn't find a previous report of this bug.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7ab01a7](https://github.com/cataclysmbn/Cataclysm-BN/commit/7ab01a7dee350be36d9d13879f7fb32b40d37fb2) (Don't try and read an empty pointer in the case all charges were used on) on 2026-08-27 22:52:58

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33119236397/artifacts/9667433314)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33119236397/artifacts/9666845337)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33119236397/artifacts/9666287409)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33119236397/artifacts/9666221628)
<!-- END artifact comment -->