### PR TITLE
refactor: convert central lab to use mapgen palette, part 1

### DIFF
--- a/data/json/mapgen/lab/lab_central/lab_central_core.json
+++ b/data/json/mapgen/lab/lab_central/lab_central_core.json
@@ -32,7 +32,8 @@
         "                        ",
         "                        "
       ],
-      "terrain": { ".": "t_thconc_floor", ">": "t_stairs_down", "<": "t_stairs_up", "|": "t_concrete_wall" }
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { ".": "t_thconc_floor", "|": "t_concrete_wall" }
     }
   },
   {
@@ -67,17 +68,8 @@
         "         |....|         ",
         "|||||||||||++|||||||||||"
       ],
-      "terrain": {
-        "!": "t_floor_red",
-        "/": "t_floor_red",
-        ".": "t_thconc_floor",
-        "+": "t_door_metal_interior_locked",
-        "=": "t_door_metal_locked",
-        "<": "t_stairs_up",
-        "|": "t_concrete_wall",
-        "7": "t_card_science",
-        "u": [ "t_thconc_floor", "t_thconc_floor_olight" ]
-      },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "+": "t_door_metal_interior_locked", ".": "t_thconc_floor", "|": "t_concrete_wall" },
       "monster": { "u": { "monster": "mon_turret_antimateriel" } },
       "signs": { "/": { "signage": "Warning!\nLive Fire Zone\nAvoid In Case of Lockdown!" } }
     }
@@ -114,21 +106,9 @@
         "    |....=....=....|    ",
         "|||||||||||..|||||||||||"
       ],
-      "terrain": {
-        " ": "t_rock",
-        "!": "t_floor_red",
-        "/": "t_floor_red",
-        ".": "t_thconc_floor",
-        "+": "t_door_metal_lab_c",
-        "=": "t_door_metal_locked",
-        "<": "t_stairs_up",
-        "|": "t_concrete_wall",
-        "7": "t_card_science",
-        "u": [ "t_thconc_floor", "t_thconc_floor_olight" ],
-        "W": "t_ballistic_glass"
-      },
-      "furniture": { "b": "f_bench", "d": "f_desk", "h": "f_chair", "L": "f_locker" },
-      "items": { "d": { "item": "office", "chance": 50, "repeat": 4 }, "L": { "item": "gear_labsecurity", "chance": 50, "repeat": 2 } },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { " ": "t_rock", ".": "t_thconc_floor", "|": "t_concrete_wall" },
+      "items": { "L": { "item": "gear_labsecurity", "chance": 50, "repeat": 2 } },
       "monster": { "u": { "monster": "mon_turret_antimateriel" } },
       "signs": { "/": { "signage": "Warning!\nLive Fire Zone\nAvoid In Case of Lockdown!" } }
     }
@@ -165,7 +145,7 @@
         "-|||||||||    |||||||||-",
         "---------|    |---------"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         {
           "chunks": [
@@ -218,7 +198,7 @@
         "-|||||||||    |||||||||-",
         "---------|    |---------"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         {
           "chunks": [
@@ -270,7 +250,7 @@
         "-|||||||||    |||||||||-",
         "---------|    |---------"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         {
           "chunks": [
@@ -321,7 +301,7 @@
         "-|||||||||    |||||||||-",
         "---------|    |---------"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", "<": "t_stairs_up", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         { "chunks": [ "central_lab_stairway_20x20" ], "x": 2, "y": 2 },
         { "chunks": [ [ "null", 2 ], [ "central_lab_locked_s_4x4", 1 ] ], "x": 10, "y": 20 },
@@ -362,16 +342,8 @@
         "-|||||||||    |||||||||-",
         "---------|    |---------"
       ],
-      "terrain": {
-        "_": "t_concrete_wall",
-        "|": "t_wall_metal",
-        "-": "t_rock",
-        "=": "t_door_metal_locked",
-        "7": "t_card_science",
-        "!": "t_floor_red",
-        ">": "t_stairs_down",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ]
-      },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "_": "t_concrete_wall" },
       "place_nested": [
         { "chunks": [ "central_lab_stairway_20x20" ], "x": 2, "y": 2 },
         { "chunks": [ [ "null", 2 ], [ "central_lab_locked_s_4x4", 1 ] ], "x": 10, "y": 20 },
@@ -412,7 +384,7 @@
         "-|||||||||    |||||||||-",
         "---------|    |---------"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", "<": "t_stairs_up", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         { "chunks": [ "central_lab_stairway_20x20" ], "x": 2, "y": 2 },
         { "chunks": [ [ "null", 2 ], [ "central_lab_locked_s_4x4", 1 ] ], "x": 10, "y": 20 },
@@ -452,7 +424,7 @@
         "-|||||||||    |||||||||-",
         "---------|    |---------"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", ">": "t_stairs_down", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         { "chunks": [ "central_lab_stairway_20x20" ], "x": 2, "y": 2 },
         { "chunks": [ [ "null", 2 ], [ "central_lab_locked_s_4x4", 1 ] ], "x": 10, "y": 20 },
@@ -493,7 +465,7 @@
         "-|||||||||    |||||||||-",
         "---------|    |---------"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", ">": "t_stairs_down", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         { "chunks": [ "central_lab_stairway_20x20" ], "x": 2, "y": 2 },
         { "chunks": [ [ "null", 2 ], [ "central_lab_locked_s_4x4", 1 ] ], "x": 10, "y": 20 },
@@ -512,47 +484,37 @@
         "A|                    |A",
         "    GGGGGGGGGGGGGGGG    ",
         "    GGGGGGGGGGGGGGGG    ",
-        "  GGGGT2277777722TGGGG  ",
-        "  GGGGt2233113322tGGGG  ",
-        "  GGTt|AA|S44S|AA|tTGG  ",
+        "  GGGG722999999227GGGG  ",
+        "  GGGG822331133228GGGG  ",
+        "  GG78|AA|S44S|AA|87GG  ",
         "  GG22A--|S44S|--A22GG  ",
         "  GG22A--|SPPS|--A22GG  ",
-        "  GG73|||||AA|||||37GG  ",
-        "  GG73SSS|----|SSS37GG  ",
-        "  GG7144PA----AP4417GG  ",
-        "  GG7144PA----AP4417GG  ",
-        "  GG73SSS|----|SSS37GG  ",
-        "  GG73|||||AA|||||37GG  ",
+        "  GG93|||||AA|||||39GG  ",
+        "  GG93SSS|----|SSS39GG  ",
+        "  GG9144PA----AP4419GG  ",
+        "  GG9144PA----AP4419GG  ",
+        "  GG93SSS|----|SSS39GG  ",
+        "  GG93|||||AA|||||39GG  ",
         "  GG22A--|SPPS|--A22GG  ",
         "  GG22A--|S44S|--A22GG  ",
-        "  GGTt|AA|S44S|AA|tTGG  ",
-        "  GGGGt2233113322tGGGG  ",
-        "  GGGGT2277^^7722TGGGG  ",
+        "  GG78|AA|S44S|AA|87GG  ",
+        "  GGGG822331133228GGGG  ",
+        "  GGGG72299^^99227GGGG  ",
         "    GGGGGGGGGGGGGGGG    ",
         "    GGGGGGGGGGGGGGGG    ",
         "A|                    |A",
         "-A                    A-"
       ],
+      "palettes": [ "central_lab_palette" ],
       "terrain": {
-        "|": "t_wall_metal",
-        "-": "t_rock",
         "1": "t_machinery_light",
         "2": "t_machinery_heavy",
         "3": "t_machinery_electronic",
-        "4": "t_metal_floor",
-        "A": "t_wall_metal",
-        "G": "t_grate",
         "P": "t_plut_generator",
-        "T": "t_radio_tower",
-        "t": "t_radio_controls"
+        "7": "t_radio_tower",
+        "8": "t_radio_controls"
       },
-      "furniture": {
-        "^": "f_supercomputer",
-        "5": "f_electrical_conduit",
-        "7": "f_control_station",
-        "A": "f_metal_cold_vent",
-        "S": "f_server"
-      },
+      "furniture": { "^": "f_supercomputer", "4": "f_electrical_conduit" },
       "place_monster": [ { "group": "GROUP_LAB_ROBOTS", "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 1, 3 ] } ]
     }
   },
@@ -567,29 +529,28 @@
         "                        ",
         "                        ",
         "                        ",
-        "  SS  SS  7777  SS  SS  ",
+        "  SS  SS  9999  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
-        "  SS  SS  7777  SS  SS  ",
+        "  SS  SS  9999  SS  SS  ",
         "                        ",
         "                        ",
-        "  SS  SS  7777  SS  SS  ",
+        "  SS  SS  9999  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
         "  SS  SS  S||S  SS  SS  ",
-        "  SS  SS  7777  SS  SS  ",
+        "  SS  SS  9999  SS  SS  ",
         "                        ",
         "                        ",
         "A|                    |A",
         "-A                    A-"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", "A": "t_wall_metal" },
-      "furniture": { "7": "f_control_station", "A": "f_metal_cold_vent", "S": "f_server" },
+      "palettes": [ "central_lab_palette" ],
       "place_monster": [ { "group": "GROUP_LAB_ROBOTS", "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 1, 3 ] } ]
     }
   },
@@ -606,13 +567,13 @@
         "                        ",
         "                        ",
         "||WWWWWWWWWWWWWWWWWWWW||",
-        "|u 777777777777777777 u|",
+        "|u 999999999999999999 u|",
         "W   h h h h  h h h h   W",
         "W6h                  h6W",
-        "W6   77777    77777   6W",
+        "W6   99999    99999   6W",
         "W6h   h h      h h   h6W",
         "W6                    6W",
-        "W    77777    77777    W",
+        "W    99999    99999    W",
         "|     h h      h h     |",
         "+                      +",
         "+                      +",
@@ -625,22 +586,7 @@
         "W     hh        hh     W",
         "|                      |"
       ],
-      "terrain": {
-        "|": "t_wall_metal",
-        "-": "t_rock",
-        "+": "t_door_metal_lab_c",
-        "A": "t_wall_metal",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ],
-        "W": "t_ballistic_glass"
-      },
-      "furniture": {
-        "6": "f_console_broken_table",
-        "7": "f_control_station",
-        "A": "f_metal_cold_vent",
-        "e": "f_table",
-        "F": "f_filing_cabinet",
-        "h": "f_chair"
-      }
+      "palettes": [ "central_lab_palette" ]
     }
   },
   {
@@ -659,38 +605,35 @@
         "                        ",
         "                        ",
         "     bb          bb     ",
-        "     bb T 7777 T bb     ",
+        "     bb I 9999 I bb     ",
         "          |AA|          ",
         "        GGA--AGG        ",
         "        GGA--AGG        ",
         "         E|AA|E         ",
         "         E 88 E         ",
-        "         ST88TS         ",
+        "         2I88I2         ",
         "                        ",
-        "    h  T  T             ",
-        "    s                   ",
-        "    T  {  h             ",
-        "    {  B  S             ",
-        "    B  T  T             ",
-        "A|  T                   ",
+        "    1  I  I             ",
+        "    3                   ",
+        "    I  {  1             ",
+        "    {  4  2             ",
+        "    4  I  I             ",
+        "A|  I                   ",
         "-A                      "
       ],
