### PR TITLE
feat(UI): Permit Using Items Inside Containers Directly

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1557,6 +1557,9 @@ bool avatar::invoke_item( item *used, const tripoint_bub_ms &pt )
     if( used->has_flag( flag_ADD_UPS_TOGGLE ) && !used->type->has_flag( flag_ADD_UPS_TOGGLE ) ) {
         use_methods["TOGGLE_UPS_CHARGING"] = item_controller->usage_from_string( "TOGGLE_UPS_CHARGING" );
     }
+    for( const auto *it : used->contents.all_items_ptr() ) {
+        use_methods.insert( it->type->use_methods.begin(), it->type->use_methods.end() );
+    }
     if( use_methods.empty() ) {
         return false;
     } else if( use_methods.size() == 1 ) {
@@ -1569,7 +1572,8 @@ bool avatar::invoke_item( item *used, const tripoint_bub_ms &pt )
     umenu.hilight_disabled = true;
 
     for( const auto &e : use_methods ) {
-        const auto res = e.second.can_call( *this, *used, false, pt );
+        item *actually_used = used->get_usable_item( e.first );
+        const auto res = e.second.can_call( *this, *actually_used, false, pt );
         umenu.addentry_desc( MENU_AUTOASSIGN, res.success(), MENU_AUTOASSIGN, e.second.get_name(),
                              res.str() );
     }


### PR DESCRIPTION
## Purpose of change (The Why)
Needed for a mod idea I had
Could be cool

## Describe the solution (The How)
Use the fact that we already search for all interior use methods when invoking items
To just invoke things from contents

## Describe alternatives you've considered
Make it an option?

## Testing
Crowbar in a web belt works

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [31ad724](https://github.com/cataclysmbn/Cataclysm-BN/commit/31ad72433bebef63ee577bbd6c39af9c152db17e) (feat(UI): Permit Using Items Inside Containers Directly) on 2026-09-09 01:42:58

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34297355889/artifacts/10083940070)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34297355889/artifacts/10084611886)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34297355889/artifacts/10083998349)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34297355889/artifacts/10084044125)
<!-- END artifact comment -->