### PR TITLE
fix: properly invalidate lightmap caches on non-gpu compute during map cache rebuilds

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9758,6 +9758,13 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     if( skip_lightmap && use_sdl_gpu_compute && gpu_transparency_dirty ) {
         cata_gpu::invalidate_lighting_transparency_levels( gpu_transparency_dirty_levels );
     }
+    if( !use_sdl_gpu_compute && gpu_transparency_dirty ) {
+        invalidate_lightmap_caches();
+    }
+#else
+    if( gpu_transparency_dirty ) {
+        invalidate_lightmap_caches();
+    }
 #endif
     TracyPlot( "Map GPU Transparency Dirty Levels",
                static_cast<int64_t>( gpu_transparency_dirty_levels.size() ) );


### PR DESCRIPTION
## Purpose of change (The Why)
closes: #10065
If it doesn't you guys need to give more examples

## Describe the solution (The How)
When the map cache was worked on
`gpu_transparency_dirty` was set for both builds, but only the GPU compute setups got their lightmaps dirtied
Meaning that there was constant flashing on the CPU compute builds

## Describe alternatives you've considered
None

## Testing
Run around that save chaos gave me
It worked fine

## Additional Context
### WARNING
This reduces performance, because now you are actually doing the lightmap work, to be honest.... I dont have the knowledge to make it any better, ping someone else if you want this done better

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1f9f209](https://github.com/cataclysmbn/Cataclysm-BN/commit/1f9f2094201cf3ad4e8e1b189d20063828913eba) (fix: properly invalidate lightmap caches on non-gpu builds) on 2026-09-02 16:50:13

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33648742662/artifacts/9856433228)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33648742662/artifacts/9855610551)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33648742662/artifacts/9854634030)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33648742662/artifacts/9854797383)
<!-- END artifact comment -->