### PR TITLE
feat(mods/Arcana): tool itemgroup audit, use of retorts in alchemy, fix Curved Claws not restricting gear, misc profession audits

### DIFF
--- a/data/mods/Arcana_BN/chargen/professions.json
+++ b/data/mods/Arcana_BN/chargen/professions.json
@@ -1,5 +1,10 @@
 [
   {
+    "type": "profession_item_substitutions",
+    "trait": "ARCANA_DRAGONCLAWS",
+    "sub": [ { "item": "gloves_leather", "new": [ "gloves_fingerless" ] } ]
+  },
+  {
     "type": "item_group",
     "subtype": "collection",
     "//": "Arcanist professions start with a relevant essence holding the equivalent of two essence per profession point cost, minus any loaded into their primary weapon if any.",
@@ -160,7 +165,8 @@
           "gloves_fingerless",
           "mbag",
           "matches",
-          "chemistry_set_basic",
+          "pot",
+          "retort_copper",
           "strength_potion",
           "chem_ethanol",
           "bottle_glass",
@@ -573,7 +579,7 @@
       "bio_tools",
       "bio_batteries",
       "bio_infolink",
-      "bio_life_sign_suppression",
+      "bio_essence_surge_cell",
       "bio_power_storage_mkII"
     ],
     "skills": [

--- a/data/mods/Arcana_BN/item_groups/item_groups_chalice.json
+++ b/data/mods/Arcana_BN/item_groups/item_groups_chalice.json
@@ -100,6 +100,8 @@
     "id": "chalice_cult_crafting",
     "type": "item_group",
     "items": [
+      [ "silver_glyph", 5 ],
+      [ "scroll_blank", 5 ],
       [ "bowl_clay", 20 ],
       [ "candle", 15 ],
       [ "matches", 15 ],

--- a/data/mods/Arcana_BN/item_groups/item_groups_cleansingflame.json
+++ b/data/mods/Arcana_BN/item_groups/item_groups_cleansingflame.json
@@ -128,9 +128,11 @@
     "id": "cleansing_flame_crafting",
     "type": "item_group",
     "items": [
+      [ "scroll_blank", 5 ],
       [ "holy_symbol", 15 ],
       [ "pot", 5 ],
       [ "bowl_clay", 10 ],
+      [ "retort_copper", 5 ],
       [ "candle", 5 ],
       [ "matches", 15 ],
       { "item": "copper", "prob": 5, "charges": [ 25, 100 ] },

--- a/data/mods/Arcana_BN/item_groups/item_groups_general.json
+++ b/data/mods/Arcana_BN/item_groups/item_groups_general.json
@@ -65,9 +65,12 @@
     "id": "magic_crafting",
     "type": "item_group",
     "items": [
+      [ "silver_glyph", 5 ],
+      [ "scroll_blank", 5 ],
       [ "holy_symbol", 5 ],
       [ "pot", 5 ],
       [ "bowl_clay", 15 ],
+      [ "retort_copper", 5 ],
       [ "candle", 10 ],
       [ "matches", 15 ],
       { "item": "copper", "prob": 5, "charges": [ 25, 100 ] },

--- a/data/mods/Arcana_BN/item_groups/item_groups_sanguine.json
+++ b/data/mods/Arcana_BN/item_groups/item_groups_sanguine.json
@@ -106,9 +106,12 @@
     "id": "sanguine_cult_crafting",
     "type": "item_group",
     "items": [
+      [ "silver_glyph", 7 ],
+      [ "scroll_blank", 3 ],
       [ "vacutainer", 25 ],
       [ "pot", 5 ],
       [ "bowl_clay", 10 ],
+      [ "retort_copper", 5 ],
       [ "candle", 5 ],
       [ "matches", 5 ],
       { "item": "silver_small", "prob": 20, "charges": [ 25, 100 ] },

--- a/data/mods/Arcana_BN/items/tools.json
+++ b/data/mods/Arcana_BN/items/tools.json
@@ -1179,7 +1179,7 @@
     "id": "transmutation_crucible",
     "type": "TOOL",
     "name": { "str": "transmutation crucible" },
-    "description": "A small container made out of a polished, glassy material resembling stone.  A shimmer of precious metal occasionally appears within the surface, as though its internal structure flowed like liquid.  Deploying it will create a temporary workspace of shifting earth, providing a hard surface usable as an anvil as well as shifting stones that can assist in metalworking and alchemy.  It can be examined afterward to reclaim it.\n\nWhen deployed it provides the following:\n* Level 3 anvil quality.\n* Level 2 boiling quality.\n* Level 2 chemical making quality.\n* Level 1 containing quality.\n* Level 1 hot containing quality.\n* Level 1 food cooking quality.",
+    "description": "A small container made out of a polished, glassy material resembling stone.  A shimmer of precious metal occasionally appears within the surface, as though its internal structure flowed like liquid.  Deploying it will create a temporary workspace of shifting earth, providing a hard surface usable as an anvil as well as shifting stones that can assist in metalworking and alchemy.  It can be examined afterward to reclaim it.\n\nWhen deployed it provides the following:\n* Level 3 anvil quality.\n* Level 2 boiling quality.\n* Level 2 chemical making quality.\n* Level 1 containing quality.\n* Level 1 hot containing quality.\n* Level 1 food cooking quality.\n* Level 1 distilling quality.",
     "weight": "1700 g",
     "volume": "1500 ml",
     "price": "6000 USD",
@@ -1198,7 +1198,7 @@
     "type": "TOOL",
     "copy-from": "fake_item",
     "name": { "str": "deployed transmutation crucible" },
-    "qualities": [ [ "ANVIL", 3 ], [ "COOK", 1 ], [ "CHEM", 2 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CONTAIN_HOT", 1 ] ]
+    "qualities": [ [ "ANVIL", 3 ], [ "COOK", 1 ], [ "CHEM", 2 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CONTAIN_HOT", 1 ], [ "DISTILL", 1 ] ]
   },
   {
     "id": "dimensional_warp_trap",

--- a/data/mods/Arcana_BN/items/tools.json
+++ b/data/mods/Arcana_BN/items/tools.json
@@ -1198,7 +1198,15 @@
     "type": "TOOL",
     "copy-from": "fake_item",
     "name": { "str": "deployed transmutation crucible" },
-    "qualities": [ [ "ANVIL", 3 ], [ "COOK", 1 ], [ "CHEM", 2 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CONTAIN_HOT", 1 ], [ "DISTILL", 1 ] ]
+    "qualities": [
+      [ "ANVIL", 3 ],
+      [ "COOK", 1 ],
+      [ "CHEM", 2 ],
+      [ "BOIL", 2 ],
+      [ "CONTAIN", 1 ],
+      [ "CONTAIN_HOT", 1 ],
+      [ "DISTILL", 1 ]
+    ]
   },
   {
     "id": "dimensional_warp_trap",

--- a/data/mods/Arcana_BN/mutations/mutations_dragonblood.json
+++ b/data/mods/Arcana_BN/mutations/mutations_dragonblood.json
@@ -339,6 +339,7 @@
     "butchering_quality": 9,
     "types": [ "CLAWS" ],
     "category": [ "DRAGONBLOOD" ],
+    "restricts_gear": [ "hand_l", "hand_r" ],
     "allowed_items": [ "ALLOWS_CLAWS" ],
     "cut_dmg_bonus": 7,
     "flags": [ "UNARMED_BONUS" ]

--- a/data/mods/Arcana_BN/recipes/crafting_requirements.json
+++ b/data/mods/Arcana_BN/recipes/crafting_requirements.json
@@ -96,7 +96,7 @@
     "id": "arcana_potioncraft_standard",
     "type": "requirement",
     "//": "Tools and components for making potions.",
-    "qualities": [ { "id": "CHEM", "level": 1 } ],
+    "qualities": [ { "id": "CHEM", "level": 1 }, { "id": "DISTILL", "level": 1 } ],
     "tools": [ [ [ "book_potioncraft", -1 ] ] ],
     "components": [
       [
@@ -111,7 +111,7 @@
     "id": "arcana_potioncraft_upgrade",
     "type": "requirement",
     "//": "Tools and components for upgrading potions.",
-    "qualities": [ { "id": "CHEM", "level": 1 } ],
+    "qualities": [ { "id": "CHEM", "level": 1 }, { "id": "DISTILL", "level": 1 } ],
     "tools": [ [ [ "book_potioncraft", -1 ] ] ]
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Couple lil tweaks again.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Somehow I forgot to actually restrict gear on the hands with Curved Claws, despite setting them to allow `ALLOWS_CLAWS` items and changing the description. Derp.
2. Added copper retort to itemgroups `cleansing_flame_crafting`, `magic_crafting`, and `sanguine_cult_crafting`, all of those being itemgroups that contain some alchemy-related stuff.
3. Added unenchanted silver glyphs to `chalice_cult_crafting`, `magic_crafting`, and `sanguine_cult_crafting`, all of those being associated with factions that have access to summon glyphs.
4. Added blank scrolls to `chalice_cult_crafting`, `cleansing_flame_crafting`, `magic_crafting`, and `sanguine_cult_crafting`, all of those being associated with factions with access to divine scrolls or pattern scrolls (with more weight towards silver glpyhs than scrolls in the case of `sanguine_cult_crafting` since they only use them for pattern scrolls and not divine scrolls).
5. Set `arcana_potioncraft_standard` and `arcana_potioncraft_upgrade` to include distilling 1 in addition to chemical making, to make the process more thematically fitting. We have retorts now which are exactly the sorta thing that fits thematically, not forcing the alchemist profession to lug around a bulky-ass still was the main reason potion-making didn't use distillation.
6. Related, changed the alchemist profession's chemistry set to a pot and copper retort instead.
7. Set deployed transmutation crucible to also provide distilling quality 1, since it's stated to be able to alter itself for alchemy specifically.
8. Added a profession item substitution for Curved Claws, which in this case applies mainly if you start as a summoner.
9. Replaced arcane purifier's life sign suppression CBM with essence surge cell, which is more fitting since that gives both purifier and operative two powergen options and removes a blood-magic-y CBM that I forgot the profession had when I forbid Cleansing Flame professions from taking it. Derp, surprised it doesn't error when presented with a profession that starts with a forbidden bionic pre-installed.

## Describe alternatives you've considered

Adding even more profession substituitions for stuff used by vanilla professions uwahhhh

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Confirmed change in tools doesn't come close to overloading alchemist profession's available storage space.
4. Confirmed picking a summoner with Curved Claws correctly changes the leather gloves into fingerless gloves.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [be8cccf](https://github.com/cataclysmbn/Cataclysm-BN/commit/be8cccfcfcb723838cba84f1156cc6b3b6962255) (Woe, lint upon thee) on 2026-08-29 04:51:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33229974348/artifacts/9708275461)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33229974348/artifacts/9709180384)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33229974348/artifacts/9708320437)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33229974348/artifacts/9708357115)
<!-- END artifact comment -->