+      "palettes": [ "central_lab_palette" ],
       "terrain": {
-        "|": "t_wall_metal",
-        "-": "t_rock",
         "{": "t_current_trans",
         "8": "t_potential_trans",
-        "9": "t_potential_trans",
-        "A": "t_wall_metal",
-        "B": "t_oil_circ_brkr_l",
         "E": "t_machinery_electronic",
         "G": "t_generator_broken",
-        "h": "t_station_disc",
-        "S": "t_switchgear_l",
-        "s": "t_switchgear_s",
-        "T": "t_support_l"
+        "1": "t_station_disc",
+        "2": "t_switchgear_l",
+        "3": "t_switchgear_s",
+        "4": "t_oil_circ_brkr_l",
+        "I": "t_support_l"
       },
-      "furniture": { "7": "f_control_station", "A": "f_metal_cold_vent", "b": "f_battery_huge" },
+      "furniture": { "b": "f_battery_huge" },
       "place_monster": [ { "group": "GROUP_LAB_ROBOTS", "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 1, 3 ] } ]
     }
   },
@@ -726,15 +669,7 @@
         "-||WWWWWWW|++|WWWWWWW||-",
         "A|                    |A"
       ],
-      "terrain": {
-        "|": "t_wall_metal",
-        "-": "t_rock",
-        "+": "t_door_metal_lab_c",
-        "A": "t_wall_metal",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ],
-        "W": "t_ballistic_glass"
-      },
-      "furniture": { "A": "f_metal_cold_vent" },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         { "chunks": [ "central_lab_melchior_mini_room_20x7" ], "x": 2, "y": 2 },
         { "chunks": [ "central_lab_melchior_mini_room_20x7" ], "x": 2, "y": 15 }
@@ -773,7 +708,7 @@
         "-|||||||||    |||||||||-",
         "|--------|    |---------"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", "+": "t_door_metal_lab_c" },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 2, "y": 2 },
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 15, "y": 2 },
@@ -816,16 +751,7 @@
         "-||WWWWWWW|++|WWWWWWW||-",
         "A|                    |A"
       ],
-      "terrain": {
-        "|": "t_wall_metal",
-        "-": "t_rock",
-        "+": "t_door_metal_lab_c",
-        ">": "t_stairs_down",
-        "A": "t_wall_metal",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ],
-        "W": "t_ballistic_glass"
-      },
-      "furniture": { "A": "f_metal_cold_vent" },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         { "chunks": [ "central_lab_melchior_mini_room_20x7" ], "x": 2, "y": 2 },
         { "chunks": [ "central_lab_melchior_mini_room_20x7" ], "x": 2, "y": 15 }
@@ -864,16 +790,8 @@
         "-|  ddddddd  ddddddd  |-",
         "||                    ||"
       ],
-      "terrain": {
-        "|": "t_wall_metal",
-        "-": "t_rock",
-        "+": "t_door_metal_lab_c",
-        "A": "t_wall_metal",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ],
-        "W": "t_ballistic_glass"
-      },
-      "furniture": { "A": "f_metal_cold_vent", "d": "f_desk", "h": "f_chair" },
-      "items": { "d": { "item": "office", "chance": 50, "repeat": 4 }, "e": { "item": "lab_bookshelves", "chance": 25, "repeat": 2 } },
+      "palettes": [ "central_lab_palette" ],
+      "items": { "d": { "item": "lab_bookshelves", "chance": 25, "repeat": 2 } },
       "place_nested": [ { "chunks": [ "central_lab_melchior_mini_room_20x7" ], "x": 2, "y": 2 } ]
     }
   },
@@ -909,7 +827,7 @@
         "-|||||||||    |||||||||-",
         "|--------|    |---------"
       ],
