### PR TITLE
feat(balance, UI): reduce ambient sound and normal monster hearing, add tiles & relative decibles UI displays

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12924,8 +12924,9 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
     }
     if( !u.has_artifact_with( AEP_STEALTH ) &&
         !u.has_enchantment_flag( enchantment_flag_id( "SILENT" ) ) ) {
-        int volume = u.is_stealthy() ? 30 : 50;
-        volume *= u.mutation_value( "noise_modifier" );
+        int volume = u.is_stealthy() ? 40 : 60;
+        // Used to be a multiplier on tile distance, this approximates that
+        volume += ( u.mutation_value( "noise_modifier" ) / 2 * 6 );
         volume += u.bonus_from_enchantments( volume, enchantment_value_id( "NOISE" ) );
         if( volume > 0 ) {
             if( u.movement_mode_is( CMM_RUN ) ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -4351,23 +4351,23 @@ void monster::hear_sound( const sound_event &source, const short heard_vol, cons
     int max_error = ( goodhearing ) ? 0 : 2;
     if( volume < -1000 ) {
         // -10dB or greater below ambient
-        max_error = ( goodhearing ) ? 8 : 16;
+        max_error = ( goodhearing ) ? 8 : 0;
 
     } else if( volume < 0 ) {
         // -10 - 0 dB below ambient
-        max_error = ( goodhearing ) ? 6 : 12;
+        max_error = ( goodhearing ) ? 6 : 0;
 
     } else if( volume < 1000 ) {
         // 0-10dB greater than ambient
-        max_error = ( goodhearing ) ? 4 : 10;
+        max_error = ( goodhearing ) ? 5 : 12;
 
     } else if( volume < 2000 ) {
         // 10-20dB greater than ambient
-        max_error = ( goodhearing ) ? 3 : 8;
+        max_error = ( goodhearing ) ? 4 : 10;
 
     } else if( volume < 4000 ) {
         // 20-40dB greater than ambient
-        max_error = ( goodhearing ) ? 2 : 6;
+        max_error = ( goodhearing ) ? 3 : 8;
 
     } else if( volume < 8000 ) {
         // 40-80dB greater than ambient

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1641,6 +1641,11 @@ void options_manager::add_options_interface()
          translate_marker( "Metric or Imperial" ),
     { { "metric", translate_marker( "Metric" ) }, { "imperial", translate_marker( "Imperial" ) } },
     "metric" );
+    add( "SOUND_DISPLAY_TYPE", interface, translate_marker( "Sound Display Type" ),
+         translate_marker( "Switch between decibles, relative decibels, and rough tile distance." ),
+    {  { "decibels", translate_marker( "Decibels" ) }, { "relative_decibels", translate_marker( "Relative Decibels" ) }, { "tiles", translate_marker( "Rough Tiles" ) } },
+    "decibels"
+       );
 
     add(
         "OVERMAP_COORDINATE_FORMAT",

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1144,6 +1144,42 @@ static std::string move_mode_string( avatar &u )
     }
 }
 
+static std::string get_sound( const avatar &u )
+{
+    std::string snd;
+    const std::string sound_option = get_option<std::string>( "SOUND_DISPLAY_TYPE" );
+    if( sound_option == "decibels" ) {
+        snd = std::to_string( u.volume );
+    } else if( sound_option == "relative_decibels" ) {
+        // Stolen from sounds::process_sounds
+        const weather_manager &weather = get_weather();
+        // Weather sound attenuation * 2, which we add to ambient noise. sound_attn ranges from 0-8
+        const short weather_vol = ( weather.weather_id->sound_attn );
+        const short wind_volume = ( std::min( 150, weather.windspeed ) );
+        const short INDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
+                                           2 * weather_vol ) ) / 100;
+        // We also use this as the base ambient to measure horde signals against.
+        const short OUTDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
+                                            wind_volume + weather_vol ) ) / 100;
+        snd = std::to_string( u.volume - ( !get_map().is_outside( u.bub_pos() ) ? INDOOR_AMBIENT :
+                                           OUTDOOR_AMBIENT ) );
+    } else if( sound_option == "tiles" ) {
+        // Stolen from sounds::process_sounds
+        const weather_manager &weather = get_weather();
+        // Weather sound attenuation * 2, which we add to ambient noise. sound_attn ranges from 0-8
+        const int weather_vol = ( weather.weather_id->sound_attn );
+        const int wind_volume = ( std::min( 150, weather.windspeed ) );
+        const int INDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
+                                         2 * weather_vol ) ) / 1000;
+        // We also use this as the base ambient to measure horde signals against.
+        const int OUTDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
+                                          wind_volume + weather_vol ) ) / 1000;
+        snd = std::to_string( average_minvol_distance( -3,
+                              u.volume - ( !get_map().is_outside( u.bub_pos() ) ? INDOOR_AMBIENT : OUTDOOR_AMBIENT ) ) );
+
+    }
+    return snd;
+}
 static void draw_stealth( avatar &u, const catacurses::window &w )
 {
     werase( w );
@@ -1156,7 +1192,7 @@ static void draw_stealth( avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 22, 0 ), c_red, _( "DEAF" ) );
     } else {
         mvwprintz( w, point( 20, 0 ), c_light_gray, _( "Sound:" ) );
-        const std::string snd = std::to_string( u.volume );
+        std::string snd = get_sound( u );
         mvwprintz( w, point( 30 - utf8_width( snd ), 0 ), u.volume != 0 ? c_yellow : c_light_gray, snd );
     }
 
