### PR TITLE
fix: give minirose and CBM grenade launcher correct uncraft recipes

### DIFF
--- a/data/json/uncraft/cbm/cbm.json
+++ b/data/json/uncraft/cbm/cbm.json
@@ -18,7 +18,7 @@
   },
   {
     "type": "uncraft",
-    "result": "afs_bio_missiles",
+    "result": "bio_minirose",
     "skill_used": "electronics",
     "difficulty": 10,
     "time": "50 m",


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Remove mininukes from the grenade launcher CBM dismantling recipe.

## Describe the solution (The How)

It seems #10113 uncraft recipe intended for that uncraft to be minirose, but I think `bio_afs_missile` recipe was copypasted, so minirose CBM has no uncraft and CBM grenade launcher has minirose's uncraft CBM

I have replaced `afs_bio_missiles` with `bio_minirose` in the correct uncraft recipe

## Describe alternatives you've considered
idk lol
## Testing

Spawn grenade launcher and minirose CBMs, confirm their correct uncraft recipes

## Additional context

I got unreasonably excited and confused seeing mininukes in grenade launcher CBMs uncrafts

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [f580b08](https://github.com/cataclysmbn/Cataclysm-BN/commit/f580b085ea716310c44fb382731dc8f7d9621a38) (fix:grenade launchers are not mininukes) on 2026-09-05 00:45:31

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33929950466/artifacts/9959289466)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33929950466/artifacts/9958929747)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33929950466/artifacts/9958410210)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33929950466/artifacts/9958561511)
<!-- END artifact comment -->