### PR TITLE
fix: when rebuilding map cache also rebuild lightmap

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2285,7 +2285,7 @@ bool game::do_turn()
     // consider a stripped down cache just for monsters.
     {
         ZoneScopedN( "do_turn_monster_visibility_cache" );
-        m.build_map_cache( get_levz(), true );
+        m.build_map_cache( get_levz(), false );
     }
     // This has to be done after updating our map caches, as sound propagation relies on terrain.
     if( !soundperf ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Closes?: #10065 
Resolves opening and closing the door sometimes resulting in the lightmap being invalid

## Describe the solution (The How)
When rebuilding map cache for monster visibility
Also rebuild the lightmap

## Describe alternatives you've considered
None

## Testing
Open and closed door in lab that was triggering it alot
Didn't happen

NOTE: This doubles rebuilding the map cache for monsters cost, which takes less then 1/10 of the time for other monster related things
This also DOES NOT affect time skip
If someone is doing activities without time skip, they should report that as an issue so we can see if we can resolve it :)

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ac10ffa](https://github.com/cataclysmbn/Cataclysm-BN/commit/ac10ffa2857f96d5710c819b79568f7284346073) (fix: when rebuilding map cache also rebuild lightmap) on 2026-09-01 03:43:51

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33463136149/artifacts/9785087247)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33463136149/artifacts/9784702422)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33463136149/artifacts/9784181561)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33463136149/artifacts/9784255689)
<!-- END artifact comment -->