### PR TITLE
fix: keep fuel when installing a filled jerrycan as a tank

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -2593,14 +2593,17 @@ class Character : public Creature, public location_visitable<Character>
                                int batch, inventory &map_inv, bool can_cancel = false,
                                const std::function<bool( const item & )> &filter = return_true<item>, bool player_inv = true );
         std::vector<detached_ptr<item>> consume_items( const comp_selection<item_comp> &is, int batch,
-                                     const std::function<bool( const item & )> &filter = return_true<item> );
+                                     const std::function<bool( const item & )> &filter = return_true<item>,
+                                     bool unload = true );
         std::vector<detached_ptr<item>> consume_items( map &m, const comp_selection<item_comp> &is,
                                      int batch,
                                      const tripoint_bub_ms &origin, int radius,
-                                     const std::function<bool( const item & )> &filter = return_true<item> );
+                                     const std::function<bool( const item & )> &filter = return_true<item>,
+                                     bool unload = true );
         std::vector<detached_ptr<item>> consume_items( const std::vector<item_comp> &components,
                                      int batch = 1,
-                                     const std::function<bool( const item & )> &filter = return_true<item> );
+                                     const std::function<bool( const item & )> &filter = return_true<item>,
+                                     bool unload = true );
         /** Consume tools for the next multiplier * 5% progress of the craft */
         bool craft_consume_tools( item &craft, int mulitplier, bool start_craft );
         void consume_tools( const comp_selection<tool_comp> &tool, int batch );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1666,16 +1666,16 @@ static void empty_buckets( Character &p )
 
 std::vector<detached_ptr<item>> Character::consume_items( const comp_selection<item_comp> &is,
                              int batch,
-                             const std::function<bool( const item & )> &filter )
+                             const std::function<bool( const item & )> &filter, bool unload )
 {
-    return consume_items( get_map(), is, batch, bub_pos(), PICKUP_RANGE, filter );
+    return consume_items( get_map(), is, batch, bub_pos(), PICKUP_RANGE, filter, unload );
 }
 
 std::vector<detached_ptr<item>> Character::consume_items( map &m,
                              const comp_selection<item_comp> &is,
                              int batch,
                              const tripoint_bub_ms &origin, int radius,
-                             const std::function<bool( const item & )> &filter )
+                             const std::function<bool( const item & )> &filter, bool unload )
 {
     std::vector<detached_ptr<item>> ret;
 
@@ -1713,7 +1713,9 @@ std::vector<detached_ptr<item>> Character::consume_items( map &m,
             for( detached_ptr<item> &i : tmp ) {
                 as_p.push_back( &*i );
             }
-            remove_ammo( as_p, *this );
+            if( unload ) {
+                remove_ammo( as_p, *this );
+            }
             ret.insert( ret.end(), std::make_move_iterator( tmp.begin() ),
                         std::make_move_iterator( tmp.end() ) );
         }
@@ -1730,7 +1732,9 @@ std::vector<detached_ptr<item>> Character::consume_items( map &m,
             for( detached_ptr<item> &i : tmp ) {
                 as_p.push_back( &*i );
             }
-            remove_ammo( as_p, *this );
+            if( unload ) {
+                remove_ammo( as_p, *this );
+            }
             ret.insert( ret.end(), std::make_move_iterator( tmp.begin() ),
                         std::make_move_iterator( tmp.end() ) );
         }
@@ -1754,12 +1758,12 @@ In that case, consider using select_item_component with 1 pre-created map invent
 to consume_items */
 std::vector<detached_ptr<item>> Character::consume_items( const std::vector<item_comp> &components,
                              int batch,
-                             const std::function<bool( const item & )> &filter )
+                             const std::function<bool( const item & )> &filter, bool unload )
 {
     inventory map_inv;
     map_inv.form_from_map( bub_pos(), PICKUP_RANGE, this );
     return consume_items( select_item_component( components, batch, map_inv, false, filter ), batch,
-                          filter );
+                          filter, unload );
 }
 
 struct avail_tool_comp {

--- a/src/vehicle/veh_interact.cpp
+++ b/src/vehicle/veh_interact.cpp
@@ -340,8 +340,7 @@ bool veh_interact::format_reqs(
         msg += string_format("> %1$s%2$s</color>", status_color(true), _("NONE")) + "\n";
     }
 
-    auto comps =
-        reqs.get_folded_components_list(getmaxx(w_msg) - 2, c_white, inv, comp_filter);
+    auto comps = reqs.get_folded_components_list(getmaxx(w_msg) - 2, c_white, inv, comp_filter);
     for (const std::string& line : comps) { msg += line + "\n"; }
     auto tools = reqs.get_folded_tools_list(getmaxx(w_msg) - 2, c_white, inv);
     for (const std::string& line : tools) { msg += line + "\n"; }
@@ -1168,9 +1167,8 @@ void veh_interact::do_repair() {
 
         bool ok;
         if (pt.is_broken()) {
-            ok = format_reqs(
-                nmsg, vp.install_requirements(), vp.install_skills, vp.install_time(you),
-                veh_utils::install_component_filter(vp));
+            ok = format_reqs(nmsg, vp.install_requirements(), vp.install_skills,
+                             vp.install_time(you), veh_utils::install_component_filter(vp));
         } else {
             if (!vp.repair_requirements().is_empty() && pt.base->max_damage() > 0) {
                 ok = format_reqs(
@@ -1768,9 +1766,9 @@ bool veh_interact::can_remove_part(int idx, const Character& who) {
     }
 
     const auto reqs = sel_vpart_info->removal_requirements();
-    bool ok =
-        format_reqs(nmsg, reqs, sel_vpart_info->removal_skills, sel_vpart_info->removal_time(who),
-                    is_crafting_component);
+    bool ok = format_reqs(
+        nmsg, reqs, sel_vpart_info->removal_skills, sel_vpart_info->removal_time(who),
+        is_crafting_component);
     std::string additional_requirements;
     bool lifting_or_jacking_required = false;
 
@@ -2120,8 +2118,8 @@ int veh_interact::part_at(tripoint_bub_ms d) {
  */
 bool veh_interact::can_potentially_install(const vpart_info& vpart) {
     return get_avatar().has_trait(trait_DEBUG_HS)
-        || vpart.install_requirements().can_make_with_inventory(
-               crafting_inv, veh_utils::install_component_filter(vpart));
+        || vpart.install_requirements()
+               .can_make_with_inventory(crafting_inv, veh_utils::install_component_filter(vpart));
 }
 
 /**
@@ -3027,8 +3025,7 @@ void veh_interact::complete_vehicle(Character& who) {
             const auto reqs = vpinfo.install_requirements();
             const auto using_debug_hammerspace = who.has_trait(trait_DEBUG_HS);
             const auto comp_filter = veh_utils::install_component_filter(vpinfo);
-            if (!using_debug_hammerspace
-                && !reqs.can_make_with_inventory(inv, comp_filter)) {
+            if (!using_debug_hammerspace && !reqs.can_make_with_inventory(inv, comp_filter)) {
                 add_msg(m_info, _("You don't meet the requirements to install the %s."),
                         vpinfo.name());
                 break;

--- a/src/vehicle/veh_interact.cpp
+++ b/src/vehicle/veh_interact.cpp
@@ -316,10 +316,10 @@ void veh_interact::allocate_windows() {
 
 bool veh_interact::format_reqs(
     std::string& msg, const requirement_data& reqs, const std::map<skill_id, int>& skills,
-    int moves) const {
+    int moves, const std::function<bool(const item&)>& comp_filter) const {
     auto& you = get_avatar();
     const inventory& inv = you.crafting_inventory();
-    bool ok = reqs.can_make_with_inventory(inv, is_crafting_component);
+    bool ok = reqs.can_make_with_inventory(inv, comp_filter);
 
     msg += _("<color_white>Time required:</color>\n");
     // TODO: better have a from_moves function
@@ -341,7 +341,7 @@ bool veh_interact::format_reqs(
     }
 
     auto comps =
-        reqs.get_folded_components_list(getmaxx(w_msg) - 2, c_white, inv, is_crafting_component);
+        reqs.get_folded_components_list(getmaxx(w_msg) - 2, c_white, inv, comp_filter);
     for (const std::string& line : comps) { msg += line + "\n"; }
     auto tools = reqs.get_folded_tools_list(getmaxx(w_msg) - 2, c_white, inv);
     for (const std::string& line : tools) { msg += line + "\n"; }
@@ -770,7 +770,8 @@ bool veh_interact::update_part_requirements() {
     Character& you = get_player_character();
     std::string nmsg;
     bool ok = format_reqs(
-        nmsg, reqs, sel_vpart_info->install_skills, sel_vpart_info->install_time(*you.as_player()));
+        nmsg, reqs, sel_vpart_info->install_skills, sel_vpart_info->install_time(*you.as_player()),
+        veh_utils::install_component_filter(*sel_vpart_info));
 
     std::string additional_requirements;
     bool lifting_or_jacking_required = false;
@@ -1168,12 +1169,14 @@ void veh_interact::do_repair() {
         bool ok;
         if (pt.is_broken()) {
             ok = format_reqs(
-                nmsg, vp.install_requirements(), vp.install_skills, vp.install_time(you));
+                nmsg, vp.install_requirements(), vp.install_skills, vp.install_time(you),
+                veh_utils::install_component_filter(vp));
         } else {
             if (!vp.repair_requirements().is_empty() && pt.base->max_damage() > 0) {
                 ok = format_reqs(
                     nmsg, vp.repair_requirements() * pt.base->damage_level(4), vp.repair_skills,
-                    vp.repair_time(you) * pt.base->damage() / pt.base->max_damage());
+                    vp.repair_time(you) * pt.base->damage() / pt.base->max_damage(),
+                    is_crafting_component);
             } else {
                 nmsg += colorize(_("This part cannot be repaired"), c_light_red);
                 ok = false;
@@ -1766,7 +1769,8 @@ bool veh_interact::can_remove_part(int idx, const Character& who) {
 
     const auto reqs = sel_vpart_info->removal_requirements();
     bool ok =
-        format_reqs(nmsg, reqs, sel_vpart_info->removal_skills, sel_vpart_info->removal_time(who));
+        format_reqs(nmsg, reqs, sel_vpart_info->removal_skills, sel_vpart_info->removal_time(who),
+                    is_crafting_component);
     std::string additional_requirements;
     bool lifting_or_jacking_required = false;
 
@@ -2116,7 +2120,8 @@ int veh_interact::part_at(tripoint_bub_ms d) {
  */
 bool veh_interact::can_potentially_install(const vpart_info& vpart) {
     return get_avatar().has_trait(trait_DEBUG_HS)
-        || vpart.install_requirements().can_make_with_inventory(crafting_inv, is_crafting_component);
+        || vpart.install_requirements().can_make_with_inventory(
+               crafting_inv, veh_utils::install_component_filter(vpart));
 }
 
 /**
@@ -3021,8 +3026,9 @@ void veh_interact::complete_vehicle(Character& who) {
 
             const auto reqs = vpinfo.install_requirements();
             const auto using_debug_hammerspace = who.has_trait(trait_DEBUG_HS);
+            const auto comp_filter = veh_utils::install_component_filter(vpinfo);
             if (!using_debug_hammerspace
-                && !reqs.can_make_with_inventory(inv, is_crafting_component)) {
+                && !reqs.can_make_with_inventory(inv, comp_filter)) {
                 add_msg(m_info, _("You don't meet the requirements to install the %s."),
                         vpinfo.name());
                 break;
@@ -3033,7 +3039,8 @@ void veh_interact::complete_vehicle(Character& who) {
             } else {
                 // Consume items, extracting the specific base item for the installed part.
                 for (const auto& e : reqs.get_components()) {
-                    for (auto& obj : who.consume_items(e, 1, is_crafting_component)) {
+                    const auto unload = veh_utils::should_unload_install_component(vpinfo, e);
+                    for (auto& obj : who.consume_items(e, 1, comp_filter, unload)) {
                         if (obj->typeId() == vpinfo.item) { base = std::move(obj); }
                     }
                 }

--- a/src/vehicle/veh_interact.h
+++ b/src/vehicle/veh_interact.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+class item;
 class player;
 class vpart_info;
 struct requirement_data;
@@ -124,7 +125,7 @@ private:
     /** Format list of requirements returning true if all are met */
     bool format_reqs(
         std::string& msg, const requirement_data& reqs, const std::map<skill_id, int>& skills,
-        int moves) const;
+        int moves, const std::function<bool(const item&)>& comp_filter) const;
 
     int part_at(tripoint_bub_ms d);
     void move_cursor(tripoint_rel_veh d, int dstart_at = 0);

--- a/src/vehicle/veh_utils.cpp
+++ b/src/vehicle/veh_utils.cpp
@@ -9,6 +9,7 @@
 #include "game_constants.h"
 #include "inventory.h"
 #include "item.h"
+#include "item_contents.h"
 #include "locations.h"
 #include "map.h"
 #include "player.h"
@@ -22,14 +23,43 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <list>
+#include <ranges>
 #include <map>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+namespace {
+namespace ranges = std::ranges;
+
+auto is_liquid_only_container(const item& it) -> bool {
+    if (!it.is_watertight_container()) { return false; }
+    if (it.contents.empty()) { return true; }
+    const auto& inside = it.contents.all_items_top();
+    return ranges::all_of(inside, [](const item* e) { return e != nullptr && e->made_of(LIQUID); });
+}
+
+} // namespace
+
 namespace veh_utils {
+
+auto install_component_filter(const vpart_info& vp) -> std::function<bool(const item&)> {
+    const auto base = vp.item;
+    const auto keep_fluid = vp.has_flag(VPFLAG_FLUIDTANK);
+    return [base, keep_fluid](const item& it) {
+        if (keep_fluid && it.typeId() == base && is_liquid_only_container(it)) { return true; }
+        return is_crafting_component(it);
+    };
+}
+
+auto should_unload_install_component(const vpart_info& vp, const std::vector<item_comp>& comps)
+    -> bool {
+    if (!vp.has_flag(VPFLAG_FLUIDTANK)) { return true; }
+    return std::ranges::none_of(comps, [&](const item_comp& c) { return c.type == vp.item; });
+}
 
 int calc_xp_gain(const vpart_info& vp, const skill_id& sk, const Character& who) {
     const auto iter = vp.install_skills.find(sk);
@@ -57,7 +87,8 @@ vehicle_part& most_repairable_part(vehicle& veh, Character& who, bool only_repai
         if (vpr.part().removed || vpr.part().damage() <= 0) { continue; }
 
         if (vpr.part().is_broken()) {
-            if (info.install_requirements().can_make_with_inventory(inv, is_crafting_component)) {
+            if (info.install_requirements().can_make_with_inventory(
+                    inv, install_component_filter(info))) {
                 repairable_cache[&vpr.part()] = repairable_status::need_replacement;
             }
 
@@ -108,7 +139,10 @@ bool repair_part(vehicle& veh, vehicle_part& pt, Character& who_c) {
     // as they have the handicap of not being able to use the veh interaction menu
     // or able to drag a welding cart etc.
     map_inv.form_from_map(who.bub_pos(), PICKUP_RANGE, &who_c, false, !who.is_npc());
-    if (!reqs.can_make_with_inventory(inv, is_crafting_component)) {
+    const auto comp_filter =
+        pt.is_broken() ? install_component_filter(vp)
+                       : std::function<bool(const item&)>(is_crafting_component);
+    if (!reqs.can_make_with_inventory(inv, comp_filter)) {
         who.add_msg_if_player(
             m_info, _("You don't meet the requirements to repair the %s."), pt.name());
         return false;
@@ -117,8 +151,10 @@ bool repair_part(vehicle& veh, vehicle_part& pt, Character& who_c) {
     // consume items extracting any base item (which we will need if replacing broken part)
     detached_ptr<item> base = item::spawn(vp.item);
     for (const auto& e : reqs.get_components()) {
-        for (auto& obj :
-             who.consume_items(who.select_item_component(e, 1, map_inv), 1, is_crafting_component)) {
+        const auto unload = !pt.is_broken() || should_unload_install_component(vp, e);
+        for (auto& obj : who.consume_items(
+                 who.select_item_component(e, 1, map_inv, false, comp_filter), 1, comp_filter,
+                 unload)) {
             if (obj->typeId() == vp.item) { base = std::move(obj); }
         }
     }

--- a/src/vehicle/veh_utils.cpp
+++ b/src/vehicle/veh_utils.cpp
@@ -25,9 +25,9 @@
 #include <cmath>
 #include <functional>
 #include <list>
-#include <ranges>
 #include <map>
 #include <memory>
+#include <ranges>
 #include <string>
 #include <utility>
 #include <vector>
@@ -87,8 +87,8 @@ vehicle_part& most_repairable_part(vehicle& veh, Character& who, bool only_repai
         if (vpr.part().removed || vpr.part().damage() <= 0) { continue; }
 
         if (vpr.part().is_broken()) {
-            if (info.install_requirements().can_make_with_inventory(
-                    inv, install_component_filter(info))) {
+            if (info.install_requirements()
+                    .can_make_with_inventory(inv, install_component_filter(info))) {
                 repairable_cache[&vpr.part()] = repairable_status::need_replacement;
             }
 
@@ -140,8 +140,9 @@ bool repair_part(vehicle& veh, vehicle_part& pt, Character& who_c) {
     // or able to drag a welding cart etc.
     map_inv.form_from_map(who.bub_pos(), PICKUP_RANGE, &who_c, false, !who.is_npc());
     const auto comp_filter =
-        pt.is_broken() ? install_component_filter(vp)
-                       : std::function<bool(const item&)>(is_crafting_component);
+        pt.is_broken()
+            ? install_component_filter(vp)
+            : std::function<bool(const item&)>(is_crafting_component);
     if (!reqs.can_make_with_inventory(inv, comp_filter)) {
         who.add_msg_if_player(
             m_info, _("You don't meet the requirements to repair the %s."), pt.name());
@@ -152,9 +153,9 @@ bool repair_part(vehicle& veh, vehicle_part& pt, Character& who_c) {
     detached_ptr<item> base = item::spawn(vp.item);
     for (const auto& e : reqs.get_components()) {
         const auto unload = !pt.is_broken() || should_unload_install_component(vp, e);
-        for (auto& obj : who.consume_items(
-                 who.select_item_component(e, 1, map_inv, false, comp_filter), 1, comp_filter,
-                 unload)) {
+        for (auto& obj :
+             who.consume_items(who.select_item_component(e, 1, map_inv, false, comp_filter), 1,
+                               comp_filter, unload)) {
             if (obj->typeId() == vp.item) { base = std::move(obj); }
         }
     }

--- a/src/vehicle/veh_utils.h
+++ b/src/vehicle/veh_utils.h
@@ -1,15 +1,31 @@
 #pragma once
 
+#include "requirements.h"
 #include "type_id.h"
 
-class vehicle;
+#include <functional>
+#include <vector>
+
 class Character;
+class item;
+class vehicle;
 class vpart_info;
 struct vehicle_part;
 
 namespace veh_utils {
 /** Calculates xp for interacting with given part. */
 int calc_xp_gain(const vpart_info& vp, const skill_id& sk, const Character& who);
+/**
+ * Crafting-component filter for installing this part.
+ * Fluid tanks also accept their base container when it only holds liquid.
+ */
+auto install_component_filter(const vpart_info& vp) -> std::function<bool(const item&)>;
+/**
+ * False when this requirement slot is the fluid-tank base item, so consume
+ * must leave the liquid in the container instead of dumping it.
+ */
+auto should_unload_install_component(const vpart_info& vp, const std::vector<item_comp>& comps)
+    -> bool;
 /**
  * Returns a part on a given vehicle that a given character can repair.
  * Prefers the most damaged parts that don't need replacements.

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -4,6 +4,7 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "catch/catch.hpp"
+#include "construction.h"
 #include "coordinates.h"
 #include "game.h"
 #include "inventory.h"
@@ -16,6 +17,7 @@
 #include "state_helpers.h"
 #include "type_id.h"
 #include "vehicle/veh_type.h"
+#include "vehicle/veh_utils.h"
 #include "vehicle/vehicle.h"
 #include "vehicle/vpart_range.h"
 
@@ -146,4 +148,103 @@ TEST_CASE("debug_hammerspace_installs_full_vehicle_battery", "[vehicle][veh_inte
 
     REQUIRE(installed_battery != all_parts.end());
     CHECK(installed_battery->part().ammo_remaining() == installed_battery->part().ammo_capacity());
+}
+
+static detached_ptr<item> spawn_filled_container(const std::string& id, const std::string& liquid) {
+    detached_ptr<item> can = item::spawn(id);
+    can->fill_with(item::spawn(liquid), -1);
+    REQUIRE_FALSE(can->contents.empty());
+    REQUIRE(can->contents.front().typeId() == itype_id(liquid));
+    return can;
+}
+
+TEST_CASE("filled_containers_install_as_vehicle_tanks", "[vehicle][crafting][construction]") {
+    clear_all_state();
+    avatar& you = get_avatar();
+    clear_avatar();
+    you.setpos(tripoint_bub_ms(60, 60, 0));
+    you.wear_item(item::spawn("backpack"), false);
+
+    const auto& tank_small = vpart_id("tank_small").obj();
+    const auto tank_filter = veh_utils::install_component_filter(tank_small);
+
+    SECTION("install menu sees a gasoline jerrycan as a 10L tank") {
+        you.i_add(item::spawn("wrench"));
+        you.i_add(item::spawn("hand_drill"));
+        get_map().add_item_or_charges(you.bub_pos(), spawn_filled_container("jerrycan", "gasoline"));
+        you.mod_moves(1);
+        const inventory crafting_inv = you.crafting_inventory();
+        CHECK_FALSE(crafting_inv.has_components(itype_id("jerrycan"), 1, is_crafting_component));
+        CHECK(crafting_inv.has_components(itype_id("jerrycan"), 1, tank_filter));
+        CHECK(tank_small.install_requirements().can_make_with_inventory(crafting_inv, tank_filter));
+    }
+
+    SECTION("install menu sees a diesel steel jerrycan as a 20L tank") {
+        const auto& tank_medium = vpart_id("tank_medium").obj();
+        you.i_add(item::spawn("wrench"));
+        you.i_add(item::spawn("hand_drill"));
+        get_map().add_item_or_charges(
+            you.bub_pos(), spawn_filled_container("jerrycan_big", "diesel"));
+        you.mod_moves(1);
+        const inventory crafting_inv = you.crafting_inventory();
+        CHECK(tank_medium.install_requirements().can_make_with_inventory(
+            crafting_inv, veh_utils::install_component_filter(tank_medium)));
+    }
+
+    SECTION("consuming a filled jerrycan for a tank leaves the gasoline inside") {
+        get_map().add_item_or_charges(you.bub_pos(), spawn_filled_container("jerrycan", "gasoline"));
+        you.mod_moves(1);
+        std::vector<item_comp> comps{item_comp(itype_id("jerrycan"), 1)};
+        std::vector<detached_ptr<item>> used = you.consume_items(comps, 1, tank_filter, false);
+        REQUIRE(used.size() == 1);
+        CHECK(used[0]->typeId() == itype_id("jerrycan"));
+        REQUIRE_FALSE(used[0]->contents.empty());
+        CHECK(used[0]->contents.front().typeId() == itype_id("gasoline"));
+    }
+
+    SECTION("vehicle install keeps gasoline in the new tank") {
+        map& here = get_map();
+        const tripoint_bub_ms vehicle_origin(60, 60, 0);
+        you.setpos(vehicle_origin + point_south);
+        you.i_add(item::spawn("wrench"));
+        you.i_add(item::spawn("hand_drill"));
+        here.add_item_or_charges(you.bub_pos(), spawn_filled_container("jerrycan", "gasoline"));
+        you.mod_moves(1);
+
+        vehicle* veh_ptr = here.add_vehicle(vproto_id("bicycle"), vehicle_origin, 0_degrees, 0, 0);
+        REQUIRE(veh_ptr != nullptr);
+
+        const auto install_part_id = vpart_id("tank_small");
+        const auto reference_part_index = 0;
+        const auto reference_part = &veh_ptr->part(reference_part_index);
+        const auto reference_pos =
+            map_local_to_abs(here, veh_ptr->bub_part_location(*reference_part));
+
+        you.assign_activity(ACT_VEHICLE, 1, static_cast<int>('i'));
+        you.activity->values = {
+            reference_pos.x(), reference_pos.y(), reference_pos.z(), 0, 0, 0, reference_part_index};
+        you.activity->str_values.push_back(install_part_id.str());
+        for (const tripoint_abs_ms& p : veh_ptr->get_points(true)) {
+            you.activity->coord_set.insert(p);
+        }
+
+        veh_interact::complete_vehicle(you);
+
+        const auto all_parts = veh_ptr->get_all_parts();
+        const auto installed_tank = std::find_if(
+            all_parts.begin(), all_parts.end(), [&install_part_id](const vpart_reference& part) {
+                return part.info().get_id() == install_part_id;
+            });
+        REQUIRE(installed_tank != all_parts.end());
+        CHECK(installed_tank->part().ammo_current() == itype_id("gasoline"));
+        CHECK(installed_tank->part().ammo_remaining() > 0);
+    }
+
+    SECTION("wood stove construction still requires an empty metal tank") {
+        get_map().add_item_or_charges(you.bub_pos(), spawn_filled_container("metal_tank", "water"));
+        you.mod_moves(1);
+        const inventory crafting_inv = you.crafting_inventory();
+        CHECK_FALSE(crafting_inv.has_components(itype_id("metal_tank"), 1, is_crafting_component));
+        CHECK(construction_str_id("constr_woodstove").is_valid());
+    }
 }

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -171,7 +171,8 @@ TEST_CASE("filled_containers_install_as_vehicle_tanks", "[vehicle][crafting][con
     SECTION("install menu sees a gasoline jerrycan as a 10L tank") {
         you.i_add(item::spawn("wrench"));
         you.i_add(item::spawn("hand_drill"));
-        get_map().add_item_or_charges(you.bub_pos(), spawn_filled_container("jerrycan", "gasoline"));
+        get_map()
+            .add_item_or_charges(you.bub_pos(), spawn_filled_container("jerrycan", "gasoline"));
         you.mod_moves(1);
         const inventory crafting_inv = you.crafting_inventory();
         CHECK_FALSE(crafting_inv.has_components(itype_id("jerrycan"), 1, is_crafting_component));
@@ -183,8 +184,8 @@ TEST_CASE("filled_containers_install_as_vehicle_tanks", "[vehicle][crafting][con
         const auto& tank_medium = vpart_id("tank_medium").obj();
         you.i_add(item::spawn("wrench"));
         you.i_add(item::spawn("hand_drill"));
-        get_map().add_item_or_charges(
-            you.bub_pos(), spawn_filled_container("jerrycan_big", "diesel"));
+        get_map()
+            .add_item_or_charges(you.bub_pos(), spawn_filled_container("jerrycan_big", "diesel"));
         you.mod_moves(1);
         const inventory crafting_inv = you.crafting_inventory();
         CHECK(tank_medium.install_requirements().can_make_with_inventory(
@@ -192,7 +193,8 @@ TEST_CASE("filled_containers_install_as_vehicle_tanks", "[vehicle][crafting][con
     }
 
     SECTION("consuming a filled jerrycan for a tank leaves the gasoline inside") {
-        get_map().add_item_or_charges(you.bub_pos(), spawn_filled_container("jerrycan", "gasoline"));
+        get_map()
+            .add_item_or_charges(you.bub_pos(), spawn_filled_container("jerrycan", "gasoline"));
         you.mod_moves(1);
         std::vector<item_comp> comps{item_comp(itype_id("jerrycan"), 1)};
         std::vector<detached_ptr<item>> used = you.consume_items(comps, 1, tank_filter, false);
@@ -221,8 +223,9 @@ TEST_CASE("filled_containers_install_as_vehicle_tanks", "[vehicle][crafting][con
             map_local_to_abs(here, veh_ptr->bub_part_location(*reference_part));
 
         you.assign_activity(ACT_VEHICLE, 1, static_cast<int>('i'));
-        you.activity->values = {
-            reference_pos.x(), reference_pos.y(), reference_pos.z(), 0, 0, 0, reference_part_index};
+        you.activity->values =
+            {reference_pos.x(),   reference_pos.y(), reference_pos.z(), 0, 0, 0,
+             reference_part_index};
         you.activity->str_values.push_back(install_part_id.str());
         for (const tripoint_abs_ms& p : veh_ptr->get_points(true)) {
             you.activity->coord_set.insert(p);


### PR DESCRIPTION
## Purpose of change (The Why)

I had a full plastic jerrycan and the 10L vehicle tank stayed red in the install list. The can is the tank. Emptying it first dumps the fuel, then I pour it back in after the install.

That happens because install uses the same "empty contents" rule as crafting. `remove_ammo` would also dump the liquid on the ground if we just ignored that rule.

## Describe the solution (The How)

- Fluid-tank install (and replacing a broken tank) accepts the part's own container when it is empty or only holds liquid.
- That requirement slot is consumed without unloading, so the liquid stays in the installed tank.
- Recipes and furniture construction still want an empty container. A gasoline jerrycan is not a wood-stove component.

## Describe alternatives you've considered

Letting any filled container count as a crafting component. That would dump fuel when you craft or build, or eat a full metal tank into a stove.

## Testing

Added `filled_containers_install_as_vehicle_tanks`: gasoline jerrycan for `tank_small`, diesel steel can for `tank_medium`, consume keeps gasoline, bicycle install keeps ammo, filled `metal_tank` still fails `is_crafting_component`.

Did not rebuild the local exe for this PR. Reviewer: put a full jerrycan in reach, open vehicle install, bolt on the 10L tank, check it already has gasoline.

## Additional context

Same family of "item in hand but menu says no" as #10244, different hole (container liquid vs battery cell). Not stacked on that PR.

<!-- BEGIN artifact comment -->
<!-- END artifact comment -->

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
