### PR TITLE
fix: fix `noise_modifier` when below or at 1

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12926,7 +12926,17 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
         !u.has_enchantment_flag( enchantment_flag_id( "SILENT" ) ) ) {
         int volume = u.is_stealthy() ? 40 : 60;
         // Used to be a multiplier on tile distance, this approximates that
-        volume += ( u.mutation_value( "noise_modifier" ) / 2 * 6 );
+        double noisemod = u.mutation_value( "noise_modifier" );
+        if( noisemod < 1 ) {
+            // Just in case someone goes below 0...
+            if( noisemod == 0 ) {
+                volume = 0;
+            } else if( noisemod > 0 ) {
+                volume -= ( 3.0 / noisemod );
+            }
+        } else {
+            volume += ( ( noisemod - 1 ) * 6.0 );
+        }
         volume += u.bonus_from_enchantments( volume, enchantment_value_id( "NOISE" ) );
         if( volume > 0 ) {
             if( u.movement_mode_is( CMM_RUN ) ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Caused by #10204 
Extension of #10016 

## Describe the solution (The How)
#10016 just taped over it, so I changed the formula in #10204
Made some mistakes; 1 ( the default ) increased it slightly, 0 didn't change, and 3 was slightly underpowered

## Describe alternatives you've considered
None

## Testing
Noises look much more reasonable, 6 ~= double

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5478e01](https://github.com/cataclysmbn/Cataclysm-BN/commit/5478e01b91eb84ccc37afd7ebad51a6f42e52d2b) (fix: fix `noise_modifier` when below or at 1) on 2026-09-10 18:37:23

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34500979317/artifacts/10163782864)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34500979317)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34500979317/artifacts/10162387059)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34500979317/artifacts/10162502069)
<!-- END artifact comment -->