### PR TITLE
feat: new hub01 physics lab mission, misc hub01 quest cleanup, revert MGOAL_GO_TO "fix"

### DIFF
--- a/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
+++ b/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
@@ -41,7 +41,7 @@
     "id": "MISSION_ROBOFAC_INTERCOM_1",
     "type": "mission_definition",
     "name": { "str": "Return Field Data" },
-    "description": "Investigate a nearby field and return with Dr. Prado and the robot prototype she was testing.  Failing that, retrieve the I/O recorder stored within the robot.  If the robot remains operational, avoid direct confrontation and use EMP grenades to disable it.",
+    "description": "Investigate a <color_red>nearby field</color> and return with Dr. Prado and the robot prototype she was testing.  Failing that, retrieve the <color_light_blue>I/O recorder</color> stored within the robot.  If the robot remains operational, avoid direct confrontation and use EMP grenades to disable it.",
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 5,
     "item": "robofac_test_data",
@@ -106,8 +106,8 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_2",
     "type": "mission_definition",
-    "name": { "str": "Steal a dead man's mind" },
-    "description": "Find the corpse of a Hub 01's AI researcher and use the mind splicer kit to recover the memories stored inside their memory implant.",
+    "name": { "str": "Steal a Dead Man's Mind" },
+    "description": "Find the corpse of Hub 01's head AI researcher at the <color_red>ambushed convoy</color>, use the mind splicer kit to recover the memories stored inside their memory implant, and copy them onto the <color_light_blue>data card</color>.",
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 5,
     "item": "mind_scan_robofac",
@@ -128,7 +128,7 @@
           "place_nested": [ { "chunks": [ "robofac_hq_surface_merc_1" ], "x": 3, "y": 10 } ]
         }
       ],
-      "effect": [ { "u_buy_item": "RobofacCoin", "count": 2 } ]
+      "effect": [ { "u_buy_item": "RobofacCoin", "count": 2 }, { "u_sell_item": "mind_splicer" }, { "u_sell_item": "data_card" } ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
@@ -140,7 +140,7 @@
       "rejected": "Yes, we recognize that our request is exceptional.  Return if you change your mind.",
       "advice": "You do know what a memory unit looks like, right?  Matte gray, pill-sized, right in front of the corpus callosum.  We suggest a forceps through the eye socket, shaking slightly, then slowly and carefully…",
       "inquire": "Do you have the scan?",
-      "success": "You have our thanks and payment.",
+      "success": "You have our thanks and payment.  We will need the mind splicer back though.",
       "success_lie": "What good does this do us?",
       "failure": "Simply useless…"
     }
@@ -148,12 +148,12 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_3",
     "type": "mission_definition",
-    "name": { "str": "Light retrieval" },
-    "description": "Reach the collapsed tower basement, and search the ruins for a photonic circuitry template.  The intercom warned you about heavy enemy presence, and of the existence of a hazardous environment.",
+    "name": { "str": "Light Retrieval" },
+    "description": "Reach the <color_red>collapsed tower basement</color>, and search the ruins for a <color_light_blue>photonic circuitry template</color>.  The intercom warned you about heavy enemy presence, and of the existence of a hazardous environment.",
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 5,
     "item": "template_photonics",
