### PR TITLE
fix: dog lover profession no longer acts like we have pockets

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3367,7 +3367,7 @@
     "items": {
       "both": {
         "items": [ "jeans", "longshirt", "socks", "sneakers", "water_clean", "wristwatch", "smart_phone", "petpack", "pet_carrier" ],
-        "entries": [ { "item": "mbag", "contents-group": "dog_lover_bag" } ]
+        "entries": [ { "item": "mbag" }, { "group": "dog_lover_bag" } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]


### PR DESCRIPTION
## Purpose of change (The Why)
Caused by: #7189

## Describe the solution (The How)
Spawn group seperate

## Describe alternatives you've considered
Make screaming checks

## Testing
I get no stuff in my bag like we had pockets

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7887aad](https://github.com/cataclysmbn/Cataclysm-BN/commit/7887aaddf0b80ab46400e3120189007da120d56e) (fix: dog lover profession no longer acts like we have pockets) on 2026-09-06 05:16:58

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33998253608/artifacts/9979519836)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33998253608/artifacts/9979241511)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33998253608/artifacts/9978927596)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/33998253608/artifacts/9979013287)
<!-- END artifact comment -->