### PR TITLE
fix: unload non-charge monster hacks

### DIFF
--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -381,14 +381,36 @@ auto unload_monster_weapons( avatar &you, monster &z ) -> void
         return;
     }
 
-    auto unloaded_ammo = item::spawn( selected_ammo, calendar::turn, loaded_ammo_iter->amount );
-    unloaded_ammo = you.i_add_or_drop( std::move( unloaded_ammo ) );
-    if( unloaded_ammo ) {
-        add_msg( m_info, _( "You can't unload the %s right now." ), z.get_name() );
-        return;
+    auto unloaded_amount = 0;
+    if( selected_ammo->count_by_charges() ) {
+        auto unloaded_ammo = item::spawn( selected_ammo, calendar::turn, loaded_ammo_iter->amount );
+        unloaded_ammo = you.i_add_or_drop( std::move( unloaded_ammo ) );
+        if( unloaded_ammo ) {
+            add_msg( m_info, _( "You can't unload the %s right now." ), z.get_name() );
+            return;
+        }
+        unloaded_amount = loaded_ammo_iter->amount;
+    } else {
+        for( auto i = 0; i < loaded_ammo_iter->amount; ++i ) {
+            auto unloaded_ammo = item::spawn( selected_ammo, calendar::turn, item::solitary_tag() );
+            unloaded_ammo = you.i_add_or_drop( std::move( unloaded_ammo ) );
+            if( unloaded_ammo ) {
+                add_msg( m_info, _( "You can't unload the %s right now." ), z.get_name() );
+                break;
+            }
+            ++unloaded_amount;
+        }
     }
 
-    z.ammo.erase( selected_ammo );
+    if( unloaded_amount > 0 ) {
+        z.ammo[selected_ammo] -= unloaded_amount;
+        if( z.ammo[selected_ammo] <= 0 ) {
+            z.ammo.erase( selected_ammo );
+        }
+    }
+    if( unloaded_amount != loaded_ammo_iter->amount ) {
+        return;
+    }
     add_msg( vgettext( "You unload %1$d x %2$s round from the %3$s.",
                        "You unload %1$d x %2$s rounds from the %3$s.", loaded_ammo_iter->amount ),
              loaded_ammo_iter->amount, selected_ammo->nname( loaded_ammo_iter->amount ),

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -1506,7 +1506,9 @@ void monexamine::deactivate_pet( monster &z )
     if( !z.has_flag( MF_INTERIOR_AMMO ) ) {
         for( auto &ammodef : z.ammo ) {
             if( ammodef.second > 0 ) {
-                here.spawn_item( z.bub_pos(), ammodef.first, 1, ammodef.second, calendar::turn );
+                const bool count_by_charges = item::spawn_temporary( ammodef.first )->count_by_charges();
+                here.spawn_item( z.bub_pos(), ammodef.first, count_by_charges ? 1 : ammodef.second,
+                                 count_by_charges ? ammodef.second : 0, calendar::turn );
             }
         }
     }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -101,7 +101,9 @@ auto compatible_reload_ammo( const avatar &you, const monster &z,
 {
     auto ammo_options = std::vector<monster_ammo_option> {};
     for( const auto &compatible_ammo_id : z.ammo_slot_items( ammo_id ) ) {
-        const auto available_ammo = you.charges_of( compatible_ammo_id );
+        const auto available_ammo = compatible_ammo_id->count_by_charges()
+                                    ? you.charges_of( compatible_ammo_id )
+                                    : you.amount_of( compatible_ammo_id );
         if( available_ammo <= 0 ) {
             continue;
         }
@@ -337,7 +339,11 @@ auto reload_monster_weapons( avatar &you, monster &z ) -> void
 
     const auto reload_amount = std::min( reload_option_iter->missing_ammo, selected_ammo_iter->amount );
     z.ammo[selected_ammo] += reload_amount;
-    you.use_charges( selected_ammo, reload_amount );
+    if( selected_ammo->count_by_charges() ) {
+        you.use_charges( selected_ammo, reload_amount );
+    } else {
+        you.use_amount( selected_ammo, reload_amount );
+    }
     add_msg( vgettext( "You load %1$d x %2$s round into the %3$s.",
                        "You load %1$d x %2$s rounds into the %3$s.", reload_amount ),
              reload_amount, selected_ammo->nname( reload_amount ), z.get_name() );

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -39,6 +39,14 @@ TEST_CASE("item_volume", "[item]") {
     }
 }
 
+TEST_CASE("solitary_item_has_no_charges", "[item]") {
+    const item &grenade = *item::spawn_temporary(
+        "grenade", calendar::start_of_cataclysm, item::solitary_tag());
+
+    REQUIRE_FALSE(grenade.count_by_charges());
+    CHECK(grenade.charges == 0);
+}
+
 TEST_CASE("large_item_storage_volumes", "[item][volume]") {
     constexpr auto legacy_int_limit_ml = static_cast<std::int64_t>(std::numeric_limits<int>::max());
     const auto volume_above_legacy_int_limit = units::from_milliliter(legacy_int_limit_ml + 1);

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -40,8 +40,8 @@ TEST_CASE("item_volume", "[item]") {
 }
 
 TEST_CASE("solitary_item_has_no_charges", "[item]") {
-    const item &grenade = *item::spawn_temporary(
-        "grenade", calendar::start_of_cataclysm, item::solitary_tag());
+    const item& grenade =
+        *item::spawn_temporary("grenade", calendar::start_of_cataclysm, item::solitary_tag());
 
     REQUIRE_FALSE(grenade.count_by_charges());
     CHECK(grenade.charges == 0);


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #10167. `monexamine` treated every item loaded in a Dispatch as charge-based ammo. Unloading non-charge deployables such as inactive C-4 hacks created one item with an invalid `charges` value, producing save/load errors.

## Describe the solution (The How)

- Keep charge-based ammo in a single stack.
- Spawn non-charge items individually with `item::solitary_tag()`.
- Decrease the monster ammo count by the number of items actually delivered.
- Add a regression test covering solitary non-charge item construction.

## Testing

- Built `cataclysm-bn-tiles`.
- Built `cata_test-tiles`.
- Ran `solitary_item_has_no_charges`: 1 test case, 2 assertions passed.
- Manually spawned a friendly `NR-031 Dispatch`, unloaded `2 x inactive C-4 hacks`, saved, and reloaded the world without a `charges` error.

## Checklist

- [x] I linked any relevant issues using GitHub keyword syntax.
- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to every AI-assisted commit.

## Additional context

The local graphical build also reports a separate missing/invalid tileset configuration in the test environment; it is unrelated to this change.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c4ab82a](https://github.com/cataclysmbn/Cataclysm-BN/commit/c4ab82a298ef42afa2c28e62b89d8d01c96335d5) (Fix deactivation of non-charge monster ammo) on 2026-09-03 23:15:02

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33803079824/artifacts/9912208854)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33803079824)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33803079824/artifacts/9912291708)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33803079824/artifacts/9912438299)
<!-- END artifact comment -->