@@ -1402,7 +1438,7 @@ static void draw_char_narrow( avatar &u, const catacurses::window &w )
     std::string movecost = std::to_string( u.movecounter ) + "(" + move_char + ")";
     bool m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
     std::string smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
-    mvwprintz( w, point( 8, 0 ), c_light_gray, std::to_string( u.volume ) );
+    mvwprintz( w, point( 8, 0 ), c_light_gray, get_sound( u ) );
 
     // print stamina
     auto needs_pair = std::make_pair( get_hp_bar( u.get_stamina(), u.get_stamina_max() ).second,
@@ -1447,7 +1483,7 @@ static void draw_char_wide( avatar &u, const catacurses::window &w )
     bool m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
     std::string smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
 
-    mvwprintz( w, point( 8, 0 ), c_light_gray, std::to_string( u.volume ) );
+    mvwprintz( w, point( 8, 0 ), c_light_gray, get_sound( u ) );
     mvwprintz( w, point( 23, 0 ), morale_pair.first, "%s", smiley );
     mvwprintz( w, point( 38, 0 ), focus_color( u.focus_pool ), "%s", u.focus_pool );
 
@@ -1711,7 +1747,7 @@ static void draw_sound_labels( const avatar &u, const catacurses::window &w )
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Sound:" ) );
     if( !u.is_deaf() ) {
-        mvwprintz( w, point( 8, 0 ), c_yellow, std::to_string( u.volume ) );
+        mvwprintz( w, point( 8, 0 ), c_yellow, get_sound( u ) );
     } else {
         mvwprintz( w, point( 8, 0 ), c_red, _( "Deaf!" ) );
     }
@@ -1724,7 +1760,7 @@ static void draw_sound_narrow( const avatar &u, const catacurses::window &w )
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Sound:" ) );
     if( !u.is_deaf() ) {
-        mvwprintz( w, point( 8, 0 ), c_yellow, std::to_string( u.volume ) );
+        mvwprintz( w, point( 8, 0 ), c_yellow, get_sound( u ) );
     } else {
         mvwprintz( w, point( 8, 0 ), c_red, _( "Deaf!" ) );
     }
@@ -2226,7 +2262,7 @@ static void draw_lighting_classic( const avatar &u, const catacurses::window &w 
 
     if( !u.is_deaf() ) {
         mvwprintz( w, point( 31, 0 ), c_light_gray, _( "Sound:" ) );
-        mvwprintz( w, point( 38, 0 ), c_yellow, std::to_string( u.volume ) );
+        mvwprintz( w, point( 38, 0 ), c_yellow, get_sound( u ) );
     } else {
         mvwprintz( w, point( 31, 0 ), c_red, _( "Deaf!" ) );
     }

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -55,6 +55,7 @@
 #include "player.h"
 #include "pldata.h"
 #include "point.h"
+#include "sounds.h"
 #include "string_formatter.h"
 #include "string_id.h"
 #include "tileray.h"
@@ -1170,13 +1171,15 @@ static std::string get_sound( const avatar &u )
         const int weather_vol = ( weather.weather_id->sound_attn );
         const int wind_volume = ( std::min( 150, weather.windspeed ) );
         const int INDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
-                                         2 * weather_vol ) ) / 1000;
+                                         2 * weather_vol ) );
         // We also use this as the base ambient to measure horde signals against.
         const int OUTDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
