### PR TITLE
fix: prevent `on_wear` type hooks from running in worker threads

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -104,6 +104,7 @@
 #include "string_utils.h"
 #include "submap.h"
 #include "text_snippets.h"
+#include "thread_pool.h"
 #include "translations.h"
 #include "trap.h"
 #include "type_id.h"
@@ -3313,16 +3314,20 @@ ret_val<bool> Character::can_wear( const item &it, bool with_equip_change ) cons
         return ret_val<bool>::make_failure( _( "Putting on a %s would be tricky." ), it.tname() );
     }
 
-    const auto &hook_results = cata::run_hooks( "on_character_try_wear",
-    [&]( sol::table & params ) {
-        params["who"] = this;
-        params["item"] = &it;
-    }, {.exit_early = true} );
+    // During multithreaded mapgen this can be called on NPC gen
+    // If so it will cause random segfaults on NPC generation
+    if( !is_pool_worker_thread() ) {
+        const auto &hook_results = cata::run_hooks( "on_character_try_wear",
+        [&]( sol::table & params ) {
+            params["who"] = this;
+            params["item"] = &it;
+        }, {.exit_early = true} );
 
-    bool allowed = hook_results.get<bool>( "allowed" );
-    if( !allowed ) {
-        return ret_val<bool>::make_failure( hook_results.get_or( "message",
-                                            _( "Wearing that is blocked for an unknown reason. One of your lua mods isn't returning the hook right." ) ) );
+        bool allowed = hook_results.get<bool>( "allowed" );
+        if( !allowed ) {
+            return ret_val<bool>::make_failure( hook_results.get_or( "message",
+                                                _( "Wearing that is blocked for an unknown reason. One of your lua mods isn't returning the hook right." ) ) );
+        }
     }
 
     if( !it.has_flag( flag_SEMITANGIBLE ) ) {
@@ -3597,18 +3602,21 @@ ret_val<bool> Character::can_takeoff( const item &it, bool dropping ) const
                                             _( "<npcname> is not wearing that item." ) );
     }
 
-    const auto &hook_results = cata::run_hooks( "on_character_try_takeoff",
-    [&]( sol::table & params ) {
-        params["who"] = this;
-        params["item"] = &it;
-    }, {.exit_early = true} );
+    // During multithreaded mapgen this can be called on NPC gen
+    // If so it will cause random segfaults on NPC generation
+    if( !is_pool_worker_thread() ) {
+        const auto &hook_results = cata::run_hooks( "on_character_try_takeoff",
+        [&]( sol::table & params ) {
+            params["who"] = this;
+            params["item"] = &it;
+        }, {.exit_early = true} );
 
-    bool allowed = hook_results.get<bool>( "allowed" );
-    if( !allowed ) {
-        return ret_val<bool>::make_failure( hook_results.get_or( "message",
-                                            _( "Taking that off is blocked for an unknown reason. One of your lua mods isn't returning the hook right." ) ) );
+        bool allowed = hook_results.get<bool>( "allowed" );
+        if( !allowed ) {
+            return ret_val<bool>::make_failure( hook_results.get_or( "message",
+                                                _( "Taking that off is blocked for an unknown reason. One of your lua mods isn't returning the hook right." ) ) );
+        }
     }
-
     if( dropping && !get_dependent_worn_items( it ).empty() ) {
         return ret_val<bool>::make_failure( !is_npc() ?
                                             _( "You can't take off power armor while wearing other power armor components." ) :
@@ -3733,10 +3741,14 @@ bool Character::unwield()
         return false;
     }
 
-    // Lua iwieldable can_unwield callback
-    if( const auto *iwield_cb = primary_weapon().type->iwieldable_callbacks ) {
-        if( !iwield_cb->call_can_unwield( *this, primary_weapon() ) ) {
-            return false;
+    // During multithreaded mapgen this can be called on NPC gen
+    // If so it will cause random segfaults on NPC generation
+    if( !is_pool_worker_thread() ) {
+        // Lua iwieldable can_unwield callback
+        if( const auto *iwield_cb = primary_weapon().type->iwieldable_callbacks ) {
+            if( !iwield_cb->call_can_unwield( *this, primary_weapon() ) ) {
+                return false;
+            }
         }
     }
 
@@ -11300,13 +11312,15 @@ void Character::on_item_wear( item &it )
         }
     }
     morale->on_item_wear( it );
-    if( it.type->iwearable_callbacks ) {
-        it.type->iwearable_callbacks->call_on_wear( *this, it );
+    if( !is_pool_worker_thread() ) {
+        if( it.type->iwearable_callbacks ) {
+            it.type->iwearable_callbacks->call_on_wear( *this, it );
+        }
+        cata::run_hooks( "on_character_item_wear", [&]( auto & params ) {
+            params["who"] = this;
+            params["item"] = &it;
+        } );
     }
-    cata::run_hooks( "on_character_item_wear", [&]( auto & params ) {
-        params["who"] = this;
-        params["item"] = &it;
-    } );
 }
 
 void Character::on_item_takeoff( item &it )
@@ -11321,13 +11335,15 @@ void Character::on_item_takeoff( item &it )
         }
     }
     morale->on_item_takeoff( it );
-    if( it.type->iwearable_callbacks ) {
-        it.type->iwearable_callbacks->call_on_takeoff( *this, it );
+    if( !is_pool_worker_thread() ) {
+        if( it.type->iwearable_callbacks ) {
+            it.type->iwearable_callbacks->call_on_takeoff( *this, it );
+        }
+        cata::run_hooks( "on_character_item_takeoff", [&]( auto & params ) {
+            params["who"] = this;
+            params["item"] = &it;
+        } );
     }
-    cata::run_hooks( "on_character_item_takeoff", [&]( auto & params ) {
-        params["who"] = this;
-        params["item"] = &it;
-    } );
 }
 
 void Character::on_effect_int_change( const efftype_id &effect_type, int intensity,


### PR DESCRIPTION
## Purpose of change (The Why)
Closes: #10162 

## Describe the solution (The How)
Multiple PRs ( In particular ): #10136 added hooks and callbacks to lua that inadvertently ( or purposefully ) could be called on multithreaded mapgen

They respectively caused #10162 when they were called at the same time as another lua function/callback

This prevents it from running then, because locks wouldn't work and I cant think of a better way

## Describe alternatives you've considered
Figure out how to make #8456 work

## Testing
#10162 the easy to replicate one no longer happens

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3600364](https://github.com/cataclysmbn/Cataclysm-BN/commit/3600364abb2cea2b2e3d29e35981c4598f2228c6) (fix: prevent multithreaded mapgen from calling on wear/unwear/wield callbacks on generating NPCs) on 2026-09-01 18:50:34

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33537352079/artifacts/9812628324)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33537352079/artifacts/9815414214)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33537352079/artifacts/9812682835)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33537352079/artifacts/9812785898)
<!-- END artifact comment -->