### PR TITLE
feat: make zombies actually shake players out of trees

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2085,7 +2085,7 @@ tripoint_bub_ms monster::scent_move() const
             ( ( can_move_to( dest ) && !here.obstructed_by_vehicle_rotation( pos, dest ) ) ||
               ( dest == g->u.bub_pos() ) ||
               ( can_bash && here.is_bashable( dest ) &&
-                ( here.bash_rating( bash_estimate( dest ), dest ) > 0 || here.has_flag( TFLAG_TREE, candidate ) ) ) ) ) {
+                ( here.bash_rating( bash_estimate( dest ), dest ) > 0 || here.has_flag( TFLAG_TREE, dest ) ) ) ) ) {
             if( ( !fleeing && smell > bestsmell ) || ( fleeing && smell < bestsmell ) ) {
                 smove_count = 0;
                 smoves[smove_count++] = dest;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1384,10 +1384,10 @@ monster_action_t monster::decide_action() const
                     continue;
                 }
                 const auto estimate = here.bash_rating( bash_estimate( candidate ), candidate );
-                if( estimate <= 0 ) {
+                if( estimate <= 0 && !here.has_flag( TFLAG_TREE, candidate ) ) {
                     continue;
                 }
-                if( estimate < 5 ) {
+                if( estimate < 5 && !here.has_flag( TFLAG_TREE, candidate ) ) {
                     bad_choice = true;
                 }
             }
@@ -2085,7 +2085,7 @@ tripoint_bub_ms monster::scent_move() const
             ( ( can_move_to( dest ) && !here.obstructed_by_vehicle_rotation( pos, dest ) ) ||
               ( dest == g->u.bub_pos() ) ||
               ( can_bash && here.is_bashable( dest ) &&
-                here.bash_rating( bash_estimate( dest ), dest ) > 0 ) ) ) {
+                ( here.bash_rating( bash_estimate( dest ), dest ) > 0 || here.has_flag( TFLAG_TREE, candidate ) ) ) ) ) {
             if( ( !fleeing && smell > bestsmell ) || ( fleeing && smell < bestsmell ) ) {
                 smove_count = 0;
                 smoves[smove_count++] = dest;


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
There is an existing mechanic where zombies can shake a player out of a tree by bashing it to counter using trees as invincible roofs to slaughter zombies from. However, zombies never actually use this mechanic because zombies never bash terrain they do not have the bash strength to actually break, and trees all have extremely high bash ratings, so this mechanic is basically never used.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes zombies bash any terrain with the flag TREE even if they do not have the bash strength to break it, thus putting this mechanic actually into play.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
they're in the trees!
## Testing
Build artifacts
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Obligatory "this will ruin the game"
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [3c190fe](https://github.com/cataclysmbn/Cataclysm-BN/commit/3c190fe0a33093190b5ee7fe5c2422f642f3daf1) (Update monmove.cpp) on 2026-09-12 19:46:09

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34711045454/artifacts/10303780155)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34711045454/artifacts/10304885708)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34711045454/artifacts/10303327828)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34711045454/artifacts/10302839859)
<!-- END artifact comment -->