-      "terrain": { "|": "t_wall_metal", "-": "t_rock", "<": "t_stairs_up", "+": "t_door_metal_lab_c" },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         { "chunks": [ "central_lab_stairway_20x20" ], "x": 2, "y": 2 },
         { "chunks": [ [ "null", 25 ], [ "central_lab_locked_s_4x4", 75 ] ], "x": 10, "y": 20 },
@@ -949,7 +867,7 @@
         "                        ",
         "========================"
       ],
-      "terrain": { "|": "t_wall_metal", "=": "t_strconc_wall", "-": "t_rock", "+": "t_door_metal_lab_c" },
+      "palettes": [ "central_lab_palette" ],
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_14x14" ], "x": 5, "y": 2 },
         { "chunks": [ "central_lab_mini_room_4x4", "central_lab_mini_room_ns_4x4" ], "x": 0, "y": 2 },
@@ -985,7 +903,7 @@
         "+    +            +    +",
         "=    =    u  u    =    =",
         "===========++===========",
-        "=  7777777u  u7777777  =",
+        "=  9999999u  u9999999  =",
         "=   h h h      h h h   =",
         "=                      =",
         "=                      =",
@@ -995,14 +913,8 @@
         "=                      =",
         "=   h h h      h h h   ="
       ],
-      "terrain": {
-        "|": "t_wall_metal",
-        "=": "t_strconc_wall",
-        "-": "t_rock",
-        "+": "t_door_metal_lab_c",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ]
-      },
-      "furniture": { "7": "f_control_station", "h": "f_chair", "S": "f_server" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "=": "t_strconc_wall" },
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 1, "y": 2 },
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 16, "y": 2 },
@@ -1041,7 +953,7 @@
         "+    +     <<     +    +",
         "=    =u          u=    =",
         "===========++===========",
-        "=  7777777u  u7777777  =",
+        "=  9999999u  u9999999  =",
         "=   h h h      h h h   =",
         "=                      =",
         "=                      =",
@@ -1051,15 +963,8 @@
         "=                      =",
         "=   h h h      h h h   ="
       ],
-      "terrain": {
-        "|": "t_wall_metal",
-        "=": "t_strconc_wall",
-        "-": "t_rock",
-        "+": "t_door_metal_lab_c",
-        "<": "t_stairs_up",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ]
-      },
-      "furniture": { "7": "f_control_station", "h": "f_chair", "S": "f_server" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "=": "t_strconc_wall" },
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 1, "y": 2 },
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 16, "y": 2 },
@@ -1108,16 +1013,8 @@
         "=                      =",
         "==========    =========="
       ],
-      "terrain": {
-        "|": "t_wall_metal",
-        "=": "t_strconc_wall",
-        "-": "t_rock",
-        "+": "t_door_metal_lab_c",
-        "6": "t_console_broken",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ]
-      },
-      "furniture": { "h": "f_chair" },
-      "nested": { "C": { "chunks": [ "null", "central_lab_crate_1x1" ] } },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "=": "t_strconc_wall" },
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 1, "y": 2 },
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 16, "y": 2 },
@@ -1166,16 +1063,9 @@
         "=       d=    =       |-",
         "===++======++=========|-"
       ],
-      "terrain": {
-        "|": "t_wall_metal",
-        "=": "t_strconc_wall",
-        "-": "t_rock",
-        "+": "t_door_metal_lab_c",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ],
-        "W": "t_ballistic_glass"
-      },
-      "furniture": { "c": "f_counter", "d": "f_desk", "e": "f_table", "g": "f_counter_gate_c", "h": "f_chair" },
-      "items": { "d": { "item": "office", "chance": 50, "repeat": 4 }, "e": { "item": "magazines", "chance": 50, "repeat": 4 } },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "=": "t_strconc_wall" },
+      "items": { "e": { "item": "magazines", "chance": 50, "repeat": 4 } },
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 1, "y": 2 },
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 15, "y": 2 },
@@ -1206,7 +1096,7 @@
     "object": {
       "fill_ter": "t_open_air_rooved",
       "rows": [
-        "|__7777777u__u7777777__|",
+        "|__9999999u__u9999999__|",
         "||WWWWWWWWWWWWWWWWWWWW||",
         "                        ",
         "                        ",
@@ -1231,14 +1121,8 @@
         "                        ",
         "                        "
       ],
-      "terrain": {
-        "|": "t_strconc_wall",
-        "_": "t_metal_floor",
-        "7": "t_metal_floor",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ],
-        "W": "t_ballistic_glass"
-      },
-      "furniture": { "7": "f_control_station" }
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall", "_": "t_metal_floor", " ": "t_open_air_rooved" }
     }
   },
   {
@@ -1257,14 +1141,14 @@
         "                      |-",
         "                      |-",
         "        RRRRRR        |-",
-        "        R7777R        |-",
+        "        R9999R        |-",
         "      RRIhGGhIRR      |-",
-        "      R7hGGGGh7R      |-",
-        "      R7GG>>GG7R      |-",
-        "      R7GG>>GG7R      |-",
-        "      R7hGGGGh7R      |-",
+        "      R9hGGGGh9R      |-",
+        "      R9GG>>GG9R      |-",
+        "      R9GG>>GG9R      |-",
+        "      R9hGGGGh9R      |-",
         "      RRIhGGhIRR      |-",
-        "        R7777R        |-",
+        "        R9999R        |-",
         "        RRRRRR        |-",
         "                      |-",
         "                      |-",
@@ -1273,17 +1157,8 @@
         "                      |-",
         "                      |-"
       ],
-      "terrain": {
-        "|": "t_strconc_wall",
-        "-": "t_wall_metal",
-        ">": "t_ladder_down",
-        "7": "t_grate",
-        "G": "t_grate",
-        "h": "t_grate",
-        "I": "t_column",
-        "R": "t_concrete_railing"
-      },
-      "furniture": { "7": "f_control_station", "h": "f_chair" }
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall", "-": "t_wall_metal", ">": "t_ladder_down", "9": "t_grate", "G": "t_grate", "h": "t_grate" }
     }
   },
   {
@@ -1318,7 +1193,8 @@
         "=                     |-",
         "===++======++=========|-"
       ],
-      "terrain": { "|": "t_wall_metal", "=": "t_strconc_wall", "-": "t_rock", "+": "t_door_metal_lab_c", ">": "t_stairs_down" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "=": "t_strconc_wall" },
       "place_nested": [ { "chunks": [ "central_lab_stairway_20x20" ], "x": 2, "y": 2 } ]
     }
   },
@@ -1354,7 +1230,8 @@
         "=                     |-",
         "===++======++=========|-"
       ],
-      "terrain": { "|": "t_wall_metal", "=": "t_strconc_wall", "-": "t_rock", "+": "t_door_metal_lab_c", "<": "t_stairs_up" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "=": "t_strconc_wall" },
       "place_nested": [ { "chunks": [ "central_lab_stairway_20x20" ], "x": 2, "y": 2 } ]
     }
   },
@@ -1367,7 +1244,7 @@
       "rows": [
         "---------||==7|---------",
         "||||||||||    ||||||||||",
-        "66666666        66666666",
+        "99999999        99999999",
         "  h  h            h  h  ",
         "                        ",
         "                        ",
@@ -1386,19 +1263,17 @@
         "                        ",
         "                        ",
         "    h  h        h  h    ",
-        "  66666666    66666666  ",
+        "  99999999    99999999  ",
         "GGGGGGGGGGGGGGGGGGGGGGGG",
         "GGGGGGGGGGGGGGGGGGGGGGGG"
       ],
