### PR TITLE
feat(mods/Arcana_MagiclalNights_Patch): add druid to the Seeker of the Arcane scenario in the Arcana/MN Patch

### DIFF
--- a/data/mods/BN_Arcana_MagicalNights_Patch/scenarios.json
+++ b/data/mods/BN_Arcana_MagicalNights_Patch/scenarios.json
@@ -62,7 +62,7 @@
     "id": "arcane_seeker",
     "copy-from": "arcane_seeker",
     "extend": {
-      "professions": [ "novice_necromancer", "novice_stormshaper", "novice_earthshaper", "novice_technomancer", "novice_kelvinist" ]
+      "professions": [ "novice_necromancer", "novice_stormshaper", "novice_earthshaper", "novice_technomancer", "novice_kelvinist", "druid" ]
     }
   },
   {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Adds druid to the Seeker of the Arcane scenario, they might be tree lovers but they do magic too, besides, one of the locations is a strange grove as well.

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Extend the `arcane_seeker` scenario to include `druid`

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
1. Create a world with the following mods enabled:
--  Arcana and Magic Items
-- Magical Nights
-- Arcana/Magical Nights Patchmod

2. Select the "Seeker of the Arcane" scenario
3. Check that it shows up in the list of Professions 
<img width="505" height="157" alt="image" src="https://github.com/user-attachments/assets/52a8128a-3ee2-43a5-ba78-7e73be064591" />

4. Generate the world and see that you spawned as druid correctly

<img width="525" height="309" alt="image" src="https://github.com/user-attachments/assets/fb5031bd-279d-41ce-b8e5-355df8c79a1b" />
<img width="519" height="238" alt="image" src="https://github.com/user-attachments/assets/465f9958-063c-415a-b70e-a6dfa85a85a5" />




## Additional context
Mages should stop bullying druids so much, they do magics just like ya'll :(
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ed127f3](https://github.com/cataclysmbn/Cataclysm-BN/commit/ed127f3ad3dcc32e4da0eecac48eb945c3e9f28f) (feat: add druid to the Seeker of the Arcane scenario in the Arcana/MN Patch) on 2026-09-08 21:52:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34278325562/artifacts/10077254460)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34278325562/artifacts/10078276596)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34278325562/artifacts/10077415219)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34278325562/artifacts/10077573059)
<!-- END artifact comment -->