### PR TITLE
feat(mods/Arcana): consistency updates for monsters

### DIFF
--- a/data/mods/Arcana_BN/items/ranged.json
+++ b/data/mods/Arcana_BN/items/ranged.json
@@ -486,11 +486,11 @@
     "flags": [ "NEVER_JAMS" ],
     "skill": "pistol",
     "durability": 10,
-    "range": 7,
+    "range": 10,
     "dispersion": 7500,
     "sight_dispersion": 1000,
-    "//": "Roughly half the damage of closest weapon equivalent, rounded up.",
-    "ranged_damage": { "damage_type": "heat", "amount": 13, "armor_penetration": 5 }
+    "//": "Half the damage of a hellfire staff, and half the arpen rounded up.",
+    "ranged_damage": { "damage_type": "heat", "amount": 20, "armor_penetration": 2 }
   },
   {
     "id": "monster_lightning_fake",
@@ -498,7 +498,7 @@
     "type": "GUN",
     "copy-from": "fake_item",
     "name": { "str": "monster lightning weapon" },
-    "description": "Used to give the Host of the Archon a specific degree of inaccuracy.  If you encounter one of these in the wild, it's a bug.",
+    "description": "Used to give the Host of the Archon a specific degree of inaccuracy, and to nerf his damage to not be an immediate instakill.  If you encounter one of these in the wild, it's a bug.",
     "ammo_effects": [ "NEVER_MISFIRES", "LIGHTNING" ],
     "flags": [ "NEVER_JAMS" ],
     "skill": "pistol",
@@ -507,7 +507,8 @@
     "dispersion": 5000,
     "sight_dispersion": 1000,
     "loudness": 65,
-    "ranged_damage": { "damage_type": "electric", "amount": 38, "armor_penetration": 10 }
+    "//": "One-third the damage of a symbol of judgment, for balance purposes because 120 would be way too strong to be fair to throw at the player.",
+    "ranged_damage": { "damage_type": "electric", "amount": 40, "armor_penetration": 5 }
   },
   {
     "id": "monster_hammer_fake",
@@ -539,6 +540,7 @@
     "range": 20,
     "dispersion": 5000,
     "sight_dispersion": 1000,
+    "//": "Half that of the bionic rift focus weapon.",
     "ranged_damage": { "damage_type": "dark", "amount": 20 }
   },
   {

--- a/data/mods/Arcana_BN/monsters/monsters.json
+++ b/data/mods/Arcana_BN/monsters/monsters.json
@@ -35,7 +35,7 @@
     "special_attacks": [
       {
         "id": "slam",
-        "cooldown": 30,
+        "cooldown": 10,
         "damage_max_instance": [ { "damage_type": "heat", "amount": 15, "armor_multiplier": 0.9 } ]
       },
       {
@@ -48,7 +48,7 @@
         "fake_dex": 4,
         "fake_per": 6,
         "max_ammo": 1000,
-        "ranges": [ [ 2, 7, "DEFAULT" ] ],
+        "ranges": [ [ 2, 10, "DEFAULT" ] ],
         "require_targeting_player": false,
         "description": "Wicked flames erupt from the spirit of fire!",
         "no_ammo_sound": "a distorted growl!"
@@ -116,7 +116,7 @@
       {
         "type": "spell",
         "spell_data": { "id": "arcana_monster_moruboru_fetid_exhalation" },
-        "cooldown": 50,
+        "cooldown": 10,
         "monster_message": "A strange vapor emanates from the moruboru."
       }
     ],
@@ -158,27 +158,26 @@
     "morale": 100,
     "melee_skill": 9,
     "melee_dice": 2,
-    "melee_dice_sides": 2,
-    "melee_damage": [ { "damage_type": "dark", "amount": 5, "armor_multiplier": 0.1 } ],
-    "melee_cut": 2,
+    "melee_dice_sides": 4,
+    "melee_damage": [ { "damage_type": "stab", "amount": 10 }, { "damage_type": "dark", "amount": 5, "armor_multiplier": 0.1 } ],
     "dodge": 3,
-    "armor_bash": 5,
-    "armor_cut": 5,
-    "armor_stab": 5,
-    "armor_bullet": 5,
+    "armor_bash": 6,
+    "armor_cut": 6,
+    "armor_stab": 4,
+    "armor_bullet": 6,
     "armor_fire": 5,
     "armor_acid": 5,
     "vision_night": 25,
     "harvest": "human",
     "starting_ammo": { "bot_vortex": 6 },
     "special_attacks": [
-      [ "STARE", 50 ],
-      [ "FEAR_PARALYZE", 40 ],
-      [ "GRENADIER_ELITE", 15 ],
+      [ "STARE", 15 ],
+      [ "FEAR_PARALYZE", 10 ],
+      [ "GRENADIER_ELITE", 10 ],
       [ "PARROT", 25 ],
       {
         "type": "gun",
-        "cooldown": 15,
+        "cooldown": 10,
         "move_cost": 50,
         "gun_type": "monster_lightning_fake",
         "ammo_type": "generic_no_ammo",
@@ -254,7 +253,7 @@
     "special_attacks": [
       {
         "id": "scratch",
-        "cooldown": 30,
+        "cooldown": 10,
         "damage_max_instance": [ { "damage_type": "cut", "amount": 25, "armor_multiplier": 0.75 } ],
         "body_parts": [ [ "leg_l", 5 ], [ "leg_r", 5 ], [ "head", 3 ], [ "arm_l", 5 ], [ "arm_r", 5 ], [ "torso", 7 ] ],
         "effects": [ { "id": "downed", "duration": 3 } ],
@@ -278,7 +277,7 @@
         "fake_dex": 3,
         "fake_per": 5,
         "max_ammo": 1000,
-        "ranges": [ [ 2, 7, "DEFAULT" ] ],
+        "ranges": [ [ 2, 10, "DEFAULT" ] ],
         "require_targeting_player": false,
         "description": "Wicked flames erupt from the dracolich's mouth!",
         "no_ammo_sound": "a howl of feral anger!"
@@ -882,13 +881,13 @@
     "regenerates_in_dark": true,
     "regen_morale": true,
     "special_attacks": [
-      [ "STARE", 75 ],
-      [ "FEAR_PARALYZE", 50 ],
-      [ "GRENADIER_ELITE", 20 ],
+      [ "STARE", 15 ],
+      [ "FEAR_PARALYZE", 10 ],
+      [ "GRENADIER_ELITE", 10 ],
       [ "PARROT", 40 ],
       {
         "type": "gun",
-        "cooldown": 25,
+        "cooldown": 10,
         "move_cost": 50,
         "gun_type": "monster_laser_fake",
         "ammo_type": "generic_no_ammo",
@@ -904,7 +903,7 @@
       {
         "type": "spell",
         "spell_data": { "id": "arcana_monster_archon_gaze_improved" },
-        "cooldown": 25,
+        "cooldown": 10,
         "monster_message": "You briefly sense the seraphic shade's otherworldly presence, as it glares at %3$s."
       }
     ],
@@ -956,7 +955,16 @@
     "vision_night": 50,
     "luminance": 1,
     "harvest": "exempt",
-    "special_attacks": [ [ "STARE", 250 ], [ "FEAR_PARALYZE", 100 ], [ "PARROT", 80 ] ],
+    "special_attacks": [
+      [ "STARE", 30 ],
+      [ "PARROT", 80 ],
+      {
+        "type": "spell",
+        "spell_data": { "id": "arcana_monster_archon_gaze_improved" },
+        "cooldown": 20,
+        "monster_message": "You briefly sense the seraphic shade's otherworldly presence, as it glares at %3$s."
+      }
+    ],
     "death_function": [ "MELT" ],
     "flags": [
       "PACIFIST",
@@ -1071,7 +1079,7 @@
     "regenerates": 1,
     "path_settings": { "max_dist": 10 },
     "special_attacks": [
-      [ "STARE", 100 ],
+      [ "STARE", 20 ],
       {
         "type": "gun",
         "cooldown": 5,
@@ -1090,7 +1098,7 @@
       {
         "type": "spell",
         "spell_data": { "id": "arcana_monster_mech_flare" },
-        "cooldown": 50,
+        "cooldown": 25,
         "monster_message": "The Autonomous Anomaly Recon Mech launches a ghostly blue flare, illuminating %3$s with ethereal light!"
       }
     ],
@@ -1130,14 +1138,14 @@
     "color": "magenta",
     "aggression": -10,
     "morale": 100,
-    "melee_skill": 4,
+    "melee_skill": 2,
     "melee_dice": 2,
     "melee_dice_sides": 3,
     "armor_bash": 2,
     "armor_cut": 2,
     "armor_stab": 2,
     "armor_bullet": 2,
-    "dodge": 1,
+    "dodge": 3,
     "harvest": "human",
     "vision_day": 40,
     "vision_night": 20,
@@ -1148,7 +1156,7 @@
       {
         "type": "spell",
         "spell_data": { "id": "arcana_monster_summoner", "hit_self": true },
-        "cooldown": 15,
+        "cooldown": 5,
         "monster_message": "The air wavers as the maddened wanderer raises its talisman!"
       }
     ],
@@ -1175,15 +1183,16 @@
     "name": { "str": "maddened hunter" },
     "description": "A cloak of metal scales obscures this humanoid figure, heavy breaths revealing it to still be among the living.  Gripped by raving madness, bloodshot eyes glower from under a metal mask, as it grasps a silver-decorated war hammer.",
     "aggression": 5,
-    "melee_skill": 6,
-    "melee_dice_sides": 8,
-    "melee_damage": [ { "damage_type": "stab", "amount": 8 } ],
+    "melee_skill": 4,
+    "melee_dice": 4,
+    "melee_dice_sides": 6,
+    "melee_damage": [ { "damage_type": "stab", "amount": 23 } ],
     "armor_bash": 12,
     "armor_cut": 12,
-    "armor_stab": 12,
-    "armor_bullet": 9,
-    "dodge": 2,
-    "diff": 2,
+    "armor_stab": 9,
+    "armor_bullet": 10,
+    "dodge": 4,
+    "diff": 10,
     "//": "Some of them may be feral arcane purifiers/operatives instead of conventional mage hunters.",
     "harvest": "human_maybe_survivalist_bionics",
     "special_attacks": [
@@ -1226,18 +1235,18 @@
     "description": "Dark robes and a heavy fur mantle conceal a human figure, still breathing despite looking to be on the edge of death.  Gripped by raving madness, it desperately clutches a golden talisman that crackles with electricity.",
     "aggression": -5,
     "melee_dice_sides": 4,
-    "melee_damage": [ { "damage_type": "stab", "amount": 6 } ],
-    "armor_bash": 4,
-    "armor_cut": 4,
+    "melee_damage": [ { "damage_type": "stab", "amount": 10 }, { "damage_type": "electric", "amount": 5 } ],
+    "armor_bash": 6,
+    "armor_cut": 6,
     "armor_stab": 4,
-    "armor_bullet": 3,
-    "dodge": 3,
-    "diff": 3,
+    "armor_bullet": 6,
+    "dodge": 4,
+    "diff": 10,
     "special_attacks": [
       [ "PARROT_AT_DANGER", 5 ],
       {
         "type": "gun",
-        "cooldown": 5,
+        "cooldown": 10,
         "move_cost": 100,
         "gun_type": "monster_lightning_fake",
         "ammo_type": "generic_no_ammo",
@@ -1268,14 +1277,14 @@
     "name": { "str": "maddened sanguinist" },
     "description": "Clad in well-worn leather armor, this wretch is still alive and breathing despite its unsteady gait and bloodshot gaze.  Gripped by raving madness, flames dance around the gem-adorned staff it uses as a walking stick.",
     "aggression": 10,
-    "melee_skill": 6,
-    "melee_dice_sides": 8,
+    "melee_skill": 3,
+    "melee_dice": 3,
+    "melee_dice_sides": 7,
     "armor_bash": 10,
     "armor_cut": 10,
-    "armor_stab": 10,
-    "armor_bullet": 7,
-    "dodge": 2,
-    "diff": 3,
+    "armor_stab": 8,
+    "armor_bullet": 10,
+    "diff": 15,
     "special_attacks": [
       [ "PARROT_AT_DANGER", 5 ],
       {
@@ -1288,7 +1297,7 @@
         "fake_dex": 10,
         "fake_per": 7,
         "max_ammo": 1000,
-        "ranges": [ [ 2, 7, "DEFAULT" ] ],
+        "ranges": [ [ 2, 10, "DEFAULT" ] ],
         "require_targeting_player": true,
         "require_targeting_npc": true,
         "require_targeting_monster": true,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Some assorted tweaks to monsters in Arcana mod.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Maddened wanderers have their melee skill lowered from 4 to 2 but dodge raised from 1 to 3, matching that of the summoner profession. They aren't armed with a quarterstaff like summoners but instead are basically-unarmed, so they're still de-facto harmless in a direct fight. However, they've also had the cooldown of their summon spell lowered from 15 turns to 5, so they can rely more on harassing the player with summoned monsters once aggro'd.
2. Maddened hunters have been given a substantial buff to their melee stats, dealing 4d6 bashing damage and getting the full 23 stabbing damage that warhammers can deal, making their max melee damage actually line up with the 24+23 damage the hammer of the hunter is set to (note that hammer of the hunter adds +2 bashing damage over a vanilla warhammer since it has more weight). Melee skill meanwhile was nerfed from 6 to 4 while dodge skill was buffed from 2 to 4, matching the starting skills the mage hunter profession has. Armor stats updated to match a gilded aegis.
3. Maddened keepers were given 10 stabbing damage and 5 electric damage, which combined with the unchanged 2d4 bash damage matches the base damage from using a symbol of judgment as a melee weapon. Dodge was likewise buffed from 3 to 4 to match starting skills of the Keeper's main profession. They do however still inherit the 2 melee skill from maddened wanderers, when dark priests start with no melee skill. Also nerfed their ranged attack's cooldown from 5 turns to 10. Armor stats updated to match a mantle of shadows.
4. Maddened sanguinists given 3d7 bash damage to match the 21 damage a hellfire staff has in melee, melee skill lowered from 6 to 3 while dodge skill set to inherit the same 3 maddened wanderers have to match the starting skills of the blood mage profession. Armor stats updated to match wyrmskin armor.
5. Likewise gave the host of the archon the same melee stats maddened keepers have, except he gets dark-type damage INSTEAD of electric damage. Also buffed the cooldown of his ranged attack from 15 turns to 10, while tweaking the cooldown of his other hardcoded special attacks a bit too. Armor stats updated to match a mantle of shadows.
6. Misc: Likewise buffed some attack cooldowns for boss monsters that had noticably massive cooldowns. In particular the seraphic shade's doppelgangers can use the special attacks they gained at twice the cooldown instead of like 10-20 times as slowly, but in exchange to avoid wacky stunlocks they've lost the ability to use `FEAR_PARALYZE`, and instead gained the version of the archon's gaze ability the original has (again at twice the cooldown).
7. Increased the generic monster fire weapon (used by the spirit of fire, dracolich, and maddened sanguinists) from 13 damage to 20, making it half that of a hellfire staff. Likewise buffed range from 7 to 10, and nerfed arpen from 3 to 2 (half that of the hellfire staff, rounded up)
8. The generic monster lightning weapon, used by the host of the archon and maddened keepers, had its damage buffed from 38 to 40, making it exactly one third the damage of a symbol of judgment, while its arpen was accordingly nerfed from 10 to 5 (not really relevant since electric armor has fuck-all implementation aside from the Battle Ward buff Via Gladium et Malleo has, more for consistency than anything else). That's still more than enough to make the player shit themselves but not be an instakill, and is explicitly nerfed even harder than the other monster guns which get to be 50% as effective because again, 120 is a LOT of damage and even 60 would feel excessive to me.

## Describe alternatives you've considered

1. Basing feral arcanist monsters off the feral versions even more heavily and thus giving them access to a wider range of attacks since those professions get a full kit of faction-specific toys to play with. Right now the only nod to this is the feral sanguinist gets to have the armor values and acid immunity wyrmskin armor provides, but going full hog would be...brutal to be honest given this would give the maddened hunter a wraithslayer, which would make them an unavoidable YASD machine when paired with the clairvoyance https://github.com/cataclysmbn/Cataclysm-BN/pull/10140 is going to give them.
2. Likewise, making the fire and lightning monster guns hit as hard as their player-usable counterparts. 40 fire damage would hurt like a motherfucker but not be THAT terrible, but the lightning weapon would be a LOT bigger of a buff that I'd really be confortable with. One can just excuse it with the assumption that its main user is the host of the archon, a being that very much does NOT have HFBTV's favor and are probably actually enemies of each other, and thus probably has to fuel it with life energy borrowed from its host.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0a53ed9](https://github.com/cataclysmbn/Cataclysm-BN/commit/0a53ed9ad646c4b89281b9e98215ebadb5bf613f) (feat(mods/Arcana): consistency updates for monsters) on 2026-08-28 01:24:21

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33128642304/artifacts/9670450192)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33128642304/artifacts/9670860253)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33128642304/artifacts/9670477974)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33128642304/artifacts/9670172705)
<!-- END artifact comment -->