### PR TITLE
fix: fix batched item process issues

### DIFF
--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -948,7 +948,7 @@ void Character::process_items( int turns )
         item &it = inv.find_item( index );
         if( it.has_flag( flag_IS_UPS ) ) {
             ch_UPS += std::min( it.ammo_remaining() * it.type->tool->ups_eff_mult,
-                                it.type->tool->ups_recharge_rate );
+                                it.type->tool->ups_recharge_rate * turns );
         }
         if( it.has_flag( flag_USE_UPS ) && needs_elec_charges( &it ) ) {
             active_held_items.push_back( index );
@@ -961,7 +961,7 @@ void Character::process_items( int turns )
         }
         if( w->has_flag( flag_IS_UPS ) ) {
             ch_UPS += std::min( w->ammo_remaining() * w->type->tool->ups_eff_mult,
-                                w->type->tool->ups_recharge_rate );
+                                w->type->tool->ups_recharge_rate * turns );
         }
         if( !update_required && w->encumbrance_update_ ) {
             update_required = true;
@@ -973,7 +973,7 @@ void Character::process_items( int turns )
         set_check_encumbrance( false );
     }
     if( has_active_bionic( bionic_id( "bio_ups" ) ) ) {
-        ch_UPS += std::min( units::to_kilojoule( get_power_level() ), 10 );
+        ch_UPS += std::min( units::to_kilojoule( get_power_level() ), 10 * turns );
     }
     int ch_UPS_used = 0;
     if( weapon_active && ch_UPS_used < ch_UPS ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11001,16 +11001,16 @@ detached_ptr<item> item::process_tool( detached_ptr<item> &&self, player *carrie
     const bool uses_UPS = self->has_flag( flag_USE_UPS );
     bool revert_destroy = false;
     if( self->type->tool->turns_per_charge > 0 ) {
-        if( self->type->tool->turns_active >= self->type->tool->turns_per_charge ) {
-            energy = std::max( self->ammo_required(), ticks );
-            self->type->tool->turns_active = 0;
+        while( self->type->tool->turns_active >= self->type->tool->turns_per_charge ) {
+            energy = std::max( self->ammo_required(), 1 );
+            self->type->tool->turns_active -= self->type->tool->turns_per_charge;
         }
         self->type->tool->turns_active += ticks;
     } else if( self->type->tool->power_draw > 0 ) {
         // power_draw in mW / 1000000 to give kJ (battery unit) per second
-        energy = ( self->type->tool->power_draw / 1000000 ) * ticks;
+        energy = ( ( self->type->tool->power_draw * ticks ) / 1000000 );
         // energy_bat remainder results in chance at additional charge/discharge
-        energy += x_in_y( self->type->tool->power_draw % 1000000, 1000000 ) ? ticks : 0;
+        energy += x_in_y( ( self->type->tool->power_draw * ticks ) % 1000000, 1000000 ) ? 1 : 0;
     }
 
     // If ammo_required is 0 we just skip over this and go to tick processing.

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -472,7 +472,7 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *c
     }
     int rate_multiplier = 1; // Not quite sure where to put this
     int ticks;
-    if( rech.type == relic_recharge_type::time ) {
+    if( rech.type == relic_recharge_type::time || rech.type == relic_recharge_type::solar ) {
         int last_relic_process = itm.get_var( "last_relic_process", 0 );
         if( last_relic_process == 0 &&
             itm.get_var( "relic_was_in_inventory",
@@ -484,6 +484,11 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *c
         }
         if( ticks > 0 ) {
             rate_multiplier = ticks;
+            // It's solar for roughly half the day
+            // This permits catchup without being broken
+            if( rech.type == relic_recharge_type::solar ) {
+                rate_multiplier /= 2;
+            }
         }
         itm.set_var( "last_relic_process", to_turn<int>( calendar::turn ) );
     }


### PR DESCRIPTION
## Purpose of change (The Why)
Caused by #10118
Closes #10150

## Describe the solution (The How)
Fix `turns_active` causing 300x charge consumption compared to normal on activity skip.
Fix the randomness of `power_draw` eating 300 charges at once when it triggers the random, instead of random being 300x more likely
Fix UPS recharging being only normal values, instead of 300x
Solar will now recharge over time when processed out of the bubble, at 50% speed to account for night and day

## Describe alternatives you've considered
None

## Testing
Candle lasts long
Smartphone flashlight drains charges right ( note it's random so it will vary slightly )
Military exosuit on UPS keeps full and seems to draw the right power

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9b8e13a](https://github.com/cataclysmbn/Cataclysm-BN/commit/9b8e13afebc12eeb11327806eb83dc94e460a2e2) (fix: fix batched item process issues) on 2026-08-30 18:13:22

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33325338263/artifacts/9736197413)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33325338263/artifacts/9736598372)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33325338263/artifacts/9736206993)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33325338263/artifacts/9736257832)
<!-- END artifact comment -->