### PR TITLE
build(port): fix macos arm build prompting rosetta

### DIFF
--- a/build-data/osx/Info.plist
+++ b/build-data/osx/Info.plist
@@ -22,5 +22,10 @@
 	<string>1</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>LSArchitecturePriority</key>
+	<array>
+		<string>arm64</string>
+		<string>x86_64</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Purpose of change (The Why)

fixes #10137

## Describe the solution (The How)

port https://github.com/CleverRaven/Cataclysm-DDA/pull/64690

## Testing

haven't tested but should work, i believe in my friendly DDA fellow (/shrug)

## Checklist


### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional


- [x] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [x] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [x] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [x] I have linked the URL of original PR(s) in the description.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c7bafb2](https://github.com/cataclysmbn/Cataclysm-BN/commit/c7bafb28807c8c61781254186b64b95fe50ed3fd) (build(port): fix macos arm build prompting rosetta) on 2026-08-29 04:57:47

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33230127214/artifacts/9708337420)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33230127214/artifacts/9709211182)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33230127214/artifacts/9708368962)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33230127214/artifacts/9708415475)
<!-- END artifact comment -->