### PR TITLE
feat: make trees harder to climb attempt 2

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -16796,6 +16796,10 @@ bool game::slip_down()
 {
     ///\EFFECT_DEX decreases chances of slipping while climbing
     int climb = u.dex_cur;
+    // Make climbing trees harder
+    if( m.has_flag( "TREE", u.bub_pos() ) ) {
+        climb = 2;
+    }
     // Parkour and Bad Knees affect it too, avoid division by zero
     if( u.mutation_value( "movecost_obstacle_modifier" ) != 0.0f ) {
         climb = climb / u.mutation_value( "movecost_obstacle_modifier" );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)
Trees are kinda OP since they are essentially an invincible roof to poke enemies from. I wanted to make this less viable with no planning while still making this strat completely usable.
<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Makes trees much harder to climb, this means that you will need to "set up" per say instead of just finding the nearest tree to gain invincibility.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
lack of balance
## Testing
build artifacts
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a51780d](https://github.com/cataclysmbn/Cataclysm-BN/commit/a51780df7695e7ea6a4b343adeb8e32ca6b0dd5d) (Update game.cpp) on 2026-09-12 22:52:23

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34720308468/artifacts/10306679027)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34720308468/artifacts/10306411559)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34720308468/artifacts/10305044576)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34720308468/artifacts/10305194440)
<!-- END artifact comment -->