### PR TITLE
feat: Change Earthshaper Cestus's recipe to require the relevant combat skill

### DIFF
--- a/data/mods/MagicalNights/recipes/weapons.json
+++ b/data/mods/MagicalNights/recipes/weapons.json
@@ -107,7 +107,7 @@
     "category": "CC_ENCHANTED",
     "subcategory": "CSC_ENCHANTED_WEAPONS",
     "skill_used": "fabrication",
-    "skills_required": [ [ "spellcraft", 2 ], [ "bashing", 2 ] ],
+    "skills_required": [ [ "spellcraft", 2 ], [ "unarmed", 2 ] ],
     "difficulty": 4,
     "time": "360 m",
     "autolearn": true,

--- a/data/mods/MagicalNights/recipes/weapons.json
+++ b/data/mods/MagicalNights/recipes/weapons.json
@@ -107,7 +107,7 @@
     "category": "CC_ENCHANTED",
     "subcategory": "CSC_ENCHANTED_WEAPONS",
     "skill_used": "fabrication",
-    "skills_required": [ [ "spellcraft", 2 ], [ "unarmed", 2 ] ],
+    "skills_required": [ [ "spellcraft", 2 ], [ "bashing", 2 ] ],
     "difficulty": 4,
     "time": "360 m",
     "autolearn": true,


### PR DESCRIPTION
## Purpose of change (The Why)

All of the other class weapons require the skill that using the weapons require. Despite this, the Earthshaper Cestus required the Bashing weapons skill rather than the Unarmed skill, despite being an unarmed weapon.

## Describe the solution (The How)

Change the `"bashing": 2` requirement to `"unarmed": 2`.

## Describe alternatives you've considered

Remove combat skills from the requirements of the recipe, as knowing how to use a thing has no bearing on knowing how to make that thing. 

## Testing

Verified that the recipe now required Unarmed instead of Bashing

## Additional context



### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [39e0989](https://github.com/cataclysmbn/Cataclysm-BN/commit/39e0989bd5083e442dda163aeea330f2d57c23ff) (Update weapons.json) on 2026-09-08 23:06:45

- [⏳ Linux tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34288901336)
- [⏳ Windows tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34288901336)
- [⏳ macOS tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34288901336)
- [⏳ Android tiles — pending](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34288901336)
<!-- END artifact comment -->