### PR TITLE
feat: make the default sound display type tiles

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1644,7 +1644,7 @@ void options_manager::add_options_interface()
     add( "SOUND_DISPLAY_TYPE", interface, translate_marker( "Sound Display Type" ),
          translate_marker( "Switch between decibles, relative decibels, and rough tile distance." ),
     {  { "decibels", translate_marker( "Decibels" ) }, { "relative_decibels", translate_marker( "Relative Decibels" ) }, { "tiles", translate_marker( "Rough Tiles" ) } },
-    "Rough Tiles"
+    "tiles"
        );
 
     add(

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1644,7 +1644,7 @@ void options_manager::add_options_interface()
     add( "SOUND_DISPLAY_TYPE", interface, translate_marker( "Sound Display Type" ),
          translate_marker( "Switch between decibles, relative decibels, and rough tile distance." ),
     {  { "decibels", translate_marker( "Decibels" ) }, { "relative_decibels", translate_marker( "Relative Decibels" ) }, { "tiles", translate_marker( "Rough Tiles" ) } },
-    "decibels"
+    "Rough Tiles"
        );
 
     add(


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Wishduck did all this good work adding this much requested feature (#10204), but it's still not selected by default meaning people are still gonna be complaining.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes tile distance the default instead of decibels so people see the values they expect and don't complain about this particular thing anymore.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
That one guy'd
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [1476128](https://github.com/cataclysmbn/Cataclysm-BN/commit/14761285351f3dcab03ba5bab5c75326d20a5a62) (Update options.cpp) on 2026-09-11 20:36:40

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34641272949/artifacts/10280462359)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34641272949/artifacts/10281286961)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34641272949/artifacts/10280069183)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34641272949/artifacts/10280577813)
<!-- END artifact comment -->