### PR TITLE
feat: make the tacoma commune clinic not overlap two mapgen

### DIFF
--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -490,10 +490,7 @@
         },
         {
           "om_terrain": "ranch_camp_59",
-          "place_nested": [
-            { "chunks": [ "tacoma_commune_toolshed_8" ], "x": 13, "y": 17 },
-            { "chunks": [ "tacoma_commune_clinic_8" ], "x": 0, "y": 0 }
-          ]
+          "place_nested": [ { "chunks": [ "tacoma_commune_toolshed_8" ], "x": 13, "y": 17 } ]
         },
         {
           "om_terrain": "ranch_camp_65",
@@ -536,12 +533,10 @@
     },
     "end": {
       "update_mapgen": [
+        { "om_terrain": "ranch_camp_50", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_9" ], "x": 0, "y": 0 } ] },
         {
           "om_terrain": "ranch_camp_59",
-          "place_nested": [
-            { "chunks": [ "tacoma_commune_toolshed_9_done" ], "x": 13, "y": 17 },
-            { "chunks": [ "tacoma_commune_clinic_9" ], "x": 0, "y": 0 }
-          ]
+          "place_nested": [ { "chunks": [ "tacoma_commune_toolshed_9_done" ], "x": 13, "y": 17 } ]
         },
         {
           "om_terrain": "ranch_camp_68",
@@ -574,7 +569,7 @@
     },
     "end": {
       "update_mapgen": [
-        { "om_terrain": "ranch_camp_59", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_10" ], "x": 0, "y": 0 } ] },
+        { "om_terrain": "ranch_camp_50", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_10" ], "x": 0, "y": 0 } ] },
         {
           "om_terrain": "ranch_camp_60",
           "place_nested": [ { "chunks": [ "tacoma_commune_chopshop_10" ], "x": 0, "y": 4 } ]
@@ -606,7 +601,11 @@
     },
     "end": {
       "update_mapgen": [
-        { "om_terrain": "ranch_camp_59", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_11" ], "x": 0, "y": 0 } ] },
+        {
+          "om_terrain": "ranch_camp_50",
+          "//": "finish the clinic",
+          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_11" ], "x": 0, "y": 0 } ]
+        },
         {
           "om_terrain": "ranch_camp_60",
           "place_nested": [ { "chunks": [ "tacoma_commune_chopshop_11" ], "x": 0, "y": 4 } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
@@ -119,9 +119,9 @@
     "end": {
       "update_mapgen": [
         {
-          "om_terrain": "ranch_camp_59",
-          "place_furniture": [ { "furn": "f_rack_wood", "x": 15, "y": 7 } ],
-          "place_item": [ { "item": "aspirin", "x": 15, "y": 7, "amount": 2 }, { "item": "bandages", "x": 15, "y": 7, "amount": [ 1, 3 ] } ]
+          "om_terrain": "ranch_camp_50",
+          "place_furniture": [ { "furn": "f_rack_wood", "x": 13, "y": 21 } ],
+          "place_item": [ { "item": "bandages", "x": 13, "y": 21, "amount": [ 1, 3 ] }, { "item": "aspirin", "x": 13, "y": 21, "amount": 2 } ]
         }
       ]
     }
@@ -151,8 +151,8 @@
     "end": {
       "update_mapgen": [
         {
-          "om_terrain": "ranch_camp_59",
-          "place_item": [ { "item": "hotplate", "x": 15, "y": 7, "amount": 3 }, { "item": "manual_first_aid", "x": 15, "y": 7 } ]
+          "om_terrain": "ranch_camp_50",
+          "place_item": [ { "item": "hotplate", "x": 13, "y": 21, "amount": 3 }, { "item": "manual_first_aid", "x": 13, "y": 21 } ]
         }
       ]
     }
@@ -180,14 +180,7 @@
       "failure": "It was a lost cause anyways…"
     },
     "end": {
-      "update_mapgen": [
-        { "om_terrain": "ranch_camp_50", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_12" ], "x": 0, "y": 16 } ] },
-        {
-          "om_terrain": "ranch_camp_59",
-          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_13" ], "x": 0, "y": 0 } ],
-          "place_item": [ { "item": "vitamins", "x": 15, "y": 7, "amount": 2 } ]
-        }
-      ]
+      "update_mapgen": [ { "om_terrain": "ranch_camp_50", "place_item": [ { "item": "vitamins", "x": 13, "y": 21, "amount": 2 } ] } ]
     }
   },
   {
@@ -214,11 +207,10 @@
     },
     "end": {
       "update_mapgen": [
-        { "om_terrain": "ranch_camp_50", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_14" ], "x": 0, "y": 16 } ] },
         {
-          "om_terrain": "ranch_camp_59",
-          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_15" ], "x": 0, "y": 0 } ],
-          "place_item": [ { "item": "char_purifier", "x": 15, "y": 7, "amount": [ 1, 3 ] } ]
+          "om_terrain": "ranch_camp_50",
+          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_12" ], "x": 0, "y": 0 } ],
+          "place_item": [ { "item": "char_purifier", "x": 13, "y": 21, "amount": [ 1, 3 ] } ]
         }
       ]
     }
@@ -246,11 +238,10 @@
     },
     "end": {
       "update_mapgen": [
-        { "om_terrain": "ranch_camp_50", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_16" ], "x": 0, "y": 16 } ] },
         {
-          "om_terrain": "ranch_camp_59",
-          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_17" ], "x": 0, "y": 0 } ],
-          "place_item": [ { "item": "chemistry_set", "x": 15, "y": 7 } ]
+          "om_terrain": "ranch_camp_50",
+          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_13" ], "x": 0, "y": 0 } ],
+          "place_item": [ { "item": "chemistry_set", "x": 13, "y": 21 } ]
         }
       ]
     }
@@ -280,13 +271,13 @@
     "end": {
       "update_mapgen": [
         {
-          "om_terrain": "ranch_camp_59",
+          "om_terrain": "ranch_camp_50",
           "place_furniture": [
-            { "furn": "f_rack_wood", "x": 15, "y": 0 },
-            { "furn": "f_rack_wood", "x": 15, "y": 1 },
-            { "furn": "f_rack_wood", "x": 15, "y": 2 }
+            { "furn": "f_rack_wood", "x": 16, "y": 12 },
+            { "furn": "f_rack_wood", "x": 16, "y": 13 },
+            { "furn": "f_rack_wood", "x": 16, "y": 14 }
           ],
-          "place_item": [ { "item": "mask_filter", "x": 15, "y": 7, "amount": [ 2, 6 ] } ]
+          "place_item": [ { "item": "mask_filter", "x": 13, "y": 21, "amount": [ 2, 6 ] } ]
         }
       ]
     }
@@ -316,9 +307,13 @@
     "end": {
       "update_mapgen": [
         {
-          "om_terrain": "ranch_camp_59",
-          "place_items": [ { "chance": 100, "item": "cleaning", "x": 15, "y": [ 0, 2 ], "repeat": [ 3, 9 ] } ],
-          "place_item": [ { "item": "gloves_rubber", "x": 15, "y": 7, "amount": [ 2, 3 ] } ]
+          "om_terrain": "ranch_camp_50",
+          "place_items": [
+            { "chance": 100, "item": "cleaning", "x": 16, "y": 12, "repeat": [ 1, 3 ] },
+            { "chance": 100, "item": "cleaning", "x": 16, "y": 13, "repeat": [ 1, 3 ] },
+            { "chance": 100, "item": "cleaning", "x": 16, "y": 14, "repeat": [ 1, 3 ] }
+          ],
+          "place_item": [ { "item": "gloves_rubber", "x": 13, "y": 21, "amount": [ 2, 3 ] } ]
         }
       ]
     }
@@ -347,8 +342,11 @@
     },
     "end": {
       "update_mapgen": [
-        { "om_terrain": "ranch_camp_50", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_18" ], "x": 0, "y": 16 } ] },
-        { "om_terrain": "ranch_camp_59", "place_item": [ { "item": "scalpel", "x": 15, "y": 7, "amount": 2 } ] }
+        {
+          "om_terrain": "ranch_camp_50",
+          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_14" ], "x": 0, "y": 0 } ],
+          "place_item": [ { "item": "scalpel", "x": 13, "y": 21, "amount": 2 } ]
+        }
       ]
     }
   },
@@ -375,8 +373,11 @@
     },
     "end": {
       "update_mapgen": [
-        { "om_terrain": "ranch_camp_50", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_19" ], "x": 0, "y": 16 } ] },
-        { "om_terrain": "ranch_camp_59", "place_item": [ { "item": "emergency_book", "x": 15, "y": 7 } ] }
+        {
+          "om_terrain": "ranch_camp_50",
+          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_15" ], "x": 0, "y": 0 } ],
+          "place_item": [ { "item": "emergency_book", "x": 13, "y": 21 } ]
+        }
       ]
     }
   },
@@ -403,7 +404,7 @@
       "failure": "It was a lost cause anyways…"
     },
     "end": {
-      "update_mapgen": [ { "om_terrain": "ranch_camp_59", "place_item": [ { "item": "syringe", "x": 15, "y": 7, "amount": [ 4, 8 ] } ] } ]
+      "update_mapgen": [ { "om_terrain": "ranch_camp_50", "place_item": [ { "item": "syringe", "x": 13, "y": 21, "amount": [ 4, 8 ] } ] } ]
     }
   }
 ]

--- a/data/json/npcs/tacoma_ranch/mission_mapgen_tacoma_commune.json
+++ b/data/json/npcs/tacoma_ranch/mission_mapgen_tacoma_commune.json
@@ -415,63 +415,36 @@
   {
     "type": "mapgen",
     "method": "json",
-    "nested_mapgen_id": "tacoma_commune_clinic_8",
-    "object": {
-      "mapgensize": [ 20, 20 ],
-      "rows": [
-        "                    ",
-        "                    ",
-        "                    ",
-        "........   .......  ",
-        "........   .......  ",
-        "..................  ",
-        "..................  ",
-        "..................  ",
-        "..................  ",
-        "..................  ",
-        "........   .......  ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    "
-      ],
-      "terrain": { ".": "t_region_soil" }
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
     "nested_mapgen_id": "tacoma_commune_clinic_9",
     "object": {
-      "mapgensize": [ 20, 20 ],
+      "mapgensize": [ 21, 24 ],
       "rows": [
-        "                    ",
-        "                    ",
-        "                    ",
-        "wwwwwwww   wwwwwww  ",
-        "w......w   w.....w  ",
-        "[......ww+ww.....[  ",
-        "w................w  ",
-        "w................w  ",
-        "[................[  ",
-        "w......wwwww.....w  ",
-        "www++www   wwwwwww  ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    "
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        " wwwwwwww   wwwwwwww ",
+        " w......w   w......w ",
+        " [......wwfww......[ ",
+        " w.................w ",
+        " w.................w ",
+        " [.................[ ",
+        " w......wwwww......w ",
+        " wwwffwww   wwwwwwww ",
+        "                     "
       ],
-      "terrain": { "w": "t_wall_half", ".": "t_region_soil", "+": "t_door_frame", "[": "t_window_empty" }
+      "terrain": { ".": "t_region_soil", "w": "t_wall_half", "f": "t_door_frame", "[": "t_window_empty" }
     }
   },
   {
@@ -479,30 +452,34 @@
     "method": "json",
     "nested_mapgen_id": "tacoma_commune_clinic_10",
     "object": {
-      "mapgensize": [ 20, 20 ],
+      "mapgensize": [ 21, 24 ],
       "rows": [
-        "                    ",
-        "                    ",
-        "                    ",
-        "wwwwwwww   wwwwwwww ",
-        "w......w   w......w ",
-        "[......ww+ww......[ ",
-        "w......w...w......w ",
-        "w......+...+......w ",
-        "[......w...w......[ ",
-        "w......wwwww......w ",
-        "www++www   wwwwwwww ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    "
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        " wwwwwwww   wwwwwwww ",
+        " w......w   w......w ",
+        " [......ww+ww......[ ",
+        " w......w...w......w ",
+        " w......+...+......w ",
+        " [......w...w......[ ",
+        " w......wwwww......w ",
+        " www++www   wwwwwwww ",
+        "                     "
       ],
-      "terrain": { "w": "t_wall_wood", ".": "t_region_soil", "+": "t_door_c", "[": "t_window_boarded_noglass" }
+      "terrain": { ".": "t_region_soil", "w": "t_wall_wood", "+": "t_door_c", "[": "t_window_boarded_noglass" }
     }
   },
   {
@@ -510,32 +487,36 @@
     "method": "json",
     "nested_mapgen_id": "tacoma_commune_clinic_11",
     "object": {
-      "mapgensize": [ 20, 20 ],
+      "mapgensize": [ 21, 24 ],
       "rows": [
-        "                    ",
-        "                    ",
-        "                    ",
-        "wwwwwwww   wwwwwwww ",
-        "w......w   wccccccw ",
-        "[..CCC.ww+ww......[ ",
-        "w......w...w......w ",
-        "w......+...+.tt...w ",
-        "[......w...w......[ ",
-        "w......wwwww......w ",
-        "www++www   wwwwwwww ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    ",
-        "                    "
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        " wwwwwwww   wwwwwwww ",
+        " w......w   wccccccw ",
+        " [..CCC.ww+ww......[ ",
+        " w......w...w......w ",
+        " w......+...+..tt..w ",
+        " [......w...w......[ ",
+        " w......wwwww......w ",
+        " www++www   wwwwwwww ",
+        "                     "
       ],
       "terrain": {
-        "w": "t_wall_wood",
         ".": "t_floor",
+        "w": "t_wall_wood",
         "+": "t_door_c",
         "[": "t_window_boarded_noglass",
         "C": "t_floor",
@@ -543,7 +524,7 @@
         "t": "t_floor"
       },
       "furniture": { "C": "f_counter", "c": "f_cupboard", "t": "f_table" },
-      "place_npcs": [ { "class": "ranch_nurse_1", "x": 5, "y": 6 } ]
+      "place_npcs": [ { "class": "ranch_nurse_1", "x": 5, "y": 16 } ]
     }
   },
   {
@@ -551,18 +532,34 @@
     "method": "json",
     "nested_mapgen_id": "tacoma_commune_clinic_12",
     "object": {
-      "mapgensize": [ 20, 8 ],
+      "mapgensize": [ 21, 24 ],
       "rows": [
-        "........   ........ ",
-        "................... ",
-        "................... ",
-        "................... ",
-        "................... ",
-        "................... ",
-        "................... ",
-        "................... "
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        " wwwwwwww   wwwwwwww ",
+        " w......wwwww......w ",
+        " [......w...w......[ ",
+        " w......f...f......w ",
+        " w......w...w......w ",
+        " [......w...w......[ ",
+        " w......w...w......w ",
+        " wwwwwwww...wwwwwwww ",
+        "   w....w...w....w   ",
+        "   w....f...f....w   ",
+        "   w....w...w....w   ",
+        "         ...         ",
+        "         ...         ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     "
       ],
-      "terrain": { ".": "t_region_soil" }
+      "terrain": { ".": "t_region_soil", "w": "t_wall_half", "f": "t_door_frame", "[": "t_window_empty" }
     }
   },
   {
@@ -570,15 +567,34 @@
     "method": "json",
     "nested_mapgen_id": "tacoma_commune_clinic_13",
     "object": {
-      "mapgensize": [ 20, 5 ],
+      "mapgensize": [ 21, 24 ],
       "rows": [
-        "  ...............   ",
-        "  ...............   ",
-        "  ...............   ",
-        "        ...         ",
-        "        ...         "
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        " wwwwwwww   wwwwwwww ",
+        " w......wwwww......w ",
+        " [......w...w......[ ",
+        " w......+...+......w ",
+        " w......w...w......w ",
+        " [......w...w......[ ",
+        " w......w...w......w ",
+        " wwwwwwww...wwwwwwww ",
+        "   w....w...w....w   ",
+        "   w....+...+....w   ",
+        "   w....w...w....w   ",
+        "         ...         ",
+        "         ...         ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     "
       ],
-      "terrain": { ".": "t_region_soil" }
+      "terrain": { ".": "t_floor", "w": "t_wall_wood", "+": "t_door_c", "[": "t_window_boarded_noglass" }
     }
   },
   {
@@ -586,18 +602,35 @@
     "method": "json",
     "nested_mapgen_id": "tacoma_commune_clinic_14",
     "object": {
-      "mapgensize": [ 20, 8 ],
+      "mapgensize": [ 21, 24 ],
       "rows": [
-        "wwwwwwww   wwwwwwww ",
-        "w......wwwww......w ",
-        "[......w...w......[ ",
-        "w......+...+......w ",
-        "w......w...w......w ",
-        "[......w...w......[ ",
-        "w......w...w......w ",
-        "wwwwwwww...wwwwwwww "
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        " wwwwwwww   wwwwwwww ",
+        " w.#..#.wwwww.#..#.w ",
+        " [.#..#.w...w.#..#.[ ",
+        " w......+...+......w ",
+        " w......w...w......w ",
+        " [.#..#.w...w.#..#.[ ",
+        " w.#..#.w...w.#..#.w ",
+        " wwwwwwww...wwwwwwww ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     "
       ],
-      "terrain": { ".": "t_region_soil", "w": "t_wall_half", "+": "t_door_frame", "[": "t_window_empty" }
+      "terrain": { ".": "t_floor", "w": "t_wall_wood", "+": "t_door_c", "[": "t_window_boarded_noglass" },
+      "furniture": { "#": "f_makeshift_bed" }
     }
   },
   {
@@ -605,91 +638,36 @@
     "method": "json",
     "nested_mapgen_id": "tacoma_commune_clinic_15",
     "object": {
-      "mapgensize": [ 20, 5 ],
+      "mapgensize": [ 21, 24 ],
       "rows": [
-        "  w....w...w....w   ",
-        "  w....+...+....w   ",
-        "  w....w...w....w   ",
-        "        ...         ",
-        "        ...         "
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        " wwwwwwww   wwwwwwww ",
+        " wd#..#dwwwwwd#..#dw ",
+        " [.#..#.w...w.#..#.[ ",
+        " w......+...+......w ",
+        " w......w...w......w ",
+        " [.#..#.w...w.#..#.[ ",
+        " wd#..#dw...wd#..#dw ",
+        " wwwwwwww...wwwwwwww ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     "
       ],
-      "terrain": { ".": "t_region_soil", "w": "t_wall_half", "+": "t_door_frame" }
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "tacoma_commune_clinic_16",
-    "object": {
-      "mapgensize": [ 20, 8 ],
-      "rows": [
-        "wwwwwwww   wwwwwwww ",
-        "w......wwwww......w ",
-        "[......w...w......[ ",
-        "w......+...+......w ",
-        "w......w...w......w ",
-        "[......w...w......[ ",
-        "w......w...w......w ",
-        "wwwwwwww...wwwwwwww "
-      ],
-      "terrain": { "w": "t_wall_wood", ".": "t_floor", "+": "t_door_c", "[": "t_window_boarded_noglass" }
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "tacoma_commune_clinic_17",
-    "object": {
-      "mapgensize": [ 20, 5 ],
-      "rows": [
-        "  w....w...w....w   ",
-        "  w....+...+....w   ",
-        "  w....w...w....w   ",
-        "        ...         ",
-        "        ...         "
-      ],
-      "terrain": { "w": "t_wall_wood", ".": "t_floor", "+": "t_door_c" }
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "tacoma_commune_clinic_18",
-    "object": {
-      "mapgensize": [ 20, 8 ],
-      "rows": [
-        "wwwwwwww   wwwwwwww ",
-        "w.#..#.wwwww.#..#.w ",
-        "[.#..#.w...w.#..#.[ ",
-        "w......+...+......w ",
-        "w......w...w......w ",
-        "[.#..#.w...w.#..#.[ ",
-        "w.#..#.w...w.#..#.w ",
-        "wwwwwwww...wwwwwwww "
-      ],
-      "terrain": { "w": "t_wall_wood", ".": "t_floor", "+": "t_door_c", "[": "t_window_boarded_noglass" },
-      "furniture": { "#": "f_makeshift_bed" }
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "tacoma_commune_clinic_19",
-    "object": {
-      "mapgensize": [ 20, 8 ],
-      "rows": [
-        "wwwwwwww   wwwwwwww ",
-        "wd#..#dwwwwwd#..#dw ",
-        "[.#..#.w...w.#..#.[ ",
-        "w......+...+......w ",
-        "w......w...w......w ",
-        "[.#..#.w...w.#..#.[ ",
-        "wd#..#dw...wd#..#dw ",
-        "wwwwwwww...wwwwwwww "
-      ],
-      "terrain": { "w": "t_wall_wood", ".": "t_floor", "+": "t_door_c", "[": "t_window_boarded_noglass" },
+      "terrain": { ".": "t_floor", "w": "t_wall_wood", "+": "t_door_c", "[": "t_window_boarded_noglass" },
       "furniture": { "#": "f_makeshift_bed", "d": "f_dresser" },
-      "place_npcs": [ { "class": "ranch_doctor", "x": 14, "y": 3 } ]
+      "place_npcs": [ { "class": "ranch_doctor", "x": 15, "y": 7 } ]
     }
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)
It's easier to update the clinic if it's on a single mapgen rather than two.
## Describe the solution (The How)
Make the missions that place and upgrade the clinic happen only on the mapgen `ranch_camp_50`
## Describe alternatives you've considered
none
## Testing

## Additional context
The entire fully upgraded clinic on a single mapgen:
<details>
<summary>Screenshot:</summary>
<br><a href="https://github.com"><img src="https://github.com/user-attachments/assets/849b47c5-95f6-4b83-9d06-a8b1c9e72f2b"></a>
</details>

## Checklist

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5983a7b](https://github.com/cataclysmbn/Cataclysm-BN/commit/5983a7b0d498a683ed859de38717369317121aee) (Update NPC_ranch_foreman.json) on 2026-08-28 21:16:59

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33207679772/artifacts/9700595585)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33207679772/artifacts/9701476563)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33207679772/artifacts/9700812916)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33207679772/artifacts/9700846099)
<!-- END artifact comment -->