### PR TITLE
fix: stop lockpicking autosave from reporting an invalid tool

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1780,7 +1780,7 @@ void lockpick_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "progress", progress );
     jsout.member( "moves_total", moves_total );
     jsout.member( "lockpick", lockpick );
-    jsout.member( "fake_lockpick", fake_lockpick );
+    jsout.member( "fake_lockpick", fake_lockpick ? *fake_lockpick : null_item_reference() );
     jsout.member( "target", target );
 
     jsout.end_object();

--- a/src/json.h
+++ b/src/json.h
@@ -20,6 +20,7 @@
 #include "memory_fast.h"
 #include "string_id.h"
 #include "detached_ptr.h"
+#include "location_ptr.h"
 #include "safe_reference.h"
 #include "cata_arena.h"
 #include "cata_utility.h"
@@ -692,12 +693,12 @@ class JsonOut
 
         template<typename T>
         void write( const location_ptr<T, true> &v ) {
-            write( *v );
+            write( v.get_or_null() );
         }
 
         template<typename T>
         void write( const location_ptr<T, false> &v ) {
-            write( *v );
+            write( v.get_or_null() );
         }
 
         template<typename T>

--- a/src/location_ptr.cpp
+++ b/src/location_ptr.cpp
@@ -141,6 +141,15 @@ T *location_ptr<T, error_if_null>::get() const
 }
 
 template<typename T, bool error_if_null>
+auto location_ptr<T, error_if_null>::get_or_null() const -> T &
+{
+    if( ptr ) {
+        return *ptr;
+    }
+    return null_item_reference();
+}
+
+template<typename T, bool error_if_null>
 location_ptr<T, error_if_null>::operator bool() const
 {
     return !!*this;

--- a/src/location_ptr.h
+++ b/src/location_ptr.h
@@ -38,6 +38,8 @@ class location_ptr
         detached_ptr<T> release();
 
         T *get() const;
+        /// Returns the object, or the item null sentinel if empty, without debugmsg.
+        auto get_or_null() const -> T &; // *NOPAD*
 
         explicit operator bool() const;
 

--- a/tests/lockpick_activity_test.cpp
+++ b/tests/lockpick_activity_test.cpp
@@ -1,0 +1,71 @@
+#include "activity_actor_definitions.h"
+#include "avatar.h"
+#include "catch/catch.hpp"
+#include "debug.h"
+#include "item.h"
+#include "json.h"
+#include "player_activity.h"
+#include "player_helpers.h"
+#include "state_helpers.h"
+#include "type_id.h"
+
+#include <sstream>
+#include <string>
+
+static const itype_id itype_picklocks("picklocks");
+static const itype_id itype_pseudo_bio_picklock("pseudo_bio_picklock");
+
+static auto serialize_activity(const player_activity& act) -> std::string {
+    auto os = std::ostringstream();
+    auto jsout = JsonOut(os);
+    act.serialize(jsout);
+    return os.str();
+}
+
+TEST_CASE(
+    "lockpick activity autosave does not resolve empty fake lockpick",
+    "[activity][lockpick][save]") {
+    clear_all_state();
+    const auto cleanup = on_out_of_scope([]() { clear_all_state(); });
+    clear_avatar();
+
+    avatar& dummy = get_avatar();
+    item& lockpick = dummy.i_add(item::spawn(itype_picklocks));
+    REQUIRE_FALSE(lockpick.is_null());
+
+    auto act = player_activity(lockpick_activity_actor::use_item(100, lockpick, dummy.abs_pos()));
+    REQUIRE(act.id() == activity_id("ACT_LOCKPICK"));
+
+    std::string saved;
+    const auto debug = capture_debugmsg_during([&]() { saved = serialize_activity(act); });
+
+    CHECK(debug.find("Attempted to resolve invalid location_ptr") == std::string::npos);
+    REQUIRE_FALSE(saved.empty());
+
+    auto iss = std::istringstream(saved);
+    auto jsin = JsonIn(iss);
+    auto loaded = player_activity();
+    const auto load_debug = capture_debugmsg_during([&]() { loaded.deserialize(jsin); });
+    CHECK(load_debug.find("Attempted to resolve invalid location_ptr") == std::string::npos);
+    CHECK(loaded.id() == activity_id("ACT_LOCKPICK"));
+}
+
+TEST_CASE(
+    "bionic lockpick activity serializes fake lockpick without debugmsg",
+    "[activity][lockpick][save]") {
+    clear_all_state();
+    const auto cleanup = on_out_of_scope([]() { clear_all_state(); });
+    clear_avatar();
+
+    avatar& dummy = get_avatar();
+    auto act = player_activity(lockpick_activity_actor::use_bionic(
+        item::spawn(itype_pseudo_bio_picklock), dummy.abs_pos()));
+    REQUIRE(act.id() == activity_id("ACT_LOCKPICK"));
+
+    std::string saved;
+    const auto debug = capture_debugmsg_during([&]() { saved = serialize_activity(act); });
+
+    CHECK(debug.find("Attempted to resolve invalid location_ptr") == std::string::npos);
+    REQUIRE_FALSE(saved.empty());
+    CHECK(saved.find("pseudo_bio_picklock") != std::string::npos);
+}


### PR DESCRIPTION
## Purpose of change (The Why)

Autosave during lockpicking popped `Attempted to resolve invalid location_ptr` from `location_ptr::get`.

`lockpick_activity_actor` holds either a real lockpick (`safe_reference`) or a bionic fake item (`location_ptr`). Item lockpicking leaves `fake_lockpick` empty. `JsonOut::write` still did `write(*v)`, which debugmsgs on a required location_ptr.

Caught on BN `c11dff5` while lockpicking: `game::autosave` → `execute_activity_fixed_window_skip` → `lockpick_activity_actor::serialize`. World `Nu Eto F5_copy`.

## Describe the solution (The How)

- Serialize empty `fake_lockpick` the same way as `aim_activity_actor::fake_weapon`: write the item null sentinel instead of dereferencing.
- JSON write of `location_ptr` uses `get_or_null()` so an empty pointer does not debugmsg.

## Describe alternatives you've considered

Skipping the empty `fake_lockpick` field would need a matching load path. Used the same null-sentinel write as `aim_activity_actor`.

## Testing

Catch2 `[lockpick]`: 10 assertions in 2 cases (`cata_test-tiles.exe "[lockpick]" --rng-seed 1`, `CATA_TEST_COMPUTE_ACCELERATION=cpu`). Item lockpick serialize/load and bionic fake-item serialize do not emit `invalid location_ptr`.

## Additional context

## Checklist

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [fdb48cb](https://github.com/cataclysmbn/Cataclysm-BN/commit/fdb48cbf2a4251f976b2ddc4dc5c75887b90240a) (chore: refresh PR head) on 2026-09-12 08:26:57

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34680430698/artifacts/10294856036)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34680430698)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34680430698)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34680430698)
<!-- END artifact comment -->