+      "palettes": [ "central_lab_palette" ],
       "terrain": {
         " ": [ [ "t_metal_floor_no_roof", 90 ], [ "t_platform_resin", 8 ], [ "t_lava", 2 ] ],
         "|": "t_strconc_wall",
-        "-": "t_wall_metal",
-        "=": "t_door_metal_locked",
-        "7": "t_card_science",
-        "G": "t_grate"
+        "-": "t_wall_metal"
       },
-      "furniture": { "6": "f_console_broken_table", "h": "f_chair" },
+      "furniture": { "9": "f_console_broken_table" },
       "place_monster": [ { "group": "GROUP_ENDGAME_FINALE", "x": [ 1, 22 ], "y": [ 4, 22 ], "repeat": [ 3, 6 ] } ]
     }
   },
@@ -1434,16 +1309,14 @@
         "                      |-",
         "                      |-"
       ],
+      "palettes": [ "central_lab_palette" ],
       "terrain": {
         " ": [ [ "t_metal_floor_no_roof", 90 ], [ "t_platform_resin", 8 ], [ "t_lava", 2 ] ],
         "|": "t_strconc_wall",
         "-": "t_wall_metal",
         "<": "t_ladder_up",
-        "I": "t_column",
-        "R": "t_concrete_railing",
         "S": "t_metal_floor_no_roof"
       },
-      "furniture": { "S": "f_server" },
       "place_monster": [ { "group": "GROUP_ENDGAME_FINALE", "x": [ 4, 22 ], "y": [ 1, 20 ], "repeat": [ 3, 6 ] } ]
     }
   }

--- a/data/json/mapgen/lab/lab_central/nested_lab_central_core.json
+++ b/data/json/mapgen/lab/lab_central/nested_lab_central_core.json
@@ -28,21 +28,8 @@
         "h                  h",
         "ehhhhh        hhhhhe"
       ],
-      "terrain": { "6": "t_console_broken" },
-      "furniture": {
-        "c": "f_counter",
-        "d": "f_desk",
-        "e": "f_table",
-        "F": "f_filing_cabinet",
-        "g": "f_counter_gate_c",
-        "h": "f_chair",
-        "S": "f_server"
-      },
-      "items": {
-        "e": { "item": "magazines", "chance": 50, "repeat": 4 },
-        "d": { "item": "office", "chance": 50, "repeat": 4 },
-        "F": { "item": "file_room", "chance": 75, "repeat": 6 }
-      },
+      "palettes": [ "central_lab_palette" ],
+      "items": { "e": { "item": "magazines", "chance": 50, "repeat": 4 } },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 5, 14 ], "y": [ 5, 14 ], "chance": 50 } ]
     }
   },
@@ -74,25 +61,11 @@
         "                    ",
         "  ehhhhe    ehhhhe  "
       ],
-      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_interior_locked", "W": "t_ballistic_glass" },
-      "furniture": {
-        "b": "f_bench",
-        "c": "f_counter",
-        "d": "f_desk",
-        "e": "f_table",
-        "h": "f_chair",
-        "L": "f_locker",
-        "s": "f_sink",
-        "t": "f_trashcan",
-        "V": "f_vending_c",
-        "v": "f_vending_c"
-      },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_interior_locked" },
       "items": {
         "e": { "item": "magazines", "chance": 50, "repeat": 4 },
-        "L": { "item": "gear_labsecurity", "chance": 50, "repeat": 2 },
-        "t": { "item": "trash_cart", "chance": 50, "repeat": 6 },
-        "V": { "item": "vending_food", "chance": 80 },
-        "v": { "item": "vending_drink", "chance": 80 }
+        "L": { "item": "gear_labsecurity", "chance": 50, "repeat": 2 }
       },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 5, 14 ], "y": [ 5, 14 ], "repeat": [ 1, 2 ] } ]
     }
@@ -110,7 +83,7 @@
         "  |--------------|  ",
         "  |-||||||||||||-|  ",
         "  |-|##########|-|  ",
-        "  |-| TTTTTTTT |-|  ",
+        "  |-| ^^^^^^^^ |-|  ",
         "  |-|          |-|  ",
         "  |-|          |-|  ",
         "  |-|          |-|  ",
@@ -125,16 +98,9 @@
         "                    ",
         "                    "
       ],
-      "terrain": {
-        "|": "t_strconc_wall",
-        "-": "t_wall_metal",
-        "+": "t_door_metal_interior_locked",
-        "=": "t_door_metal_locked",
-        "7": "t_card_science",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ],
-        "W": "t_ballistic_glass"
-      },
-      "furniture": { "#": "f_sandbag_half", "c": "f_counter", "r": "f_rack", "T": "f_target" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall", "-": "t_wall_metal", "+": "t_door_metal_interior_locked" },
+      "furniture": { "^": "f_target" },
       "items": { "c": { "item": "ear_protection", "chance": 25 }, "r": { "item": "energy_weapon_armory", "chance": 50, "repeat": 2 } },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 6, 13 ], "y": [ 7, 12 ], "repeat": [ 1, 2 ] } ]
     }
@@ -167,13 +133,8 @@
         "                    ",
         "        u  u        "
       ],
-      "terrain": {
-        "6": "t_console_broken",
-        "$": "t_elevator_control_off",
-        "E": "t_elevator",
-        "I": "t_column",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ]
-      },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "$": "t_elevator_control_off", "E": "t_elevator" },
       "furniture": { "c": "f_charger", "j": "f_cable_connector", "r": "f_utility_shelf" },
       "items": { "c": { "item": "gas_charging_rack", "chance": 25 }, "r": { "item": "mechanics", "chance": 50, "repeat": 3 } },
       "place_vehicles": [ { "vehicle": "experimental_military_vehicles", "x": 6, "y": 7, "chance": 75, "rotation": 270 } ],
@@ -195,46 +156,32 @@
         "     r|S    S|r     ",
         "u    r|Y    Y|r    u",
         "||++||||7==|||||++||",
-        "b     |~~gg~~|     b",
-        "b    L|~gggg~|L    b",
-        "     L|~gRRg~|L     ",
-        "     L|~gRRg~|L     ",
-        "b    L|~gggg~|L    b",
+        "b     |~~GG~~|     b",
+        "b    L|~GGGG~|L    b",
+        "     L|~GRRG~|L     ",
+        "     L|~GRRG~|L     ",
+        "b    L|~GGGG~|L    b",
         "b     |~~~~~~|     b",
         "||++||||WWWW||||++||",
-        "u      888888      u",
+        "u      999999      u",
         "dh      h  h      hd",
-        "d      888888      d",
+        "d      999999      d",
         "d       h  h       d",
         "dh                hd",
         "                    "
       ],
+      "palettes": [ "central_lab_palette" ],
       "set": [ { "square": "radiation", "amount": 50, "x": 7, "y": 7, "x2": 12, "y2": 12 } ],
       "terrain": {
         "~": "t_water_dp",
         "|": "t_strconc_wall",
         "+": "t_door_metal_interior_locked",
-        "=": "t_door_metal_locked",
-        "7": "t_card_science",
-        "g": "t_bridge",
-        "R": "t_nuclear_reactor",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ],
-        "W": "t_ballistic_glass"
+        "G": "t_bridge",
+        "R": "t_nuclear_reactor"
       },
