### PR TITLE
fix: allow mutation butchery to function

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -552,7 +552,10 @@ butchery_setup consider_butchery( const item &corpse_item, player &u, butcher_ty
     };
 
     const inventory &inv = u.crafting_inventory();
-    const int factor = u.max_quality( action == DISSECT ? qual_CUT_FINE : qual_BUTCHER );
+    // Must check both u and inventory because crafting inventory lacks mutation butcher items
+    const int factor = std::max(
+                           u.max_quality( action == DISSECT ? qual_CUT_FINE : qual_BUTCHER ),
+                           inv.max_quality( action == DISSECT ? qual_CUT_FINE : qual_BUTCHER ) );
 
     const mtype &corpse = *corpse_item.get_mtype();
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -552,7 +552,7 @@ butchery_setup consider_butchery( const item &corpse_item, player &u, butcher_ty
     };
 
     const inventory &inv = u.crafting_inventory();
-    const int factor = inv.max_quality( action == DISSECT ? qual_CUT_FINE : qual_BUTCHER );
+    const int factor = u.max_quality( action == DISSECT ? qual_CUT_FINE : qual_BUTCHER );
 
     const mtype &corpse = *corpse_item.get_mtype();
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11978,12 +11978,14 @@ static void butcher_submenu( const std::vector<item *> &corpses, int corpse = -1
     avatar &you = get_avatar();
     const inventory &inv = you.crafting_inventory();
 
-    const int factor = you.max_quality( quality_id( "BUTCHER" ) );
+    const int factor = std::max( you.max_quality( quality_id( "BUTCHER" ) ),
+                                 inv.max_quality( quality_id( "BUTCHER" ) ) );
     const std::string msg_inv = factor > INT_MIN
                                 ? string_format( _( "Your best tool has <color_cyan>%d butchering</color>." ), factor )
                                 :  _( "You have no butchering tool." );
 
-    const int factor_diss = inv.max_quality( quality_id( "CUT_FINE" ) );
+    const int factor_diss = std::max( you.max_quality( quality_id( "CUT_FINE" ) ),
+                                      inv.max_quality( quality_id( "CUT_FINE" ) ) );
     const std::string msg_inv_diss = factor_diss > INT_MIN
                                      ? string_format( _( "Your best tool has <color_cyan>%d fine cutting</color>." ), factor_diss )
                                      :  _( "You have no fine cutting tool." );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11978,7 +11978,7 @@ static void butcher_submenu( const std::vector<item *> &corpses, int corpse = -1
     avatar &you = get_avatar();
     const inventory &inv = you.crafting_inventory();
 
-    const int factor = inv.max_quality( quality_id( "BUTCHER" ) );
+    const int factor = you.max_quality( quality_id( "BUTCHER" ) );
     const std::string msg_inv = factor > INT_MIN
                                 ? string_format( _( "Your best tool has <color_cyan>%d butchering</color>." ), factor )
                                 :  _( "You have no butchering tool." );

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -354,7 +354,9 @@ int visitable<Character>::max_quality( const quality_id &qual ) const
 
     if( qual == qual_BUTCHER ) {
         for( const trait_id &mut : self->get_mutations() ) {
-            res = std::max( res, mut->butchering_quality );
+            if( mut->butchering_quality > 0 ) {
+                res = std::max( res, mut->butchering_quality );
+            }
         }
     }
 

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -285,6 +285,14 @@ bool visitable<Character>::has_quality( const quality_id &qual, int level, int q
             qty--;
         }
     }
+    if( qual == qual_BUTCHER ) {
+        for( const trait_id &mut : self->get_mutations() ) {
+            if( mut->butchering_quality > level ) {
+                if( qty <= 1 ) { return true; }
+                qty--;
+            }
+        }
+    }
 
     return qty <= 0 ? true : has_quality_internal( *this, qual, level, qty ) == qty;
 }
@@ -337,6 +345,11 @@ int visitable<Character>::max_quality( const quality_id &qual ) const
 
     for( const auto &bio : *self->my_bionics ) {
         res = std::max( res, bio.get_quality( qual ) );
+    }
+    for( const auto it : self->get_enchantment_fake_items() ) {
+        if( it->qualities.contains( qual ) ) {
+            res = std::max( res, it->qualities.at( qual ) );
+        }
     }
 
     if( qual == qual_BUTCHER ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Fix fix fix

## Describe the solution (The How)
Use character has quality -> Iterates over fake mutations
Fix miss in #10146 of adding enchantment tools to max_quality

## Describe alternatives you've considered
None

## Testing
Butcher with curved claws works

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a18d8d8](https://github.com/cataclysmbn/Cataclysm-BN/commit/a18d8d8bf0e1424547a601432bf3fbfbeabaa3af) (just check both) on 2026-09-07 19:53:54

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34150243438/artifacts/10029361436)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34150243438/artifacts/10031004737)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34150243438/artifacts/10029541913)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34150243438/artifacts/10029559087)
<!-- END artifact comment -->