### PR TITLE
feat(mods/innawoods): make streams not spawn trash in innawoods mod

### DIFF
--- a/data/mods/innawoods/regional_settings.json
+++ b/data/mods/innawoods/regional_settings.json
@@ -576,9 +576,6 @@
         [ "f_boulder_large", 1 ]
       ]
     },
-    "items": {
-      "1": [ { "item": "creek_bed", "chance": 1 } ],
-      "2": [ { "item": "creek_bed", "chance": 1 } ]
-    }
+    "items": { "1": [ { "item": "creek_bed", "chance": 1 } ], "2": [ { "item": "creek_bed", "chance": 1 } ] }
   }
 ]

--- a/data/mods/innawoods/regional_settings.json
+++ b/data/mods/innawoods/regional_settings.json
@@ -542,5 +542,43 @@
       ]
     },
     "overmap_feature_flag_settings": { "clear_blacklist": false, "blacklist": [  ], "clear_whitelist": false, "whitelist": [  ] }
+  },
+  {
+    "type": "palette",
+    "id": "stream_palette",
+    "terrain": {
+      " ": "t_null",
+      "~": "t_water_moving_sh",
+      "1": [
+        [ "t_null", 100 ],
+        [ "t_sand", 1 ],
+        [ "t_clay", 4 ],
+        [ "t_grass_long", 900 ],
+        [ "t_region_shrub", 20 ],
+        [ "t_region_tree", 20 ]
+      ],
+      "2": [ [ "t_null", 150 ], [ "t_grass_long", 10 ], [ "t_region_shrub", 1 ], [ "t_region_tree", 1 ] ]
+    },
+    "furniture": {
+      " ": "f_null",
+      "1": [
+        [ "f_null", 800 ],
+        [ "f_region_weed", 10 ],
+        [ "f_boulder_small", 3 ],
+        [ "f_boulder_medium", 2 ],
+        [ "f_boulder_large", 1 ]
+      ],
+      "2": [
+        [ "f_null", 1400 ],
+        [ "f_region_weed", 10 ],
+        [ "f_boulder_small", 3 ],
+        [ "f_boulder_medium", 2 ],
+        [ "f_boulder_large", 1 ]
+      ]
+    },
+    "items": {
+      "1": [ { "item": "creek_bed", "chance": 1 } ],
+      "2": [ { "item": "creek_bed", "chance": 1 } ]
+    }
   }
 ]


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
By default streams spawn trash and wheels around them in high quantities due to high amount of spawn chances in their palettes. While it's okay in normal gameplay, I believe it can interfere with innawoods runs

## Describe the solution (The How)
Redefine the `stream_palette` in innawoods mod file (not sure if that's the best one or if a new file should be created) without the trash or wheels spawn groups

## Describe alternatives you've considered
Deleting streams altogether,  uhh idk

## Testing
Start an innawoods character, find a stream, walk for a while and confirm no trash spawns

## Additional context
Thanks Thog for pointing out on discord that I could do this

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b19da4b](https://github.com/cataclysmbn/Cataclysm-BN/commit/b19da4b21609bf6fb3a34006eeee8c0d66ded135) (style(autofix.ci): automated formatting) on 2026-09-07 20:18:52

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34134627092/artifacts/10030630888)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34134627092/artifacts/10031876227)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34134627092/artifacts/10024080343)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34134627092/artifacts/10024136961)
<!-- END artifact comment -->