### PR TITLE
fix: MGOAL_GO_TO and MGOAL_GO_TO_TYPE now properly complete themselves

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13218,6 +13218,17 @@ auto game::place_player( const tripoint_bub_ms &dest_loc ) -> point_rel_sm
     }
     const auto submap_shift = ( m.get_abs_sub() - origin_before_setpos );
 
+    if( submap_shift != point_rel_sm() ) {
+        for( mission *miss : u.get_active_missions() ) {
+            const auto goal = miss->get_type().goal;
+            if( goal == MGOAL_GO_TO_TYPE || goal == MGOAL_GO_TO ) {
+                if( miss->is_complete( u.getID() ) ) {
+                    miss->wrap_up();
+                }
+            }
+        }
+    }
+
     //Auto pulp or butcher and Auto foraging
     if( get_option<bool>( "AUTO_FEATURES" ) && mostseen == 0  && !u.is_mounted() ) {
         ZoneScopedN( "place_player_auto_features" );


### PR DESCRIPTION
## Purpose of change (The Why)
Reported by dedmem

## Describe the solution (The How)
On submap shift, check if player is in correct submap

## Describe alternatives you've considered
None

## Testing
Last flight scenario mission was completeable
Will need someone more knowledgeable is missions to make sure I did this right.

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [5efb020](https://github.com/cataclysmbn/Cataclysm-BN/commit/5efb0202c8945d3361c2424a6d5e22b2097fca83) (fix: MGOAL_GO_TO and MGOAL_GO_TO_TYPE now properly complete themselves) on 2026-09-11 16:36:02

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34615627625/artifacts/10270787143)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34615627625/artifacts/10270409923)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34615627625/artifacts/10270747846)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34615627625/artifacts/10270452684)
<!-- END artifact comment -->