### PR TITLE
perf: improve activity performance in rain

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2858,7 +2858,7 @@ auto game::execute_activity_fixed_window_skip( const time_duration &duration ) -
         cleanup_dead();
 
         if( get_levz() >= 0 && !u.is_underwater() ) {
-            handle_weather_effects( weather.weather_id );
+            handle_weather_effects( weather.weather_id, false );
         }
         u.update_bodytemp( m, weather );
         character_funcs::update_body_wetness( u, get_weather().get_precise() );
@@ -2869,6 +2869,7 @@ auto game::execute_activity_fixed_window_skip( const time_duration &duration ) -
             break;
         }
     }
+    handle_bulk_weather_field_decay( weather.weather_id, skipped_turns );
     run_activity_skip_batch_turns( skipped_turns );
     return skipped_turns;
 }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4122,10 +4122,10 @@ void iexamine::keg( player &p, const tripoint_bub_ms &examp )
                 }
                 detached_ptr<item> tmp = item::spawn( drink.typeId(), calendar::turn, charges_held );
                 tmp = pour_into_keg( examp, std::move( tmp ) );
-                if (tmp) { // tmp->charges contains the charges left after pouring into the keg
-                    p.use_charges(drink.typeId(), charges_held - tmp->charges);
+                if( tmp ) { // tmp->charges contains the charges left after pouring into the keg
+                    p.use_charges( drink.typeId(), charges_held - tmp->charges );
                 } else { // tmp being empty means all charges were used up
-                    p.use_charges(drink.typeId(), charges_held);
+                    p.use_charges( drink.typeId(), charges_held );
                 }
                 add_msg( _( "You fill the %1$s with %2$s." ), keg_name, drink_nname );
                 notify_contents_changed( examp );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3765,7 +3765,7 @@ void map::decay_fields_and_scent( const time_duration &amount )
         }
 
         if( to_proc > 0 ) {
-            for( const auto sm_ms : submap_tiles() ) {
+            for( const auto sm_ms : cur_submap->field_cache ) {
                 const auto ms_pos = project_combine( p, sm_ms );
 
                 field &fields = cur_submap->get_field( sm_ms );

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -596,7 +596,7 @@ double precip_mm_per_hour( precip_class const p )
         0;
 }
 
-void handle_weather_effects( const weather_type_id &w )
+void handle_bulk_weather_field_decay( const weather_type_id &w, int turns )
 {
     ZoneScoped;
     if( w->rains && w->precip != precip_class::none ) {
@@ -617,7 +617,33 @@ void handle_weather_effects( const weather_type_id &w )
             decay_time = 45_turns;
             wetness = 60;
         }
-        g->m.decay_fields_and_scent( decay_time );
+        g->m.decay_fields_and_scent( decay_time * turns );
+    }
+}
+void handle_weather_effects( const weather_type_id &w, bool do_decay )
+{
+    ZoneScoped;
+    if( w->rains && w->precip != precip_class::none ) {
+        fill_water_collectors( precip_mm_per_hour( w->precip ),
+                               w->acidic );
+        int wetness = 0;
+        time_duration decay_time = 60_turns;
+        if( w->precip == precip_class::very_light ) {
+            wetness = 5;
+            decay_time = 5_turns;
+        } else if( w->precip == precip_class::light ) {
+            wetness = 30;
+            decay_time = 15_turns;
+        } else if( w->precip == precip_class::medium ) {
+            wetness = 45;
+            decay_time = 30_turns;
+        } else if( w->precip == precip_class::heavy ) {
+            decay_time = 45_turns;
+            wetness = 60;
+        }
+        if( do_decay ) {
+            g->m.decay_fields_and_scent( decay_time );
+        }
         weather_effect::wet_player( wetness );
     }
     glare( w );

--- a/src/weather.h
+++ b/src/weather.h
@@ -47,7 +47,8 @@ struct trap;
 struct rl_vec2d;
 
 double precip_mm_per_hour( precip_class p );
-void handle_weather_effects( const weather_type_id &w );
+void handle_bulk_weather_field_decay( const weather_type_id &w, int turns );
+void handle_weather_effects( const weather_type_id &w, bool do_decay = true );
 
 /**
  * Weather drawing tracking.


### PR DESCRIPTION
## Purpose of change (The Why)
Rain resulted in an 1000 -> 1800 perf loss last I checked

## Describe the solution (The How)
Batch the loop the world to once per activity tick

## Describe alternatives you've considered
None

## Testing
No rain: 850-950
Rain: ~1000
No longer rain: eater of perf

## Additional Context
Additional changes are due to someone NOT RUNNING THE TREE

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a21b775](https://github.com/cataclysmbn/Cataclysm-BN/commit/a21b775198ad57c4b9e2a83fee77ec09f293395c) (perf: improve activity performance in rain) on 2026-08-28 15:47:38

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33178083502/artifacts/9690295093)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33178083502/artifacts/9691375534)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33178083502/artifacts/9689139324)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33178083502/artifacts/9689246904)
<!-- END artifact comment -->