### PR TITLE
fix: also swap bionic operator to correct skill for their weapon

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4627,7 +4627,7 @@
       { "level": 6, "name": "rifle" },
       { "level": 3, "name": "pistol" },
       { "level": 4, "name": "survival" },
-      { "level": 7, "name": "cutting" },
+      { "level": 7, "name": "unarmed" },
       { "level": 7, "name": "melee" },
       { "level": 7, "name": "dodge" },
       { "level": 3, "name": "firstaid" },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

More followups to skill oversights I didn't spot in https://github.com/cataclysmbn/Cataclysm-BN/pull/9933

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Changed bionic operator from cutting skill to unarmed skill, since they start with bionic claws which have the `UNARMED_WEAPON` flag and thus use unarmed for hit rolls. Seems to be because normal spec-ops starts with a kukri.

This also in turn updates the Aftershock bionic merc profession since it inherits same skills.

## Describe alternatives you've considered

Giving them both unarmed AND cutting skill? I don't think the melee code cares about other skills for unarmed weapons admittedly, far as I could tell from looking at it, but if it turns out it does they likely oughta have both.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Woe, I can read :D

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [68bd0a3](https://github.com/cataclysmbn/Cataclysm-BN/commit/68bd0a31605b1c27a13010cc6b76cf845ecedcd9) (fix: also swap bionic operator to correct skill for their weapon) on 2026-09-04 03:24:52

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33830509444/artifacts/9921714140)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33830509444/artifacts/9922325017)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33830509444/artifacts/9921783570)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33830509444/artifacts/9921850760)
<!-- END artifact comment -->