### PR TITLE
feat: make unit warnings debug debug messages

### DIFF
--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -1,6 +1,7 @@
 #include "assign.h"
 #include "data_vars.h"
 #include "sounds.h"
+#include "units/sound.h"
 #include <algorithm>
 
 void report_strict_violation( const JsonObject &jo, const std::string &message,
@@ -37,7 +38,7 @@ bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
     const auto parse = [&name]( const JsonObject & obj, units::volume & out ) {
         if( obj.has_int( name ) ) {
             obj.show_warning( "legacy volume values used, support will be removed eventually.",
-                              name );
+                              name, true );
             out = obj.get_int( name ) * units::legacy_volume_factor;
             return true;
         }
@@ -115,7 +116,7 @@ bool assign( const JsonObject &jo,
     const auto parse = [&name]( const JsonObject & obj, units::mass & out ) {
         if( obj.has_int( name ) ) {
             obj.show_warning( "legacy mass values used, support will be removed eventually.",
-                              name );
+                              name, true );
             out = units::from_gram<std::int64_t>( obj.get_int( name ) );
             return true;
         }
@@ -181,7 +182,7 @@ bool assign( const JsonObject &jo,
     const auto parse = [&name]( const JsonObject & obj, units::money & out ) {
         if( obj.has_int( name ) ) {
             obj.show_warning( "legacy money values used, support will be removed eventually.",
-                              name );
+                              name, true );
             out = units::from_cent( obj.get_int( name ) );
             return true;
         }
@@ -247,7 +248,7 @@ bool assign( const JsonObject &jo,
     const auto parse = [&name]( const JsonObject & obj, units::energy & out ) {
         if( obj.has_int( name ) ) {
             obj.show_warning( "legacy energy values used, support will be removed eventually.",
-                              name );
+                              name, true );
             const std::int64_t tmp = obj.get_int( name );
             if( tmp > units::to_kilojoule( units::energy_max ) ) {
                 out = units::energy_max;
@@ -317,10 +318,12 @@ auto assign( const JsonObject &jo,
 {
     const auto parse = [&name]( const JsonObject & obj, units::sound & out ) {
         if( obj.has_int( name ) ) {
-            obj.show_warning( "legacy sound volume values used, support will be removed eventually.",
-                              name );
             out = units::from_decibel(
-                      approximate_dB_volume_from_legacy_tile_distance_vol( obj.get_int( name ) ) );
+                      approximate_dB_volume_from_legacy_tile_distance_vol( obj.get_int( name ) ) + 50 );
+            obj.show_warning(
+                string_format( "legacy sound volume values used, support will be removed eventually. Recommended value: \"%s dB\"",
+                               units::to_decibel( out ) ),
+                name, true );
             return true;
         }
         if( obj.has_string( name ) ) {

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -249,70 +249,76 @@ void JsonObject::throw_error( const std::string &err ) const
     jsin->error( err );
 }
 
-void JsonObject::show_warning( const std::string &err ) const
+void JsonObject::show_warning( const std::string &err, bool debug ) const
 {
 #ifndef CATA_IN_TOOL
     try {
         throw_error( err );
     } catch( const std::exception &e ) {
-        debugmsg( "%s", e.what() );
+        debugmsg_of( debug ? DL::Debug : DL::Error, "%s", e.what() );
     }
 #else
     ( void )err;
+    ( void )debug;
 #endif // CATA_IN_TOOL
 }
 
-void JsonObject::show_warning( const std::string &err, const std::string &name ) const
+void JsonObject::show_warning( const std::string &err, const std::string &name,
+                               const bool debug ) const
 {
 #ifndef CATA_IN_TOOL
     try {
         throw_error( err, name );
     } catch( const std::exception &e ) {
-        debugmsg( "%s", e.what() );
+        debugmsg_of( debug ? DL::Debug : DL::Error, "%s", e.what() );
     }
 #else
     ( void )err;
     ( void )name;
+    ( void )debug;
 #endif // CATA_IN_TOOL
 }
 
-void JsonArray::show_warning( const std::string &err )
+void JsonArray::show_warning( const std::string &err, const bool debug )
 {
 #ifndef CATA_IN_TOOL
     try {
         throw_error( err );
     } catch( const std::exception &e ) {
-        debugmsg( "%s", e.what() );
+        debugmsg_of( debug ? DL::Debug : DL::Error, "%s", e.what() );
     }
 #else
     ( void )err;
+    ( void )debug;
 #endif // CATA_IN_TOOL
 }
 
-void JsonArray::show_warning( const std::string &err, int idx )
+void JsonArray::show_warning( const std::string &err, int idx, const bool debug )
 {
 #ifndef CATA_IN_TOOL
     try {
         throw_error( err, idx );
     } catch( const std::exception &e ) {
-        debugmsg( "%s", e.what() );
+        debugmsg_of( debug ? DL::Debug : DL::Error, "%s", e.what() );
     }
 #else
     ( void )err;
     ( void )idx;
+    ( void )debug;
 #endif // CATA_IN_TOOL
 }
 
-void JsonValue::show_warning( const std::string &err ) const
+void JsonValue::show_warning( const std::string &err, const bool debug ) const
 {
 #ifndef CATA_IN_TOOL
     try {
         throw_error( err );
     } catch( const std::exception &e ) {
-        debugmsg( "%s", e.what() );
+        debugmsg_of( debug ? DL::Debug : DL::Error, "%s", e.what() );
     }
 #else
     ( void )err;
+    ( void )debug;
 #endif // CATA_IN_TOOL
 }
 

--- a/src/json.h
+++ b/src/json.h
@@ -970,8 +970,9 @@ class JsonObject
         std::string str() const; // copy object json as string
         [[noreturn]] void throw_error( const std::string &err ) const;
         [[noreturn]] void throw_error( const std::string &err, const std::string &name ) const;
-        void show_warning( const std::string &err ) const;
-        void show_warning( const std::string &err, const std::string &name ) const;
+        void show_warning( const std::string &err, const bool debug = false ) const;
+        void show_warning( const std::string &err, const std::string &name,
+                           const bool debug = false ) const;
         // seek to a value and return a pointer to the JsonIn (member must exist)
         JsonIn *get_raw( const std::string &name ) const;
         JsonValue get_member( const std::string &name ) const;
@@ -1165,8 +1166,8 @@ class JsonArray
         [[noreturn]] void throw_error( const std::string &err, int idx );
         // See JsonIn::string_error
         [[noreturn]] void string_error( const std::string &err, int idx, int offset );
-        void show_warning( const std::string &err );
-        void show_warning( const std::string &err, int idx );
+        void show_warning( const std::string &err, const bool debug = false );
+        void show_warning( const std::string &err, int idx, const bool debug = false );
 
         // iterative access
         JsonValue next();
@@ -1294,7 +1295,7 @@ class JsonValue
         [[noreturn]] void throw_error( const std::string &err ) const {
             seek().error( err );
         }
-        void show_warning( const std::string &err ) const;
+        void show_warning( const std::string &err, const bool debug = false ) const;
 
         std::string get_string() const {
             return seek().get_string();

--- a/tests/units_test.cpp
+++ b/tests/units_test.cpp
@@ -101,8 +101,9 @@ TEST_CASE("sound parsing from JSON", "[units]") {
         legacy_sound = assign_sound_quantity("{ \"volume\": 2 }");
     });
     CHECK(warning.find("legacy sound volume values used") != std::string::npos);
+    // Legacy sounds increased by 50 so it's above ambient and thus audible
     CHECK(legacy_sound
-          == units::from_decibel(approximate_dB_volume_from_legacy_tile_distance_vol(2)));
+          == units::from_decibel(approximate_dB_volume_from_legacy_tile_distance_vol(2) + 50));
 }
 
 TEST_CASE("energy parsing from JSON", "[units]") {


### PR DESCRIPTION
## Purpose of change (The Why)
Stop the complaining

## Describe the solution (The How)
Make them debug debug messages
Make sound messages contain recommended dB values

## Describe alternatives you've considered
None

## Testing
Debug logging off ( default off ) -> No warning
Debug logging on -> warning

## Additional context
This also improves default migrated sound values, makes them include rough ambient ( 50 ) in their value

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7e40079](https://github.com/cataclysmbn/Cataclysm-BN/commit/7e40079e383aefafac3386720c64a8627d9e9079) (whhhhhhhhhyyyyyyyyyyy) on 2026-09-09 19:25:57

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34381802053/artifacts/10118364101)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34381802053/artifacts/10119756353)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34381802053/artifacts/10118404570)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34381802053/artifacts/10121003515)
<!-- END artifact comment -->