### PR TITLE
feat: make trees harder to climb

### DIFF
--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -2391,6 +2391,7 @@ auto mapbuffer::climb_difficulty( const tripoint_abs_ms &p,
                 best_difficulty = 5;
             }
         }
+    }
 
     return std::max( 0, best_difficulty - blocks_movement );
 }

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -2386,14 +2386,14 @@ auto mapbuffer::climb_difficulty( const tripoint_abs_ms &p,
 
         if( best_difficulty > 5 && tile && has_flag( tile->tile(), "CLIMBABLE" ) ) {
             if( has_flag( tile->tile(), "TREE" ) {
-                best_difficulty = 15;
-            } else {
-                best_difficulty = 5;
-            }
+            best_difficulty = 15;
+        } else {
+            best_difficulty = 5;
         }
     }
+}
 
-    return std::max( 0, best_difficulty - blocks_movement );
+return std::max( 0, best_difficulty - blocks_movement );
 }
 
 auto mapbuffer::has_flag( const std::string &flag, const tripoint_abs_ms &p,

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -2392,7 +2392,7 @@ auto mapbuffer::climb_difficulty( const tripoint_abs_ms &p,
             }
         }
     }
-    
+
     return std::max( 0, best_difficulty - blocks_movement );
 }
 

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -2386,14 +2386,14 @@ auto mapbuffer::climb_difficulty( const tripoint_abs_ms &p,
 
         if( best_difficulty > 5 && tile && has_flag( tile->tile(), "CLIMBABLE" ) ) {
             if( has_flag( tile->tile(), "TREE" ) {
-            best_difficulty = 15;
-        } else {
-            best_difficulty = 5;
+                best_difficulty = 15;
+            } else {
+                best_difficulty = 5;
+            }
         }
     }
-}
-
-return std::max( 0, best_difficulty - blocks_movement );
+    
+    return std::max( 0, best_difficulty - blocks_movement );
 }
 
 auto mapbuffer::has_flag( const std::string &flag, const tripoint_abs_ms &p,

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -2385,16 +2385,15 @@ auto mapbuffer::climb_difficulty( const tripoint_abs_ms &p,
         }
 
         if( best_difficulty > 5 && tile && has_flag( tile->tile(), "CLIMBABLE" ) ) {
-            if ( has_flag( tile->tile(), "TREE" ) {
-                best_difficulty = 15;
-            }
-            else {
-                best_difficulty = 5;
-            }
+            if( has_flag( tile->tile(), "TREE" ) {
+            best_difficulty = 15;
+        } else {
+            best_difficulty = 5;
         }
     }
+}
 
-    return std::max( 0, best_difficulty - blocks_movement );
+return std::max( 0, best_difficulty - blocks_movement );
 }
 
 auto mapbuffer::has_flag( const std::string &flag, const tripoint_abs_ms &p,

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -2385,7 +2385,12 @@ auto mapbuffer::climb_difficulty( const tripoint_abs_ms &p,
         }
 
         if( best_difficulty > 5 && tile && has_flag( tile->tile(), "CLIMBABLE" ) ) {
-            best_difficulty = 5;
+            if ( has_flag( tile->tile(), "TREE" ) {
+                best_difficulty = 15;
+            }
+            else {
+                best_difficulty = 5;
+            }
         }
     }
 

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -2385,15 +2385,14 @@ auto mapbuffer::climb_difficulty( const tripoint_abs_ms &p,
         }
 
         if( best_difficulty > 5 && tile && has_flag( tile->tile(), "CLIMBABLE" ) ) {
-            if( has_flag( tile->tile(), "TREE" ) {
-            best_difficulty = 15;
-        } else {
-            best_difficulty = 5;
+            if( has_flag( tile->tile(), "TREE" ) ) {
+                best_difficulty = 15;
+            } else {
+                best_difficulty = 5;
+            }
         }
-    }
-}
 
-return std::max( 0, best_difficulty - blocks_movement );
+    return std::max( 0, best_difficulty - blocks_movement );
 }
 
 auto mapbuffer::has_flag( const std::string &flag, const tripoint_abs_ms &p,


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Trees are kinda OP since they are essentially an invincible roof to poke enemies from. I wanted to make this less viable with no planning while still making this strat completely usable.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes trees much harder to climb, this means that you will need to "set up" per say instead of just finding the nearest tree to gain invincibility.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
lack of balance
## Testing
build artifacts
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [c396d09](https://github.com/cataclysmbn/Cataclysm-BN/commit/c396d090f1501ae683841aec345f856082e53727) (Update mapbuffer.cpp) on 2026-09-12 21:59:30

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34718025656/artifacts/10306296588)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34718025656/artifacts/10305149311)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34718025656/artifacts/10305872802)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34718025656/artifacts/10305203860)
<!-- END artifact comment -->