### PR TITLE
feat: add `mountable_pixels_up` to monster definitions

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2030,7 +2030,6 @@
       "max_level": 3,
       "level_flags": [ { "level": 1, "flags": [ "COMBAT_MOUNT" ] } ]
     },
-    "mountable_pixels_up": 50,
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER_1", "WARM" ]
   },
   {

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2030,6 +2030,7 @@
       "max_level": 3,
       "level_flags": [ { "level": 1, "flags": [ "COMBAT_MOUNT" ] } ]
     },
+    "mountable_pixels_up": 50,
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER_1", "WARM" ]
   },
   {

--- a/docs/en/mod/json/reference/creatures/monsters.md
+++ b/docs/en/mod/json/reference/creatures/monsters.md
@@ -304,6 +304,11 @@ are slower.
 Used as the acceptable rider vs. mount weight percentage ratio. Defaults to "0.3", which means the
 mount is capable of carrying riders weighing <= 30% of the mount's weight.
 
+## "mountable_pixels_up"
+
+(int, optional)
+Used as the number of pixels upward to place the player when the mount is mounted
+
 ## "melee_skill"
 
 (integer, optional)

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -5937,7 +5937,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
                 const auto ent_name = m->type->id;
                 std::string chosen_id = ent_name.str();
                 if( m->has_effect( effect_ridden ) ) {
-                    int pl_under_height = 6;
+                    int pl_under_height = m->type->mountable_pixels_up;
                     if( m->mounted_player ) {
                         draw_entity_with_overlays( *m->mounted_player, p, ll, pl_under_height );
                     }

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -804,6 +804,8 @@ void mtype::load( const JsonObject &jo, const std::string &src )
 
     assign( jo, "mountable_weight_ratio", mountable_weight_ratio, strict );
 
+    optional( jo, was_loaded, "mountable_pixels_up", mountable_pixels_up, 6 );
+
     assign( jo, "attack_cost", attack_cost, strict, 0 );
     assign( jo, "melee_skill", melee_skill, strict, 0 );
     assign( jo, "melee_dice", melee_dice, strict, 0 );

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -339,6 +339,8 @@ struct mtype {
 
         // mountable ratio for rider weight vs. mount weight, default 0.3
         float mountable_weight_ratio = 0.3;
+        // how many pixels up does player go
+        int mountable_pixels_up = 6;
 
         int attack_cost = 100;  /** moves per regular attack */
         int melee_skill = 0;    /** melee hit skill, 20 is superhuman hitting abilities */


### PR DESCRIPTION
## Purpose of change (The Why)
Request of Thog

## Describe the solution (The How)
Add `mountable_pixels_up` which jsonizes the pixel shift upwards that you get

## Describe alternatives you've considered
None

## Testing
<img width="1920" height="1080" alt="Sep05::181744" src="https://github.com/user-attachments/assets/1f52547a-648f-4614-a6c1-513817385687" />
This is what you get when you revert to first commit of PR
Normal without that commit

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.<!-- BEGIN docs comment -->

## Translations

| post                                     | changed | stale  | missing |
| ---------------------------------------- | ------- | ------ | ------- |
| mod/json/reference/creatures/monsters.md | en      | ja, ko |         |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [129119a](https://github.com/cataclysmbn/Cataclysm-BN/commit/129119a8a6e8df9858d36549fa623136c28fd613) (no flying player for you) on 2026-09-06 02:54:55

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34003816524/artifacts/9980990639)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34003816524/artifacts/9981450500)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34003816524/artifacts/9981066602)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34003816524/artifacts/9980754594)
<!-- END artifact comment -->