### PR TITLE
fix: refill containers from rain under gutter downspouts

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -846,6 +846,17 @@ void game::load_map( const point_abs_sm &pos_sm, const bool pump_events )
     submap_loader.add_listener( this );
     submap_loader.add_listener( &m );
 
+    // m.load() above cleared map::funnel_locations_ and the map listener was
+    // only just registered, so the submaps loaded by m.load() never fired
+    // on_submap_loaded() for it.  Replay on_submap_loaded() for every
+    // currently-resident submap so funnel traps (e.g. gutter downspouts) are
+    // registered and fill_water_collectors() can find them (#10171).
+    for( auto &[raw_pos, sm_ptr] : MAPBUFFER_REGISTRY.get( new_dim_id ) ) {
+        if( sm_ptr ) {
+            m.on_submap_loaded( tripoint_abs_sm( raw_pos ), new_dim_id );
+        }
+    }
+
     const auto bubble_begin = pos_sm;
     const auto bubble_end = bubble_begin + point_rel_sm( g_mapsize, g_mapsize );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8007,8 +8007,10 @@ bool item::is_funnel_container( units::volume &bigger_than ) const
         contents.front().typeId() == itype_water ||
         contents.front().typeId() == itype_water_acid ||
         contents.front().typeId() == itype_water_acid_weak ) {
-        bigger_than = get_container_capacity();
-        return true;
+        if( !is_container_full() ) {
+            bigger_than = get_container_capacity();
+            return true;
+        }
     }
     return false;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -619,7 +619,7 @@ void map::on_submap_loaded( const tripoint_abs_sm &p, const dimension_id &dim_id
     // are absent from trap_cache. get_effective_trap() resolves terrain-attached
     // traps first, then standalone ones.
     if( sm != nullptr ) {
-        for( const point_sm_ms & lp : submap_tiles() ) {
+        for( const point_sm_ms &lp : submap_tiles() ) {
             if( sm->get_effective_trap( lp ).obj().is_funnel() ) {
                 if( !std::ranges::contains( funnel_locations_, std::pair( p, lp ) ) ) {
                     funnel_locations_.emplace_back( p, lp );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -618,8 +618,8 @@ void map::on_submap_loaded( const tripoint_abs_sm &p, const dimension_id &dim_id
     // downspouts, whose funnel is a ter_t::trap) never go through set_trap() and so
     // are absent from trap_cache. get_effective_trap() resolves terrain-attached
     // traps first, then standalone ones.
-    if( sm != nullptr ) {
-        for( const point_sm_ms &lp : submap_tiles() ) {
+    if( sm != nullptr && !sm->trap_cache.empty() ) {
+        for( const point_sm_ms &lp : sm->trap_cache ) {
             if( sm->get_effective_trap( lp ).obj().is_funnel() ) {
                 if( !std::ranges::contains( funnel_locations_, std::pair( p, lp ) ) ) {
                     funnel_locations_.emplace_back( p, lp );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -609,12 +609,23 @@ void map::on_submap_loaded( const tripoint_abs_sm &p, const dimension_id &dim_id
     get_mapbuffer().refresh_active_item_submap_index( p, resident_item_lookup() );
 
     // Register any funnel traps so fill_water_collectors can skip the mapbuffer scan.
-    if( sm != nullptr && !sm->trap_cache.empty() ) {
-        std::ranges::for_each( sm->trap_cache, [&]( const point_sm_ms & lp ) {
-            if( sm->get_trap( lp ).obj().is_funnel() ) {
-                funnel_locations_.emplace_back( p, lp );
+    // Guard against duplicate registration: on_submap_loaded() may be replayed for
+    // already-resident submaps (e.g. game::load_map() after m.load() cleared the
+    // list, or submap_loader.update() firing for the bubble), and funnel_locations_
+    // is a vector with no natural dedup — a double entry would fill at 2x rate (#10171).
+    //
+    // Scan every tile, not just trap_cache: funnels attached to terrain (e.g. gutter
+    // downspouts, whose funnel is a ter_t::trap) never go through set_trap() and so
+    // are absent from trap_cache. get_effective_trap() resolves terrain-attached
+    // traps first, then standalone ones.
+    if( sm != nullptr ) {
+        for( const point_sm_ms & lp : submap_tiles() ) {
+            if( sm->get_effective_trap( lp ).obj().is_funnel() ) {
+                if( !std::ranges::contains( funnel_locations_, std::pair( p, lp ) ) ) {
+                    funnel_locations_.emplace_back( p, lp );
+                }
             }
-        } );
+        }
     }
 
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -613,11 +613,6 @@ void map::on_submap_loaded( const tripoint_abs_sm &p, const dimension_id &dim_id
     // already-resident submaps (e.g. game::load_map() after m.load() cleared the
     // list, or submap_loader.update() firing for the bubble), and funnel_locations_
     // is a vector with no natural dedup — a double entry would fill at 2x rate (#10171).
-    //
-    // Scan every tile, not just trap_cache: funnels attached to terrain (e.g. gutter
-    // downspouts, whose funnel is a ter_t::trap) never go through set_trap() and so
-    // are absent from trap_cache. get_effective_trap() resolves terrain-attached
-    // traps first, then standalone ones.
     if( sm != nullptr && !sm->trap_cache.empty() ) {
         for( const point_sm_ms &lp : sm->trap_cache ) {
             if( sm->get_effective_trap( lp ).obj().is_funnel() ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4638,6 +4638,9 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version,
                 --remaining;
             }
             ter[sm_ms.x()][sm_ms.y()] = iid;
+            if( iid->trap != tr_null ) {
+                trap_cache.push_back( sm_ms );
+            }
         }
         if( remaining ) {
             debugmsg( "Mapbuffer terrain data is corrupt, tile data remaining." );

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -462,6 +462,8 @@ void submap::rotate( int turns )
     [this]( const point_sm_ms & p ) {
         if( trp[p.x()][p.y()] != tr_null ) {
             trap_cache.push_back( p );
+        } else if( ter[p.x()][p.y()].obj().trap != tr_null ) {
+            trap_cache.push_back( p );
         }
         if( fld[p.x()][p.y()].displayed_field_type() ) {
             field_cache.push_back( p );

--- a/src/submap.h
+++ b/src/submap.h
@@ -104,6 +104,18 @@ class submap : maptile_soa<SEEX, SEEY>
             return trp[p.x()][p.y()];
         }
 
+        /// The effective trap at a tile: a terrain-attached trap (ter_t::trap) takes
+        /// precedence over a standalone trap in the trp array. Mirrors map::tr_at().
+        /// Funnels attached to terrain (e.g. gutter downspouts) are only reachable
+        /// through this, since they never land in trap_cache.
+        trap_id get_effective_trap( const point_sm_ms &p ) const {
+            const trap_id ter_trap = get_ter( p ).obj().trap;
+            if( ter_trap != tr_null ) {
+                return ter_trap;
+            }
+            return get_trap( p );
+        }
+
         void set_trap( const point_sm_ms &p, trap_id trap ) {
             is_uniform = false;
             trp[p.x()][p.y()] = trap;

--- a/src/submap.h
+++ b/src/submap.h
@@ -162,6 +162,9 @@ class submap : maptile_soa<SEEX, SEEY>
             is_uniform = false;
             emitter_cache = std::nullopt;
             ter[p.x()][p.y()] = terr;
+            if( terr->trap != tr_null ) {
+                trap_cache.push_back( p );
+            }
         }
 
         void set_all_ter( const ter_id &terr ) {
@@ -299,6 +302,7 @@ class submap : maptile_soa<SEEX, SEEY>
         // Entries may be stale (tile no longer has the relevant data); callers must validate.
         // A stale entry is benign — it just costs a cheap branch on iteration.
         // trap_cache: positions of any non-null trap; rebuilt incrementally via set_trap.
+        // NOTE: can be terrain traps too
         std::vector<point_sm_ms> trap_cache;
         // field_cache: positions of tiles with active fields; compacted after each
         // processing pass to remove positions whose fields have fully decayed.

--- a/src/submap.h
+++ b/src/submap.h
@@ -106,8 +106,8 @@ class submap : maptile_soa<SEEX, SEEY>
 
         /// The effective trap at a tile: a terrain-attached trap (ter_t::trap) takes
         /// precedence over a standalone trap in the trp array. Mirrors map::tr_at().
-        /// Funnels attached to terrain (e.g. gutter downspouts) are only reachable
-        /// through this, since they never land in trap_cache.
+        /// Use this (not get_trap()) when a tile may carry a terrain-attached trap,
+        /// e.g. a gutter downspout's funnel.
         trap_id get_effective_trap( const point_sm_ms &p ) const {
             const trap_id ter_trap = get_ter( p ).obj().trap;
             if( ter_trap != tr_null ) {
@@ -301,8 +301,9 @@ class submap : maptile_soa<SEEX, SEEY>
         // Per-submap flat lists used to avoid full 144-tile scans.
         // Entries may be stale (tile no longer has the relevant data); callers must validate.
         // A stale entry is benign — it just costs a cheap branch on iteration.
-        // trap_cache: positions of any non-null trap; rebuilt incrementally via set_trap.
-        // NOTE: can be terrain traps too
+        // trap_cache: positions of any non-null trap — standalone (trp) or
+        // terrain-attached (ter_t::trap). Maintained by set_trap/set_ter, the
+        // rotate() rebuild, and load(); entries may be stale, so callers re-validate.
         std::vector<point_sm_ms> trap_cache;
         // field_cache: positions of tiles with active fields; compacted after each
         // processing pass to remove positions whose fields have fully decayed.

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -359,7 +359,9 @@ static void fill_water_collectors( int mmPerHour, bool acid )
         if( !sm ) {
             return;
         }
-        const trap &tr = sm->get_trap( lp ).obj();
+        // Resolve the effective trap: terrain-attached funnels (e.g. gutter
+        // downspouts) live in ter_t::trap, not the standalone trp array.
+        const trap &tr = sm->get_effective_trap( lp ).obj();
         if( !tr.is_funnel() ) {
             return;
         }


### PR DESCRIPTION
# fix: refill containers from rain under gutter downspouts

## Purpose of change (The Why)

closes #10171

Containers placed under a gutter downspout never collect rainwater, even after hours of rain. Standalone funnels (e.g. a metal funnel) work fine, but downspouts — which are a *terrain* (`t_gutter_downspout`) whose funnel is attached via the terrain's `trap` field (`tr_downspout_funnel`) — are silently skipped by the water-collection code.

The funnel-filling path only ever looked at **standalone** traps in the submap's `trp` array / `trap_cache`. A terrain-attached funnel never goes through `set_trap()`, so it is absent from `trap_cache` and is never registered in `map::funnel_locations_` nor read by `fill_water_collectors()`.

This regressed in the Map Data Overhaul (#8252), which replaced the old `map::trap_locations(trap_id)` index — that indexed terrain-attached traps via `traplocs[ter.trap.to_i()]` — with `trap_cache` iteration that only covers standalone traps.

## Describe the solution (The How)

Both funnel stages assumed the funnel is a *standalone* trap in the submap's `trp` array. A downspout's funnel is a *terrain-attached* trap (`ter_t::trap`), so both stages missed it. The fix makes both resolve the **effective** trap (terrain-attached first, then standalone) and replays registration after a save/load:

- **`submap::get_effective_trap(p)`** (new, `src/submap.h`) — returns the terrain-attached trap if present, else the standalone one; mirrors `map::tr_at()`.
- **`map::on_submap_loaded()`** (`src/map.cpp`) — scan every tile and register any whose effective trap is a funnel (was: only `trap_cache`, which never holds terrain-attached traps). Dedup guard kept to prevent 2× fill on replay.
- **`weather.cpp::fill_water_collectors()`** — read the trap via `get_effective_trap(lp)` instead of `get_trap(lp)`.
- **`game.cpp::load_map()`** — replay `on_submap_loaded()` for resident submaps after `m.load()` clears `funnel_locations_` (the loader won't re-fire for already-resident submaps).

> Full code-level walkthrough (with line references) is in the PR comment `PR-comment-deep-dive.md`.

## Describe alternatives you've considered

- Re-adding a terrain-trap index to `map` (the pre-#8252 approach) — rejected; the `funnel_locations_` cache is the current design and the fix is smaller by reusing it.
- Special-casing downspouts by terrain id — rejected; `get_effective_trap()` generalizes to any terrain-attached funnel.

## Testing

- Created a new world and character, then put 100L drums under a metal funnel and a downspout. Waited until weather changed to some kind of rain. Saw both drums fill, then moved them so they wouldn't get full while I walked far away (left the bubble,) then walked back. Moved the drums back under the funnel and the spout and saw they still filled the drums.

## Additional context

Root cause traced to #8252 (Map Data Overhaul), which dropped terrain-attached-trap handling from the funnel path.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html). (Assistant: `qwen3.8-27b` — e.g. `Assisted-by: qwen3.8-27b`)

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b7ec572](https://github.com/cataclysmbn/Cataclysm-BN/commit/b7ec5724840a7cf723ff645093eb6c4b6468fb38) (fix: if container is full, it is not a valid funnel container) on 2026-09-07 00:09:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34066612984/artifacts/9999394398)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34066612984/artifacts/9999798284)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34066612984/artifacts/9999526474)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34066612984/artifacts/9999423226)
<!-- END artifact comment -->