### PR TITLE
fix: allow examining your mount to restore mech battery message

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -831,7 +831,7 @@ bool can_examine_at( const tripoint_bub_ms &p )
     }
 
     Creature *c = g->critter_at( p );
-    if( c != nullptr && p != u.bub_pos() ) {
+    if( c != nullptr && ( p != u.bub_pos() || u.is_mounted() ) ) {
         return true;
     }
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

This re-implements the ability to examine a mech you're riding to get battery status (added in https://github.com/cataclysmbn/Cataclysm-BN/pull/2829), as somehow the tripoint update killed it.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In action.cpp, changed the logic for `can_examine_at` so that the tile you're standing on is also valid to examine if you're currently mounted. This allows you to examine your mount, which gives you the "there is an X" message which also prints battery status if said mount is a mech.

## Describe alternatives you've considered

1. The "this is an X" messages for examining terrain could also be nice to have via examining terrain that's not highlighted, but that's a minor flavor thing since you can get detailed info via the `;` menu already, whereas the entire point of the mech battery status is there IS no way to get that info otherwise when you're currently mounted. I can't see any easy way to let you get examine info while still preserving the highlight feature, which is useful for stuff like telling underbrush and shrubs apart when you intiate an examine.
2. Related to the above, I suppose a viable alternative would be to also add battery status somewhere when examining a mech with `;` instead of or in addition to fixing the existing method to work again.
3. Maybe adding health info or some other useful shit to the message for non-mech mounts, though this runs into the issue of anything I can even think of to add would already be info you can get by `;`ing over them.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in and tried to examine myself, still not allowed since not mounted.
3. Spawned, tamed, and mounted a horse, I can examine myself now and it tells me about the horse, also printing name if renamed.
4. Confirmed that being mounted doesn't magically make adjacent tiles without creatures in them examinable.
5. Mounted a mech instead, I get battery status as before.
6. Turned auto-forage on and set to everything along with turning all other auto features on, confirmed that honse being examinable doesn't somehow cause me to print messages with every turn or whatever other weird interaction one might in theory get with autoexamine-related stuff.

<img width="491" height="38" alt="image" src="https://github.com/user-attachments/assets/253042f4-afd0-42b3-a2f1-23f2d9beed23" />

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [37078ff](https://github.com/cataclysmbn/Cataclysm-BN/commit/37078ff89364934dd22f6e1aeaaf7d5ce8ea16ed) (fix: allow examining your mount to restore mech battery message) on 2026-09-03 16:59:46

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33777613015/artifacts/9902624976)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33777613015/artifacts/9903742183)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33777613015/artifacts/9902770822)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33777613015/artifacts/9902840107)
<!-- END artifact comment -->