### PR TITLE
fix(UI): remove double `(wet)` tag from wet towels

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1907,7 +1907,7 @@
     "to_hit": -1,
     "revert_to": "towel",
     "use_action": "TOWEL",
-    "flags": [ "WET", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ],
+    "flags": [ "OVERSIZE", "ALLOWS_TAIL_SNAKE" ],
     "coverage": 50,
     "material_thickness": 1
   },

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1885,7 +1885,7 @@
     "to_hit": -1,
     "revert_to": "towel",
     "use_action": "TOWEL",
-    "flags": [ "WET", "OVERSIZE", "ALLOWS_TAIL_SNAKE" ],
+    "flags": [ "OVERSIZE", "ALLOWS_TAIL_SNAKE" ],
     "coverage": 50,
     "material_thickness": 1
   },


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Smol fix for a UI goof:
<img width="233" height="85" alt="image" src="https://github.com/user-attachments/assets/0f65c124-5c23-42f5-94df-9e91c6a541ad" />

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Removed `WET` flag from `towel_wet` because it already gets that flag dynamically via code fuckery.

## Describe alternatives you've considered

Explode.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Load-tested in compiled test build.
2. Dunked myself in water and used a towel.
3. Correctly get a `towel (wet)`
4. Use action still has it say it's too wet to use.
5. Waited, towel indeed dries off.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [ffbba00](https://github.com/cataclysmbn/Cataclysm-BN/commit/ffbba006fc32b7841a9de7702257638e4dde6e82) (Cock exploder 5000) on 2026-09-09 18:01:01

- [❌ Linux tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34386039017)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34386039017)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34386039017)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34386039017)
<!-- END artifact comment -->