### PR TITLE
fix: stop flying flee from creating immortal sky kites

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -386,6 +386,47 @@ void monster::wander_to( const tripoint_bub_ms &p, int f )
     }
 }
 
+int monster::flying_flee_altitude( const int current_z, const int target_z ) const
+{
+    int desired_z = current_z;
+    if( type->preferred_z ) {
+        desired_z = *type->preferred_z;
+    } else if( current_z == target_z ) {
+        // Hit-and-run hop: one level, not a rocket.
+        desired_z = current_z + 1;
+    }
+    int result = current_z;
+    if( desired_z > current_z ) {
+        result = current_z + 1;
+    } else if( desired_z < current_z ) {
+        result = current_z - 1;
+    }
+    return clamp( result, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
+}
+
+int monster::unengageable_altitude_penalty( const Creature &critter ) const
+{
+    if( flies() ) {
+        return 0;
+    }
+    const auto from = bub_pos();
+    const auto to = critter.bub_pos();
+    if( std::abs( to.z() - from.z() ) <= 1 ) {
+        return 0;
+    }
+    const map &here = get_map();
+    // Floored tiles (roofs, interiors) stay fully attractive.  Forgetting them
+    // is the "wait on a roof until they wander off" exploit.
+    if( here.has_floor_or_support( to ) ) {
+        return 0;
+    }
+    if( here.has_flag( TFLAG_GOES_UP, from ) || here.has_flag( TFLAG_GOES_DOWN, from ) ||
+        here.has_flag( TFLAG_RAMP_UP, from ) || here.has_flag( TFLAG_RAMP_DOWN, from ) ) {
+        return 0;
+    }
+    return std::max( 15, type->vision_day / 2 );
+}
+
 // Per-turn terrain LOS blocker cache.  This is keyed only by the current
 // positions, and a true result means the real sight check can be rejected early.
 // A false result is not visibility; callers still have to run Creature::sees().
@@ -412,8 +453,10 @@ float monster::rate_target( Creature &c, float best, bool smart, int precalc_dis
         return FLT_MAX;
     }
 
+    const int rated_dist = d + unengageable_altitude_penalty( c );
+
     // Check a very common and cheap case first
-    if( !smart && d >= best ) {
+    if( !smart && rated_dist >= best ) {
         return FLT_MAX;
     }
 
@@ -426,7 +469,7 @@ float monster::rate_target( Creature &c, float best, bool smart, int precalc_dis
     }
 
     if( !smart ) {
-        return int( d );
+        return rated_dist;
     }
 
     float power = c.power_rating();
@@ -437,7 +480,7 @@ float monster::rate_target( Creature &c, float best, bool smart, int precalc_dis
     }
 
     if( power > 0 ) {
-        return int( d ) / power;
+        return rated_dist / power;
     }
 
     return FLT_MAX;
@@ -913,13 +956,7 @@ monster_plan_t monster::compute_plan( const monster::compute_plan_context &ctx )
             const auto away = current_pos - dest;
             auto flee_goal = current_pos + away.xy();
             if( flies() ) {
-                if( const auto preferred_z = type->preferred_z ) {
-                    flee_goal.z() = *preferred_z;
-                } else if( away.z() != 0 ) {
-                    flee_goal.z() = current_pos.z() + away.z();
-                } else {
-                    flee_goal.z() = current_pos.z() + 1;
-                }
+                flee_goal.z() = flying_flee_altitude( current_pos.z(), dest.z() );
             } else {
                 flee_goal.z() = current_pos.z();
             }
@@ -1343,6 +1380,17 @@ monster_action_t monster::decide_action() const
             }
 
             if( !can_z_move ) {
+                // Cannot occupy the tile (grounded monster vs open air) but a
+                // vertical strike may still be legal — roofs fail can_z_attack
+                // above because the upper tile has a floor.
+                const auto *z_target = g->critter_at( candidate, hallucination );
+                if( !pacified && z_target != nullptr &&
+                    attitude_to( *z_target ) == Attitude::A_HOSTILE ) {
+                    next_step = candidate;
+                    has_next_step = true;
+                    action.target = const_cast<Creature *>( z_target );
+                    break;
+                }
                 continue;
             }
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -250,6 +250,19 @@ class monster : public Creature, public location_visitable<monster>
         // when the caller already has the distance.
         float rate_target( Creature &c, float best, bool smart = false,
                            int precalc_dist = -1 ) const;
+        /**
+         * Z a flying monster should use while fleeing this turn.
+         * Steps at most one z-level toward preferred_z, or one z-level up when
+         * sharing the target's z.  Never adds the current z-delta — that
+         * doubled altitude every flee turn and parked drones at OVERMAP_HEIGHT.
+         */
+        int flying_flee_altitude( int current_z, int target_z ) const;
+        /**
+         * Extra rate_target distance for a target this monster cannot occupy
+         * and cannot melee (open air, |dz| > 1).  Roofs and other floored
+         * tiles return 0 so last-known hunting of a rooftop survivor is unchanged.
+         */
+        int unengageable_altitude_penalty( const Creature &critter ) const;
         void plan();
         /**
          * Snapshot of alive creature pointers passed to compute_plan() so that

--- a/tests/monster_vertical_ai_test.cpp
+++ b/tests/monster_vertical_ai_test.cpp
@@ -1,0 +1,174 @@
+#include "avatar.h"
+#include "calendar.h"
+#include "catch/catch.hpp"
+#include "coordinates.h"
+#include "game.h"
+#include "game_constants.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "monster.h"
+#include "monster_action.h"
+#include "state_helpers.h"
+
+#include <cfloat>
+
+namespace {
+
+const auto midday = calendar::turn_zero + 12_hours;
+
+auto rebuild_z_caches(int z_min, int z_max) -> void {
+    auto& here = get_map();
+    for (int z = z_min; z <= z_max; ++z) {
+        here.invalidate_map_cache(z);
+        here.build_map_cache(z, true);
+    }
+}
+
+auto setup_open_sky() -> void {
+    clear_all_state();
+    calendar::turn = midday;
+    move_player_out_of_the_way();
+    rebuild_z_caches(0, OVERMAP_HEIGHT);
+}
+
+} // namespace
+
+TEST_CASE("flying flee does not rocket altitude", "[monster][ai][zlevel]") {
+    setup_open_sky();
+
+    auto& wasp = spawn_test_monster("mon_wasp_guard", tripoint_bub_ms(60, 60, 0));
+    auto& eyebot = spawn_test_monster("mon_eyebot", tripoint_bub_ms(62, 60, 0));
+
+    SECTION("same-z hop is one level, then altitude holds") {
+        CHECK(wasp.flying_flee_altitude(0, 0) == 1);
+        CHECK(wasp.flying_flee_altitude(1, 0) == 1);
+        CHECK(wasp.flying_flee_altitude(2, 0) == 2);
+        CHECK(wasp.flying_flee_altitude(8, 0) == 8);
+
+        auto z = 0;
+        for (auto i = 0; i < 4; ++i) {
+            z = wasp.flying_flee_altitude(z, 0);
+        }
+        CHECK(z <= 1);
+    }
+
+    SECTION("eyebot sibling uses the same cap") {
+        auto z = 0;
+        for (auto i = 0; i < 4; ++i) {
+            z = eyebot.flying_flee_altitude(z, 0);
+        }
+        CHECK(z <= 1);
+        CHECK(eyebot.flying_flee_altitude(9, 0) == 9);
+    }
+
+    SECTION("result stays inside overmap z bounds") {
+        CHECK(wasp.flying_flee_altitude(OVERMAP_HEIGHT, OVERMAP_HEIGHT) == OVERMAP_HEIGHT);
+        CHECK(wasp.flying_flee_altitude(-OVERMAP_DEPTH, 0) == -OVERMAP_DEPTH);
+    }
+}
+
+TEST_CASE("crow preferred_z is approached one level at a time", "[monster][ai][zlevel]") {
+    setup_open_sky();
+
+    auto& crow = spawn_test_monster("mon_crow", tripoint_bub_ms(60, 60, 0));
+    REQUIRE(crow.type->preferred_z);
+    CHECK(*crow.type->preferred_z == 3);
+
+    CHECK(crow.flying_flee_altitude(0, 0) == 1);
+    CHECK(crow.flying_flee_altitude(1, 0) == 2);
+    CHECK(crow.flying_flee_altitude(3, 0) == 3);
+    CHECK(crow.flying_flee_altitude(5, 0) == 4);
+}
+
+TEST_CASE("ground monsters melee open air at dz 1 but not through floors",
+          "[monster][ai][zlevel][melee]") {
+    setup_open_sky();
+
+    const auto ground = tripoint_bub_ms(60, 60, 0);
+    const auto above = tripoint_bub_ms(60, 60, 1);
+
+    SECTION("open air wasp is a legal upward strike") {
+        auto& zed = spawn_test_monster("mon_zombie", ground);
+        auto& wasp = spawn_test_monster("mon_wasp_guard", above);
+        zed.moves = 100;
+        zed.set_dest(wasp.bub_pos());
+
+        const auto action = zed.decide_action();
+        CHECK(action.kind == monster_action_kind::attack);
+        CHECK(action.target == &wasp);
+        CHECK(action.dest == above);
+    }
+
+    SECTION("roof floor blocks the upward strike") {
+        auto& here = get_map();
+        here.ter_set(above, ter_id("t_floor"));
+        rebuild_z_caches(0, 1);
+
+        auto& zed = spawn_test_monster("mon_zombie", ground);
+        g->place_player(above);
+        zed.moves = 100;
+        zed.set_dest(get_avatar().bub_pos());
+
+        const auto action = zed.decide_action();
+        CHECK(action.kind != monster_action_kind::attack);
+    }
+}
+
+TEST_CASE("open air altitude penalty ignores roofs and adjacent hover",
+          "[monster][ai][zlevel]") {
+    setup_open_sky();
+
+    auto& zed = spawn_test_monster("mon_zombie", tripoint_bub_ms(60, 60, 0));
+    auto& wasp = spawn_test_monster("mon_wasp_guard", tripoint_bub_ms(60, 60, 1));
+    auto& high_bot = spawn_test_monster("mon_eyebot", tripoint_bub_ms(60, 60, 9));
+
+    const auto roof = tripoint_bub_ms(62, 60, 2);
+    auto& here = get_map();
+    here.ter_set(roof, ter_id("t_floor"));
+    rebuild_z_caches(0, 9);
+    auto& roof_dummy = spawn_test_monster("debug_mon", roof);
+
+    CHECK(zed.unengageable_altitude_penalty(wasp) == 0);
+    CHECK(zed.unengageable_altitude_penalty(roof_dummy) == 0);
+    CHECK(zed.unengageable_altitude_penalty(high_bot) > 0);
+    CHECK(wasp.unengageable_altitude_penalty(zed) == 0);
+}
+
+TEST_CASE("zombies prefer a ground survivor over a stratospheric drone",
+          "[monster][ai][zlevel]") {
+    setup_open_sky();
+
+    const auto zed_pos = tripoint_bub_ms(60, 60, 0);
+    g->place_player(tripoint_bub_ms(60, 75, 0));
+    auto& zed = spawn_test_monster("mon_zombie", zed_pos);
+    auto& bot = spawn_test_monster("mon_eyebot", tripoint_bub_ms(60, 60, 2));
+    rebuild_z_caches(0, 2);
+
+    REQUIRE(zed.sees(get_avatar()));
+    REQUIRE(zed.sees(bot));
+
+    const auto player_rating = zed.rate_target(get_avatar(), 100.0f);
+    const auto bot_rating = zed.rate_target(bot, 100.0f);
+    REQUIRE(player_rating < FLT_MAX);
+    REQUIRE(bot_rating < FLT_MAX);
+    CHECK(player_rating < bot_rating);
+
+    const auto plan = zed.compute_plan();
+    CHECK(plan.goal == get_avatar().bub_pos());
+}
+
+TEST_CASE("unreachable open air target is not dropped when it is the only prey",
+          "[monster][ai][zlevel]") {
+    setup_open_sky();
+    put_player_underground();
+
+    auto& zed = spawn_test_monster("mon_zombie", tripoint_bub_ms(60, 60, 0));
+    auto& bot = spawn_test_monster("mon_eyebot", tripoint_bub_ms(60, 60, 2));
+    rebuild_z_caches(-2, 2);
+
+    REQUIRE(zed.sees(bot));
+    REQUIRE(zed.unengageable_altitude_penalty(bot) > 0);
+
+    const auto plan = zed.compute_plan();
+    CHECK(plan.goal == bot.bub_pos());
+}

--- a/tests/monster_vertical_ai_test.cpp
+++ b/tests/monster_vertical_ai_test.cpp
@@ -46,17 +46,13 @@ TEST_CASE("flying flee does not rocket altitude", "[monster][ai][zlevel]") {
         CHECK(wasp.flying_flee_altitude(8, 0) == 8);
 
         auto z = 0;
-        for (auto i = 0; i < 4; ++i) {
-            z = wasp.flying_flee_altitude(z, 0);
-        }
+        for (auto i = 0; i < 4; ++i) { z = wasp.flying_flee_altitude(z, 0); }
         CHECK(z <= 1);
     }
 
     SECTION("eyebot sibling uses the same cap") {
         auto z = 0;
-        for (auto i = 0; i < 4; ++i) {
-            z = eyebot.flying_flee_altitude(z, 0);
-        }
+        for (auto i = 0; i < 4; ++i) { z = eyebot.flying_flee_altitude(z, 0); }
         CHECK(z <= 1);
         CHECK(eyebot.flying_flee_altitude(9, 0) == 9);
     }
@@ -80,8 +76,9 @@ TEST_CASE("crow preferred_z is approached one level at a time", "[monster][ai][z
     CHECK(crow.flying_flee_altitude(5, 0) == 4);
 }
 
-TEST_CASE("ground monsters melee open air at dz 1 but not through floors",
-          "[monster][ai][zlevel][melee]") {
+TEST_CASE(
+    "ground monsters melee open air at dz 1 but not through floors",
+    "[monster][ai][zlevel][melee]") {
     setup_open_sky();
 
     const auto ground = tripoint_bub_ms(60, 60, 0);
@@ -114,8 +111,7 @@ TEST_CASE("ground monsters melee open air at dz 1 but not through floors",
     }
 }
 
-TEST_CASE("open air altitude penalty ignores roofs and adjacent hover",
-          "[monster][ai][zlevel]") {
+TEST_CASE("open air altitude penalty ignores roofs and adjacent hover", "[monster][ai][zlevel]") {
     setup_open_sky();
 
     auto& zed = spawn_test_monster("mon_zombie", tripoint_bub_ms(60, 60, 0));
@@ -134,8 +130,7 @@ TEST_CASE("open air altitude penalty ignores roofs and adjacent hover",
     CHECK(wasp.unengageable_altitude_penalty(zed) == 0);
 }
 
-TEST_CASE("zombies prefer a ground survivor over a stratospheric drone",
-          "[monster][ai][zlevel]") {
+TEST_CASE("zombies prefer a ground survivor over a stratospheric drone", "[monster][ai][zlevel]") {
     setup_open_sky();
 
     const auto zed_pos = tripoint_bub_ms(60, 60, 0);
@@ -157,8 +152,9 @@ TEST_CASE("zombies prefer a ground survivor over a stratospheric drone",
     CHECK(plan.goal == get_avatar().bub_pos());
 }
 
-TEST_CASE("unreachable open air target is not dropped when it is the only prey",
-          "[monster][ai][zlevel]") {
+TEST_CASE(
+    "unreachable open air target is not dropped when it is the only prey",
+    "[monster][ai][zlevel]") {
     setup_open_sky();
     put_player_underground();
 


### PR DESCRIPTION
## Purpose of change (The Why)

I was looking at a parking-lot horde that wouldn't aggro me. They were all staring at a wasp queen one z-level up in open air. There was also an eyebot at z=9 marked Fleeing. You can't punch either of those from the ground, so the zeds just piled up under them.

Fleeing flyers were adding their current height difference every turn, so they keep going higher. HIT_AND_RUN wasps hit the same path after a melee hit. After that, the closest thing the zeds can see is the flyer, they path to it, and nothing dies.

## Describe the solution (The How)

This is all in `monmove.cpp`:

- Fleeing flyers only change z by one level per turn, or stay put if they're already above the target.
- Ground monsters can melee into open air one z-level up. They still can't punch through a roof.
- If something is in open air more than 1 z away, it counts as farther, so zeds pick you if they can see you. If the flyer is all they can see, they still go for it.

## Describe alternatives you've considered

I didn't add a timeout that drops unreachable goals. That would also dump last-known when you climb onto a roof.

Taking `FLIES` off the wasp queen, or making insects ignore zombies, would only hide this for one spawn.

## Testing

Catch2 in `tests/monster_vertical_ai_test.cpp`, tag `[monster][ai][zlevel]`. Six cases, all passed locally.

In-game: wasp or eyebot over pavement with zeds around. They should get hit from below if they're only one level up, and zeds should notice you if you're closer than a drone two levels up. Climb onto a roof; they shouldn't lose interest after a few turns.

## Additional context

Looked at this on a save: queen at `(59,99,1)` over pavement, eyebot at `(136,85,9)` Fleeing. First glance I thought the drone was a manhack. It was an eyebot.

## Checklist

### Mandatory

- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [2be1ffa](https://github.com/cataclysmbn/Cataclysm-BN/commit/2be1ffa9efb0bfc199760004d63ea0a23abc1a6e) (style(autofix.ci): automated formatting) on 2026-09-12 06:00:19

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34673944993/artifacts/10291754924)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34673944993/artifacts/10292262640)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34673944993/artifacts/10291909086)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34673944993/artifacts/10292186884)
<!-- END artifact comment -->