-    "value": 0,
+    "value": 1000,
     "start": {
       "assign_mission_target": {
         "om_terrain": "office_tower_collapse_b_a0",
@@ -183,14 +183,40 @@
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
+    "followup": "MISSION_ROBOFAC_INTERCOM_4",
     "dialogue": {
       "describe": "…",
-      "offer": "Our facility once sourced advanced photonic circuitry from a nearby robotics manufacturer.  Their building suffered major damage during the portal storms, and collapsed almost entirely.  However, preliminary scouting reveals that the basement prototyping lab likely remains intact.\n\nthe intercom: We ask you to investigate the ruins, and if possible, retrieve a template for the fabrication of said photonic circuitry.",
+      "offer": "Our facility once sourced advanced photonic circuitry from a nearby robotics manufacturer.  Their building suffered major damage during the portal storms, and collapsed almost entirely.  However, preliminary scouting reveals that the basement prototyping lab likely remains intact.  We ask you to investigate the ruins, and if possible, retrieve a template for the fabrication of said photonic circuitry.",
       "accepted": "We expect your success, mercenary.",
       "rejected": "Return if you change your mind.",
       "advice": "The scout drone also revealed extensive heat signatures and high concentrations of toxic compounds within the ruins, plan accordingly.  We are willing to sell you some protective gear at a discount, if you require it.",
       "inquire": "Have you retrieved the blueprints?",
       "success": "Fantastic.  You have our thanks and payment.  The elevator access doors have been opened, and you are now authorized to use the elevator.",
+      "success_lie": "What good does this do us?",
+      "failure": "Simply useless…"
+    }
+  },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_4",
+    "type": "mission_definition",
+    "name": { "str": "Bury the Light" },
+    "description": "Reach the <color_red>physics lab</color> and investigate the <color_light_blue>gravitational anomaly</color>.",
+    "goal": "MGOAL_GO_TO_TYPE",
+    "destination": "microlab_nether_glass_entrance",
+    "difficulty": 5,
+    "value": 1000,
+    "start": { "assign_mission_target": { "om_terrain": "microlab_nether_glass_entrance", "reveal_radius": 0, "z": -10 } },
+    "end": { "effect": [ { "u_buy_item": "RobofacCoin", "count": 4 } ] },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
+    "dialogue": {
+      "describe": "…",
+      "offer": "One of our recon drones recently detected something strange.  A faint gravitational anomaly was detected by the drone's gravimetric sensors, and analysis seems to indicate its source is deep underground.  We suspect this to be related to a classified research facility our records indicate was located in the area, though we have no records as to what kind of research was conducted in this facility other than 'advanced physics'.  We need you to investigate this facility and report back on the cause of this anomaly.",
+      "accepted": "We await results, mercenary.",
+      "rejected": "Return if you change your mind.",
+      "advice": "The lab itself should be similar in format to a standard 'microlab', and thus is likely only accessible through the subway system.  We have no information as to what could be inside this facility.",
+      "inquire": "Anything to report?",
+      "success": "Fascinating.  It is possible the portal storms caused a sort of 'synergy' with the anomaly, causing its effects to expand greatly during the initial days of the Cataclysm.",
       "success_lie": "What good does this do us?",
       "failure": "Simply useless…"
     }

--- a/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
+++ b/data/json/npcs/robofac/NPC_ROBOFAC_INTERCOM.json
@@ -200,23 +200,25 @@
     "id": "MISSION_ROBOFAC_INTERCOM_4",
     "type": "mission_definition",
     "name": { "str": "Bury the Light" },
-    "description": "Reach the <color_red>physics lab</color> and investigate the <color_light_blue>gravitational anomaly</color>.",
-    "goal": "MGOAL_GO_TO_TYPE",
-    "destination": "microlab_nether_glass_entrance",
+    "description": "Reach the <color_red>physics lab</color> and retrieve the document <color_light_blue>PROCEDURE 025-EPSILON</color>.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "physics_anomaly_epsilon",
     "difficulty": 5,
     "value": 1000,
-    "start": { "assign_mission_target": { "om_terrain": "microlab_nether_glass_entrance", "reveal_radius": 0, "z": -10 } },
+    "start": {
+      "assign_mission_target": { "om_terrain": "microlab_portal_elevator_nether_glass", "om_special": "physics_microlab", "z": -10 }
+    },
     "end": { "effect": [ { "u_buy_item": "RobofacCoin", "count": 4 } ] },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
     "dialogue": {
       "describe": "…",
-      "offer": "One of our recon drones recently detected something strange.  A faint gravitational anomaly was detected by the drone's gravimetric sensors, and analysis seems to indicate its source is deep underground.  We suspect this to be related to a classified research facility our records indicate was located in the area, though we have no records as to what kind of research was conducted in this facility other than 'advanced physics'.  We need you to investigate this facility and report back on the cause of this anomaly.",
+      "offer": "We have identified the location of an underground classified research facility that our records indicate was dedicated to the study of 'advanced physics'.  We need you to investigate this facility and retrieve a critical document that is likely located inside, titled 'PROCEDURE 025-EPSILON'.",
       "accepted": "We await results, mercenary.",
       "rejected": "Return if you change your mind.",
-      "advice": "The lab itself should be similar in format to a standard 'microlab', and thus is likely only accessible through the subway system.  We have no information as to what could be inside this facility.",
-      "inquire": "Anything to report?",
-      "success": "Fascinating.  It is possible the portal storms caused a sort of 'synergy' with the anomaly, causing its effects to expand greatly during the initial days of the Cataclysm.",
+      "advice": "The lab itself should be similar in format to a standard microlab, and thus is likely only accessible through the subway system.  We have no information as to what could be inside this facility.",
+      "inquire": "Have you found the document?",
+      "success": "Fascinating.  It is possible the portal storms caused a sort of synergy with the anomaly, causing its effects to expand greatly during the initial days of the Cataclysm.  This would align with the development of...",
       "success_lie": "What good does this do us?",
       "failure": "Simply useless…"
     }

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -933,7 +933,8 @@
     "verb": "using the mind splicer",
     "rooted": true,
     "no_resume": true,
-    "complex_moves": { "speed": true }
+    "complex_moves": { "speed": true },
+    "bubble_size_effect": "idle"
   },
   {
     "id": "ACT_HACKING",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13218,17 +13218,6 @@ auto game::place_player( const tripoint_bub_ms &dest_loc ) -> point_rel_sm
     }
     const auto submap_shift = ( m.get_abs_sub() - origin_before_setpos );
 
-    if( submap_shift != point_rel_sm() ) {
-        for( mission *miss : u.get_active_missions() ) {
-            const auto goal = miss->get_type().goal;
-            if( goal == MGOAL_GO_TO_TYPE || goal == MGOAL_GO_TO ) {
-                if( miss->is_complete( u.getID() ) ) {
-                    miss->wrap_up();
-                }
-            }
-        }
-    }
-
     //Auto pulp or butcher and Auto foraging
     if( get_option<bool>( "AUTO_FEATURES" ) && mostseen == 0  && !u.is_mounted() ) {
         ZoneScopedN( "place_player_auto_features" );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
I spent a lot of time making the physics lab, but like one person has found it so far, and people are always asking for more hub01 content, so why not get these two birds? Also, quests are scuffed as usual.

Also, reverts wishducks' fix as it would break several quests involving escorting npcs to locations.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds a new hub01 mission that sends the player to investigate a physics lab. Also fixes several problems with existing hub01 missions, such as bringing their descriptions up to standard, fixing some grammatical errors, improving task descriptions, making the mind splicer not take forever in real time, etc
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Lack of content
## Testing
Debugged the quest onto an npc and did it, everything seems correct.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
writing descriptions that tell you what to do while not spoiling everything is hard... 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [67c58b5](https://github.com/cataclysmbn/Cataclysm-BN/commit/67c58b5e309c8eac38a399f7d67a6a3b240da088) (Update NPC_ROBOFAC_INTERCOM.json) on 2026-09-11 19:14:15

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34633702893/artifacts/10277828298)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34633702893/artifacts/10278783713)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34633702893/artifacts/10278720063)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34633702893/artifacts/10277349886)
<!-- END artifact comment -->