-      "furniture": {
-        "8": "f_control_station",
-        "b": "f_bench",
-        "d": "f_desk",
-        "h": "f_chair",
-        "L": "f_locker",
-        "r": "f_rack",
-        "S": "f_shower",
-        "Y": "f_eyewash"
-      },
-      "nested": { "C": { "chunks": [ "null", "central_lab_crate_1x1" ] } },
+      "furniture": { "S": "f_shower" },
       "place_nested": [ { "chunks": [ [ "null", 50 ], [ "central_lab_reactor_meltdown_20x20", 50 ] ], "x": 0, "y": 0 } ],
       "items": {
-        "d": { "item": "office", "chance": 50, "repeat": 4 },
         "L": { "item": "reactor_gear", "chance": 25, "repeat": 3 },
         "r": { "item": "gear_medical", "chance": 50, "repeat": 3 }
       },
@@ -291,7 +238,8 @@
         "       |    |       ",
         "       |    |       "
       ],
-      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_lab_c" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 0, "y": 0 },
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 13, "y": 0 },
@@ -341,7 +289,8 @@
         "                    ",
         "                    "
       ],
-      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_lab_c" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_nested": [ { "chunks": [ "central_lab_mini_room_14x14" ], "x": 3, "y": 3 } ]
     }
   },
@@ -355,26 +304,27 @@
       "rows": [
         "       +    +       ",
         "       +    +       ",
-        "       ||||||       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "++||||||----||||||++",
-        "  |--------------|  ",
-        "  |--------------|  ",
-        "  |--------------|  ",
-        "  |--------------|  ",
-        "++||||||----||||||++",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       ||||||       ",
+        "       ======       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "++======||||======++",
+        "  =||||||||||||||=  ",
+        "  =||||||||||||||=  ",
+        "  =||||||||||||||=  ",
+        "  =||||||||||||||=  ",
+        "++======||||======++",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       ======       ",
         "       +    +       ",
         "       +    +       "
       ],
-      "terrain": { "|": "t_strconc_wall", "-": "t_wall_metal", "+": "t_door_metal_lab_c" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "=": "t_strconc_wall" },
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 0, "y": 0 },
         { "chunks": [ "central_lab_mini_room_7x7" ], "x": 13, "y": 0 },
@@ -402,12 +352,12 @@
         "                    ",
         "                    ",
         "                    ",
-        "++||||||||||||||||++",
-        "  |--------------|  ",
-        "  |--------------|  ",
-        "  |--------------|  ",
-        "  |--------------|  ",
-        "++||||||||||||||||++",
+        "++================++",
+        "  =||||||||||||||=  ",
+        "  =||||||||||||||=  ",
+        "  =||||||||||||||=  ",
+        "  =||||||||||||||=  ",
+        "++================++",
         "                    ",
         "                    ",
         "                    ",
@@ -416,7 +366,8 @@
         "                    ",
         "                    "
       ],
-      "terrain": { "|": "t_strconc_wall", "-": "t_wall_metal", "+": "t_door_metal_lab_c" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_20x7" ], "x": 0, "y": 0 },
         { "chunks": [ "central_lab_mini_room_20x7" ], "x": 0, "y": 13 },
@@ -458,26 +409,27 @@
       "rows": [
         "       +    +       ",
         "       +    +       ",
-        "       ||||||       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       |----|       ",
-        "       ||||||       ",
+        "       ======       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       =||||=       ",
+        "       ======       ",
         "       +    +       ",
         "       +    +       "
       ],
-      "terrain": { "|": "t_strconc_wall", "-": "t_wall_metal", "+": "t_door_metal_lab_c" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "=": "t_strconc_wall" },
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_20x7" ], "x": 0, "y": 0, "rotation": 1 },
         { "chunks": [ "central_lab_mini_room_20x7" ], "x": 13, "y": 0, "rotation": 1 },
@@ -522,7 +474,8 @@
         "    ",
         "    "
       ],
-      "terrain": { "|": "t_strconc_wall", "=": "t_door_metal_locked", "7": "t_card_science" }
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" }
     }
   },
   {
@@ -537,7 +490,8 @@
         "|==7",
         "    "
       ],
-      "terrain": { "|": "t_strconc_wall", "=": "t_door_metal_locked", "7": "t_card_science" }
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" }
     }
   },
   {
@@ -552,7 +506,8 @@
         "  = ",
         "  | "
       ],
-      "terrain": { "|": "t_strconc_wall", "=": "t_door_metal_locked", "7": "t_card_science" }
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" }
     }
   },
   {
@@ -567,7 +522,8 @@
         " =  ",
         " 7  "
       ],
-      "terrain": { "|": "t_strconc_wall", "=": "t_door_metal_locked", "7": "t_card_science" }
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" }
     }
   },
   {
@@ -578,14 +534,15 @@
     "object": {
       "mapgensize": [ 6, 6 ],
       "rows": [
-        "||||||",
-        "|----|",
-        "|----|",
-        "|----|",
-        "|----|",
-        "||||||"
+        "======",
+        "=||||=",
+        "=||||=",
+        "=||||=",
+        "=||||=",
+        "======"
       ],
-      "terrain": { "|": "t_strconc_wall", "-": "t_wall_metal" }
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "=": "t_strconc_wall" }
     }
   },
   {
@@ -603,7 +560,8 @@
         "|....|",
         "||||||"
       ],
-      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_lab_c", ".": "t_metal_floor" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_nested": [ { "chunks": [ "central_lab_mini_room_4x4", "central_lab_mini_room_ns_4x4" ], "x": 1, "y": 1 } ]
     }
   },
@@ -621,7 +579,8 @@
         "|....|",
         "||++||"
       ],
-      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_lab_c", ".": "t_metal_floor" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_nested": [ { "chunks": [ "central_lab_mini_room_4x4", "central_lab_mini_room_ns_4x4" ], "x": 1, "y": 1 } ]
     }
   },
@@ -639,7 +598,8 @@
         "|....|",
         "||||||"
       ],
-      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_lab_c", ".": "t_metal_floor" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_nested": [ { "chunks": [ "central_lab_mini_room_4x4", "central_lab_mini_room_ew_4x4" ], "x": 1, "y": 1 } ]
     }
   },
@@ -657,7 +617,8 @@
         "|....|",
         "||||||"
       ],
-      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_lab_c", ".": "t_metal_floor" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_nested": [ { "chunks": [ "central_lab_mini_room_4x4", "central_lab_mini_room_ew_4x4" ], "x": 1, "y": 1 } ]
     }
   },
@@ -674,7 +635,7 @@
         "CCCC",
         "CCCC"
       ],
-      "nested": { "C": { "chunks": [ "null", "central_lab_crate_1x1" ] } }
+      "palettes": [ "central_lab_palette" ]
     }
   },
   {
@@ -685,12 +646,13 @@
       "mapgensize": [ 4, 4 ],
       "rows": [
         "u  u",
-        " VV ",
-        " VV ",
+        " 11 ",
+        " 11 ",
         "u  u"
       ],
-      "terrain": { "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "V": "f_cloning_vat" }
+      "palettes": [ "central_lab_palette" ],
+      "furniture": { "1": "f_cloning_vat" },
+      "items": { "1": [ { "item": "cloning_vat", "chance": 50 } ] }
     }
   },
   {
@@ -700,13 +662,13 @@
     "object": {
       "mapgensize": [ 4, 4 ],
       "rows": [
-        "????",
-        "????",
-        "????",
-        "????"
+        "1111",
+        "1111",
+        "1111",
+        "1111"
       ],
       "terrain": {
-        "?": [
+        "1": [
           [ "t_metal_floor", 5 ],
           "t_console_broken",
           "t_machinery_light",
@@ -729,8 +691,8 @@
         "Y bL",
         "u  L"
       ],
-      "terrain": { "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "b": "f_bench", "L": "f_locker", "S": "f_shower", "Y": "f_eyewash" },
+      "palettes": [ "central_lab_palette" ],
+      "furniture": { "S": "f_shower" },
       "items": { "L": [ { "item": "cleaning", "chance": 50, "repeat": 4 }, { "item": "rad_gear", "chance": 50, "repeat": 2 } ] },
       "place_loot": [ { "item": "eyedrops", "x": 0, "y": 2, "chance": 75, "repeat": 2 } ],
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 2, 3 ], "y": [ 2, 3 ], "chance": 50 } ]
@@ -748,10 +710,8 @@
         "T  t",
         "u  u"
       ],
-      "terrain": { "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "s": "f_sink", "t": "f_trashcan" },
-      "toilets": { "T": {  } },
-      "items": { "s": { "item": "cleaning", "chance": 50, "repeat": 2 }, "t": { "item": "trash_cart", "chance": 25, "repeat": 3 } },
+      "palettes": [ "central_lab_palette" ],
+      "items": { "s": { "item": "cleaning", "chance": 50, "repeat": 2 } },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 2, 3 ], "y": [ 2, 3 ], "chance": 50 } ]
     }
   },
