### PR TITLE
fix: allow UPS toggle mod to work on tools without an activate menu

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1834,6 +1834,7 @@
     "id": "ADD_UPS_TOGGLE",
     "type": "json_flag",
     "context": [  ],
+    "inherit": true,
     "use_method": "TOGGLE_UPS_CHARGING"
   },
   {

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1833,7 +1833,8 @@
   {
     "id": "ADD_UPS_TOGGLE",
     "type": "json_flag",
-    "context": [  ]
+    "context": [  ],
+    "use_method": "TOGGLE_UPS_CHARGING"
   },
   {
     "id": "IS_UPS",

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -10,7 +10,7 @@
   "craft_inherit": true, // Items made with it will keep this flag
   "requires_flag": true, // Used by vehicle part flags, requires another part with this ID on the tile
   "inherit": true, // Item mods will pass this flag down to the item
-  "use_method": "USE_METHOD_ID", // Use method this flag injects when present on a mod but not the base item
+  "use_method": "USE_METHOD_ID", // This flag gives the connected item this use method if it doesn't already have it
   "tag": "string" // Translatable string appended to the item's UI display name, if the item has this flag
 }
 ```
@@ -24,13 +24,7 @@
 - Many of the flags intended for one category or item type, can be used in other categories or item
   types. Experiment to see where else flags can be used.
 - Offensive and defensive flags can be used on any item type that can be wielded.
-- `use_method` lets a flag inject a use method (an activate-menu action) into an item that does not
-  have one of its own. When the flag is present on an attached mod (gun or tool) but not on the base
-  item, the named use method is added to the item's activate menu. The value must be a valid use
-  method ID (e.g. `TOGGLE_UPS_CHARGING`). For the flag to propagate from the mod to the item it must
-  also be marked `"inherit": true`. Example: `ADD_UPS_TOGGLE` declares
-  `"use_method": "TOGGLE_UPS_CHARGING"` so the UPS battery conversion mod adds a UPS-charging toggle
-  to tools like the electrohack that have no activate menu of their own.
+- `use_method` needs to be on the item, so if it's on a mod flag, that flag also needs to set inherit to true.
 
 ## Inheritance
 

--- a/docs/en/mod/json/reference/json_flags.md
+++ b/docs/en/mod/json/reference/json_flags.md
@@ -10,6 +10,7 @@
   "craft_inherit": true, // Items made with it will keep this flag
   "requires_flag": true, // Used by vehicle part flags, requires another part with this ID on the tile
   "inherit": true, // Item mods will pass this flag down to the item
+  "use_method": "USE_METHOD_ID", // Use method this flag injects when present on a mod but not the base item
   "tag": "string" // Translatable string appended to the item's UI display name, if the item has this flag
 }
 ```
@@ -23,6 +24,13 @@
 - Many of the flags intended for one category or item type, can be used in other categories or item
   types. Experiment to see where else flags can be used.
 - Offensive and defensive flags can be used on any item type that can be wielded.
+- `use_method` lets a flag inject a use method (an activate-menu action) into an item that does not
+  have one of its own. When the flag is present on an attached mod (gun or tool) but not on the base
+  item, the named use method is added to the item's activate menu. The value must be a valid use
+  method ID (e.g. `TOGGLE_UPS_CHARGING`). For the flag to propagate from the mod to the item it must
+  also be marked `"inherit": true`. Example: `ADD_UPS_TOGGLE` declares
+  `"use_method": "TOGGLE_UPS_CHARGING"` so the UPS battery conversion mod adds a UPS-charging toggle
+  to tools like the electrohack that have no activate menu of their own.
 
 ## Inheritance
 

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1553,10 +1553,8 @@ bool avatar::invoke_item( item *used, const tripoint_bub_ms &pt )
 {
     std::map<std::string, use_function> use_methods;
     use_methods.insert( used->type->use_methods.begin(), used->type->use_methods.end() );
-    // Make sure the flag is that of the mod, not of the item being used :P
-    if( used->has_flag( flag_ADD_UPS_TOGGLE ) && !used->type->has_flag( flag_ADD_UPS_TOGGLE ) ) {
-        use_methods["TOGGLE_UPS_CHARGING"] = item_controller->usage_from_string( "TOGGLE_UPS_CHARGING" );
-    }
+    const auto flag_injected = used->get_flag_injected_use_methods();
+    use_methods.insert( flag_injected.begin(), flag_injected.end() );
     if( use_methods.empty() ) {
         return false;
     } else if( use_methods.size() == 1 ) {

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -586,7 +586,7 @@ void use_item( avatar &you, item &used )
     you.last_item = used.typeId();
 
     if( used.is_tool() ) {
-        if( !used.type->has_use() ) {
+        if( !used.has_use() ) {
             add_msg( _( "You can't do anything interesting with your %s." ), used.tname() );
             return;
         }

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -585,24 +585,17 @@ void use_item( avatar &you, item &used )
 
     you.last_item = used.typeId();
 
-    if( used.is_tool() ) {
-        if( !used.has_use() ) {
-            add_msg( _( "You can't do anything interesting with your %s." ), used.tname() );
-            return;
-        }
+    // medication has special logic in consume, so it shouldn't be passed to invoke even though it has an iuse
+    if( used.has_use() && !used.is_medication() ) {
         if( used.has_flag( flag_TEMPORARY_ITEM ) ) {
             you.invoke_item( &used );
-        } else {
-            you.invoke_item( &used, used.bub_pos() );
         }
-
-    } else if( is_pet_food( used ) ) {
         you.invoke_item( &used, used.bub_pos() );
 
     } else if( !used.is_container_empty() && is_pet_food( used.get_contained() ) ) {
         unload_item( you, used );
 
-    } else if( !used.is_craft() && ( used.is_medication() || ( !used.type->has_use() &&
+    } else if( !used.is_craft() && ( used.is_medication() || ( !used.has_use() &&
                                      ( used.is_food() ||
                                        used.get_contained().is_food() ||
                                        used.get_contained().is_medication() ) ) ) ) {
@@ -610,8 +603,6 @@ void use_item( avatar &you, item &used )
 
     } else if( used.is_book() ) {
         you.read( &used );
-    } else if( used.type->has_use() ) {
-        you.invoke_item( &used, used.bub_pos() );
     } else if( used.has_flag( flag_SPLINT ) ) {
         ret_val<bool> need_splint = you.can_wear( used );
         if( need_splint.success() ) {

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -422,6 +422,7 @@ void json_flag::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "taste_mod", taste_mod_ );
     optional( jo, was_loaded, "restriction", restriction_ );
     optional( jo, was_loaded, "tag", tag_ );
+    optional( jo, was_loaded, "use_method", use_method_ );
 
     // FIXME: most flags have a "context" field that isn't used for anything
     // Test for it here to avoid errors about unvisited members

--- a/src/flag.h
+++ b/src/flag.h
@@ -451,6 +451,11 @@ class json_flag
             return taste_mod_;
         }
 
+        /** The use method this flag injects when present on a mod but not the base item */
+        std::string use_method() const {
+            return use_method_;
+        }
+
         /** Is this a valid (non-null) flag */
         operator bool() const;
 
@@ -472,6 +477,7 @@ class json_flag
         std::string requires_flag_;
         translation tag_;
         int taste_mod_ = 0;
+        std::string use_method_;
 
         /** Load flag definition from JSON */
         void load( const JsonObject &jo, const std::string &src );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -870,7 +870,7 @@ class activatable_inventory_preset : public pickup_inventory_preset
                 ( *loc ).get_contained().type->has_use() ) {
                 return true;
             }
-            return loc->type->has_use();
+            return loc->has_use();
         }
 
         std::string get_denial( const item *loc ) const override {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9131,33 +9131,29 @@ bool item::has_use() const
 auto item::get_flag_injected_use_methods() const -> std::map<std::string, use_function>
 {
     auto result = std::map<std::string, use_function> {};
-    // Collect flags from the item itself and its attached mods (guns or tools).
     auto candidate_flags = item_tags;
     auto mods = is_gun() ? gunmods() : toolmods();
+
+    // There's similar logic in has_flag, but it uses scary recursion and a nested function. Also, 
+    // it checks if a specific flag exists on an item, where this method GETS all the flags on
+    // an item
     for( const item *mod : mods ) {
-        // A mod's flags live on its type (e.g. "flags": [ ... ] in the TOOLMOD JSON),
-        // not on the mod instance. Mirror item::has_flag, which checks both the mod's
-        // type flags and its instance flags.
         for( const flag_id &f : mod->type->item_tags ) {
-            if( json_flag::get( f.str() ).inherit() ) {
+            if( f->inherit() ) {
                 candidate_flags.insert( f );
             }
         }
         for( const flag_id &f : mod->item_tags ) {
-            if( json_flag::get( f.str() ).inherit() ) {
+            if( f->inherit() ) {
                 candidate_flags.insert( f );
             }
         }
     }
     for( const flag_id &f : candidate_flags ) {
-        if( type->has_flag( f ) ) {
+        if( type->has_flag( f ) || f->use_method().empty() ) {
             continue;
         }
-        const auto &def = json_flag::get( f.str() );
-        if( def.use_method().empty() ) {
-            continue;
-        }
-        result[def.use_method()] = item_controller->usage_from_string( def.use_method() );
+        result[f->use_method()] = item_controller->usage_from_string( f->use_method() );
     }
     return result;
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9135,6 +9135,14 @@ auto item::get_flag_injected_use_methods() const -> std::map<std::string, use_fu
     auto candidate_flags = item_tags;
     auto mods = is_gun() ? gunmods() : toolmods();
     for( const item *mod : mods ) {
+        // A mod's flags live on its type (e.g. "flags": [ ... ] in the TOOLMOD JSON),
+        // not on the mod instance. Mirror item::has_flag, which checks both the mod's
+        // type flags and its instance flags.
+        for( const flag_id &f : mod->type->item_tags ) {
+            if( json_flag::get( f.str() ).inherit() ) {
+                candidate_flags.insert( f );
+            }
+        }
         for( const flag_id &f : mod->item_tags ) {
             if( json_flag::get( f.str() ).inherit() ) {
                 candidate_flags.insert( f );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9125,7 +9125,15 @@ void item::gun_cycle_mode()
 
 bool item::has_use() const
 {
-    return type->has_use();
+    if( type->has_use() ) {
+        return true;
+    }
+    // Mod flags can inject use methods not present on the type itself.
+    // e.g. ADD_UPS_TOGGLE (from battery_ups_toggle mod) → TOGGLE_UPS_CHARGING
+    if( has_flag( flag_ADD_UPS_TOGGLE ) && !type->has_flag( flag_ADD_UPS_TOGGLE ) ) {
+        return true;
+    }
+    return false;
 }
 
 const use_function *item::get_use( const std::string &use_name ) const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9134,7 +9134,7 @@ auto item::get_flag_injected_use_methods() const -> std::map<std::string, use_fu
     auto candidate_flags = item_tags;
     auto mods = is_gun() ? gunmods() : toolmods();
 
-    // There's similar logic in has_flag, but it uses scary recursion and a nested function. Also, 
+    // There's similar logic in has_flag, but it uses scary recursion and a nested function. Also,
     // it checks if a specific flag exists on an item, where this method GETS all the flags on
     // an item
     for( const item *mod : mods ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9125,15 +9125,33 @@ void item::gun_cycle_mode()
 
 bool item::has_use() const
 {
-    if( type->has_use() ) {
-        return true;
+    return type->has_use() || !get_flag_injected_use_methods().empty();
+}
+
+auto item::get_flag_injected_use_methods() const -> std::map<std::string, use_function>
+{
+    auto result = std::map<std::string, use_function> {};
+    // Collect flags from the item itself and its attached mods (guns or tools).
+    auto candidate_flags = item_tags;
+    auto mods = is_gun() ? gunmods() : toolmods();
+    for( const item *mod : mods ) {
+        for( const flag_id &f : mod->item_tags ) {
+            if( json_flag::get( f.str() ).inherit() ) {
+                candidate_flags.insert( f );
+            }
+        }
     }
-    // Mod flags can inject use methods not present on the type itself.
-    // e.g. ADD_UPS_TOGGLE (from battery_ups_toggle mod) → TOGGLE_UPS_CHARGING
-    if( has_flag( flag_ADD_UPS_TOGGLE ) && !type->has_flag( flag_ADD_UPS_TOGGLE ) ) {
-        return true;
+    for( const flag_id &f : candidate_flags ) {
+        if( type->has_flag( f ) ) {
+            continue;
+        }
+        const auto &def = json_flag::get( f.str() );
+        if( def.use_method().empty() ) {
+            continue;
+        }
+        result[def.use_method()] = item_controller->usage_from_string( def.use_method() );
     }
-    return false;
+    return result;
 }
 
 const use_function *item::get_use( const std::string &use_name ) const

--- a/src/item.h
+++ b/src/item.h
@@ -22,6 +22,7 @@
 #include "game_object.h"
 #include "gun_mode.h"
 #include "io_tags.h"
+#include "iuse.h" // use_function
 #include "item_contents.h"
 #include "kill_tracker.h"
 #include "location_vector.h"
@@ -2263,6 +2264,11 @@ class item : public location_visitable<item>, public game_object<item>
          * Returns true if the item has any use function.
          */
         bool has_use() const;
+        /**
+         * Returns use methods injected by flags present on this item (or its mods)
+         * but not on the item type itself, as declared via the flag's "use_method" field.
+         */
+        auto get_flag_injected_use_methods() const -> std::map<std::string, use_function>;
         /**
          * Returns the pointer to use_function with name use_name assigned to the type of
          * this item or any of its contents. Checks contents recursively.


### PR DESCRIPTION

## Purpose of change (The Why)

Closes #9613.

So the electrohack counts as a tool, but it doesn't actually have an iuse by itself, so the check for uses short circuited before checking for uses added by mods. This meant that an electrohack with a mod that ADDS an iuse like the ups battery conversion mod couldn't toggle charging.

## Describe the solution (The How)

Because the check for TOGGLE_UPS_CHARGING was hardcoded in invoke_item, and use_item was checking item.type::has_use, and item::has_use just called item.type::has_use, I decided to add some extra logic into the item has_use to check if the item has an iuse, or if an item has a flag that adds an iuse. 

Right now, the only thing that was being manually checked for was the ups battery conversion mod, but to make it easier to add similar mods in the future, or just flags that add use effects, I added a field to the flag type which maps to an iuse string, so you can just include that field when you're defining a flag and it should automatically get picked up. Note that inherit also has to be set to true so the item the mod is on technically has the flag on it and not the mod.

Another plus to this method is that you can connect a flag with an iuse now without making any c++ changes! (as long as the iuse already exists)

## Describe alternatives you've considered

- Change item.type has_use checks to just item has_use since they were a bit redundant, and then add a check there for the ups toggle flag, but that would duplicate the logic in avatar.cpp and now there would be two lists to update if you wanted to add another mod like this.

## Testing

- be me
- set all skills to 10
- spawn in  ups, electrohack, ups battery mod, and flashlight
- put battery from electrohack into flashlight
- turn on flashlight and wait 30 minutes
- apply mod to electrohack
- press "a" key to open use menu
- mrw
<img width="785" height="395" alt="Screenshot from 2026-09-09 22-21-47" src="https://github.com/user-attachments/assets/6dcc5d14-9557-4006-bcc4-4d1a256f44b3" />
<img width="336" height="58" alt="Screenshot from 2026-09-09 22-22-40" src="https://github.com/user-attachments/assets/3d277147-1205-41b8-8a89-4d6f755e00cf" />
<img width="564" height="380" alt="Screenshot from 2026-09-09 22-23-18" src="https://github.com/user-attachments/assets/53e759b6-6a1e-4a46-b050-76808e1b72a0" />

I also made sure that the ups battery mod worked on a flashlight, which already has an iuse, and confirmed it worked with no issues. The menu just listed the turn flashlight on action as "transform", which is just what that action is actually named. It just doesn't come up that often because the flashlight usually skips the action menu since it only has the one by default.

**UPDATE:** After updating the decision tree in use item, I retested the above and also tested pet food, and temporary items using the integrated tool set. Nothing seemed broken that I could tell.

## Additional context

- Related source PRs: #4775 (added the `TOGGLE_UPS_CHARGING` action and the UPS battery conversion mod) and #6125 (UPS charge on/off for tools). This PR generalizes the flag→use-method injection that those relied on.
- Documented the new `use_method` flag field in `docs/en/mod/json/reference/json_flags.md`
  (added to the example `json_flag` block and explained in the Notes section, including the
  `inherit: true` requirement and the `ADD_UPS_TOGGLE` example).

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet. -- The flag should be covered by data/json, but I'm leaving this on for awareness and also because I'm not sure what to do about the flags doc
<!-- BEGIN docs comment -->

## Translations

| post                             | changed | stale  | missing |
| -------------------------------- | ------- | ------ | ------- |
| mod/json/reference/json_flags.md | en      | ja, ko |         |

<!-- END docs comment -->

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [9092bfd](https://github.com/cataclysmbn/Cataclysm-BN/commit/9092bfdb6265e0cdce5b87fb2bddd85496859332) (Merge branch 'main' into pr/10214) on 2026-09-13 23:16:46

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784596870/artifacts/10327396822)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784596870/artifacts/10327118143)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784596870/artifacts/10327268162)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784596870/artifacts/10327400919)
<!-- END artifact comment -->