### PR TITLE
feat: add rotatable nesteds

### DIFF
--- a/data/json/mapgen/lab/lab_central/nested_lab_central_core.json
+++ b/data/json/mapgen/lab/lab_central/nested_lab_central_core.json
@@ -1079,13 +1079,13 @@
     "object": {
       "mapgensize": [ 20, 7 ],
       "rows": [
-        "        !  !        ",
-        "C       !!!!       C",
+        "       !    !       ",
+        "C      !!!!!!      C",
         "##                ##",
         "u#                #u",
         "##                ##",
-        "C       !!!!       C",
-        "        !  !        "
+        "C      !!!!!!      C",
+        "       !    !       "
       ],
       "terrain": { "!": "t_floor_red", "/": "t_floor_red", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
       "furniture": { "#": "f_sandbag_half" },

--- a/data/json/mapgen/lab/lab_central/nested_lab_central_core.json
+++ b/data/json/mapgen/lab/lab_central/nested_lab_central_core.json
@@ -479,8 +479,8 @@
       ],
       "terrain": { "|": "t_strconc_wall", "-": "t_wall_metal", "+": "t_door_metal_lab_c" },
       "place_nested": [
-        { "chunks": [ "central_lab_mini_room_7x20" ], "x": 0, "y": 0 },
-        { "chunks": [ "central_lab_mini_room_7x20" ], "x": 13, "y": 0 },
+        { "chunks": [ "central_lab_mini_room_20x7" ], "x": 0, "y": 0, "rotation": 1 },
+        { "chunks": [ "central_lab_mini_room_20x7" ], "x": 13, "y": 0, "rotation": 1 },
         {
           "chunks": [
             [ "null", 50 ],
@@ -1151,141 +1151,6 @@
       ],
       "furniture": { "S": "f_server" },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 18 ], "y": [ 1, 5 ], "chance": 50 } ]
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "central_lab_mini_room_7x20",
-    "//": "Vertical counterpart to the other divided room interior.",
-    "object": {
-      "mapgensize": [ 7, 20 ],
-      "rows": [
-        " C#u#C ",
-        "  ###  ",
-        "       ",
-        "       ",
-        "       ",
-        "       ",
-        "       ",
-        "       ",
-        "!!   /!",
-        " !   ! ",
-        " !   ! ",
-        "!/   !!",
-        "       ",
-        "       ",
-        "       ",
-        "       ",
-        "       ",
-        "       ",
-        "  ###  ",
-        " C#u#C "
-      ],
-      "terrain": { "!": "t_floor_red", "/": "t_floor_red", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "#": "f_sandbag_half" },
-      "monster": { "u": { "monster": "mon_turret_medium" } },
-      "signs": { "/": { "signage": "Warning!\nLive Fire Zone\nAvoid In Case of Lockdown!" } },
-      "nested": { "C": { "chunks": [ [ "null", 25 ], [ "central_lab_ammo_rack_1x1", 75 ] ] } }
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "central_lab_mini_room_7x20",
-    "object": {
-      "mapgensize": [ 7, 20 ],
-      "rows": [
-        "       ",
-        "       ",
-        " ddddd ",
-        " dh hd ",
-        " d   d ",
-        " dh hd ",
-        "       ",
-        "       ",
-        " dh hd ",
-        " d   d ",
-        " d   d ",
-        " dh hd ",
-        "       ",
-        "       ",
-        " dh hd ",
-        " d   d ",
-        " dh hd ",
-        " ddddd ",
-        "       ",
-        "       "
-      ],
-      "furniture": { "d": "f_desk", "h": "f_chair" },
-      "items": { "d": { "item": "office", "chance": 50, "repeat": 4 } },
-      "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 5 ], "y": [ 1, 18 ], "chance": 50 } ]
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "central_lab_mini_room_7x20",
-    "object": {
-      "mapgensize": [ 7, 20 ],
-      "rows": [
-        "       ",
-        "  hhh  ",
-        " heeeh ",
-        " heeeh ",
-        "  hhh  ",
-        "       ",
-        "t     t",
-        "pp   pp",
-        "       ",
-        "       ",
-        "       ",
-        "       ",
-        "pp   pp",
-        "t     t",
-        "       ",
-        "  hhh  ",
-        " heeeh ",
-        " heeeh ",
-        "  hhh  ",
-        "       "
-      ],
-      "furniture": { "e": "f_table", "h": "f_chair", "p": [ "f_indoor_plant", "f_indoor_plant_y" ], "t": "f_trashcan" },
-      "items": { "t": { "item": "trash_cart", "chance": 25, "repeat": 3 } },
-      "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 5 ], "y": [ 1, 18 ], "chance": 50 } ]
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "central_lab_mini_room_7x20",
-    "//": "Todo: Potential room variants include: rows of chemical storage shelves, central conference table, bionic storage room",
-    "object": {
-      "mapgensize": [ 7, 20 ],
-      "rows": [
-        "       ",
-        "       ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        "       ",
-        "       ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        " SS SS ",
-        "       ",
-        "       "
-      ],
-      "furniture": { "S": "f_server" },
-      "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 5 ], "y": [ 1, 18 ], "chance": 50 } ]
     }
   },
   {

--- a/docs/en/mod/json/reference/map/mapgen.md
+++ b/docs/en/mod/json/reference/map/mapgen.md
@@ -1043,7 +1043,7 @@ mutable structure.
 | neighbors          | (optional) Any of the neighboring overmaps that should be checked before placing the chunk. Each direction is associated with a list of overmap `"id"` substrings.        |
 | joins              | (optional) Any mutable overmap special joins that should be checked before placing the chunk. Each direction is associated with a list of join `"id"` strings.            |
 | connections        | (optional) Any connection that should be directed toward this overmap before placing the chunk. Each direction is associated with a list of connection `"id"` strings.    |
-| rotation | (optional) How many turns to rotate the map, 90 degree turns |
+| rotation           | (optional) How many turns to rotate the map, 90 degree turns                                                                                                              |
 |                    |                                                                                                                                                                           |
 
 The adjacent overmaps which can be checked in this manner are:

--- a/docs/en/mod/json/reference/map/mapgen.md
+++ b/docs/en/mod/json/reference/map/mapgen.md
@@ -1043,6 +1043,7 @@ mutable structure.
 | neighbors          | (optional) Any of the neighboring overmaps that should be checked before placing the chunk. Each direction is associated with a list of overmap `"id"` substrings.        |
 | joins              | (optional) Any mutable overmap special joins that should be checked before placing the chunk. Each direction is associated with a list of join `"id"` strings.            |
 | connections        | (optional) Any connection that should be directed toward this overmap before placing the chunk. Each direction is associated with a list of connection `"id"` strings.    |
+| rotation | (optional) How many turns to rotate the map, 90 degree turns |
 |                    |                                                                                                                                                                           |
 
 The adjacent overmaps which can be checked in this manner are:
@@ -1057,7 +1058,7 @@ Example:
 
 ```json
 "place_nested": [
-  { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": [ "empty_rock", "field" ] } },
+  { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": [ "empty_rock", "field" ] }, "rotation": 0  },
   { "chunks": [ "gate_north" ], "x": 0, "y": 0, "joins": { "north": [ "interior_to_exterior" ] } },
   { "else_chunks": [ "concrete_wall_ns" ], "x": 0, "y": 0, "neighbors": { "north_west": [ "field", "microlab" ] } }
 ],

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -542,7 +542,7 @@ void spawn_nested_mapgen()
             return;
         }
         const auto nested_offset = point_rel_ms( local_ms.x(), local_ms.y() );
-        ( *ptr )->nest( md, nested_offset );
+        ( *ptr )->nest( md, nested_offset, 0 );
         g->load_npcs();
         get_map().invalidate_map_cache( g->get_levz() );
     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -522,7 +522,7 @@ void call_mapgen_function( std::string name, mapgendata &dat, bool nested, const
         if( ptr == nullptr ) {
             return;
         }
-        ( *ptr )->nest( dat, pos );
+        ( *ptr )->nest( dat, pos, 0 );
     } else {
         oter_mapgen.generate( dat, name );
     }
@@ -1013,6 +1013,26 @@ void jmapgen_place::offset( const point_rel_ms &offset )
     x.valmax -= offset.x();
     y.val -= offset.y();
     y.valmax -= offset.y();
+}
+
+void jmapgen_place::edit( std::function<point_omt_ms( const point_omt_ms & )> func )
+{
+    point_omt_ms low = func( point_omt_ms( x.val, y.val ) );
+    point_omt_ms high = func( point_omt_ms( x.valmax, y.valmax ) );
+    if( low.x() > high.x() ) {
+        x.valmax = low.x();
+        x.val = high.x();
+    } else {
+        x.val = low.x();
+        x.valmax = high.x();
+    }
+    if( low.y() > high.y() ) {
+        y.valmax = low.y();
+        y.val = high.y();
+    } else {
+        y.val = low.y();
+        y.valmax = high.y();
+    }
 }
 
 map_key::map_key( const std::string &s ) : str( s )
@@ -3173,6 +3193,7 @@ class jmapgen_nested : public jmapgen_piece
         neighbor_oter_check neighbor_oters;
         neighbor_join_check neighbor_joins;
         neighbor_connection_check neighbor_connections;
+        jmapgen_int rotation = 0;
         jmapgen_nested( const JsonObject &jsi )
             : neighbor_oters( jsi.get_object( "neighbors" ) )
             , neighbor_joins( jsi.get_object( "joins" ) )
@@ -3182,6 +3203,9 @@ class jmapgen_nested : public jmapgen_piece
             }
             if( jsi.has_member( "else_chunks" ) ) {
                 load_weighted_list( jsi.get_member( "else_chunks" ), else_entries, 100 );
+            }
+            if( jsi.has_member( "rotation" ) ) {
+                rotation = jmapgen_int( jsi, "rotation" );
             }
         }
 
@@ -3257,7 +3281,7 @@ class jmapgen_nested : public jmapgen_piece
 
             {
                 ZoneScopedN( "jmapgen_nested_nest" );
-                ( *ptr )->nest( dat, point_rel_ms( x.get(), y.get() ) );
+                ( *ptr )->nest( dat, point_rel_ms( x.get(), y.get() ), rotation.get() );
             }
         }
 
@@ -4106,7 +4130,8 @@ void jmapgen_objects::merge_parameters_into( mapgen_parameters &params,
  * (set|line|square)_(ter|furn|trap|radiation); simple (x, y, int) or (x1,y1,x2,y2, int) functions
  * TODO: optimize, though gcc -O2 optimizes enough that splitting the switch has no effect
  */
-bool jmapgen_setmap::apply( const mapgendata &dat, const point_rel_ms &offset ) const
+bool jmapgen_setmap::apply( const mapgendata &dat, const point_rel_ms &offset,
+                            std::function<point_omt_ms( const point_omt_ms & )> func ) const
 {
     if( chance != 1 && !one_in( chance ) ) {
         return true;
@@ -4123,47 +4148,55 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const point_rel_ms &offset ) 
     auto &m = dat.m;
     const int trepeat = repeat.get();
     for( int i = 0; i < trepeat; i++ ) {
+        point_omt_ms pt = func( point_omt_ms( x_get(), y_get() ) );
+        point_omt_ms pt2 = func( point_omt_ms( x2_get(), y2_get() ) );
+        if( pt.x() > pt2.x() ) {
+            int inter = pt.x();
+            pt.x() = pt2.x();
+            pt2.x() = inter;
+        }
+        if( pt.y() > pt2.y() ) {
+            int inter = pt.y();
+            pt.y() = pt2.y();
+            pt2.y() = inter;
+        }
         switch( op ) {
             case JMAPGEN_SETMAP_TER: {
                 // TODO: the ter_id should be stored separately and not be wrapped in an jmapgen_int
-                m.ter_set( point_omt_ms( x_get(), y_get() ), ter_id( val.get() ) );
+                m.ter_set( pt, ter_id( val.get() ) );
             }
             break;
             case JMAPGEN_SETMAP_FURN: {
                 // TODO: the furn_id should be stored separately and not be wrapped in an jmapgen_int
-                m.furn_set( point_omt_ms( x_get(), y_get() ), furn_id( val.get() ) );
+                m.furn_set( pt, furn_id( val.get() ) );
             }
             break;
             case JMAPGEN_SETMAP_TRAP: {
                 // TODO: the trap_id should be stored separately and not be wrapped in an jmapgen_int
-                mtrap_set( &m, point_omt_ms( x_get(), y_get() ), trap_id( val.get() ) );
+                mtrap_set( &m, pt, trap_id( val.get() ) );
             }
             break;
             case JMAPGEN_SETMAP_RADIATION: {
-                m.set_radiation( point_omt_ms( x_get(), y_get() ), val.get() );
+                m.set_radiation( pt, val.get() );
             }
             break;
             case JMAPGEN_SETMAP_BASH: {
-                m.bash( point_omt_ms( x_get(), y_get() ), 9999, true );
+                m.bash( pt, 9999, true );
             }
             break;
 
             case JMAPGEN_SETMAP_LINE_TER: {
                 // TODO: the ter_id should be stored separately and not be wrapped in an jmapgen_int
-                m.draw_line_ter( ter_id( val.get() ), point_omt_ms( x_get(), y_get() ), point_omt_ms( x2_get(),
-                                 y2_get() ) );
+                m.draw_line_ter( ter_id( val.get() ), pt, pt2 );
             }
             break;
             case JMAPGEN_SETMAP_LINE_FURN: {
                 // TODO: the furn_id should be stored separately and not be wrapped in an jmapgen_int
-                m.draw_line_furn( furn_id( val.get() ), point_omt_ms( x_get(), y_get() ), point_omt_ms( x2_get(),
-                                  y2_get() ) );
+                m.draw_line_furn( furn_id( val.get() ), pt, pt2 );
             }
             break;
             case JMAPGEN_SETMAP_LINE_TRAP: {
-                const std::vector<point_omt_ms> line = line_to( point_omt_ms( x_get(), y_get() ),
-                                                       point_omt_ms( x2_get(), y2_get() ),
-                                                       0 );
+                const std::vector<point_omt_ms> line = line_to( pt, pt2, 0 );
                 for( auto &i : line ) {
                     // TODO: the trap_id should be stored separately and not be wrapped in an jmapgen_int
                     mtrap_set( &m, i, trap_id( val.get() ) );
@@ -4171,9 +4204,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const point_rel_ms &offset ) 
             }
             break;
             case JMAPGEN_SETMAP_LINE_RADIATION: {
-                const std::vector<point_omt_ms> line = line_to( point_omt_ms( x_get(), y_get() ),
-                                                       point_omt_ms( x2_get(), y2_get() ),
-                                                       0 );
+                const std::vector<point_omt_ms> line = line_to( pt, pt2, 0 );
                 for( auto &i : line ) {
                     m.set_radiation( i, val.get() );
                 }
@@ -4181,21 +4212,17 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const point_rel_ms &offset ) 
             break;
             case JMAPGEN_SETMAP_SQUARE_TER: {
                 // TODO: the ter_id should be stored separately and not be wrapped in an jmapgen_int
-                m.draw_square_ter( ter_id( val.get() ), point_omt_ms( x_get(), y_get() ), point_omt_ms( x2_get(),
-                                   y2_get() ) );
+                m.draw_square_ter( ter_id( val.get() ), pt, pt2 );
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_FURN: {
                 // TODO: the furn_id should be stored separately and not be wrapped in an jmapgen_int
-                m.draw_square_furn( furn_id( val.get() ), point_omt_ms( x_get(), y_get() ), point_omt_ms( x2_get(),
-                                    y2_get() ) );
+                m.draw_square_furn( furn_id( val.get() ), pt, pt2 );
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_TRAP: {
-                const point_omt_ms c{ x_get(), y_get() };
-                const point_omt_ms c2{ x2_get(), y2_get() };
-                for( int tx = c.x(); tx <= c2.x(); tx++ ) {
-                    for( int ty = c.y(); ty <= c2.y(); ty++ ) {
+                for( int tx = pt.x(); tx <= pt2.x(); tx++ ) {
+                    for( int ty = pt.y(); ty <= pt2.y(); ty++ ) {
                         // TODO: the trap_id should be stored separately and not be wrapped in an jmapgen_int
                         mtrap_set( &m, point_omt_ms( tx, ty ), trap_id( val.get() ) );
                     }
@@ -4203,12 +4230,8 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const point_rel_ms &offset ) 
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_RADIATION: {
-                const int cx = x_get();
-                const int cy = y_get();
-                const int cx2 = x2_get();
-                const int cy2 = y2_get();
-                for( int tx = cx; tx <= cx2; tx++ ) {
-                    for( int ty = cy; ty <= cy2; ty++ ) {
+                for( int tx = pt.x(); tx <= pt2.x(); tx++ ) {
+                    for( int ty = pt.y(); ty <= pt2.y(); ty++ ) {
                         m.set_radiation( point_omt_ms( tx, ty ), val.get() );
                     }
                 }
@@ -4364,11 +4387,16 @@ mapgen_parameters mapgen_function_json::get_mapgen_params( mapgen_parameter_scop
     return parameters.params_for_scope( scope );
 }
 
-void mapgen_function_json_nested::nest( const mapgendata &md, const point_rel_ms &offset ) const
+void mapgen_function_json_nested::nest( const mapgendata &md, const point_rel_ms &offset,
+                                        const int rotation ) const
 {
     ZoneScopedN( "mapgen_json_nested" );
-    // TODO: Make rotation work for submaps, then pass this value into elem & objects apply.
-    //int chosen_rotation = rotation.get() % 4;
+
+    int chosen_rotation = rotation;
+
+    const auto rot_func = [&]( const point_omt_ms & pt ) -> point_omt_ms {
+        return pt.rotate( chosen_rotation, total_size.raw() );
+    };
 
     auto args = mapgen_arguments {};
     {
@@ -4381,13 +4409,13 @@ void mapgen_function_json_nested::nest( const mapgendata &md, const point_rel_ms
             ZoneScopedN( "mapgen_json_nested_setmap" );
             for( const auto &elem : setmap_points )
             {
-                elem.apply( active_md, offset );
+                elem.apply( active_md, offset, rot_func );
             }
         }
 
         {
             ZoneScopedN( "mapgen_json_nested_objects" );
-            objects.apply( active_md, offset );
+            objects.apply( active_md, offset, rot_func );
         }
 
         {
@@ -4426,10 +4454,11 @@ void jmapgen_objects::apply( const mapgendata &dat ) const
     }
 }
 
-void jmapgen_objects::apply( const mapgendata &dat, const point_rel_ms &offset ) const
+void jmapgen_objects::apply( const mapgendata &dat, const point_rel_ms &offset,
+                             std::function<point_omt_ms( const point_omt_ms & )> func ) const
 {
     ZoneScopedN( "jmapgen_objects_apply_offset" );
-    if( offset == point_rel_ms::zero() ) {
+    if( offset == point_rel_ms::zero() && func( point_omt_ms::zero() ) == point_omt_ms::zero() ) {
         // It's a bit faster
         apply( dat );
         return;
@@ -4437,6 +4466,7 @@ void jmapgen_objects::apply( const mapgendata &dat, const point_rel_ms &offset )
 
     for( auto &obj : objects ) {
         auto where = obj.first;
+        where.edit( func );
         where.offset( -offset );
 
         const auto &what = *obj.second;

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -131,7 +131,12 @@ struct jmapgen_setmap {
         x( ix ), y( iy ), x2( ix2 ), y2( iy2 ), op( iop ), val( ival ), chance( ione_in ),
         repeat( irepeat ), rotation( irotation ),
         fuel( ifuel ), status( istatus ) {}
-    bool apply( const mapgendata &dat, const point_rel_ms &offset ) const;
+
+    static point_omt_ms default_rotate( const point_omt_ms &pt ) { return pt; }
+
+    bool apply( const mapgendata &dat, const point_rel_ms &offset,
+                std::function<point_omt_ms( const point_omt_ms & )> func = default_rotate ) const;
+
     /**
      * checks if applying these objects to data would cause cause a collision with vehicles
      * on the same map
@@ -221,6 +226,7 @@ class jmapgen_place
         jmapgen_place( const point_rel_ms &p ) : x( p.x() ), y( p.y() ), repeat( 1, 1 ) { }
         jmapgen_place( const JsonObject &jsi );
         void offset( const point_rel_ms &offset );
+        void edit( std::function<point_omt_ms( const point_omt_ms & )> func );
         jmapgen_int x;
         jmapgen_int y;
         jmapgen_int repeat;
@@ -376,7 +382,9 @@ struct jmapgen_objects {
         void merge_parameters_into( mapgen_parameters &, const std::string &outer_context ) const;
 
         void apply( const mapgendata &dat ) const;
-        void apply( const mapgendata &dat, const point_rel_ms &offset ) const;
+        static point_omt_ms default_rotate( const point_omt_ms &pt ) { return pt; }
+        void apply( const mapgendata &dat, const point_rel_ms &offset,
+                    std::function<point_omt_ms( const point_omt_ms & )> func = default_rotate ) const;
 
         /**
          * checks if applying these objects to data would cause cause a collision with vehicles
@@ -487,7 +495,7 @@ class mapgen_function_json_nested : public mapgen_function_json_base
         explicit mapgen_function_json_nested( const json_source_location &jsrcloc );
         ~mapgen_function_json_nested() override = default;
 
-        void nest( const mapgendata &md, const point_rel_ms &offset ) const;
+        void nest( const mapgendata &md, const point_rel_ms &offset, const int rotation ) const;
     protected:
         bool setup_internal( const JsonObject &jo ) override;
 


### PR DESCRIPTION
## Purpose of change (The Why)
Closes #10063 

## Describe the solution (The How)
Add `rotation` field to nested mapgen

## Describe alternatives you've considered
None

## Testing
Central lab vertical rooms

## Additional Context
Must delete more lines
More red lines goods

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
<!-- BEGIN docs comment -->

## Translations

| post                             | changed | stale | missing |
| -------------------------------- | ------- | ----- | ------- |
| mod/json/reference/map/mapgen.md | en      | ko    | ja      |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ba1be62](https://github.com/cataclysmbn/Cataclysm-BN/commit/ba1be628626fbf977f6ed8c8b77cef16f3e57a4d) (style(autofix.ci): automated formatting) on 2026-09-01 23:37:16

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33564672320/artifacts/9823032827)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33564672320/artifacts/9825148944)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33564672320/artifacts/9823161635)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33564672320/artifacts/9823198002)
<!-- END artifact comment -->