### PR TITLE
feat: add incubator

### DIFF
--- a/data/json/construction/construct_workshop.json
+++ b/data/json/construction/construct_workshop.json
@@ -377,6 +377,19 @@
   },
   {
     "type": "construction",
+    "id": "constr_gridincubator",
+    "group": "install_incubator",
+    "category": "WORKSHOP",
+    "required_skills": [  ],
+    "time": "10 m",
+    "qualities": [  ],
+    "components": [ [ [ "incubator", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_furniture": "f_incubator"
+  },
+  {
+    "type": "construction",
     "id": "constr_gridplut_generator",
     "group": "install_plut_generator",
     "category": "WORKSHOP",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1036,6 +1036,11 @@
   },
   {
     "type": "construction_group",
+    "id": "install_incubator",
+    "name": "Plug In Incubator"
+  },
+  {
+    "type": "construction_group",
     "id": "install_plut_generator",
     "name": "Plug In Plutonium Generator"
   },

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -3236,5 +3236,87 @@
       "sound_fail": "clang!",
       "items": [ { "item": "dna_editor", "count": 1 } ]
     }
+  },
+  {
+    "type": "furniture",
+    "abstract": "f_incubator_base",
+    "name": "abstract incubator",
+    "looks_like": "f_incubator",
+    "symbol": "H",
+    "description": "Abstract furniture.  If you see this, something went wrong.",
+    "color": "brown",
+    "move_cost_mod": -1,
+    "coverage": 90,
+    "required_str": -1,
+    "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "items": [ { "item": "incubator", "count": 1 } ] },
+    "max_volume": "50 L",
+    "bash": {
+      "str_min": 8,
+      "str_max": 50,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "sheet_metal", "count": [ 1, 2 ] },
+        { "item": "sheet_metal_small", "count": [ 4, 6 ] },
+        { "item": "steel_chunk", "count": [ 0, 1 ] },
+        { "item": "scrap", "count": [ 1, 4 ] },
+        { "item": "cable", "charges": [ 1, 2 ] },
+        { "item": "motor_tiny", "prob": 25 },
+        { "item": "element", "count": [ 1, 2 ] }
+      ],
+      "//": "Variable reduction since might hit more or less material.",
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50 }
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_incubator_off",
+    "copy-from": "f_incubator_base",
+    "name": "incubator (off)",
+    "symbol": "H",
+    "description": "Put things in here to make them hot. Technically for eggs.  It is switched off.",
+    "examine_action": "transform",
+    "transforms_into": "f_incubator",
+    "prompt": "Switch on the incubator.",
+    "message": "You switch on the incubator.",
+    "color": "brown"
+  },
+  {
+    "type": "furniture",
+    "id": "f_incubator",
+    "name": "incubator",
+    "copy-from": "f_incubator_base",
+    "symbol": "H",
+    "description": "Put things in here to make them hot. Technically for eggs.  It has no power.",
+    "examine_action": "transform",
+    "transforms_into": "f_incubator_off",
+    "prompt": "Switch off the incubator.",
+    "message": "You switch off the incubator.",
+    "active": [ "charge_watcher", { "min_power": 10, "transform": { "id": "f_incubator_on", "msg": "The incubator starts up." } } ],
+    "color": "brown"
+  },
+  {
+    "type": "furniture",
+    "id": "f_incubator_on",
+    "name": "incubator (on)",
+    "copy-from": "f_incubator_base",
+    "symbol": "H",
+    "description": "Put things in here to make them hot. Technically for eggs.  It is switched on.",
+    "examine_action": "transform",
+    "transforms_into": "f_incubator_off",
+    "prompt": "Switch off the incubator.",
+    "message": "You switch off the incubator.",
+    "color": "brown",
+    "extend": { "flags": [ "INCUBATOR" ] },
+    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
+    "active": [
+      "steady_consumer",
+      {
+        "power": 10,
+        "consume_every": "600 s",
+        "transform": { "id": "f_incubator", "msg": "The incubator shuts down." }
+      }
+    ]
   }
 ]

