### PR TITLE
feat: define `absolute_spawn_loc` for plot-critical locations

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1912,6 +1912,7 @@
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 80, 100 ],
+    "absolute_spawn_loc": { "x": 0, "y": 0 },
     "flags": [ "CLASSIC", "WILDERNESS", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1649,7 +1649,8 @@
     "locations": [ "wilderness" ],
     "city_sizes": [ 1, -1 ],
     "city_distance": [ 12, -1 ],
-    "occurrences": [ 30, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": 0, "y": 1 },
     "flags": [ "UNIQUE", "GLOBALLY_UNIQUE" ]
   },
   {
@@ -1897,7 +1898,8 @@
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 1, 1 ],
-    "flags": [ "UNIQUE", "GLOBALLY_UNIQUE", "ELECTRIC_GRID", "ENDGAME" ]
+    "absolute_spawn_loc": { "x": 0, "y": 0 },
+    "flags": [ "UNIQUE", "GLOBALLY_UNIQUE", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -1927,8 +1929,9 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 50, 100 ],
-    "flags": [ "CLASSIC", "WILDERNESS", "UNIQUE", "ELECTRIC_GRID" ]
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": -1, "y": 0 },
+    "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -2094,7 +2097,8 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "rotate": false,
-    "occurrences": [ 30, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": -1, "y": 0 },
     "flags": [ "UNIQUE", "GLOBALLY_UNIQUE" ]
   },
   {
@@ -3106,7 +3110,7 @@
     "city_sizes": [ 1, 16 ],
     "occurrences": [ 1, 1 ],
     "rotate": false,
-    "absolute_spawn_loc": { "x": 0, "y": 0 },
+    "absolute_spawn_loc": { "x": 0, "y": 1 },
     "flags": [ "ELECTRIC_GRID", "UNIQUE", "GLOBALLY_UNIQUE" ]
   },
   {

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -31,7 +31,8 @@
     "type": "start_location",
     "id": "sloc_refugee_center",
     "name": "Refugee Center",
-    "terrain": [ "evac_center_7" ]
+    "terrain": [ "evac_center_7" ],
+    "absolute_place_location": { "x": 0, "y": 0 }
   },
   {
     "type": "start_location",
@@ -287,7 +288,7 @@
     "name": "Hub 01",
     "terrain": [ "robofachq_surface_parking" ],
     "flags": [ "ALLOW_OUTSIDE" ],
-    "absolute_place_location": { "x": 0, "y": 0 }
+    "absolute_place_location": { "x": 0, "y": 1 }
   },
   {
     "type": "start_location",

--- a/data/mods/Arcana_BN/chargen/scenarios.json
+++ b/data/mods/Arcana_BN/chargen/scenarios.json
@@ -137,7 +137,7 @@
     "copy-from": "survivor_holdout",
     "add_professions": true,
     "extend": {
-      "allowed_locs": [ "hermit_house" ],
+      "allowed_locs": [ "hermit_house", "sloc_rural_church" ],
       "professions": [
         "arcanist_alchemist",
         "arcanist_scribe",

--- a/data/mods/Arcana_BN/chargen/start_locations.json
+++ b/data/mods/Arcana_BN/chargen/start_locations.json
@@ -4,26 +4,30 @@
     "id": "strange_grove",
     "name": "Strange Grove",
     "terrain": [ "strange_grove" ],
-    "flags": [ "ALLOW_OUTSIDE" ]
+    "flags": [ "ALLOW_OUTSIDE" ],
+    "absolute_place_location": { "x": 1, "y": -1 }
   },
   {
     "type": "start_location",
     "id": "island_temple",
     "name": "Sanguine Ruins",
-    "terrain": [ "island_temple_1" ]
+    "terrain": [ "island_temple_1" ],
+    "absolute_place_location": { "x": 1, "y": 0 }
   },
   {
     "type": "start_location",
     "id": "impact_site",
     "name": "Impact Site",
     "terrain": [ "impact_site" ],
-    "flags": [ "ALLOW_OUTSIDE" ]
+    "flags": [ "ALLOW_OUTSIDE" ],
+    "absolute_place_location": { "x": -1, "y": -1 }
   },
   {
     "type": "start_location",
     "id": "curious_structure",
     "name": "Curious Structure",
-    "terrain": [ "curious_structure_2" ]
+    "terrain": [ "curious_structure_2" ],
+    "absolute_place_location": { "x": -1, "y": 0 }
   },
   {
     "type": "start_location",
@@ -41,12 +45,21 @@
     "type": "start_location",
     "ident": "necropolis_basement",
     "name": "Ruined City …?",
-    "terrain": [ "necropolis_b_54" ]
+    "terrain": [ "necropolis_b_54" ],
+    "absolute_place_location": { "x": 0, "y": 1 }
   },
   {
     "type": "start_location",
     "ident": "hermit_house",
     "name": "Odd House",
-    "terrain": [ "arcana_hermitage_1" ]
+    "terrain": [ "arcana_hermitage_1" ],
+    "absolute_place_location": { "x": -1, "y": -1 }
+  },
+  {
+    "type": "start_location",
+    "ident": "sloc_rural_church",
+    "name": "Rural Church",
+    "terrain": [ "cf_church_3" ],
+    "absolute_place_location": { "x": -1, "y": -1 }
   }
 ]

--- a/data/mods/Arcana_BN/npcs/missiondef.json
+++ b/data/mods/Arcana_BN/npcs/missiondef.json
@@ -208,15 +208,7 @@
     "has_generic_rewards": false,
     "start": {
       "effect": [ { "npc_add_effect": "rural_church_aware" }, { "u_add_effect": "already_asked_deacon" } ],
-      "assign_mission_target": {
-        "om_terrain": "cf_church_4",
-        "om_special": "cf_rural_church",
-        "om_terrain_replace": "field",
-        "reveal_radius": 3,
-        "random": true,
-        "search_range": 180,
-        "min_distance": 10
-      }
+      "assign_mission_target": { "om_terrain": "cf_church_4", "om_special": "cf_rural_church", "reveal_radius": 3 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {
@@ -281,7 +273,7 @@
     "item": "cf_rep_trade_receipt",
     "start": {
       "effect": [ { "u_buy_item": "cf_rep_trade_arrangement" }, { "u_buy_item": "CF_golden_scale", "count": 20 } ],
-      "assign_mission_target": { "om_terrain": "evac_center_18", "om_special": "evac_center", "must_see": true, "reveal_radius": 1 }
+      "assign_mission_target": { "om_terrain": "evac_center_18", "om_special": "evac_center", "reveal_radius": 1 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_CF_REP_3",

--- a/data/mods/Arcana_BN/overmap_and_mapgen/overmap_specials.json
+++ b/data/mods/Arcana_BN/overmap_and_mapgen/overmap_specials.json
@@ -15,7 +15,8 @@
     "locations": [ "field", "forest" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 12 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": -1, "y": 0 },
     "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "ELECTRIC_GRID" ]
   },
   {
@@ -30,7 +31,8 @@
     "locations": [ "forest" ],
     "city_distance": [ 0, -1 ],
     "city_sizes": [ 0, 12 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": 1, "y": -1 },
     "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE" ]
   },
   {
@@ -51,7 +53,8 @@
     "locations": [ "field", "forest", "swamp" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 12 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": -1, "y": -1 },
     "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE" ],
     "spawns": { "group": "GROUP_ARCHON", "population": [ 150, 300 ], "radius": [ 20, 40 ] }
   },
@@ -75,7 +78,8 @@
     "locations": [ "forest", "swamp" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 12 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": 1, "y": 0 },
     "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "ELECTRIC_GRID" ]
   },
   {
@@ -117,7 +121,8 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 16, -1 ],
     "city_sizes": [ 0, 12 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": -1, "y": -1 },
     "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "ELECTRIC_GRID" ]
   },
   {
@@ -184,9 +189,9 @@
     "locations": [ "land" ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 1, 20 ],
-    "//": "Has to be spawned in by a mission, to avoid bugs.",
-    "occurrences": [ 0, 0 ],
-    "flags": [ "CLASSIC", "WILDERNESS", "UNIQUE", "ELECTRIC_GRID" ],
+    "occurrences": [ 1, 1 ],
+    "absolute_spawn_loc": { "x": 0, "y": 0 },
+    "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "ELECTRIC_GRID" ],
     "rotate": false
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This adds "canonical" spawn locations for certain quest-important globally unique locations, following up on https://github.com/cataclysmbn/Cataclysm-BN/pull/10133

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Vanilla:
1. Converted refugee center's use of the `ENDGAME` flag in favor of `absolute_spawn_loc` of [0, 0], effectively making its location unchanged but using the new method.
2. Set Necropolis and Hub 01 to use `absolute_spawn_loc` of [0, 1], canonically placing them both south of the refugee center.
3. Set Tacoma Commune to use `absolute_spawn_loc` of [-1, 0], canonically placing it west of the refugee center.
4. Converted bandit camp to be a global unique and also placed it at [-1, 0], establishing it as a threat to the Tacoma Commune in particular.
5. Updated `absolute_place_location` positions for affected starting locations accordingly.

Places like the Lapin cabin and Isherwood farms, due to not really ever having much quest connection with other locations, were still allowed to spawn wherever to retain some randomness.

Arcana:
1. Set it so the rural church now spawns like a normal location instead of not existing normally and instead being spawned by mission fuckery, making it a global unique placed in [0, 0] to be comfortably close to the refugee center.
2. Set the curious structure to use `absolute_spawn_loc` of [-1, 0], placing it west of the refugee center.
3. Placed both the floating temple and Alexander's house in [-1, -1], making them northwest of the refugee center and ensuring the hermit doesn't send you too far away.
4. Placed sanguine ruins in [1, 0], placing it east of the refugee center and directly opposite orientation from the Cleansing Flame's old sanctum.
5. Placed strange grove in [1, -1] to place it northeast of refugee center.
6. Kept the deacon NPC for now but set their initial mission to no longer try to create the rural church out of thin air, while conversely Sofia's second mission no longer assumes you would've already seen the refugee center when placing mission target.
7. Updated `absolute_place_location` positions for relevant starting locations in Arcana.
8. For bonus fun as with being able to spawn in the hermit house, added a start location for the rural church and added to same scenario odd house is allowed in.

May or may not also spawn some of the other core mission locations in Arcana pre-placed instead of generating them on mission start, but will save that for a followup.

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Finale lab will get its own placement in [0, -1] added to the PR that converts it to a global unique location instead of in here.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Started poking around in the map, finding locations in the region I expected them to be.
4. Confirmed I can now start in the rural church when doing the Survivor Holdout scenario, it correctly spawns in [0, 0] as expected, and getting sent to the refugee center by Sofia doesn't explode the game.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [0410ab4](https://github.com/cataclysmbn/Cataclysm-BN/commit/0410ab44b18871c93637e48fe54688b68510cc34) (Update data/json/overmap/overmap_special/specials.json) on 2026-08-31 18:58:32

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33422488688/artifacts/9771163595)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33422488688/artifacts/9770805584)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33422488688/artifacts/9769935644)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33422488688/artifacts/9770005596)
<!-- END artifact comment -->