### PR TITLE
feat: allow multiple of the same type of iuse action on the same item

### DIFF
--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -467,7 +467,7 @@
     "looks_like": "longbow",
     "type": "GUN",
     "name": { "str": "compound bow" },
-    "description": "A high-power bow with shaped cams and extra cables for high velocity shots that can be used effectively by fairly strong archers.  Currently set to a medium weight.",
+    "description": "A high-power bow with shaped cams and extra cables for high velocity shots that can be used effectively by fairly strong archers.  Currently set to a medium weight, activate it to choose between a lower or higher draw weight.",
     "price": "550 USD",
     "material": [ "steel", "plastic" ],
     "extend": { "flags": [ "STR_DRAW" ] },
@@ -482,47 +482,77 @@
     "range": 18,
     "dispersion": 850,
     "durability": 6,
-    "use_action": {
-      "menu_text": "Tighten Limbs",
-      "type": "transform",
-      "target": "compbow_high",
-      "qualities_needed": { "SCREW_FINE": 1 },
-      "msg": "You tighten the limbs, increasing the strength of the bow."
-    }
+    "use_action": [
+      {
+        "menu_text": "Tighten Limbs",
+        "type": "transform",
+        "target": "compbow_high",
+        "qualities_needed": { "SCREW_FINE": 1 },
+        "msg": "You tighten the limbs, increasing the strength of the bow."
+      },
+      {
+        "menu_text": "Loosen Limbs",
+        "type": "transform",
+        "target": "compbow_low",
+        "qualities_needed": { "SCREW_FINE": 1 },
+        "msg": "You loosen the limbs, decreasing the strength of the bow.",
+        "internal_name": "loosen_limbs"
+      }
+    ]
   },
   {
     "id": "compbow_high",
     "copy-from": "compbow",
     "type": "GUN",
     "name": { "str": "compound bow (high)", "str_pl": "compound bows (high)" },
-    "description": "A high-power bow with shaped cams and extra cables for high velocity shots that can be used effectively by very strong archers.  Currently set to a high weight, and ready to cause some real damage - if you can draw it.",
+    "description": "A high-power bow with shaped cams and extra cables for high velocity shots that can be used effectively by very strong archers.  Currently set to a high weight, and ready to cause some real damage - if you can draw it.  Activate it to adjust it to lower draw weights.",
     "min_strength": 11,
     "ranged_damage": { "damage_type": "stab", "amount": 50 },
     "range": 20,
-    "use_action": {
-      "menu_text": "Loosen Limbs",
-      "type": "transform",
-      "target": "compbow_low",
-      "qualities_needed": { "SCREW_FINE": 1 },
-      "msg": "You loosen the limbs, decreasing the strength of the bow."
-    }
+    "use_action": [
+      {
+        "menu_text": "Loosen Limbs (low)",
+        "type": "transform",
+        "target": "compbow_low",
+        "qualities_needed": { "SCREW_FINE": 1 },
+        "msg": "You loosen the limbs, decreasing the strength of the bow significantly."
+      },
+      {
+        "menu_text": "Loosen Limbs (medium)",
+        "type": "transform",
+        "target": "compbow_low",
+        "qualities_needed": { "SCREW_FINE": 1 },
+        "msg": "You loosen the limbs, decreasing the strength of the bow.",
+        "internal_name": "tighten_limbs_medium"
+      }
+    ]
   },
   {
     "id": "compbow_low",
     "copy-from": "compbow",
     "type": "GUN",
     "name": { "str": "compound bow (low)", "str_pl": "compound bows (low)" },
-    "description": "A high-power bow with shaped cams and extra cables for high velocity shots that can be used effectively by average archers.  Currently set to a low weight, making it much easier to draw.",
+    "description": "A high-power bow with shaped cams and extra cables for high velocity shots that can be used effectively by average archers.  Currently set to a low weight, making it much easier to draw.  Activate it to adjust it to higher draw weights.",
     "min_strength": 7,
     "ranged_damage": { "damage_type": "stab", "amount": 32 },
     "range": 16,
-    "use_action": {
-      "menu_text": "Tighten Limbs",
-      "type": "transform",
-      "target": "compbow",
-      "qualities_needed": { "SCREW_FINE": 1 },
-      "msg": "You tighten the limbs, increasing the strength of the bow."
-    }
+    "use_action": [
+      {
+        "menu_text": "Tighten Limbs (medium)",
+        "type": "transform",
+        "target": "compbow",
+        "qualities_needed": { "SCREW_FINE": 1 },
+        "msg": "You tighten the limbs, increasing the strength of the bow."
+      },
+      {
+        "menu_text": "Tighten Limbs (high)",
+        "type": "transform",
+        "target": "compbow_high",
+        "qualities_needed": { "SCREW_FINE": 1 },
+        "msg": "You tighten the limbs, increasing the strength of the bow significantly.",
+        "internal_name": "tighten_limbs_high"
+      }
+    ]
   },
   {
     "id": "compositebow",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -207,11 +207,16 @@
       "WEATHER_TOOL",
       "CAMERA",
       {
-        "type": "music_player",
         "target": "wrist_comp_budget_music",
         "msg": "You put in the earbuds and start listening to music.",
+        "active": true,
         "moves": 200,
-        "need_charges": 1
+        "need_charges": 1,
+        "transform_charges": 1,
+        "need_charges_msg": "The wrist computer's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       },
       "PORTABLE_GAME",
       "EINKTABLETPC",
@@ -243,7 +248,7 @@
     "description": "This wrist computer is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 5000,
     "revert_to": "wrist_comp_budget",
-    "use_action": [ "MP3_ON" ],
+    "use_action": { "target": "wrist_comp_budget", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
     "flags": [
       "WATCH",
       "WATER_FRIENDLY",
@@ -316,11 +321,16 @@
       "CAMERA",
       "WEATHER_TOOL",
       {
-        "type": "music_player",
         "target": "wrist_comp_control_music",
         "msg": "You put in the earbuds and start listening to music.",
+        "active": true,
         "moves": 200,
-        "need_charges": 1
+        "need_charges": 1,
+        "transform_charges": 1,
+        "need_charges_msg": "The wrist control computer's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       },
       "PORTABLE_GAME",
       "RADIOCONTROL",
@@ -355,7 +365,7 @@
     "description": "This wrist computer is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 5000,
     "revert_to": "wrist_comp_control",
-    "use_action": [ "MP3_ON" ],
+    "use_action": { "target": "wrist_comp_control", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
     "magazine_well": "250 ml"
   },
   {
@@ -431,11 +441,16 @@
     "use_action": [
       "EINKTABLETPC",
       {
-        "type": "music_player",
         "target": "eink_tablet_pc_music",
         "msg": "You put in the earbuds and start listening to music.",
+        "active": true,
         "moves": 200,
-        "need_charges": 1
+        "need_charges": 1,
+        "transform_charges": 1,
+        "need_charges_msg": "The e-ink tablet PC's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       },
       "TOGGLE_UPS_CHARGING"
     ],
@@ -449,7 +464,7 @@
     "description": "This e-ink tablet PC is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 2500,
     "revert_to": "eink_tablet_pc",
-    "use_action": [ "MP3_ON" ]
+    "use_action": { "target": "eink_tablet_pc", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
   },
   {
     "id": "electrohack",
@@ -593,11 +608,16 @@
         "type": "transform"
       },
       {
-        "type": "music_player",
         "target": "laptop_music",
         "msg": "You put in the earbuds and start listening to music.",
+        "active": true,
         "moves": 200,
-        "need_charges": 1
+        "need_charges": 1,
+        "transform_charges": 1,
+        "need_charges_msg": "The laptop computer's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       },
       "TOGGLE_UPS_CHARGING"
     ],
@@ -610,7 +630,7 @@
     "name": { "str": "laptop computer - music", "str_pl": "laptop computers - music" },
     "power_draw": 7000,
     "revert_to": "laptop",
-    "use_action": "MP3_ON",
+    "use_action": { "target": "laptop", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
     "flags": [ "WATCH", "TRADER_AVOID", "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
@@ -642,11 +662,16 @@
     "flags": [ "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ],
     "use_action": [
       {
-        "type": "music_player",
         "target": "mp3_on",
         "msg": "You put in the earbuds and start listening to music.",
+        "active": true,
         "moves": 200,
-        "need_charges": 5
+        "need_charges": 1,
+        "transform_charges": 1,
+        "need_charges_msg": "The mp3 player's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       },
       "TOGGLE_UPS_CHARGING"
     ],
@@ -660,7 +685,7 @@
     "description": "This mp3 player is turned on and playing some great tunes, raising your morale steadily while on your person.  It runs through batteries quickly; you can turn it off by using it.  It also obscures your hearing.",
     "power_draw": 3500,
     "revert_to": "mp3",
-    "use_action": "MP3_ON",
+    "use_action": { "target": "mp3", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
     "flags": [ "TRADER_AVOID", "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
@@ -757,11 +782,16 @@
       },
       "CAMERA",
       {
-        "type": "music_player",
         "target": "smart_phone_music",
         "msg": "You put in the earbuds and start listening to music.",
+        "active": true,
         "moves": 200,
-        "need_charges": 5
+        "need_charges": 1,
+        "transform_charges": 1,
+        "need_charges_msg": "The smart phone's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       },
       "PORTABLE_GAME",
       "TOGGLE_UPS_CHARGING"
@@ -776,7 +806,7 @@
     "description": "This phone is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 7000,
     "revert_to": "smart_phone",
-    "use_action": "MP3_ON",
+    "use_action": { "target": "smart_phone", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
     "flags": [ "WATCH", "TRADER_AVOID", "ALARMCLOCK", "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ],
     "magazine_well": "250 ml"
   },
@@ -831,10 +861,14 @@
       "CAMERA",
       "PORTABLE_GAME",
       {
-        "type": "music_player",
         "target": "afs_atomic_smartphone_music",
         "msg": "You put in the earbuds and start listening to music.",
-        "moves": 200
+        "active": true,
+        "moves": 200,
+        "need_charges_msg": "The atomic smartphone's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       }
     ],
     "flags": [ "WATCH", "ALARMCLOCK", "NO_UNLOAD", "NO_RELOAD" ]
@@ -846,7 +880,7 @@
     "name": { "str": "atomic smartphone - music", "str_pl": "atomic smartphones - music" },
     "description": "This phone is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "revert_to": "afs_atomic_smartphone",
-    "use_action": [ "MP3_ON" ],
+    "use_action": { "target": "afs_atomic_smartphone", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
     "flags": [ "WATCH", "TRADER_AVOID", "ALARMCLOCK", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -124,11 +124,16 @@
         "type": "transform"
       },
       {
-        "type": "music_player",
         "target": "control_laptop_music",
         "msg": "You put in the earbuds and start listening to music.",
+        "active": true,
         "moves": 200,
-        "need_charges": 1
+        "need_charges": 1,
+        "transform_charges": 1,
+        "need_charges_msg": "The control laptop's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       },
       "ROBOTCONTROL",
       "RADIOCONTROL",
@@ -157,7 +162,7 @@
     "name": { "str": "control laptop - music", "str_pl": "control laptops - music" },
     "power_draw": 7000,
     "revert_to": "control_laptop",
-    "use_action": "MP3_ON",
+    "use_action": { "target": "control_laptop", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
     "flags": [ "WATCH", "TRADER_AVOID", "RECHARGE", "NO_UNLOAD", "NO_RELOAD", "DRONE_CAM" ]
   },
   {

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -162,7 +162,7 @@
     "name": { "str": "control laptop - music", "str_pl": "control laptops - music" },
     "power_draw": 7000,
     "revert_to": "control_laptop",
-    "use_action": { "target": "control_laptop", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": [ "MP3_ON" ],
     "flags": [ "WATCH", "TRADER_AVOID", "RECHARGE", "NO_UNLOAD", "NO_RELOAD", "DRONE_CAM" ]
   },
   {
@@ -248,7 +248,7 @@
     "description": "This wrist computer is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 5000,
     "revert_to": "wrist_comp_budget",
-    "use_action": { "target": "wrist_comp_budget", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": [ "MP3_ON" ],
     "flags": [
       "WATCH",
       "WATER_FRIENDLY",
@@ -365,7 +365,7 @@
     "description": "This wrist computer is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 5000,
     "revert_to": "wrist_comp_control",
-    "use_action": { "target": "wrist_comp_control", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": [ "MP3_ON" ],
     "magazine_well": "250 ml"
   },
   {
@@ -464,7 +464,7 @@
     "description": "This e-ink tablet PC is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 2500,
     "revert_to": "eink_tablet_pc",
-    "use_action": { "target": "eink_tablet_pc", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" }
+    "use_action": [ "MP3_ON" ],
   },
   {
     "id": "electrohack",
@@ -630,7 +630,7 @@
     "name": { "str": "laptop computer - music", "str_pl": "laptop computers - music" },
     "power_draw": 7000,
     "revert_to": "laptop",
-    "use_action": { "target": "laptop", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": [ "MP3_ON" ],
     "flags": [ "WATCH", "TRADER_AVOID", "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
@@ -685,7 +685,7 @@
     "description": "This mp3 player is turned on and playing some great tunes, raising your morale steadily while on your person.  It runs through batteries quickly; you can turn it off by using it.  It also obscures your hearing.",
     "power_draw": 3500,
     "revert_to": "mp3",
-    "use_action": { "target": "mp3", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": [ "MP3_ON" ],
     "flags": [ "TRADER_AVOID", "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
@@ -806,7 +806,7 @@
     "description": "This phone is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 7000,
     "revert_to": "smart_phone",
-    "use_action": { "target": "smart_phone", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": [ "MP3_ON" ],
     "flags": [ "WATCH", "TRADER_AVOID", "ALARMCLOCK", "RECHARGE", "NO_UNLOAD", "NO_RELOAD" ],
     "magazine_well": "250 ml"
   },
@@ -880,12 +880,7 @@
     "name": { "str": "atomic smartphone - music", "str_pl": "atomic smartphones - music" },
     "description": "This phone is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "revert_to": "afs_atomic_smartphone",
-    "use_action": {
-      "target": "afs_atomic_smartphone",
-      "msg": "You stop listening to music.",
-      "menu_text": "Turn off",
-      "type": "transform"
-    },
+    "use_action": [ "MP3_ON" ],
     "flags": [ "WATCH", "TRADER_AVOID", "ALARMCLOCK", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -464,7 +464,7 @@
     "description": "This e-ink tablet PC is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 2500,
     "revert_to": "eink_tablet_pc",
-    "use_action": [ "MP3_ON" ],
+    "use_action": [ "MP3_ON" ]
   },
   {
     "id": "electrohack",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -464,7 +464,7 @@
     "description": "This e-ink tablet PC is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "power_draw": 2500,
     "revert_to": "eink_tablet_pc",
-    "use_action": { "target": "eink_tablet_pc", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": { "target": "eink_tablet_pc", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" }
   },
   {
     "id": "electrohack",
@@ -880,7 +880,12 @@
     "name": { "str": "atomic smartphone - music", "str_pl": "atomic smartphones - music" },
     "description": "This phone is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "revert_to": "afs_atomic_smartphone",
-    "use_action": { "target": "afs_atomic_smartphone", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": {
+      "target": "afs_atomic_smartphone",
+      "msg": "You stop listening to music.",
+      "menu_text": "Turn off",
+      "type": "transform"
+    },
     "flags": [ "WATCH", "TRADER_AVOID", "ALARMCLOCK", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -17,10 +17,14 @@
       },
       "CAMERA",
       {
-        "type": "music_player",
         "target": "afs_wraitheon_smartphone_music",
         "msg": "You put in the earbuds and start listening to music.",
-        "moves": 200
+        "active": true,
+        "moves": 200,
+        "need_charges_msg": "The Wraitheon executive's smartphone's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       },
       {
         "//": "40 xp/hr.  Tier 1, 0-3 skill, higher-tier EXP since requires power.",
@@ -45,7 +49,7 @@
     "name": { "str": "Wraitheon executive's smartphone - music", "str_pl": "Wraitheon executive's smartphones - music" },
     "description": "This phone is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "revert_to": "afs_atomic_smartphone",
-    "use_action": [ "MP3_ON" ],
+    "use_action": { "target": "afs_wraitheon_smartphone", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
     "flags": [ "WATCH", "TRADER_AVOID", "ALARMCLOCK", "NO_UNLOAD", "NO_RELOAD", "DRONE_CAM" ]
   },
   {

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -49,12 +49,7 @@
     "name": { "str": "Wraitheon executive's smartphone - music", "str_pl": "Wraitheon executive's smartphones - music" },
     "description": "This phone is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "revert_to": "afs_atomic_smartphone",
-    "use_action": {
-      "target": "afs_wraitheon_smartphone",
-      "msg": "You stop listening to music.",
-      "menu_text": "Turn off",
-      "type": "transform"
-    },
+    "use_action": [ "MP3_ON" ],
     "flags": [ "WATCH", "TRADER_AVOID", "ALARMCLOCK", "NO_UNLOAD", "NO_RELOAD", "DRONE_CAM" ]
   },
   {

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -49,7 +49,12 @@
     "name": { "str": "Wraitheon executive's smartphone - music", "str_pl": "Wraitheon executive's smartphones - music" },
     "description": "This phone is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
     "revert_to": "afs_atomic_smartphone",
-    "use_action": { "target": "afs_wraitheon_smartphone", "msg": "You stop listening to music.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": {
+      "target": "afs_wraitheon_smartphone",
+      "msg": "You stop listening to music.",
+      "menu_text": "Turn off",
+      "type": "transform"
+    },
     "flags": [ "WATCH", "TRADER_AVOID", "ALARMCLOCK", "NO_UNLOAD", "NO_RELOAD", "DRONE_CAM" ]
   },
   {

--- a/data/mods/Arcana_BN/items/ranged.json
+++ b/data/mods/Arcana_BN/items/ranged.json
@@ -78,7 +78,14 @@
     "modes": [ [ "DEFAULT", "single", 1 ], [ "BURST", "triple", 3 ] ],
     "ammo_effects": [ "FLAME", "STREAM", "IGNITE" ],
     "techniques": [ "WBLOCK_1", "RAPID" ],
-    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_sparks", "no_fail": true, "level": 0, "need_wielding": true },
+    "use_action": {
+      "type": "cast_spell",
+      "spell_id": "arcana_item_sparks",
+      "no_fail": true,
+      "level": 0,
+      "need_wielding": true,
+      "menu_text": "Ignite something"
+    },
     "relic_data": {
       "passive_effects": [
         {
@@ -304,7 +311,14 @@
     "loudness": 186,
     "clip_size": 1,
     "reload": 200,
-    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_sparks", "no_fail": true, "level": 0, "need_wielding": true },
+    "use_action": {
+      "type": "cast_spell",
+      "spell_id": "arcana_item_sparks",
+      "no_fail": true,
+      "level": 0,
+      "need_wielding": true,
+      "menu_text": "Ignite something"
+    },
     "ammo_effects": [ "NAPALM_CLAW", "NO_PENETRATE_OBSTACLES" ],
     "relic_data": {
       "passive_effects": [
@@ -646,7 +660,14 @@
         }
       ]
     },
-    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_mech_flare", "no_fail": true, "level": 0, "need_wielding": true },
+    "use_action": {
+      "type": "cast_spell",
+      "spell_id": "arcana_item_mech_flare",
+      "no_fail": true,
+      "level": 0,
+      "need_wielding": true,
+      "menu_text": "Launch flare"
+    },
     "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "BLINDS_EYES", "BEANBAG", "AMMO_RIFT_FOCUS_SHADOWS", "AMMO_RIFT_FOCUS_TINDALOS" ],
     "flags": [
       "NO_UNLOAD",

--- a/data/mods/Arcana_BN/items/tool_armor.json
+++ b/data/mods/Arcana_BN/items/tool_armor.json
@@ -586,7 +586,8 @@
         "spell_id": "arcana_item_jade_hauberk_healing",
         "no_fail": true,
         "level": 0,
-        "need_worn": true
+        "need_worn": true,
+        "menu_text": "Heal yourself"
       }
     ],
     "relative": { "weight": "3020 g", "price": "550 USD", "material_thickness": 1 },

--- a/data/mods/Arcana_BN/items/tools.json
+++ b/data/mods/Arcana_BN/items/tools.json
@@ -154,7 +154,8 @@
         "spell_id": "arcana_item_chalice_offering",
         "no_fail": true,
         "need_wielding": true,
-        "level": 0
+        "level": 0,
+        "menu_text": "Convert life force into blood essence"
       }
     ]
   },
@@ -185,7 +186,8 @@
         "spell_id": "arcana_item_athame_sanguine_art",
         "no_fail": true,
         "need_wielding": true,
-        "level": 0
+        "level": 0,
+        "menu_text": "Convert life force into blood essence"
       }
     ],
     "flags": [ "STAB", "SHEATH_KNIFE", "USE_PLAYER_ENERGY", "NO_SALVAGE" ]
@@ -1129,7 +1131,16 @@
     "charges_per_use": 2,
     "ammo": "essence_blood_type",
     "relative": { "weight": "230 g" },
-    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_lichhook", "no_fail": true, "need_wielding": true, "level": 0 } ],
+    "use_action": [
+      {
+        "type": "cast_spell",
+        "spell_id": "arcana_item_lichhook",
+        "no_fail": true,
+        "need_wielding": true,
+        "level": 0,
+        "menu_text": "Immobilize victim"
+      }
+    ],
     "extend": { "flags": [ "NO_SALVAGE", "SHEATH_SWORD" ] }
   },
   {
@@ -1715,7 +1726,14 @@
     "max_charges": 10,
     "charges_per_use": 1,
     "ammo": "essence_pure_type",
-    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_ritual_blade", "no_fail": true, "need_wielding": true, "level": 0 },
+    "use_action": {
+      "type": "cast_spell",
+      "spell_id": "arcana_item_ritual_blade",
+      "no_fail": true,
+      "need_wielding": true,
+      "level": 0,
+      "menu_text": "Offer power to the Beyond"
+    },
     "relic_data": {
       "passive_effects": [
         {
@@ -1731,6 +1749,7 @@
       ]
     },
     "techniques": [ "WBLOCK_1", "WIDE", "BRUTAL", "SWEEP" ],
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 4 ] ],
     "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE", "MAGIC_FOCUS", "NONCONDUCTIVE", "SHEATH_SWORD" ]
   },
   {

--- a/data/mods/ebook_lua/items/tools.json
+++ b/data/mods/ebook_lua/items/tools.json
@@ -7,11 +7,16 @@
     "use_action": [
       "EINKTABLETPC",
       {
-        "type": "music_player",
         "target": "eink_tablet_pc_music",
         "msg": "You put in the earbuds and start listening to music.",
+        "active": true,
         "moves": 200,
-        "need_charges": 1
+        "need_charges": 1,
+        "transform_charges": 1,
+        "need_charges_msg": "The e-ink tablet PC's batteries need more charge.",
+        "type": "transform",
+        "internal_name": "music_player",
+        "menu_text": "Listen to music"
       },
       "TOGGLE_UPS_CHARGING",
       "LUA_EBOOK"

--- a/docs/en/mod/json/reference/items/item_creation.md
+++ b/docs/en/mod/json/reference/items/item_creation.md
@@ -864,6 +864,17 @@ The contents of use_action fields can either be a string indicating a built-in f
 the item is activated (defined in iuse.cpp), or one of several special definitions that invoke a
 more structured function.
 
+All object defined use actions support the following two types.
+
+```jsonc
+"use_action": {
+  "menu_text": "xyz", // What string is shown in the activate menu
+  // Unique key for the iuse, defaults to the `type`
+  // Note: This should only be used on repeated type definitions
+  "internal_name": "test"
+}
+```
+
 ```json
 "use_action": {
     "type": "transform",  // The type of method, in this case one that transforms the item.

--- a/docs/en/mod/json/reference/items/item_creation.md
+++ b/docs/en/mod/json/reference/items/item_creation.md
@@ -871,6 +871,7 @@ All object defined use actions support the following two types.
   "menu_text": "xyz", // What string is shown in the activate menu
   // Unique key for the iuse, defaults to the `type`
   // Note: This should only be used on repeated type definitions
+  // WARN: This does not work on `repair_item` iuse actors -> they have their own special `item_action_type`
   "internal_name": "test"
 }
 ```

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -356,6 +356,9 @@ bool iuse_actor::is_valid() const
 
 std::string iuse_actor::get_name() const
 {
+    if( use_local_display_name ) {
+        return display_name.translated();
+    }
     return item_action_generator::generator().get_action_name( type );
 }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3625,6 +3625,9 @@ std::pair<std::string, use_function> Item_factory::usage_from_object( const Json
     }
 
     method.get_actor_ptr()->load( obj );
+    if( obj.has_string( "menu_text" ) ) {
+        method.get_actor_ptr()->set_name( obj.get_string( "menu_text" ) );
+    }
     return std::make_pair( internal_name, method );
 }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1043,7 +1043,6 @@ void Item_factory::init()
     add_iuse( "MININUKE", &iuse::mininuke );
     add_iuse( "MOLOTOV_LIT", &iuse::molotov_lit );
     add_iuse( "MOP", &iuse::mop );
-    // Obsolete
     add_iuse( "MP3_ON", &iuse::mp3_on );
     add_iuse( "MYCUS", &iuse::mycus );
     add_iuse( "NOISE_EMITTER_OFF", &iuse::noise_emitter_off );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1043,6 +1043,7 @@ void Item_factory::init()
     add_iuse( "MININUKE", &iuse::mininuke );
     add_iuse( "MOLOTOV_LIT", &iuse::molotov_lit );
     add_iuse( "MOP", &iuse::mop );
+    // Obsolete
     add_iuse( "MP3_ON", &iuse::mp3_on );
     add_iuse( "MYCUS", &iuse::mycus );
     add_iuse( "NOISE_EMITTER_OFF", &iuse::noise_emitter_off );
@@ -1162,6 +1163,7 @@ void Item_factory::init()
     add_actor( std::make_unique<hand_crank_actor>() );
     add_actor( std::make_unique<sex_toy_actor>() );
     add_actor( std::make_unique<train_skill_actor>() );
+    // Obsolete
     add_actor( std::make_unique<iuse_music_player>() );
     add_actor( std::make_unique<iuse_prospect_pick>() );
     add_actor( std::make_unique<iuse_reveal_contents>() );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3608,6 +3608,7 @@ void Item_factory::emplace_usage( std::map<std::string, use_function> &container
 std::pair<std::string, use_function> Item_factory::usage_from_object( const JsonObject &obj )
 {
     auto type = obj.get_string( "type" );
+    auto internal_name = obj.get_string( "internal_name", type );
 
     if( type == "repair_item" ) {
         type = obj.get_string( "item_action_type" );
@@ -3624,7 +3625,7 @@ std::pair<std::string, use_function> Item_factory::usage_from_object( const Json
     }
 
     method.get_actor_ptr()->load( obj );
-    return std::make_pair( type, method );
+    return std::make_pair( internal_name, method );
 }
 
 use_function Item_factory::usage_from_string( const std::string &type ) const

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3618,6 +3618,7 @@ std::pair<std::string, use_function> Item_factory::usage_from_object( const Json
             add_actor( std::make_unique<repair_item_actor>( type ) );
             repair_actions.insert( type );
         }
+        internal_name = type;
     }
 
     use_function method = usage_from_string( type );

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -224,7 +224,7 @@ class iuse_actor
 {
     protected:
         iuse_actor( const std::string &type, int cost = -1 ) : type( type ), cost( cost ) {}
-        bool use_local_display_name;
+        bool use_local_display_name = false;
         translation display_name;
 
     public:

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -7,6 +7,7 @@
 #include "clone_ptr.h"
 #include "coordinates.h"
 #include "type_id.h"
+#include "translations.h"
 #include "units.h"
 
 class map;
@@ -223,6 +224,8 @@ class iuse_actor
 {
     protected:
         iuse_actor( const std::string &type, int cost = -1 ) : type( type ), cost( cost ) {}
+        bool use_local_display_name;
+        translation display_name;
 
     public:
         /**
@@ -260,6 +263,12 @@ class iuse_actor
          * Returns the translated name of the action. It is used for the item action menu.
          */
         virtual std::string get_name() const;
+
+        void set_name( std::string name ) {
+            use_local_display_name = true;
+            display_name = to_translation( name );
+        }
+
         /**
          * Finalizes the actor. Must be called after all items are loaded.
          */

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -263,8 +263,6 @@ void iuse_transform::load( const JsonObject &obj )
     obj.read( "need_dry", need_dry );
 
     obj.read( "qualities_needed", qualities_needed );
-
-    obj.read( "menu_text", menu_text );
 }
 
 int iuse_transform::use( player &p, item &it, bool t, const tripoint_bub_ms &pos ) const
@@ -427,14 +425,6 @@ ret_val<bool> iuse_transform::can_use( const Character &p, const item &, bool,
     } );
     return ret_val<bool>::make_failure( vgettext( "You need a tool with %s.", "You need tools with %s.",
                                         unmet_reqs.size() ), unmet_reqs_string );
-}
-
-std::string iuse_transform::get_name() const
-{
-    if( !menu_text.empty() ) {
-        return menu_text.translated();
-    }
-    return iuse_actor::get_name();
 }
 
 void iuse_transform::finalize( const itype_id & )

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -103,8 +103,6 @@ class iuse_transform : public iuse_actor
         /** Tool qualities needed, e.g. "fine bolt turning 1". **/
         std::map<quality_id, int> qualities_needed;
 
-        translation menu_text;
-
         iuse_transform( const std::string &type = "transform" ) : iuse_actor( type ) {}
 
         ~iuse_transform() override = default;
@@ -113,7 +111,6 @@ class iuse_transform : public iuse_actor
         ret_val<bool> can_use( const Character &, const item &, bool,
                                const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
-        std::string get_name() const override;
         void finalize( const itype_id &my_item_type ) override;
         void info( const item &, std::vector<iteminfo> & ) const override;
 };


### PR DESCRIPTION
## Purpose of change (The Why)
Is it not clear
DEATH TO THE MP3 USE ACTOR

## Describe the solution (The How)
Add `internal_name` which is the unique abnormal key for use actions
Make `menu_text` a global iuse actor field

## Describe alternatives you've considered
None

## Testing
See control laptop

## Additional context
There is going to be a ton of json that needs updating
But it should all be done

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.<!-- BEGIN docs comment -->

## Translations

| post                                      | changed | stale  | missing |
| ----------------------------------------- | ------- | ------ | ------- |
| mod/json/reference/items/item_creation.md | en      | ja, ko |         |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [d356e3b](https://github.com/cataclysmbn/Cataclysm-BN/commit/d356e3b6d1b7212bfaa1a4a9d3fd28153e7930ee) (Merge branch 'multipleuseactions' of https://github.com/WishDuck/Cataclysm-BN into pr/10156) on 2026-09-01 00:03:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33432339049/artifacts/9780057567)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33432339049/artifacts/9780450890)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33432339049/artifacts/9774371219)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33432339049/artifacts/9774322414)
<!-- END artifact comment -->