### PR TITLE
fix: Changed Bionic Assassin's cutting skill to unarmed skill

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4709,7 +4709,7 @@
     ],
     "skills": [
       { "level": 8, "name": "melee" },
-      { "level": 8, "name": "cutting" },
+      { "level": 8, "name": "unarmed" },
       { "level": 8, "name": "dodge" },
       { "level": 4, "name": "speech" }
     ],


### PR DESCRIPTION
## Purpose of change (The Why)

#9933 made changes to the `Bionic Assassin` profession's skills, relevant to this PR was the addition of the cutting skill which the profession makes no use of it since it has no weapon that uses cutting; the `Monomolecular Blade` counts as an unarmed weapon.

## Describe the solution (The How)

Replaced the `cutting` skill for the `unarmed` skill.

## Describe alternatives you've considered

Could leave it as is but would have a high skill that is not used by the profession.

## Testing

Created a new world with no mods and default settings, and then created a character using the `Evacuee` scenario and the `Bionic Assassin` profession with no additions to stats, traits, or skills. Once in the game I deployed the `Monomolecular Blade` bionic and attacked the nearest zombie. Each successful hit increased the ` unarmed` skill's percentage to raise to next level while leaving the `cutting` skill with no such changes.



## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1ce2aa8](https://github.com/cataclysmbn/Cataclysm-BN/commit/1ce2aa85282346996d441f3bf4ff9926a714ac1c) (changed cutting to unarmed) on 2026-09-04 06:48:41

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33823300037/artifacts/9920344763)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33823300037)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33823300037/artifacts/9919378754)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33823300037/artifacts/9919427999)
<!-- END artifact comment -->