### PR TITLE
fix: predator mutations now actually prevent combat-skill rust

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4442,32 +4442,38 @@ void Character::do_skill_rust( const time_duration &duration )
         const Skill &aSkill = *pair.first;
         SkillLevel &skill_level_obj = pair.second;
 
-        const int pred_tick = has_trait_flag( trait_flag_PRED2 ) ? calendar::ticks_between( duration,
-                              8_hours ) :
-                              has_trait_flag( trait_flag_PRED3 ) ? calendar::ticks_between( duration, 4_hours ) :
-                              has_trait_flag( trait_flag_PRED4 ) ? calendar::ticks_between( duration, 3_hours ) : 0;
+        const bool has_pred = has_trait_flag( trait_flag_PRED2 ) || has_trait_flag( trait_flag_PRED3 ) ||
+                              has_trait_flag( trait_flag_PRED4 );
 
-        if( aSkill.is_combat_skill() && pred_tick > 0 ) {
-            // Their brain is optimized to remember this
-            int tries = 0;
-            for( int i = 0; i < pred_tick; i++ ) {
-                tries += one_in( 13 ) ? 1 : 0;
-            }
-            if( tries > 0 && !has_effect( effect_sleep ) ) {
-                // They've already passed the roll to avoid rust at
-                // this point, but print a message about it now and
-                // then.
-                //
-                // 13 combat skills.
-                // This means PRED2/PRED3/PRED4 think of hunting on
-                // average every 8/4/3 hours, enough for immersion
-                // without becoming an annoyance.
-                //
-                // Additionally, catching up NPCs will prevent rust
-                // for combat skills, presumably they'd hunt while
-                // the player is gone.
-                add_msg_if_player( _( "Your heart races as you recall your most recent hunt." ) );
-                mod_stim( tries );
+        if( aSkill.is_combat_skill() && has_pred ) {
+            // Predator mutations always prevent combat-skill rust (see mutation
+            // descriptions: "effortlessly master and maintain combat skills").
+            // The flavor message/stim below is cosmetic and only fires on its
+            // own rare cadence; it must not gate the actual protection, since
+            // during normal turn-by-turn play `duration` is a single turn and
+            // essentially never spans a full 3/4/8-hour block.
+            const int pred_tick = has_trait_flag( trait_flag_PRED2 ) ? calendar::ticks_between( duration,
+                                  8_hours ) :
+                                  has_trait_flag( trait_flag_PRED3 ) ? calendar::ticks_between( duration, 4_hours ) :
+                                  calendar::ticks_between( duration, 3_hours );
+            if( pred_tick > 0 ) {
+                // Their brain is optimized to remember this
+                int tries = 0;
+                for( int i = 0; i < pred_tick; i++ ) {
+                    tries += one_in( 13 ) ? 1 : 0;
+                }
+                if( tries > 0 && !has_effect( effect_sleep ) ) {
+                    // 13 combat skills.
+                    // This means PRED2/PRED3/PRED4 think of hunting on
+                    // average every 8/4/3 hours, enough for immersion
+                    // without becoming an annoyance.
+                    //
+                    // Additionally, catching up NPCs will prevent rust
+                    // for combat skills, presumably they'd hunt while
+                    // the player is gone.
+                    add_msg_if_player( _( "Your heart races as you recall your most recent hunt." ) );
+                    mod_stim( tries );
+                }
             }
             continue;
         }

--- a/tests/predator_skill_rust_test.cpp
+++ b/tests/predator_skill_rust_test.cpp
@@ -1,0 +1,44 @@
+#include "avatar.h"
+#include "calendar.h"
+#include "catch/catch.hpp"
+#include "game.h"
+#include "options.h"
+#include "player_helpers.h"
+#include "type_id.h"
+
+// Reproduces issue #7559: predator mutations (PRED2/3/4) are supposed to
+// prevent combat-skill rust, but Character::do_skill_rust only checked this
+// via pred_tick = calendar::ticks_between( duration, N_hours ), which is
+// only > 0 when a *single* call's duration spans a whole N-hour block
+// (NPC catch-up). During real-time play, update_body() is called every
+// turn with duration == 1_turns, so pred_tick was always 0 and the
+// protection never engaged.
+TEST_CASE( "predator_prevents_combat_skill_rust_in_real_time_play", "[skill][mutation]" )
+{
+    avatar &dummy = get_avatar();
+    clear_avatar();
+
+    get_options().get_option( "SKILL_RUST" ).setValue( "vanilla" );
+
+    dummy.set_mutation( trait_id( "PRED4" ) );
+
+    const skill_id melee_skill( "melee" );
+    const skill_id fabrication_skill( "fabrication" );
+
+    dummy.set_skill_level( melee_skill, 8 );
+    dummy.set_skill_level( fabrication_skill, 8 );
+
+    // Simulate several hours of real-time play, one turn at a time,
+    // exactly like the normal game loop does via update_body(), advancing
+    // the game clock the same way the main loop does.
+    for( int i = 0; i < to_turns<int>( 6_hours ); ++i ) {
+        calendar::turn += 1_turns;
+        dummy.update_body();
+    }
+
+    UNSCOPED_INFO( "melee level after 6h: " << dummy.get_skill_level( melee_skill ) );
+    UNSCOPED_INFO( "fabrication level after 6h: " << dummy.get_skill_level( fabrication_skill ) );
+
+    CHECK( dummy.get_skill_level( fabrication_skill ) < 8 );
+    CHECK( dummy.get_skill_level( melee_skill ) == 8 );
+}

--- a/tests/predator_skill_rust_test.cpp
+++ b/tests/predator_skill_rust_test.cpp
@@ -13,32 +13,31 @@
 // (NPC catch-up). During real-time play, update_body() is called every
 // turn with duration == 1_turns, so pred_tick was always 0 and the
 // protection never engaged.
-TEST_CASE( "predator_prevents_combat_skill_rust_in_real_time_play", "[skill][mutation]" )
-{
-    avatar &dummy = get_avatar();
+TEST_CASE("predator_prevents_combat_skill_rust_in_real_time_play", "[skill][mutation]") {
+    avatar& dummy = get_avatar();
     clear_avatar();
 
-    get_options().get_option( "SKILL_RUST" ).setValue( "vanilla" );
+    get_options().get_option("SKILL_RUST").setValue("vanilla");
 
-    dummy.set_mutation( trait_id( "PRED4" ) );
+    dummy.set_mutation(trait_id("PRED4"));
 
-    const skill_id melee_skill( "melee" );
-    const skill_id fabrication_skill( "fabrication" );
+    const skill_id melee_skill("melee");
+    const skill_id fabrication_skill("fabrication");
 
-    dummy.set_skill_level( melee_skill, 8 );
-    dummy.set_skill_level( fabrication_skill, 8 );
+    dummy.set_skill_level(melee_skill, 8);
+    dummy.set_skill_level(fabrication_skill, 8);
 
     // Simulate several hours of real-time play, one turn at a time,
     // exactly like the normal game loop does via update_body(), advancing
     // the game clock the same way the main loop does.
-    for( int i = 0; i < to_turns<int>( 6_hours ); ++i ) {
+    for (int i = 0; i < to_turns<int>(6_hours); ++i) {
         calendar::turn += 1_turns;
         dummy.update_body();
     }
 
-    UNSCOPED_INFO( "melee level after 6h: " << dummy.get_skill_level( melee_skill ) );
-    UNSCOPED_INFO( "fabrication level after 6h: " << dummy.get_skill_level( fabrication_skill ) );
+    UNSCOPED_INFO("melee level after 6h: " << dummy.get_skill_level(melee_skill));
+    UNSCOPED_INFO("fabrication level after 6h: " << dummy.get_skill_level(fabrication_skill));
 
-    CHECK( dummy.get_skill_level( fabrication_skill ) < 8 );
-    CHECK( dummy.get_skill_level( melee_skill ) == 8 );
+    CHECK(dummy.get_skill_level(fabrication_skill) < 8);
+    CHECK(dummy.get_skill_level(melee_skill) == 8);
 }


### PR DESCRIPTION
## Purpose of change (The Why)

Closes #7559

Predator mutations (PRED2/PRED3/PRED4) are documented to make combat skills "more easily learned and maintained," but combat skills still rusted at the exact same rate as everything else during normal play.

## Describe the solution (The How)

`Character::do_skill_rust` only skipped rust for combat skills when `pred_tick = calendar::ticks_between(duration, N_hours) > 0`. That's only nonzero when a *single* `do_skill_rust` call's `duration` spans a whole 3/4/8-hour block, which happens for NPC catch-up (loading, off-screen simulation) but essentially never during real-time play, where `update_body()` is called every turn with `duration == 1_turns`. Since actual rust triggers on its own much shorter interval (`rustRate`, based on skill level), combat skills rusted normally almost all the time despite the trait.

Fix: the protection now applies unconditionally to combat skills whenever PRED2/3/4 is present. The hourly-tick logic is kept, but only gates the cosmetic "heart races" flavor message/stim, not the actual rust prevention.

## Describe alternatives you've considered

Considered reworking the flavor-message cadence to use a persistent per-character counter instead of `ticks_between`, but that's unrelated to the actual bug and would be a bigger, riskier change for no behavioral benefit.

## Testing

- Added `tests/predator_skill_rust_test.cpp`, which simulates 6 hours of turn-by-turn play (mirroring the real game loop's `update_body()` call pattern) for a PRED4 character with melee and fabrication both at level 8. Before the fix, melee rusted 8→7 identically to fabrication; after the fix, melee stays protected while fabrication rusts normally.
- Ran the existing `[mutation]` and `[skill]` test suites (144 assertions, 6 cases) with no regressions.
- Manually reproduced and then verified the fix in a real compiled build (curses): created a PRED4 character via debug menu, set melee/fabrication to level 8, and played ~2400 real turns (walking) with `SKILL_RUST=vanilla`. Before the fix, melee rusted with fabrication. After the fix, melee stayed at 8 while fabrication dropped to 7.

## Additional context

None.

## Checklist

### Mandatory

- [x] I linked the relevant issue using `closes #7559` above.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an `Assisted-by:` trailer to the AI-assisted commit.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [df08253](https://github.com/cataclysmbn/Cataclysm-BN/commit/df082532d152d22c6634ec3a4fc09308620f6a2c) (style(autofix.ci): automated formatting) on 2026-09-05 01:45:10

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33934661962/artifacts/9959997613)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33934661962/artifacts/9960516893)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33934661962/artifacts/9960010993)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33934661962/artifacts/9960124921)
<!-- END artifact comment -->