### PR TITLE
feat(balance): convert electric tankette to atomic

### DIFF
--- a/data/json/vehicles/military.json
+++ b/data/json/vehicles/military.json
@@ -2250,7 +2250,7 @@
   {
     "id": "tank_xm7_elec",
     "type": "vehicle",
-    "name": "XM7 Electric Mini-Tank",
+    "name": "XM7 Atomic Tankette",
     "blueprint": [
       [ "oooooo  " ],
       [ "=--+-|  " ],
@@ -2268,15 +2268,11 @@
       { "x": 1, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
       { "x": 2, "y": -2, "parts": [ "hdframe_vertical_2", "tread3", "plating_military" ] },
       { "x": -3, "y": -1, "parts": [ "hdframe_vertical_2", "trunk", "omnicam", "plating_military" ] },
-      {
-        "x": -2,
-        "y": -1,
-        "parts": [ "hdframe_vertical_2", "hdboard_sw", "storage_battery", "plating_military", "solar_panel_v2" ]
-      },
+      { "x": -2, "y": -1, "parts": [ "hdframe_vertical_2", "hdboard_sw", "storage_battery", "plating_military" ] },
       {
         "x": -1,
         "y": -1,
-        "parts": [ "hdframe_vertical_2", "hdstowboard_vertical", "plating_military", "solar_panel_v2" ]
+        "parts": [ "hdframe_vertical_2", "hdstowboard_vertical", "minireactor", "plating_military" ]
       },
       {
         "x": 0,
@@ -2331,15 +2327,11 @@
         "parts": [ "hdframe_vertical_2", "hdhalfboard_vertical", "hdroof", "NBC_seal", "plating_military" ]
       },
       { "x": -3, "y": 1, "parts": [ "hdframe_vertical_2", "trunk", "omnicam", "plating_military" ] },
-      {
-        "x": -2,
-        "y": 1,
-        "parts": [ "hdframe_vertical_2", "hdboard_se", "storage_battery", "plating_military", "solar_panel_v2" ]
-      },
+      { "x": -2, "y": 1, "parts": [ "hdframe_vertical_2", "hdboard_se", "storage_battery", "plating_military" ] },
       {
         "x": -1,
         "y": 1,
-        "parts": [ "hdframe_vertical_2", "hdstowboard_vertical", "plating_military", "solar_panel_v2" ]
+        "parts": [ "hdframe_vertical_2", "hdstowboard_vertical", "minireactor", "plating_military" ]
       },
       {
         "x": 0,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Way back when I was revamping the tankmod vehicles for Tankmod: Revived, when DDA was either in the process of or stating plans to obsolete vehicle minireactors, which is why the atomic minitank was revamped as a goofy solar-electric tank instead. Needless to say, this isn't a concern in BN. :3

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Removed the solar panels from the XM7 tankette, added a pair of minireators to the rear area instead, and accordingly renamed it from the XM7 Solar Mini-Tank to the XM7 Atomic Tankette (using a lil more fitting term for the sorta silly thing it is :3)

## Describe alternatives you've considered

Picking a different designation since XM7 ended up being used IRL for the 6.8mm meme gun that became the M7. I guess it can be excused by the fact that in BN's setting the M7 has already exited trials, been adopted, and is back on its way out of favor so the designation of XM7 has long since been freed up for an armored vehicle to use without risk of confusion. :3

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned one, confirmed no more solars and 2 reactors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [52fa62a](https://github.com/cataclysmbn/Cataclysm-BN/commit/52fa62a11bce95a6dc8fb3dc1b0b18f223aa5f8c) (feat(balance): convert electric tankette to atomic) on 2026-08-30 23:31:23

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33338044212/artifacts/9739775171)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33338044212/artifacts/9740805189)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33338044212/artifacts/9739797399)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33338044212/artifacts/9740222204)
<!-- END artifact comment -->