### PR TITLE
fix: actually apply ACTIVE to infrared CBM

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -680,7 +680,7 @@
     "react_cost": "5 J",
     "time": 1,
     "points": 1,
-    "bio_enchantments": [ { "flags": [ "INFRARED_VISION" ] } ]
+    "bio_enchantments": [ { "conditions": [ "ACTIVE" ], "flags": [ "INFRARED_VISION" ] } ]
   },
   {
     "id": "bio_int_enhancer",


### PR DESCRIPTION
## Purpose of change (The Why)
Made a mistake in one of the enchantment PRs

## Describe the solution (The How)
Actually use active condition

## Describe alternatives you've considered
None

## Testing
Saw no NPC with off, saw NPC with on

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [6e9d7a4](https://github.com/cataclysmbn/Cataclysm-BN/commit/6e9d7a48f3713368f0781b48a752310da9412c0e) (fix: actually apply ACTIVE to infrared CBM) on 2026-08-28 02:46:39

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33133385761/artifacts/9671298645)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33133385761)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33133385761)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33133385761)
<!-- END artifact comment -->