@@ -767,8 +727,8 @@
         " b  ",
         "LLLL"
       ],
-      "terrain": { "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "b": "f_bench", "L": "f_locker", "S": "f_shower", "Y": "f_eyewash" },
+      "palettes": [ "central_lab_palette" ],
+      "furniture": { "S": "f_shower" },
       "items": { "L": [ { "item": "cleaning", "chance": 50, "repeat": 4 }, { "item": "rad_gear", "chance": 50, "repeat": 2 } ] },
       "place_loot": [ { "item": "eyedrops", "x": 1, "y": 0, "chance": 75, "repeat": 2 } ],
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 2, 3 ], "y": [ 2, 3 ], "chance": 50 } ]
@@ -787,10 +747,8 @@
         "    ",
         "utsu"
       ],
-      "terrain": { "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "s": "f_sink", "t": "f_trashcan" },
-      "toilets": { "T": {  } },
-      "items": { "s": { "item": "cleaning", "chance": 50, "repeat": 2 }, "t": { "item": "trash_cart", "chance": 25, "repeat": 3 } },
+      "palettes": [ "central_lab_palette" ],
+      "items": { "s": { "item": "cleaning", "chance": 50, "repeat": 2 } },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 2, 3 ], "y": [ 2, 3 ], "chance": 50 } ]
     }
   },
@@ -810,8 +768,8 @@
         " c   r ",
         "       "
       ],
-      "furniture": { "c": "f_counter", "r": "f_rack" },
-      "items": { "c": { "item": "dissection", "chance": 25, "repeat": 2 }, "t": { "item": "chem_lab", "chance": 25, "repeat": 2 } },
+      "palettes": [ "central_lab_palette" ],
+      "items": { "c": { "item": "dissection", "chance": 25, "repeat": 2 }, "r": { "item": "chem_lab", "chance": 25, "repeat": 2 } },
       "place_traps": [ { "trap": "tr_dissector", "x": [ 2, 4 ], "y": [ 1, 5 ] } ],
       "place_monster": [ { "monster": "mon_broken_cyborg", "x": [ 0, 6 ], "y": [ 0, 6 ], "chance": 50, "pack_size": [ 1, 2 ] } ]
     }
@@ -823,17 +781,15 @@
     "object": {
       "mapgensize": [ 7, 7 ],
       "rows": [
-        "  C C  ",
+        "  ? ?  ",
         " !!!!! ",
-        "C!###!C",
+        "?!###!?",
         " !#u#! ",
-        "C!###!C",
+        "?!###!?",
         " !!!!! ",
-        "  C C  "
+        "  ? ?  "
       ],
-      "terrain": { "!": "t_floor_red", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "#": "f_sandbag_half" },
-      "nested": { "C": { "chunks": [ [ "null", 75 ], [ "central_lab_ammo_rack_1x1", 25 ] ] } },
+      "palettes": [ "central_lab_palette" ],
       "place_monster": [ { "monster": "mon_turret_medium", "x": 3, "y": 3 } ]
     }
   },
@@ -870,8 +826,7 @@
         " dd6dd ",
         "       "
       ],
-      "furniture": { "d": "f_desk", "F": "f_filing_cabinet", "h": "f_chair", "S": "f_server" },
-      "items": { "d": { "item": "office", "chance": 50, "repeat": 4 }, "F": { "item": "file_room", "chance": 75, "repeat": 6 } },
+      "palettes": [ "central_lab_palette" ],
       "computers": {
         "6": {
           "name": "Log Console",
@@ -895,19 +850,15 @@
       "mapgensize": [ 7, 7 ],
       "rows": [
         "u     u",
-        " |fff| ",
+        " |HHH| ",
         " ||||| ",
-        " |fff| ",
+        " |HHH| ",
         "       ",
-        " FFFFF ",
+        " fffff ",
         "u     u"
       ],
-      "terrain": { "|": "t_strconc_wall", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "F": "f_glass_fridge", "f": "f_fume_hood" },
-      "items": {
-        "F": [ { "item": "supplies_reagents_lab", "chance": 50, "repeat": 2 }, { "item": "supplies_samples_lab", "chance": 75 } ],
-        "f": [ { "item": "chem_lab", "chance": 25, "repeat": 2 }, { "item": "tools_science", "chance": 25 } ]
-      },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 5 ], "y": [ 1, 5 ], "chance": 50 } ]
     }
   },
@@ -918,9 +869,9 @@
     "object": {
       "mapgensize": [ 14, 14 ],
       "rows": [
-        "u C# #!!# #C u",
+        "u ?# #!!# #? u",
         "   ###  ###   ",
-        "C            C",
+        "?            ?",
         "##          ##",
         " #  ||==7|  # ",
         "##  |t   |  ##",
@@ -929,19 +880,12 @@
         "##  |T  B|  ##",
         " #  ||||||  # ",
         "##          ##",
-        "C            C",
+        "?            ?",
         "   ###  ###   ",
-        "u C# #!!# #C u"
+        "u ?# #!!# #? u"
       ],
-      "terrain": {
-        "|": "t_strconc_wall",
-        "=": "t_door_metal_locked",
-        "!": "t_floor_red",
-        "7": "t_card_science",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ]
-      },
-      "furniture": { "#": "f_sandbag_half", "B": "f_bed", "s": "f_sink", "t": "f_trashcan" },
-      "toilets": { "T": {  } },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_monster": [ { "monster": [ "mon_mutant_alpha", "mon_mutant_medical" ], "x": [ 6, 7 ], "y": [ 6, 7 ] } ],
       "place_nested": [
         {
@@ -949,8 +893,7 @@
           "x": 0,
           "y": 0
         }
-      ],
-      "nested": { "C": { "chunks": [ "central_lab_ammo_rack_1x1" ] } }
+      ]
     }
   },
   {
@@ -1015,24 +958,23 @@
     "object": {
       "mapgensize": [ 14, 14 ],
       "rows": [
-        "ff|ff|  |ff|ff",
+        "HH|HH|  |HH|HH",
         "              ",
         "              ",
-        "ff|ff|  |ff|ff",
+        "HH|HH|  |HH|HH",
         "||||||  ||||||",
-        "ff|ff|  |ff|ff",
+        "HH|HH|  |HH|HH",
         "              ",
         "              ",
-        "ff|ff|  |ff|ff",
+        "HH|HH|  |HH|HH",
         "||||||  ||||||",
-        "ff|ff|  |ff|ff",
+        "HH|HH|  |HH|HH",
         "              ",
         "              ",
-        "ff|ff|  |ff|ff"
+        "HH|HH|  |HH|HH"
       ],
-      "terrain": { "|": "t_strconc_wall", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "f": "f_fume_hood" },
-      "items": { "f": [ { "item": "chem_lab", "chance": 25, "repeat": 2 }, { "item": "tools_science", "chance": 25 } ] },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 12 ], "y": [ 1, 12 ], "chance": 50 } ]
     }
   },
