### PR TITLE
fix: fix dino dave questline errors

### DIFF
--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -244,8 +244,8 @@
       "effect": [
         { "finish_mission": "MISSION_BEGGAR_2_PERMISSION", "success": true },
         { "npc_first_topic": "TALK_DINODAVE_1" },
-        { "mapgen_update": "cardboard_castle_1_main", "om_terrain": "evac_center_13_z1" },
-        { "mapgen_update": "cardboard_castle_1_roof", "om_terrain": "evac_center_13_z2" }
+        { "mapgen_update": "cardboard_castle_1_main", "om_terrain": "evac_center_13_z1", "z": 1 },
+        { "mapgen_update": "cardboard_castle_1_roof", "om_terrain": "evac_center_13_z2", "z": 2 }
       ]
     },
     "responses": [ { "text": "I'll see you on the rooftop.  Good luck, Dave.", "topic": "TALK_DONE" } ]
@@ -467,9 +467,9 @@
     "update_mapgen_id": "refcenter_unlock_roofstairs",
     "method": "json",
     "object": {
-      "set": [
-        { "point": "terrain", "id": "t_door_metal_c", "x": 1, "y": 14 },
-        { "point": "terrain", "id": "t_door_metal_c", "x": 21, "y": 14 }
+      "translate_ter": [
+        { "from": "t_door_metal_locked", "to": "t_door_metal_c", "x": 1, "y": 14 },
+        { "from": "t_door_metal_locked", "to": "t_door_metal_c", "x": 21, "y": 14 }
       ]
     }
   }


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Dino Dave's questline has multiple errors, including a game freeze + error upon completion, and the doors to the roof not actually unlocking.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Fixes these issues.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Errors
## Testing
Did the questline, everything "works" as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Dino Dave doesn't actually go to the roof, and it seems like there is no mechanic currently to make him go to the roof, but at least no errors and doors not stuck.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a972376](https://github.com/cataclysmbn/Cataclysm-BN/commit/a9723767df7599d855f66169f33d79b0f14ff8b5) (Update BEGGAR_2_Dino_Dave.json) on 2026-09-12 19:24:13

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34710214197/artifacts/10303991418)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34710214197)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34710214197/artifacts/10302864308)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34710214197/artifacts/10302759078)
<!-- END artifact comment -->