--- a/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
+++ b/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
@@ -75,7 +75,8 @@
       [ "v_reaper_item", 41 ],
       [ "v_reaper_item_advanced", 8 ],
       [ "v_planter_item_advanced", 8 ],
-      [ "beehive_empty", 10 ]
+      [ "beehive_empty", 10 ],
+      [ "incubator", 10 ]
     ]
   },
   {

--- a/data/json/items/furniture.json
+++ b/data/json/items/furniture.json
@@ -14,6 +14,21 @@
     "color": "light_cyan"
   },
   {
+    "id": "incubator",
+    "type": "TOOL",
+    "looks_like": "f_incubator",
+    "name": "incubator",
+    "description": "A large incubator, with removable racks for storing eggs.",
+    "weight": "30 kg",
+    "volume": "110000 ml",
+    "price": "500 USD",
+    "price_postapoc": "5 USD",
+    "material": "steel",
+    "symbol": "{",
+    "color": "brown",
+    "category": "scrap_electronics"
+  },
+  {
     "id": "fridge",
     "type": "TOOL",
     "looks_like": "f_fridge",

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -619,6 +619,29 @@
   },
   {
     "type": "recipe",
+    "result": "incubator",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "40 m",
+    "reversible": true,
+    "decomp_learn": 4,
+    "book_learn": [ [ "textbook_mechanics", 4 ], [ "manual_mechanics", 4 ], [ "textbook_fabrication", 4 ] ],
+    "using": [ [ "soldering_standard", 20 ], [ "welding_standard", 5 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "sheet_metal", 3 ] ],
+      [ [ "sheet_metal_small", 2 ] ],
+      [ [ "steel_chunk", 2 ] ],
+      [ [ "cable", 2 ] ],
+      [ [ "thermostat", 1 ] ],
+      [ [ "motor_tiny", 1 ] ],
+      [ [ "element", 2 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "result": "oven",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_OTHER",

--- a/src/enums.h
+++ b/src/enums.h
@@ -75,6 +75,7 @@ struct enum_traits<creature_size> {
 
 enum class temperature_flag : int {
     TEMP_NORMAL = 0,
+    TEMP_INCUBATOR,
     TEMP_HEATER,
     TEMP_FRIDGE,
     TEMP_FREEZER,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10142,8 +10142,8 @@ auto item::actualize_rot( detached_ptr<item> &&self,
 
 // ALL ROT HAPPENS HERE (unless I missed some)
 auto item::do_rot_step( detached_ptr<item> &&self,
-                                 const rot_context &context,
-                                 const bool seals, player *carrier ) -> detached_ptr<item>
+                        const rot_context &context,
+                        const bool seals, player *carrier ) -> detached_ptr<item>
 {
     auto removed_snapshot = self->is_comestible() || self->is_corpse() ?
                             item::spawn( *self ) : detached_ptr<item>();
@@ -10157,9 +10157,9 @@ auto item::do_rot_step( detached_ptr<item> &&self,
     if( !result && removed_snapshot ) {
         map &here = get_map();
         MAPBUFFER_REGISTRY.get( here.get_bound_dimension() ).handle_rotten_away_item(
-            context.position, *removed_snapshot, {
-                .mode = mapbuffer_lookup_mode::resident_only,
-            } );
+        context.position, *removed_snapshot, {
+            .mode = mapbuffer_lookup_mode::resident_only,
+        } );
     }
     return result;
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2120,7 +2120,7 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
                     case temperature_flag::TEMP_NORMAL:
                     case temperature_flag::TEMP_INCUBATOR: {
                         temperature_description = _( "* Current storage conditions <bad>accelerate</bad> this "
-                                                    "item\'s decay. It will go bad in <info>%s</info>." );
+                                                     "item\'s decay. It will go bad in <info>%s</info>." );
                     }
                     case temperature_flag::TEMP_HEATER: {
                         temperature_description = _( "* Current storage conditions <bad>do not</bad> "

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2121,15 +2121,15 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
             } else {
                 switch( temperature ) {
                     case temperature_flag::TEMP_NORMAL:
+                    case temperature_flag::TEMP_HEATER: {
+                        temperature_description = _( "* Current storage conditions <bad>do not</bad> "
+                                                     "protect this item from rot." );
+                    }
+                    break;
                     case temperature_flag::TEMP_INCUBATOR: {
                         temperature_description = _( "* Current storage conditions <bad>accelerate</bad> this "
                                                      "item\'s decay. It will go bad in <info>%s</info>." );
                         print_freshness_duration = true;
-                    }
-                    break;
-                    case temperature_flag::TEMP_HEATER: {
-                        temperature_description = _( "* Current storage conditions <bad>do not</bad> "
-                                                     "protect this item from rot." );
                     }
                     break;
                     case temperature_flag::TEMP_FRIDGE:
@@ -10140,6 +10140,30 @@ auto item::actualize_rot( detached_ptr<item> &&self,
     return actualize_rot( std::move( self ), context, false );
 }
 
+// ALL ROT HAPPENS HERE (unless I missed some)
+auto item::do_rot_step( detached_ptr<item> &&self,
+                                 const rot_context &context,
+                                 const bool seals, player *carrier ) -> detached_ptr<item>
+{
+    auto removed_snapshot = self->is_comestible() || self->is_corpse() ?
+                            item::spawn( *self ) : detached_ptr<item>();
+
+    auto result = process_rot( std::move( self ), {
+        .seals = seals,
+        .carrier = carrier,
+        .context = context,
+    } );
+
+    if( !result && removed_snapshot ) {
+        map &here = get_map();
+        MAPBUFFER_REGISTRY.get( here.get_bound_dimension() ).handle_rotten_away_item(
+            context.position, *removed_snapshot, {
+                .mode = mapbuffer_lookup_mode::resident_only,
+            } );
+    }
+    return result;
+}
+
 auto item::actualize_rot( detached_ptr<item> &&self,
                           const rot_context &context, const bool seals ) -> detached_ptr<item>
 {
@@ -10153,25 +10177,7 @@ auto item::actualize_rot( detached_ptr<item> &&self,
         return std::move( self );
     }
     if( self->goes_bad() ) {
-        const auto can_spawn_rot = self->is_comestible();
-        const auto can_decay_corpse = self->is_corpse();
-        auto removed_snapshot = can_spawn_rot || can_decay_corpse ?
-                                item::spawn( *self ) : detached_ptr<item>();
-
-        auto result = process_rot( std::move( self ), {
-            .seals = seals,
-            .carrier = nullptr,
-            .context = context,
-        } );
-
-        if ( !result && removed_snapshot ) {
-            map& here = get_map();
-            MAPBUFFER_REGISTRY.get( here.get_bound_dimension() ).handle_rotten_away_item(
-                context.position, *removed_snapshot, {
-                    .mode = mapbuffer_lookup_mode::resident_only,
-                } );
-        };
-        return result;
+        return do_rot_step( std::move( self ), context, seals, nullptr );
     } else if( self->type->container && self->type->container->preserves ) {
         // Containers like tin cans preserve all items inside; they do not rot at all.
         return std::move( self );
@@ -11440,16 +11446,12 @@ detached_ptr<item> item::process_internal( detached_ptr<item> &&self, player *ca
     // Rot automatically applies ticks, no need to catch up
     if( ( self->is_food() || self->is_corpse() ) ) {
         ZoneScopedN( "item_process_rot" );
-        auto removed_snapshot = self->is_comestible() || self->is_corpse() ?
-                                item::spawn( *self ) : detached_ptr<item>();
-        self = process_rot( std::move( self ), seals, pos, carrier, flag, weather_generator );
-        // If the item has rotted away, then self becomes a null pointer.
-        if( !self && removed_snapshot ) {
-            MAPBUFFER_REGISTRY.get( here.get_bound_dimension() ).handle_rotten_away_item(
-            map_local_to_abs( here, pos ), *removed_snapshot, {
-                .mode = mapbuffer_lookup_mode::resident_only,
-            } );
-        }
+        self = do_rot_step( std::move( self ), {
+            .position = bub_to_abs( pos ),
+            .temperature = flag,
+            .weather = &weather_generator,
+            .local_temperature = g != nullptr && !g->new_game ? here.get_temperature( pos ) : 0,
+        }, seals, carrier );
     }
     return std::move( self );
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2118,6 +2118,10 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
             } else {
                 switch( temperature ) {
                     case temperature_flag::TEMP_NORMAL:
+                    case temperature_flag::TEMP_INCUBATOR: {
+                        temperature_description = _( "* Current storage conditions <bad>accelerate</bad> this "
+                                                    "item\'s decay. It will go bad in <info>%s</info>." );
+                    }
                     case temperature_flag::TEMP_HEATER: {
                         temperature_description = _( "* Current storage conditions <bad>do not</bad> "
                                                      "protect this item from rot." );
@@ -6600,6 +6604,8 @@ auto temperature_flag_to_highest_temperature( temperature_flag temperature ) -> 
         case temperature_flag::TEMP_NORMAL:
         case temperature_flag::TEMP_HEATER:
             return units::temperature_max;
+        case temperature_flag::TEMP_INCUBATOR:
+            return temperatures::hot;
         case temperature_flag::TEMP_FRIDGE:
             return temperatures::fridge;
         case temperature_flag::TEMP_FREEZER:
@@ -10352,6 +10358,8 @@ static units::temperature clip_by_temperature_flag( units::temperature temperatu
             return std::min( temperature, temperatures::freezer );
         case temperature_flag::TEMP_HEATER:
             return std::max( temperature, temperatures::normal );
+        case temperature_flag::TEMP_INCUBATOR:
+            return std::max( temperature, temperatures::hot );
         case temperature_flag::TEMP_ROOT_CELLAR:
             return temperatures::root_cellar;
         default:

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2121,7 +2121,9 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
                     case temperature_flag::TEMP_INCUBATOR: {
                         temperature_description = _( "* Current storage conditions <bad>accelerate</bad> this "
                                                      "item\'s decay. It will go bad in <info>%s</info>." );
+                        print_freshness_duration = true;
                     }
+                    break;
                     case temperature_flag::TEMP_HEATER: {
                         temperature_description = _( "* Current storage conditions <bad>do not</bad> "
                                                      "protect this item from rot." );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -75,6 +75,7 @@
 #include "magic/magic.h"
 #include "map.h"
 #include "mapbuffer.h"
+#include "mapdata.h"
 #include "martialarts.h"
 #include "material.h"
 #include "melee.h"
@@ -829,6 +830,7 @@ auto item::prepare_for_location_removal() -> void
                 .root_cellar = tile->get_ter() == t_rootcellar,
                 .fridge = furn.has_flag( TFLAG_FRIDGE ),
                 .freezer = furn.has_flag( TFLAG_FREEZER ),
+                .incubator = furn.has_flag( TFLAG_INCUBATOR ),
             } );
         } else {
             storage_temperature = rot::temp::for_location( get_map(), *this );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -75,6 +75,7 @@
 #include "magic/magic.h"
 #include "map.h"
 #include "mapbuffer.h"
+#include "mapbuffer_registry.h"
 #include "mapdata.h"
 #include "martialarts.h"
 #include "material.h"
@@ -10152,11 +10153,25 @@ auto item::actualize_rot( detached_ptr<item> &&self,
         return std::move( self );
     }
     if( self->goes_bad() ) {
-        return process_rot( std::move( self ), {
+        const auto can_spawn_rot = self->is_comestible();
+        const auto can_decay_corpse = self->is_corpse();
+        auto removed_snapshot = can_spawn_rot || can_decay_corpse ?
+                                item::spawn( *self ) : detached_ptr<item>();
+
+        auto result = process_rot( std::move( self ), {
             .seals = seals,
             .carrier = nullptr,
             .context = context,
         } );
+
+        if ( !result && removed_snapshot ) {
+            map& here = get_map();
+            MAPBUFFER_REGISTRY.get( here.get_bound_dimension() ).handle_rotten_away_item(
+                context.position, *removed_snapshot, {
+                    .mode = mapbuffer_lookup_mode::resident_only,
+                } );
+        };
+        return result;
     } else if( self->type->container && self->type->container->preserves ) {
         // Containers like tin cans preserve all items inside; they do not rot at all.
         return std::move( self );

--- a/src/item.h
+++ b/src/item.h
@@ -2476,6 +2476,9 @@ class item : public location_visitable<item>, public game_object<item>
                                    const rot_context &context, bool seals ) -> detached_ptr<item>;
         static auto process_rot( detached_ptr<item> &&self,
                                  const absolute_rot_process_options &options ) -> detached_ptr<item>;
+        static auto do_rot_step( detached_ptr<item> &&self,
+                                          const rot_context &context,
+                                          bool seals, player *carrier ) -> detached_ptr<item>;
         auto is_in_preserving_container() const -> bool;
         auto is_in_sealing_container() const -> bool;
         auto mark_rot_checked_now() -> void;

--- a/src/item.h
+++ b/src/item.h
@@ -2477,8 +2477,8 @@ class item : public location_visitable<item>, public game_object<item>
         static auto process_rot( detached_ptr<item> &&self,
                                  const absolute_rot_process_options &options ) -> detached_ptr<item>;
         static auto do_rot_step( detached_ptr<item> &&self,
-                                          const rot_context &context,
-                                          bool seals, player *carrier ) -> detached_ptr<item>;
+                                 const rot_context &context,
+                                 bool seals, player *carrier ) -> detached_ptr<item>;
         auto is_in_preserving_container() const -> bool;
         auto is_in_sealing_container() const -> bool;
         auto mark_rot_checked_now() -> void;

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -179,6 +179,7 @@ auto temperature_flag_at_tile( const submap &sm, const point_sm_ms &local ) -> t
         .root_cellar = sm.get_ter( local ) == t_rootcellar,
         .fridge = furn.has_flag( TFLAG_FRIDGE ),
         .freezer = furn.has_flag( TFLAG_FREEZER ),
+        .incubator = furn.has_flag( TFLAG_INCUBATOR ),
     } );
 }
 

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -276,24 +276,30 @@ auto rotten_item_spawn( const actualize_tile_options &options, const item &sourc
         return;
     }
 
-    const auto chance = static_cast<int>( comestible->rot_spawn_chance *
-                                          get_option<float>( "CARRION_SPAWNRATE" ) );
-    if( rng( 0, 100 ) >= chance ) {
-        return;
+    bool spawned = false;
+    for( int i = 0; i < source.count(); i++ ) {
+        const auto chance = static_cast<int>( comestible->rot_spawn_chance *
+                                              get_option<float>( "CARRION_SPAWNRATE" ) );
+        if( rng( 0, 100 ) >= chance ) {
+            continue;
+        }
+
+        const auto spawn_details = MonsterGroupManager::GetResultFromGroup( comestible->rot_spawn );
+        const auto disposition = source.has_own_flag( flag_SPAWN_FRIENDLY ) ?
+                                 spawn_disposition::SpawnDisp_Pet :
+                                 spawn_disposition::SpawnDisp_Default;
+        add_spawn_to_submap( {
+            .sm = options.sm,
+            .local = options.local,
+            .type = spawn_details.name,
+            .disposition = disposition,
+        } );
+
+        spawned = true;
     }
 
-    const auto spawn_details = MonsterGroupManager::GetResultFromGroup( comestible->rot_spawn );
-    const auto disposition = source.has_own_flag( flag_SPAWN_FRIENDLY ) ?
-                             spawn_disposition::SpawnDisp_Pet :
-                             spawn_disposition::SpawnDisp_Default;
-    add_spawn_to_submap( {
-        .sm = options.sm,
-        .local = options.local,
-        .type = spawn_details.name,
-        .disposition = disposition,
-    } );
-
-    if( !options.active_bubble_pos || g == nullptr || !g->u.sees( *options.active_bubble_pos ) ) {
+    if( !spawned || !options.active_bubble_pos || g == nullptr ||
+        !g->u.sees( *options.active_bubble_pos ) ) {
         return;
     }
 

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -309,7 +309,6 @@ auto rotten_item_spawn( const actualize_tile_options &options, const item &sourc
 auto remove_rotten_items( const actualize_tile_options &options,
                           location_vector<item> &items ) -> void
 {
-    auto decayed_corpses = std::vector<detached_ptr<item>> {};
     const auto temperature = temperature_flag_at_tile( options.sm, options.local );
     items.remove_with( [&]( detached_ptr<item> &&it ) {
         if( !it ) {
@@ -320,29 +319,16 @@ auto remove_rotten_items( const actualize_tile_options &options,
             debugmsg( "remove_rotten_items: item with null type at %s", options.abs_pos.to_string() );
             return std::move( it );
         }
-        const auto can_spawn_rot = it->is_comestible();
-        const auto can_decay_corpse = it->is_corpse();
-        auto removed_snapshot = can_spawn_rot || can_decay_corpse ?
-                                item::spawn( *it ) : detached_ptr<item>();
+
         it = item::actualize_rot( std::move( it ), {
             .position = options.abs_pos,
             .temperature = temperature,
             .weather = &get_weather(),
             .local_temperature = options.sm.get_temperature(),
         } );
-        if( !it ) {
-            if( can_spawn_rot && removed_snapshot ) {
-                rotten_item_spawn( options, *removed_snapshot );
-            } else if( can_decay_corpse && removed_snapshot ) {
-                decayed_corpses.push_back( std::move( removed_snapshot ) );
-            }
-        }
+
         return std::move( it );
     } );
-
-    for( const auto &corpse : decayed_corpses ) {
-        handle_decayed_corpse( options, *corpse );
-    }
 }
 
 auto fill_funnels( const actualize_tile_options &options ) -> void

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -177,6 +177,7 @@ static const std::unordered_map<std::string, ter_bitflags> ter_bitflags_map = { 
         { "SUSPENDED",                TFLAG_SUSPENDED },      // This furniture is suspended between other terrain, and will cause a cascading failure on break.
         { "FRIDGE",                   TFLAG_FRIDGE },         // This is an active fridge.
         { "FREEZER",                  TFLAG_FREEZER },        // This is an active freezer.
+        { "INCUBATOR",                TFLAG_INCUBATOR },      // This is an active incubator.
         { "ELEVATOR",                 TFLAG_ELEVATOR },       // This is an elevator.
         { "NO_MEMORY",                TFLAG_NO_MEMORY },      // This should not be added to map memory
         { "ROAD",                     TFLAG_ROAD },           // Some floors have this flag, as do some passable transformation of otherwise impassible terrain/furniture. Very notably, open doors.

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -358,6 +358,7 @@ enum ter_bitflags : int {
     TFLAG_SUSPENDED,
     TFLAG_FRIDGE,
     TFLAG_FREEZER,
+    TFLAG_INCUBATOR,
     TFLAG_ELEVATOR,
     TFLAG_NO_MEMORY,
     TFLAG_ROAD,

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -1,5 +1,6 @@
 #include "rot.h"
 
+#include "enums.h"
 #include "item.h"
 #include "map.h"
 #include "vehicle.h"
@@ -20,6 +21,9 @@ auto for_tile( const tile_flags &flags ) -> temperature_flag
     }
     if( flags.fridge ) {
         return temperature_flag::TEMP_FRIDGE;
+    }
+    if( flags.incubator ) {
+        return temperature_flag::TEMP_INCUBATOR;
     }
 
     return temperature_flag::TEMP_NORMAL;
@@ -42,6 +46,7 @@ auto for_location( const map &m, const item &loc ) -> temperature_flag
                 .root_cellar = m.ter( pos ) == t_rootcellar,
                 .fridge = m.has_flag_furn( TFLAG_FRIDGE, pos ),
                 .freezer = m.has_flag_furn( TFLAG_FREEZER, pos ),
+                .incubator = m.has_flag_furn( TFLAG_INCUBATOR, pos )
             } );
         }
         case item_location_type::vehicle: {

--- a/src/rot.h
+++ b/src/rot.h
@@ -15,6 +15,7 @@ struct tile_flags {
     bool root_cellar = false;
     bool fridge = false;
     bool freezer = false;
+    bool incubator = false;
 };
 
 /** Resolve the rot temperature modifier for map terrain/furniture storage. */


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
closes #10176 
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Adds an incubator, which you may have heard of as a "reverse fridge". Put simply, it's like a fridge, but it makes things hot instead so it goes bad _faster_.

Also, while I was in there, I rewrote the rot logic so everything routes through a single do_rot_step function, as opposed relying on callers of item::actualize_rot defining rot logic, which was causing eggs rotting in anything but an open field to not spawn hatched creatures. I suspect this might also have been causing other problems, but they must not have been situations that people run into that often.

In addition, I noticed that a stack of eggs only did one spawn roll, so I've made it that a stack of N items rolls N spawns. 

## Describe alternatives you've considered
I also considered making this furniture egg specific and work more like a smoker, but reverse fridge is a good enough approximation to how it works irl. If someone wants to spoil other food faster, that's player choice.
## Testing
Connect an incubator to a powered grid.
Spawn a number of eggs or other rottables and put them into the incubator.
<img width="498" height="221" alt="image" src="https://github.com/user-attachments/assets/9d9f5357-d6b3-4cbc-8952-c972b5043633" />

Check to make sure they display the new heated rot speed message.
<img width="346" height="850" alt="image" src="https://github.com/user-attachments/assets/c8df8c43-25f8-4def-b588-e448ec91f5d2" />

Advance time and make sure they are actually rotting faster. (This was after 12 hours)
<img width="348" height="859" alt="image" src="https://github.com/user-attachments/assets/315d65a7-c2b0-4199-9135-5ddcb3036908" />

When the eggs rot away, make sure that they spawn a gaggle of chicks. (This step relies on a roll so you might get _very_ unlucky and spawn nothing)
<img width="1564" height="688" alt="behold" src="https://github.com/user-attachments/assets/de095fb3-edde-4f71-9d54-eb992279f201" />


Because I edited the rot logic, I also tested different scenarios:
Rotting in a container is covered by the incubator
Rotting in a vehicle works (the item disappears and chicks spawn)
Rotting on the ground works
I also made sure a chunk of meat rots away on the ground, in a vehicle, and in an incubator to test the case of an item that DOESN'T spawn anything rotting away. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
There is one small issue where chicks can spawn behind walls, but that is an existing issue that has to do with how the spawn logic works, so to fix it I'd have to change how monsters spawn or write a custom spawn that's just for this, and the scope on this PR has expanded a bit already. In any case, this does not make that issue worse.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [7f45195](https://github.com/cataclysmbn/Cataclysm-BN/commit/7f45195fe810052d16800d265a200e7d16cde54e) (Merge branch 'main' into pr/10231) on 2026-09-14 03:39:45

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784486053/artifacts/10327266936)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784486053/artifacts/10327366969)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784486053/artifacts/10326478714)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784486053/artifacts/10326702322)
<!-- END artifact comment -->