@@ -1044,30 +986,22 @@
     "object": {
       "mapgensize": [ 14, 14 ],
       "rows": [
-        "u FFF    FFF u",
+        "u fff    fff u",
         "              ",
-        "F   c    c   F",
-        "F   c    c   F",
-        "F ccc    ccc F",
-        "              ",
-        "              ",
+        "f   c    c   f",
+        "f   c    c   f",
+        "f ccc    ccc f",
         "              ",
         "              ",
-        "F ccc    ccc F",
-        "F   c    c   F",
-        "F   c    c   F",
         "              ",
-        "u FFF    FFF u"
+        "              ",
+        "f ccc    ccc f",
+        "f   c    c   f",
+        "f   c    c   f",
+        "              ",
+        "u fff    fff u"
       ],
-      "terrain": { "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "c": "f_counter", "F": "f_glass_fridge" },
-      "items": {
-        "c": { "item": "dissection", "chance": 25, "repeat": 2 },
-        "F": [
-          { "item": "supplies_reagents_lab", "chance": 50, "repeat": 3 },
-          { "item": "supplies_samples_lab", "chance": 50, "repeat": 3 }
-        ]
-      },
+      "palettes": [ "central_lab_palette" ],
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 12 ], "y": [ 1, 12 ], "chance": 50 } ]
     }
   },
@@ -1080,18 +1014,16 @@
       "mapgensize": [ 20, 7 ],
       "rows": [
         "       !    !       ",
-        "C      !!!!!!      C",
+        "?      !!!!!!      ?",
         "##                ##",
         "u#                #u",
         "##                ##",
-        "C      !!!!!!      C",
+        "?      !!!!!!      ?",
         "       !    !       "
       ],
-      "terrain": { "!": "t_floor_red", "/": "t_floor_red", "u": [ "t_metal_floor", "t_metal_floor_olight" ] },
-      "furniture": { "#": "f_sandbag_half" },
+      "palettes": [ "central_lab_palette" ],
       "monster": { "u": { "monster": "mon_turret_medium" } },
-      "signs": { "/": { "signage": "Warning!\nLive Fire Zone\nAvoid In Case of Lockdown!" } },
-      "nested": { "C": { "chunks": [ [ "null", 25 ], [ "central_lab_ammo_rack_1x1", 75 ] ] } }
+      "signs": { "/": { "signage": "Warning!\nLive Fire Zone\nAvoid In Case of Lockdown!" } }
     }
   },
   {
@@ -1109,8 +1041,7 @@
         "  dddd  dddd  dddd  ",
         "                    "
       ],
-      "furniture": { "d": "f_desk", "h": "f_chair" },
-      "items": { "d": { "item": "office", "chance": 50, "repeat": 4 } },
+      "palettes": [ "central_lab_palette" ],
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 18 ], "y": [ 1, 5 ], "chance": 50 } ]
     }
   },
@@ -1129,8 +1060,7 @@
         "  hh   p    p   hh  ",
         "       p    pt      "
       ],
-      "furniture": { "e": "f_table", "h": "f_chair", "p": [ "f_indoor_plant", "f_indoor_plant_y" ], "t": "f_trashcan" },
-      "items": { "t": { "item": "trash_cart", "chance": 25, "repeat": 3 } },
+      "palettes": [ "central_lab_palette" ],
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 18 ], "y": [ 1, 5 ], "chance": 50 } ]
     }
   },
@@ -1149,7 +1079,7 @@
         "  SSSSSSS  SSSSSSS  ",
         "                    "
       ],
-      "furniture": { "S": "f_server" },
+      "palettes": [ "central_lab_palette" ],
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 1, 18 ], "y": [ 1, 5 ], "chance": 50 } ]
     }
   },
@@ -1182,8 +1112,7 @@
         "                    ",
         "                    "
       ],
-      "furniture": { "d": "f_desk", "e": "f_table", "F": "f_filing_cabinet", "h": "f_chair" },
-      "items": { "d": { "item": "office", "chance": 50, "repeat": 4 }, "F": { "item": "file_room", "chance": 75, "repeat": 6 } },
+      "palettes": [ "central_lab_palette" ],
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 5, 14 ], "y": [ 5, 14 ], "chance": 50 } ]
     }
   },
@@ -1215,25 +1144,11 @@
         "                    ",
         "                    "
       ],
-      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_interior_locked", "W": "t_ballistic_glass" },
-      "furniture": {
-        "b": "f_bench",
-        "c": "f_counter",
-        "d": "f_desk",
-        "e": "f_table",
-        "h": "f_chair",
-        "L": "f_locker",
-        "s": "f_sink",
-        "t": "f_trashcan",
-        "V": "f_vending_c",
-        "v": "f_vending_c"
-      },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_interior_locked" },
       "items": {
         "e": { "item": "magazines", "chance": 50, "repeat": 4 },
-        "L": { "item": "gear_labsecurity", "chance": 50, "repeat": 2 },
-        "t": { "item": "trash_cart", "chance": 50, "repeat": 6 },
-        "V": { "item": "vending_food", "chance": 80 },
-        "v": { "item": "vending_drink", "chance": 80 }
+        "L": { "item": "gear_labsecurity", "chance": 50, "repeat": 2 }
       },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 4, 15 ], "y": [ 4, 15 ], "repeat": [ 1, 2 ] } ]
     }
@@ -1266,7 +1181,8 @@
         "                    ",
         "                    "
       ],
-      "terrain": { "|": "t_strconc_wall", "+": "t_door_metal_lab_c" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_nested": [
         { "chunks": [ "central_lab_mini_room_4x4", "central_lab_mini_room_ns_4x4" ], "x": 3, "y": 3 },
         { "chunks": [ "central_lab_mini_room_4x4", "central_lab_mini_room_ns_4x4" ], "x": 13, "y": 3 },
@@ -1287,24 +1203,23 @@
         "      RRRGGRRR      ",
         "     RRGGGGGGRR     ",
         "    RRGGGGGGGGRR    ",
-        "   RR7777GG7777RR   ",
-        "  RRG7h hGGh h7GRR  ",
-        "  RGG7   GG   7GGR  ",
-        "  RGG7h IGGI h7GGR  ",
+        "   RR9999GG9999RR   ",
+        "  RRG9h hGGh h9GRR  ",
+        "  RGG9   GG   9GGR  ",
+        "  RGG9h IGGI h9GGR  ",
         "  GGGGGGG  GGGGGGG  ",
         "  GGGGGGG  GGGGGGG  ",
-        "  RGG7h IGGI h7GGR  ",
-        "  RGG7   GG   7GGR  ",
-        "  RRG7h hGGh h7GRR  ",
-        "   RR7777GG7777RR   ",
+        "  RGG9h IGGI h9GGR  ",
+        "  RGG9   GG   9GGR  ",
+        "  RRG9h hGGh h9GRR  ",
+        "   RR9999GG9999RR   ",
         "    RRGGGGGGGGRR    ",
         "     RRGGGGGGRR     ",
         "      RRRGGRRR      ",
         "                    ",
         "                    "
       ],
