### PR TITLE
fix: match Barbaran Represa, Vulgar Preparation and Kick Stance code numbers to their descriptions

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -83,9 +83,9 @@
         "description": "Sliding footwork enhances the crushing continuity of your attacks.\n\nArmor penetration increased by 100% of Strength.",
         "melee_allowed": true,
         "flat_bonuses": [
-          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
-          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.75 },
-          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.75 }
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 1 },
+          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 1 }
         ]
       }
     ],
@@ -134,7 +134,7 @@
         "flat_bonuses": [
           { "stat": "hit", "scaling-stat": "str", "scale": 0.15 },
           { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.25 },
-          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 2.25 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 1.25 },
           { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 1.25 }
         ],
         "buff_duration": 1
@@ -570,7 +570,7 @@
         "name": "Kick stance",
         "description": "You have adopted a stance which allows for greater mobility and stability.  Your hands are in a guard position with elbows forward to protect yourself.\n\nBlocked damage reduced by 25% of Strength.\n+1.0 Dodging skill",
         "unarmed_allowed": true,
-        "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 }, { "stat": "dodge", "scale": 1 } ]
+        "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.25 }, { "stat": "dodge", "scale": 1 } ]
       }
     ],
     "techniques": [


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
While rummaging through hitchhiker's guide I noticed that Barbaran Represa gave 75% armor pen instead of description's 100%. I went ahead and corrected that and checked a few other stances that did that, and fixed them.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Shrimply matches the code to the descriptions (and not the descriptions to the code)
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Matching the descriptions to the code

## Testing
Load in character with all three fighstyles:
1. Check that I do not annihiliate Grunt Combat Mech with Vulgar Preparation (which gave 225% cut armor pen, now it's proper 125%)
2. Check that I take more damage now because of kickboxing stance giving 25% damage block instead of 50%
3. Check the slightly increased damage numbers (100% instead of 75% scaling) with Barbaran Montante
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [73d9e58](https://github.com/cataclysmbn/Cataclysm-BN/commit/73d9e58423fc9fc64651f1461aa0d3c88854f687) (feat(balance): correct martial arts code numbers to their descriptions) on 2026-09-07 16:24:58

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34136434372/artifacts/10024684345)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34136434372/artifacts/10026598926)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34136434372/artifacts/10024756537)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34136434372/artifacts/10025013659)
<!-- END artifact comment -->