### PR TITLE
build: upload windows artifacts before running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -822,42 +822,6 @@ jobs:
           $target = if ("${{ matrix.tiles }}" -eq "true") { "cata_test-tiles" } else { "cata_test" }
           cmake --build $buildDir --target $target --config Release
 
-      - name: Run sharded tests (desktop)
-        if: inputs.run-tests && (runner.os == 'Windows' || (runner.os == 'Linux' && (matrix.android == '' || matrix.android == 'none')))
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $buildDir = if ($IsWindows) {
-            "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc"
-          } else {
-            "${{ github.workspace }}/build"
-          }
-          $exeName = if ("${{ matrix.tiles }}" -eq "true") { "cata_test-tiles" } else { "cata_test" }
-          if ($IsWindows) {
-            $exeName = "$exeName.exe"
-          }
-          $testBin = Join-Path $buildDir (Join-Path "tests" $exeName)
-          if (-not (Test-Path $testBin)) {
-            throw "Missing test executable: $testBin"
-          }
-
-          $testOpts = @(
-            "--min-duration", "20",
-            "--use-colour", "yes",
-            "--rng-seed", "time",
-            "--error-format=github-action"
-          )
-          if ($IsLinux -and "${{ matrix.tiles }}" -eq "true") {
-            $testOpts += "--gpu-backend=software"
-          }
-          deno run --allow-read --allow-write --allow-run --allow-env `
-            build-scripts/run-linux-test-shards.ts `
-            --mode file-tags `
-            --jobs 4 `
-            --non-slow-shards 8 `
-            $testBin `
-            -- `
-            @testOpts
 
       # Upload artifacts
       - name: Upload packaged build artifact
@@ -897,3 +861,40 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
+
+      - name: Run sharded tests (desktop)
+        if: inputs.run-tests && (runner.os == 'Windows' || (runner.os == 'Linux' && (matrix.android == '' || matrix.android == 'none')))
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $buildDir = if ($IsWindows) {
+            "${{ github.workspace }}/out/build/windows-tiles-sounds-x64-msvc"
+          } else {
+            "${{ github.workspace }}/build"
+          }
+          $exeName = if ("${{ matrix.tiles }}" -eq "true") { "cata_test-tiles" } else { "cata_test" }
+          if ($IsWindows) {
+            $exeName = "$exeName.exe"
+          }
+          $testBin = Join-Path $buildDir (Join-Path "tests" $exeName)
+          if (-not (Test-Path $testBin)) {
+            throw "Missing test executable: $testBin"
+          }
+
+          $testOpts = @(
+            "--min-duration", "20",
+            "--use-colour", "yes",
+            "--rng-seed", "time",
+            "--error-format=github-action"
+          )
+          if ($IsLinux -and "${{ matrix.tiles }}" -eq "true") {
+            $testOpts += "--gpu-backend=software"
+          }
+          deno run --allow-read --allow-write --allow-run --allow-env `
+            build-scripts/run-linux-test-shards.ts `
+            --mode file-tags `
+            --jobs 4 `
+            --non-slow-shards 8 `
+            $testBin `
+            -- `
+            @testOpts


### PR DESCRIPTION
## Purpose of change (The Why)
Let derg get artifact fasters

## Describe the solution (The How)
Move things around

## Describe alternatives you've considered
None

## Testing
I dont really know how to test...

## Additional context
This was just copy paste so should work...
And I copy pasted the unchanged portion above so....

## Checklist
### Mandatory
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [b15858f](https://github.com/cataclysmbn/Cataclysm-BN/commit/b15858f13b6672e09e177240ca29ca217319f452) (build: upload windows artifacts before running tests) on 2026-09-12 20:31:54

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34713518282/artifacts/10305555216)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34713518282/artifacts/10304332772)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34713518282/artifacts/10305080301)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34713518282/artifacts/10304171912)
<!-- END artifact comment -->