-      "terrain": { "G": "t_grate", "I": "t_column", "R": "t_concrete_railing" },
-      "furniture": { "7": "f_control_station", "h": "f_chair" },
+      "palettes": [ "central_lab_palette" ],
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 5, 14 ], "y": [ 5, 14 ], "chance": 50 } ]
     }
   },
@@ -1318,31 +1233,26 @@
         "                    ",
         "                    ",
         "  ||WWWW|++|WWWW||  ",
-        "  |u 77      77 u|  ",
+        "  |u 99      99 u|  ",
         "  W              W  ",
-        "  W7            7W  ",
-        "  W7  SS    SS  7W  ",
+        "  W9            9W  ",
+        "  W9  SS    SS  9W  ",
         "  W   SS    SS   W  ",
         "  |              |  ",
         "  +              +  ",
         "  +              +  ",
         "  |              |  ",
         "  W   SS    SS   W  ",
-        "  W7  SS    SS  7W  ",
-        "  W7            7W  ",
+        "  W9  SS    SS  9W  ",
+        "  W9            9W  ",
         "  W              W  ",
-        "  |u 77      77 u|  ",
+        "  |u 99      99 u|  ",
         "  ||WWWW|++|WWWW||  ",
         "                    ",
         "                    "
       ],
-      "terrain": {
-        "|": "t_strconc_wall",
-        "+": "t_door_metal_lab_c",
-        "u": [ "t_metal_floor", "t_metal_floor_olight" ],
-        "W": "t_ballistic_glass"
-      },
-      "furniture": { "7": "f_control_station", "S": "f_server" },
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "|": "t_strconc_wall" },
       "place_monster": [ { "group": "GROUP_CENTRAL_LAB", "x": [ 4, 15 ], "y": [ 4, 15 ], "repeat": [ 1, 2 ] } ]
     }
   },
@@ -1362,26 +1272,25 @@
         "  SSSSSSS  SSSSSSS  ",
         "                    "
       ],
-      "furniture": { "S": "f_server" }
+      "palettes": [ "central_lab_palette" ]
     }
   },
   {
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "central_lab_melchior_mini_room_20x7",
-    "//": "Additional room variations for the Melchior layer, with more focus on computer stuff.",
     "object": {
       "mapgensize": [ 20, 7 ],
       "rows": [
         "                    ",
-        "6h                h6",
-        "6   SS SS  SS SS   6",
-        "6h  SS SS  SS SS  h6",
-        "6   SS SS  SS SS   6",
-        "6h                h6",
+        "9h                h9",
+        "9   SS SS  SS SS   9",
+        "9h  SS SS  SS SS  h9",
+        "9   SS SS  SS SS   9",
+        "9h                h9",
         "                    "
       ],
-      "furniture": { "h": "f_chair", "S": "f_server", "6": "f_control_station" }
+      "palettes": [ "central_lab_palette" ]
     }
   },
   {
@@ -1417,8 +1326,7 @@
         "6h  h6        6h  h6",
         "                    "
       ],
-      "terrain": { "6": "t_console_broken" },
-      "furniture": { "h": "f_chair" }
+      "palettes": [ "central_lab_palette" ]
     }
   },
   {
@@ -1436,8 +1344,7 @@
         "  6666666  6666666  ",
         "                    "
       ],
-      "terrain": { "6": "t_console_broken" },
-      "furniture": { "h": "f_chair" }
+      "palettes": [ "central_lab_palette" ]
     }
   },
   {
@@ -1503,8 +1410,8 @@
         "                    ",
         "                    "
       ],
-      "terrain": { "1": "t_conveyor" },
-      "nested": { "C": { "chunks": [ "null", "central_lab_crate_1x1" ] } }
+      "palettes": [ "central_lab_palette" ],
+      "terrain": { "1": "t_conveyor" }
     }
   }
 ]

--- a/data/json/mapgen_palettes/central_lab_palette.json
+++ b/data/json/mapgen_palettes/central_lab_palette.json
@@ -1,0 +1,63 @@
+[
+  {
+    "type": "palette",
+    "id": "central_lab_palette",
+    "terrain": {
+      "|": "t_wall_metal",
+      "-": "t_rock",
+      ".": "t_metal_floor",
+      "!": "t_floor_red",
+      "/": "t_floor_red",
+      "+": "t_door_metal_lab_c",
+      "=": "t_door_metal_locked",
+      ">": "t_stairs_down",
+      "<": "t_stairs_up",
+      "6": "t_console_broken",
+      "7": "t_card_science",
+      "A": "t_wall_metal",
+      "G": "t_grate",
+      "I": "t_column",
+      "R": "t_concrete_railing",
+      "u": [ "t_metal_floor", "t_metal_floor_olight" ],
+      "W": "t_ballistic_glass"
+    },
+    "furniture": {
+      "#": "f_sandbag_half",
+      "9": "f_control_station",
+      "A": "f_metal_cold_vent",
+      "B": "f_bed",
+      "b": "f_bench",
+      "c": "f_counter",
+      "d": "f_desk",
+      "e": "f_table",
+      "F": "f_filing_cabinet",
+      "f": "f_glass_fridge",
+      "g": "f_counter_gate_c",
+      "H": "f_fume_hood",
+      "h": "f_chair",
+      "L": "f_locker",
+      "p": [ "f_indoor_plant", "f_indoor_plant_y" ],
+      "r": "f_rack",
+      "S": "f_server",
+      "s": "f_sink",
+      "t": "f_trashcan",
+      "V": "f_vending_c",
+      "v": "f_vending_c",
+      "Y": "f_eyewash"
+    },
+    "toilets": { "T": {  } },
+    "nested": {
+      "?": { "chunks": [ [ "null", 25 ], [ "central_lab_ammo_rack_1x1", 75 ] ] },
+      "C": { "chunks": [ "null", "central_lab_crate_1x1" ] }
+    },
+    "items": {
+      "d": { "item": "office", "chance": 50, "repeat": 4 },
+      "F": { "item": "file_room", "chance": 75, "repeat": 6 },
+      "f": [ { "item": "supplies_reagents_lab", "chance": 50, "repeat": 2 }, { "item": "supplies_samples_lab", "chance": 75 } ],
+      "H": [ { "item": "chem_lab", "chance": 25, "repeat": 2 }, { "item": "tools_science", "chance": 25 } ],
+      "t": { "item": "trash_cart", "chance": 25, "repeat": 3 },
+      "V": { "item": "vending_food", "chance": 80 },
+      "v": { "item": "vending_drink", "chance": 80 }
+    }
+  }
+]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Belatedly starts work on moving redundant terrain and furniture defs in the new central lab to a mapgen palette.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Defined `central_lab_palette`, converting the contents of lab_central_core.json and nested_lab_central_core.json to make use of it. Surface bits will get their own palette in a follow-up PR, wanted to avoid too giant a PR at once this time.

Also in the process changed around some tiles to fit within the palette since a few were using characters widely used for something else, and fixed two misc cases I spotted where an item spawn was assigned to the wrong character and thus wouldn't trigger.

## Describe alternatives you've considered

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [037a730](https://github.com/cataclysmbn/Cataclysm-BN/commit/037a7308e4dd9107da678595cece40addd8d8728) (feat: convert central lab to use mapgen palette, part 1) on 2026-09-03 01:25:27

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33690838616/artifacts/9874133162)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33690838616/artifacts/9871120290)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33690838616/artifacts/9870352358)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33690838616/artifacts/9870484930)
<!-- END artifact comment -->