### PR TITLE
fix: invalidate the vehicle floor and transparency cache more

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -664,6 +664,7 @@ void map::set_seen_cache_dirty( const tripoint_bub_ms &change_location )
 {
     if( inbounds( change_location ) ) {
         level_cache &cache = get_cache( change_location.z() );
+        cache.vehicle_caches_dirty = true;
         if( cache.seen_cache_dirty ) {
             return;
         }
@@ -808,6 +809,7 @@ void map::set_transparency_cache_dirty( const tripoint_bub_ms &p )
     if( inbounds( p ) ) {
         const auto smp = project_to<coords::sm>( p );
         level_cache &ch = get_cache( smp.z() );
+        ch.vehicle_caches_dirty = true;
         ch.transparency_cache_dirty.set( static_cast<size_t>( ch.bidx( smp.x(), smp.y() ) ) );
         const auto abs_sm = map_local_to_abs( *this, smp );
         get_mapbuffer().mark_submap_caches_dirty( {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1,5 +1,6 @@
 #include "vehicle.h"
 #include "detached_ptr.h"
+#include "locations.h"
 #include "type_id.h"
 #include "units_mass.h"
 #include "vehicle_part.h" // IWYU pragma: associated
@@ -222,6 +223,7 @@ class DefaultRemovePartHandler : public RemovePartHandler
             map &here = get_map();
             here.set_transparency_cache_dirty( z );
             here.set_seen_cache_dirty( tripoint_bub_ms::zero() );
+            here.set_vehicle_cache_dirty( z );
         }
         void set_floor_cache_dirty( const int z ) override {
             get_map().set_floor_cache_dirty( z );
@@ -2275,6 +2277,7 @@ int vehicle::install_part( const tripoint_mnt_veh &dp, vehicle_part &&new_part )
     refresh();
     get_map().invalidate_lightmap_caches();
     get_map().get_mapbuffer().refresh_vehicle_footprint( this );
+    get_map().set_vehicle_cache_dirty( abs_sm_pos.z() );
     coeff_air_changed = true;
     return parts.size() - 1;
 }
@@ -2464,6 +2467,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
         here.dirty_vehicle_list.insert( this );
         here.set_transparency_cache_dirty( abs_sm_pos.z() );
         here.set_seen_cache_dirty( tripoint_bub_ms::zero() );
+        here.set_vehicle_cache_dirty( abs_sm_pos.z() );
         refresh();
     } else {
         //~ %1$s is the vehicle being loaded onto the bicycle rack
@@ -2626,6 +2630,7 @@ void vehicle::part_removal_cleanup()
     if( changed || parts.empty() ) {
         refresh();
         here.invalidate_lightmap_caches();
+        here.set_vehicle_cache_dirty( abs_sm_pos.z() );
         if( parts.empty() ) {
             here.destroy_vehicle( this );
             return;
@@ -2860,6 +2865,7 @@ bool vehicle::find_and_split_vehicles( int exclude )
         if( success ) {
             // update the active cache
             g->m.reset_vehicle_cache();
+            g->m.set_vehicle_cache_dirty( abs_sm_pos.z() );
             return true;
         }
     }
@@ -3032,6 +3038,7 @@ bool vehicle::split_vehicles( const std::vector<std::vector <int>> &new_vehs,
         here.dirty_vehicle_list.insert( new_vehicle );
         here.set_transparency_cache_dirty( abs_sm_pos.z() );
         here.set_seen_cache_dirty( tripoint_bub_ms::zero() );
+        here.set_vehicle_cache_dirty( abs_sm_pos.z() );
         if( !new_labels.empty() ) {
             new_vehicle->labels = new_labels;
         }
@@ -7985,6 +7992,7 @@ int vehicle::damage_direct( int p, int dmg, damage_type type )
         stop_autodriving();
     }
     here.set_memory_seen_cache_dirty( bub_part_location( p ) );
+    here.set_vehicle_cache_dirty( abs_sm_pos.z() );
     if( parts[p].is_broken() ) {
         return break_off( p, dmg );
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -160,6 +160,7 @@ void vehicle::add_toggle_to_opts( std::vector<uilist_entry> &options,
         }
         refresh();
         get_map().invalidate_lightmap_caches();
+        get_map().set_vehicle_cache_dirty( abs_sm_pos.z() );
     } );
 }
 
@@ -361,6 +362,7 @@ void vehicle::set_electronics_menu_options( std::vector<uilist_entry> &options,
                 add_msg( _( "Camera system won't turn on" ) );
             }
             get_map().set_seen_cache_dirty( bub_ms_location().z() );
+            get_map().set_vehicle_cache_dirty( bub_ms_location().z() );
             get_map().invalidate_visibility_caches();
             refresh();
         } );
@@ -1813,6 +1815,7 @@ void vehicle::open_or_close( const int part_index, const bool opening )
     here.set_transparency_cache_dirty( abs_sm_pos.z() );
     const auto part_location = mount_to_bubble( parts[part_index].mount );
     here.set_seen_cache_dirty( part_location );
+    here.set_vehicle_cache_dirty( part_location.z() );
     const int dist = rl_dist( get_player_character().bub_pos(), part_location );
     if( dist < 20 ) {
         sfx::play_variant_sound( opening ? "vehicle_open" : "vehicle_close",


### PR DESCRIPTION
## Purpose of change (The Why)
Reported bad vehicle visibility blocker cache when opening a vehicle door

## Describe the solution (The How)
Whenever seen cache dirty -> Invalidate vehicle ( Note: Different then visibility cache )
Whenever transparency dirty -> Invalidate vehicle

## Describe alternatives you've considered
None

## Testing
Opening and closing a troop carrier door will no longer reveal the whole vehicle.
Ran tracy -> Still no constant lightmap recalc at the start of each turn

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [fe324e3](https://github.com/cataclysmbn/Cataclysm-BN/commit/fe324e3137a9bab196ffcdc344041e310edc8755) (fix: invalidate the vehicle cache more) on 2026-08-30 23:29:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33337820015/artifacts/9740693306)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33337820015/artifacts/9740618763)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33337820015/artifacts/9739731979)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33337820015/artifacts/9740125016)
<!-- END artifact comment -->