### PR TITLE
fix: stop charged tools from vanishing in install menus

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9787,6 +9787,23 @@ bool item::allow_crafting_component() const
         return valid;
     }
 
+    // Tools with inserted magazines (battery cells, etc) still count as components.
+    // consume_items already returns those magazines via remove_ammo.
+    if( is_tool() ) {
+        bool valid = true;
+        visit_items( [&]( const item * it ) {
+            if( this == it ) {
+                return VisitResponse::NEXT;
+            }
+            if( it->is_magazine() || ( it->is_toolmod() && it->is_irremovable() ) ) {
+                return VisitResponse::NEXT;
+            }
+            valid = false;
+            return VisitResponse::ABORT;
+        } );
+        return valid;
+    }
+
     return contents.empty();
 }
 

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -413,3 +413,63 @@ TEST_CASE("gunmod_weight_volume_test", "[item][gunmod]") {
         CHECK(gun->volume() == std::max(v0 - 999_ml, v0 / 100));
     }
 }
+
+TEST_CASE("magazine_tools_are_crafting_components", "[item][crafting]") {
+    SECTION("empty water purifier counts") {
+        item& purifier = *item::spawn_temporary("water_purifier");
+        REQUIRE(purifier.is_tool());
+        REQUIRE(purifier.contents.empty());
+        CHECK(is_crafting_component(purifier));
+    }
+
+    SECTION("water purifier with a charged battery cell counts") {
+        item& purifier = *item::spawn_temporary("water_purifier");
+        const itype_id ammo = purifier.ammo_default();
+        REQUIRE_FALSE(ammo.is_null());
+        purifier.ammo_set(ammo, -1);
+        REQUIRE(purifier.magazine_current() != nullptr);
+        CHECK(is_crafting_component(purifier));
+    }
+
+    SECTION("water purifier with an empty battery cell still inserted counts") {
+        item& purifier = *item::spawn_temporary("water_purifier");
+        const itype_id mag = purifier.magazine_default();
+        REQUIRE_FALSE(mag.is_null());
+        purifier.put_in(item::spawn(mag));
+        REQUIRE(purifier.magazine_current() != nullptr);
+        REQUIRE(purifier.ammo_remaining() == 0);
+        CHECK(is_crafting_component(purifier));
+    }
+
+    SECTION("flashlight with a battery cell counts") {
+        item& light = *item::spawn_temporary("flashlight");
+        const itype_id ammo = light.ammo_default();
+        REQUIRE_FALSE(ammo.is_null());
+        light.ammo_set(ammo, -1);
+        REQUIRE(light.magazine_current() != nullptr);
+        CHECK(is_crafting_component(light));
+    }
+
+    SECTION("UPS-modded welder does not count") {
+        item& welder = *item::spawn_temporary("welder", calendar::start_of_cataclysm, 0);
+        welder.put_in(item::spawn("battery_ups"));
+        REQUIRE_FALSE(welder.toolmods().empty());
+        CHECK_FALSE(is_crafting_component(welder));
+    }
+
+    SECTION("filled jerrycan still does not count") {
+        detached_ptr<item> can = item::spawn("jerrycan");
+        can->fill_with(item::spawn("water"), -1);
+        REQUIRE_FALSE(can->contents.empty());
+        CHECK_FALSE(is_crafting_component(*can));
+    }
+
+    SECTION("loaded gun still counts") {
+        item& gun = *item::spawn_temporary("glock_19");
+        REQUIRE(gun.is_gun());
+        const itype_id ammo = gun.ammo_default();
+        REQUIRE_FALSE(ammo.is_null());
+        gun.ammo_set(ammo, -1);
+        CHECK(is_crafting_component(gun));
+    }
+}

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -172,11 +172,10 @@ TEST_CASE("loaded_tools_install_and_craft_as_components", "[vehicle][crafting][c
         you.i_add(spawn_tool_with_cell("water_purifier"));
         you.mod_moves(1);
         const inventory crafting_inv = you.crafting_inventory();
-        CHECK(crafting_inv.has_components(
-            itype_id("water_purifier"), 1, is_crafting_component));
+        CHECK(crafting_inv.has_components(itype_id("water_purifier"), 1, is_crafting_component));
         CHECK(vpart_id("water_purifier")
-              ->install_requirements()
-              .can_make_with_inventory(crafting_inv, is_crafting_component));
+                  ->install_requirements()
+                  .can_make_with_inventory(crafting_inv, is_crafting_component));
     }
 
     SECTION("vehicle install sees a charged flashlight as aisle lights") {
@@ -185,8 +184,8 @@ TEST_CASE("loaded_tools_install_and_craft_as_components", "[vehicle][crafting][c
         you.mod_moves(1);
         const inventory crafting_inv = you.crafting_inventory();
         CHECK(vpart_id("aisle_lights")
-              ->install_requirements()
-              .can_make_with_inventory(crafting_inv, is_crafting_component));
+                  ->install_requirements()
+                  .can_make_with_inventory(crafting_inv, is_crafting_component));
     }
 
     SECTION("grid water purifier construction sees a charged purifier") {

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -4,6 +4,7 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "catch/catch.hpp"
+#include "construction.h"
 #include "coordinates.h"
 #include "game.h"
 #include "inventory.h"
@@ -12,6 +13,8 @@
 #include "map_helpers.h"
 #include "player_activity.h"
 #include "player_helpers.h"
+#include "recipe.h"
+#include "recipe_dictionary.h"
 #include "requirements.h"
 #include "state_helpers.h"
 #include "type_id.h"
@@ -146,4 +149,93 @@ TEST_CASE("debug_hammerspace_installs_full_vehicle_battery", "[vehicle][veh_inte
 
     REQUIRE(installed_battery != all_parts.end());
     CHECK(installed_battery->part().ammo_remaining() == installed_battery->part().ammo_capacity());
+}
+
+static detached_ptr<item> spawn_tool_with_cell(const std::string& id) {
+    detached_ptr<item> tool = item::spawn(id);
+    const itype_id ammo = tool->ammo_default();
+    REQUIRE_FALSE(ammo.is_null());
+    tool->ammo_set(ammo, -1);
+    REQUIRE(tool->magazine_current() != nullptr);
+    return tool;
+}
+
+TEST_CASE("loaded_tools_install_and_craft_as_components", "[vehicle][crafting][construction]") {
+    clear_all_state();
+    avatar& you = get_avatar();
+    clear_avatar();
+    you.setpos(tripoint_bub_ms(60, 60, 0));
+    you.wear_item(item::spawn("backpack"), false);
+
+    SECTION("vehicle install sees a charged water purifier") {
+        you.i_add(item::spawn("screwdriver"));
+        you.i_add(spawn_tool_with_cell("water_purifier"));
+        you.mod_moves(1);
+        const inventory crafting_inv = you.crafting_inventory();
+        CHECK(crafting_inv.has_components(
+            itype_id("water_purifier"), 1, is_crafting_component));
+        CHECK(vpart_id("water_purifier")
+              ->install_requirements()
+              .can_make_with_inventory(crafting_inv, is_crafting_component));
+    }
+
+    SECTION("vehicle install sees a charged flashlight as aisle lights") {
+        you.i_add(item::spawn("screwdriver"));
+        you.i_add(spawn_tool_with_cell("flashlight"));
+        you.mod_moves(1);
+        const inventory crafting_inv = you.crafting_inventory();
+        CHECK(vpart_id("aisle_lights")
+              ->install_requirements()
+              .can_make_with_inventory(crafting_inv, is_crafting_component));
+    }
+
+    SECTION("grid water purifier construction sees a charged purifier") {
+        you.i_add(spawn_tool_with_cell("water_purifier"));
+        you.mod_moves(1);
+        const inventory crafting_inv = you.crafting_inventory();
+        const construction& con = construction_str_id("constr_gridwater_purifier").obj();
+        bool found_purifier = false;
+        for (const auto& opts : con.requirements.obj().get_components()) {
+            for (const item_comp& comp : opts) {
+                if (comp.type == itype_id("water_purifier")) {
+                    found_purifier = true;
+                    CHECK(comp.has(crafting_inv, is_crafting_component, 1));
+                }
+            }
+        }
+        REQUIRE(found_purifier);
+    }
+
+    SECTION("kitchen buddy recipe sees a charged purifier") {
+        you.i_add(spawn_tool_with_cell("water_purifier"));
+        you.mod_moves(1);
+        const inventory crafting_inv = you.crafting_inventory();
+        const recipe& rec = recipe_id("craftrig").obj();
+        bool found_purifier = false;
+        for (const auto& opts : rec.simple_requirements().get_components()) {
+            for (const item_comp& comp : opts) {
+                if (comp.type == itype_id("water_purifier")) {
+                    found_purifier = true;
+                    CHECK(comp.has(crafting_inv, rec.get_component_filter(), 1));
+                }
+            }
+        }
+        REQUIRE(found_purifier);
+    }
+
+    SECTION("consuming a charged purifier returns the battery cell") {
+        detached_ptr<item> loaded = spawn_tool_with_cell("water_purifier");
+        const itype_id mag = loaded->magazine_default();
+        REQUIRE_FALSE(mag.is_null());
+        you.i_add(std::move(loaded));
+        REQUIRE_FALSE(player_has_item_of_type(mag.str()));
+
+        std::vector<item_comp> comps{item_comp(itype_id("water_purifier"), 1)};
+        std::vector<detached_ptr<item>> used = you.consume_items(comps, 1, is_crafting_component);
+
+        REQUIRE(used.size() == 1);
+        CHECK(used[0]->typeId() == itype_id("water_purifier"));
+        CHECK(used[0]->magazine_current() == nullptr);
+        CHECK(player_has_item_of_type(mag.str()));
+    }
 }


### PR DESCRIPTION
## Purpose of change (The Why)

I tried to screw a water purifier onto the car. It was in my inventory with a battery cell in it, and the install pane listed `1 water purifier` in red like I didn't have one. Pulled the cell out and it went green right away.

Construction and recipes use the same check when they eat the tool as a part, not as a power source. A charged flashlight won't count for aisle lights, and a charged purifier won't count for the grid unit or a kitchen buddy.

## Describe the solution (The How)

- Tools with a battery cell (or other magazine) now count as components, the same way loaded guns already count for turrets.
- When you actually consume the tool, the cell still gets dumped back into inventory.
- A filled jerrycan or a welder with a UPS conversion kit still does not count.

## Describe alternatives you've considered

A special "unload first" tag, or only patching the vehicle menu. That would leave construction and kitchen-buddy crafting with the same silent miss.

## Testing

Catch2 covers a charged water purifier and flashlight, an empty cell still in the well, a UPS-modded welder, a filled jerrycan, a loaded gun, vehicle install requirements, grid purifier construction, the kitchen buddy recipe, and consume returning the cell.

For a reviewer: put a charged water purifier in inventory, open vehicle install, it should show as in stock. After install the cell should be back in your pack.

## Additional context

Open #8740 is a different bug (ammo recovery *after* a charged item is consumed). Here the loaded tool never counted as a component at all.

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [943ca52](https://github.com/cataclysmbn/Cataclysm-BN/commit/943ca52c6bc6c3f5099930a47296aa01f6d76888) (style: apply astyle wrapping in vehicle interact tests) on 2026-09-13 04:00:06

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34733765285/artifacts/10310978294)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34733765285/artifacts/10310925726)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34733765285/artifacts/10310339457)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34733765285/artifacts/10309948431)
<!-- END artifact comment -->