### PR TITLE
feat(balance): add partial resting status to various waiting or leisure activities

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -117,7 +117,8 @@
     "verb": "fishing",
     "special": true,
     "auto_needs": true,
-    "bubble_size_effect": "mobile"
+    "bubble_size_effect": "mobile",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_GENERIC_GAME",
@@ -125,7 +126,8 @@
     "verb": "playing",
     "rooted": true,
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_GAME",
@@ -133,7 +135,8 @@
     "verb": "playing",
     "rooted": true,
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_WAIT",
@@ -144,7 +147,8 @@
     "refuel_fires": true,
     "auto_needs": true,
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_WASH_SELF",
@@ -153,7 +157,8 @@
     "rooted": true,
     "no_resume": true,
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_CRAFT",
@@ -347,7 +352,8 @@
     "verb": "socializing",
     "rooted": true,
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_WAIT_WEATHER",
@@ -357,7 +363,8 @@
     "no_resume": true,
     "auto_needs": true,
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_FIRSTAID",
@@ -373,8 +380,9 @@
     "rooted": true,
     "suspendable": false,
     "complex_moves": { "light": true, "morale": true, "speed": true, "skills": [ [ "survival" ] ], "stats": [ [ "PER" ] ] },
-    "bubble_size_effect": "idle"
-  },
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
+    },
   {
     "id": "ACT_PICKAXE",
     "type": "activity_type",
@@ -423,7 +431,8 @@
     "type": "activity_type",
     "verb": "training",
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_MAKE_ZLAVE",
@@ -693,7 +702,8 @@
     "rooted": true,
     "no_resume": true,
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_WAIT_STAMINA",
@@ -702,7 +712,8 @@
     "rooted": true,
     "no_resume": true,
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_CLEAR_RUBBLE",
@@ -717,7 +728,8 @@
     "verb": "meditating",
     "rooted": true,
     "complex_moves": { "speed": true, "stats": [ [ "INT" ] ] },
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_HACKSAW",
@@ -834,7 +846,8 @@
     "suspendable": false,
     "complex_moves": { "speed": true, "stats": [ [ "INT" ] ] },
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_OPERATION",
@@ -867,7 +880,8 @@
     "suspendable": false,
     "no_resume": true,
     "verbose_tooltip": false,
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_EAT_MENU",
@@ -907,7 +921,8 @@
     "rooted": true,
     "no_resume": true,
     "complex_moves": { "speed": true },
-    "bubble_size_effect": "idle"
+    "bubble_size_effect": "idle",
+    "rest_amount": 0.2
   },
   {
     "id": "ACT_CONSUME_DRINK_MENU",

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -77,6 +77,7 @@ void activity_type::load( const JsonObject &jo )
     assign( jo, "auto_needs", result.auto_needs, false );
     assign( jo, "morale_blocked", result.morale_blocked_, false );
     assign( jo, "verbose_tooltip", result.verbose_tooltip_, false );
+    assign( jo, "rest_amount", result.rest_amount_, false);
     result.bubble_effect_ = jo.get_enum_value<activity_bubble_effect>( "bubble_size_effect",
                             activity_bubble_effect::none );
     if( jo.has_member( "complex_moves" ) ) {

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -93,6 +93,7 @@ class activity_type
         bool morale_blocked_ = false;
         bool verbose_tooltip_ = true;
         unsigned short max_assistants_ = 0;
+        float rest_amount_ = 0.0f;
         activity_bubble_effect bubble_effect_ = activity_bubble_effect::none;
 
     public:
@@ -159,6 +160,9 @@ class activity_type
         }
         inline bool verbose_tooltip() const {
             return verbose_tooltip_;
+        }
+        inline float rest_amount() const { 
+            return rest_amount_;
         }
         inline activity_bubble_effect bubble_effect() const {
             return bubble_effect_;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7573,9 +7573,20 @@ float Character::mutation_armor( bodypart_id bp, const damage_unit &du ) const
 
 float Character::rest_quality() const
 {
-    // Just a placeholder for now.
-    // TODO: Waiting/reading/being unconscious on bed/sofa/grass
-    return has_effect( effect_sleep ) ? 1.0f : 0.0f;
+    // TODO: Make comfort (bed, sofa, blankets, etc) contribute to rest, both while asleep and awake
+	float rest_rate = 0.0f;
+	const float activity_rest = activity->get_rest_amount();
+	
+	if( activity_rest > 0.0f ) {
+		rest_rate += activity_rest;
+	}
+	
+	if( has_effect ( effect_sleep ) ) {
+        // Can be reduced below 1 once comfort is involved
+		rest_rate += 1.0f;
+	}
+	
+    return clamp( rest_rate, 0.0f, 1.0f );
 }
 
 bodypart_str_id Character::bp_to_hp( const bodypart_str_id &bp )

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -167,6 +167,10 @@ class player_activity
             return type->verb();
         }
 
+        const float &get_rest_amount() const { 
+            return type->rest_amount();
+        }
+
         int get_value( size_t index, int def = 0 ) const;
         std::string get_str_value( size_t index, const std::string &def = "" ) const;
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->
When heavily injured, the player often wants to rest away from danger to recover. Unintuitively though, you heal just as slowly when sitting on your couch at home reading a book as you do while actively in combat, with the only functional rest being full on sleep.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Added a resting value (0.2 for now, or 20%) to various downtime or leisure activities, such as reading, fishing, and waiting. This will give a portion of the same healing that sleep already gives. This value is set per activity in player_activities.json so it can be easily added, removed, or modified for any given activity.

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->
I loaded in a fresh, unmutated character who had no regeneration capabilities, set their HP to 10, and waited 24 hours multiple times. Their HP recovery per 24 hour period was consistently around the expected value of ~3.5 for an activity that is 20% restful.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [bf9a3a4](https://github.com/cataclysmbn/Cataclysm-BN/commit/bf9a3a4166f7742c657436e9f0a3687d17517509) (Adding rest values to several activities, and a way to check for said rest values from the json.) on 2026-09-11 07:39:42

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34570136941/artifacts/10188248935)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34570136941/artifacts/10188819220)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34570136941/artifacts/10188301164)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34570136941/artifacts/10188173013)
<!-- END artifact comment -->