### PR TITLE
feat(mods): add Medieval Mod Reborn to bundled mods

### DIFF
--- a/data/mods/external.json
+++ b/data/mods/external.json
@@ -54,5 +54,11 @@
     "version": "0.0.0",
     "url": "https://github.com/chaosvolt/MST_Extra_Mod/archive/refs/heads/master.zip",
     "extract_path": "MST_Extra_BN"
+  },
+  {
+    "id": "medieval_mod_reborn",
+    "version": "0.0.0",
+    "url": "https://github.com/chaosvolt/cdda_medieval_mod_reborn/archive/refs/heads/master.zip",
+    "extract_path": "Medieval_Mod_Reborn_BN"
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Another mod I work on since we added MST Extra and Cata++ that way.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Adds MMR to bundled mods file.

## Describe alternatives you've considered

I need to do a mainlining pass on it someday uwahhh

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

Waiting for PR artifact

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c896af4](https://github.com/cataclysmbn/Cataclysm-BN/commit/c896af43c77b6eb2889038498a2620e5e81d101b) (feat(mods): add Medieval Mod Reborn to bundled mods) on 2026-09-07 05:09:53

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34081356809/artifacts/10004943448)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34081356809/artifacts/10005108118)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34081356809/artifacts/10004043658)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34081356809/artifacts/10004108946)
<!-- END artifact comment -->