-                                          wind_volume + weather_vol ) ) / 1000;
-        snd = std::to_string( average_minvol_distance( -3,
-                              u.volume - ( !get_map().is_outside( u.bub_pos() ) ? INDOOR_AMBIENT : OUTDOOR_AMBIENT ) ) );
-
+                                          wind_volume + weather_vol ) );
+        const int AMBIENT = ( get_map().is_outside( u.bub_pos() ) ?
+                              OUTDOOR_AMBIENT :
+                              INDOOR_AMBIENT ) / 100;
+        const int dist_to_ambient = std::pow( 10, ( u.volume - AMBIENT ) / 20 );
+        snd = std::to_string( dist_to_ambient );
     }
     return snd;
 }

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1171,14 +1171,14 @@ static std::string get_sound( const avatar &u )
         const int weather_vol = ( weather.weather_id->sound_attn );
         const int wind_volume = ( std::min( 150, weather.windspeed ) );
         const int INDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
-                                         2 * weather_vol ) );
+                                         2 * weather_vol ) ) / 100;
         // We also use this as the base ambient to measure horde signals against.
         const int OUTDOOR_AMBIENT = ( AMBIENT_VOLUME_ABOVEGROUND + dBspl_to_mdBspl(
-                                          wind_volume + weather_vol ) );
-        const int AMBIENT = ( get_map().is_outside( u.bub_pos() ) ?
-                              OUTDOOR_AMBIENT :
-                              INDOOR_AMBIENT ) / 100;
-        const int dist_to_ambient = std::pow( 10, ( u.volume - AMBIENT ) / 20 );
+                                          wind_volume + weather_vol ) ) / 100;
+        const int AMBIENT = get_map().is_outside( u.bub_pos() ) ?
+                            OUTDOOR_AMBIENT :
+                            INDOOR_AMBIENT;
+        const int dist_to_ambient = std::pow( 10.0, double( u.volume - AMBIENT ) / 20.0 );
         snd = std::to_string( dist_to_ambient );
     }
     return snd;

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1178,7 +1178,7 @@ static std::string get_sound( const avatar &u )
         const int AMBIENT = get_map().is_outside( u.bub_pos() ) ?
                             OUTDOOR_AMBIENT :
                             INDOOR_AMBIENT;
-        const int dist_to_ambient = std::pow( 10.0, double( u.volume - AMBIENT ) / 20.0 );
+        const int dist_to_ambient = average_minvol_distance( 0, ( u.volume - AMBIENT ) * 100, 0, 0 );
         snd = std::to_string( dist_to_ambient );
     }
     return snd;

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -121,9 +121,9 @@ static constexpr short SOUND_MINIMUM_VOLUME_FOR_PROPAGATION = 2000;
 // Cache this because we call it every time we check a sound to see if a monster hears it, which adds up quickly.
 static constexpr short SOUND_ABSORPTION_PER_ZLEV = 4200;
 // The base ambient volume above ground in mdB spl. Called frequently enough to warrant caching, and to avoid magic number usage.
-static constexpr short AMBIENT_VOLUME_ABOVEGROUND = 4500;
+static constexpr short AMBIENT_VOLUME_ABOVEGROUND = 3500;
 // The base ambient volume underground in mdB spl. Called frequently enough to warrant caching, and to avoid magic number usage.
-static constexpr short AMBIENT_VOLUME_UNDERGROUND = 3500;
+static constexpr short AMBIENT_VOLUME_UNDERGROUND = 2500;
 
 // Well made residential walls with sound proofing materials can have transmission loss values of upwards of 63 dB.
 // STC ratings (in dB of sound reduction) range from 25 to 55+


### PR DESCRIPTION
## Purpose of change (The Why)
Screm

## Describe the solution (The How)
No goodhearing zombie -> cant hear below ambient
Thus relative decibles worky
Walking now produces a bit of sound above average ambient ( but not much )
Expect goodhearing zombies to hear you walking, but not much else, because you are quiet compared to the wind and everything else outside
Fix mutation noise modifier being absolutely useless to have used, making it approximate the prior value

## Describe alternatives you've considered
Let someone who complains about it do it

## Testing
UI looks right.
It is VERY high for guns
Expect that

Notes:
Tiles of sound will change -> ambient changes, the audible sound you make too changes

## Additional context
This should work balance wise but...

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5483841](https://github.com/cataclysmbn/Cataclysm-BN/commit/5483841e8e41a47851655f166cc8e04703a317fa) (use the known solution even with it's cap, it's really the cap) on 2026-09-09 09:27:58

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34307251409/artifacts/10087962391)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34307251409/artifacts/10088544056)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34307251409/artifacts/10088235924)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34307251409/artifacts/10087911269)
<!-- END artifact comment -->