### PR TITLE
feat: Update Earthshaper cestus crafting recipe-Magical Nights

### DIFF
--- a/data/mods/MagicalNights/recipes/weapons.json
+++ b/data/mods/MagicalNights/recipes/weapons.json
@@ -107,7 +107,7 @@
     "category": "CC_ENCHANTED",
     "subcategory": "CSC_ENCHANTED_WEAPONS",
     "skill_used": "fabrication",
-    "skills_required": [ [ "spellcraft", 2 ], [ "bashing", 2 ] ],
+    "skills_required": [ [ "spellcraft", 2 ], [ "unarmed", 2 ] ],
     "difficulty": 4,
     "time": "360 m",
     "autolearn": true,


### PR DESCRIPTION
Changed Earthshaper Cestus to use Unarmed as the skill to craft rather than Bashing, as the Cestus is an Unarmed weapon.

<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

The Cestus is an unarmed weapon and uses the unarmed skill to use. However, it requires the bashing skill to craft, which forces the player into grinding a skill that they may or may not want to use. 

## Describe the solution (The How)

Changed the requirement from "bashing": 2 to "unarmed": 2

## Describe alternatives you've considered

Removing the requirement of a combat skill entirely from the crafting recipe, as the ability to use a thing is not directly tied to being able to use said thing.

## Testing

Loaded up a new world with the change, verified that the recipe is changed

## Checklist



### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional
