### PR TITLE
fix: count a turned-on flashlight as a flashlight

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -48,6 +48,7 @@
 #include "iteminfo_format_utils.h"
 #include "iteminfo_query.h"
 #include "itype.h"
+#include "item_type_match.h"
 #include "iuse.h"
 #include "iuse_actor.h"
 #include "line.h"
@@ -9739,7 +9740,8 @@ detached_ptr<item> item::use_amount( detached_ptr<item> &&self, const itype_id &
     int old_quantity = quantity;
 
     self->remove_items_with( [&]( detached_ptr<item> &&a ) {
-        if( quantity > 0  && a->typeId() == it && filter( *a ) ) {
+        if( quantity > 0  && item_matches_itype( *a, it ) && filter( *a ) ) {
+            normalize_consumed_item( *a, it );
             used.push_back( std::move( a ) );
             quantity--;
             return VisitResponse::SKIP;
@@ -9751,7 +9753,8 @@ detached_ptr<item> item::use_amount( detached_ptr<item> &&self, const itype_id &
         self->on_contents_changed();
     }
 
-    if( quantity > 0 && self->typeId() == it && filter( *self ) ) {
+    if( quantity > 0 && item_matches_itype( *self, it ) && filter( *self ) ) {
+        normalize_consumed_item( *self, it );
         used.push_back( std::move( self ) );
         quantity--;
         return detached_ptr<item>();

--- a/src/item_type_match.h
+++ b/src/item_type_match.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "item.h"
+#include "itype.h"
+#include "iuse_actor.h"
+
+#include <ranges>
+
+/// True when @p base has a transform use that produces @p on_id (flashlight → flashlight_on).
+inline auto itype_transforms_into( const itype &base, const itype_id &on_id ) -> bool
+{
+    namespace ranges = std::ranges;
+    return ranges::any_of( base.use_methods, [&]( const auto &entry ) {
+        const auto *actor = dynamic_cast<const iuse_transform *>( entry.second.get_actor_ptr() );
+        return actor != nullptr && actor->target == on_id;
+    } );
+}
+
+/// True when @p it is @p id, or is the transform-"on" form of @p id (revert_to plus matching transform).
+inline auto item_matches_itype( const item &it, const itype_id &id ) -> bool
+{
+    if( it.typeId() == id ) {
+        return true;
+    }
+    if( !id.is_valid() || !it.is_tool() || !it.type->tool ) {
+        return false;
+    }
+    const auto &revert = it.type->tool->revert_to;
+    if( !revert || *revert != id ) {
+        return false;
+    }
+    return itype_transforms_into( *id, it.typeId() );
+}
+
+/// Turn a matched "on" tool into the requested type before it is consumed as a component.
+inline auto normalize_consumed_item( item &it, const itype_id &wanted ) -> void
+{
+    if( it.typeId() == wanted ) {
+        return;
+    }
+    it.convert( wanted );
+    it.deactivate();
+}

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -7,6 +7,7 @@
 #include "inventory.h"
 #include "item.h"
 #include "item_contents.h"
+#include "item_type_match.h"
 #include "itype.h"
 #include "make_static.h"
 #include "map.h"
@@ -1033,7 +1034,7 @@ static int charges_of_internal( const T &self, const M &main, const itype_id &id
     self.visit_items( [&]( const item * e ) {
         if( filter( *e ) ) {
             if( e->is_tool() ) {
-                if( e->typeId() == id ) {
+                if( item_matches_itype( *e, id ) ) {
                     // includes charges from any included magazine.
                     qty = sum_no_wrap( qty, e->ammo_remaining() );
                     if( e->has_flag( STATIC( flag_id( "USE_UPS" ) ) ) ) {
@@ -1085,16 +1086,30 @@ int visitable<inventory>::charges_of( const itype_id &what, int limit,
         return std::min( qty, limit );
     }
     const auto &binned = static_cast<const inventory *>( this )->get_binned_items();
-    const auto iter = binned.find( what );
-    if( iter == binned.end() ) {
-        return 0;
-    }
-
     int res = 0;
-    for( const item *it : iter->second ) {
-        res = sum_no_wrap( res, charges_of_internal( *it, *this, what, limit, filter, visitor ) );
-        if( res >= limit ) {
-            break;
+    const auto add_charges_from_bin = [&]( const auto &stack ) {
+        for( const item *it : stack ) {
+            res = sum_no_wrap( res, charges_of_internal( *it, *this, what, limit, filter, visitor ) );
+            if( res >= limit ) {
+                return false;
+            }
+        }
+        return true;
+    };
+    if( const auto iter = binned.find( what ); iter != binned.end() ) {
+        if( !add_charges_from_bin( iter->second ) ) {
+            return std::min( limit, res );
+        }
+    }
+    if( what.is_valid() && what->tool ) {
+        for( const auto &kv : binned ) {
+            if( kv.first == what || kv.second.empty() ||
+                !item_matches_itype( *kv.second.front(), what ) ) {
+                continue;
+            }
+            if( !add_charges_from_bin( kv.second ) ) {
+                break;
+            }
         }
     }
     return std::min( limit, res );
@@ -1177,7 +1192,7 @@ static int amount_of_internal( const T &self, const itype_id &id, bool pseudo, i
 {
     int qty = 0;
     self.visit_items( [&qty, &id, &pseudo, &limit, &filter]( const item * e ) {
-        if( ( id.str() == "any" || e->typeId() == id ) && filter( *e ) && ( pseudo ||
+        if( ( id.str() == "any" || item_matches_itype( *e, id ) ) && filter( *e ) && ( pseudo ||
                 !e->has_flag( STATIC( flag_id( "PSEUDO" ) ) ) ) ) {
             qty = sum_no_wrap( qty, 1 );
         }
@@ -1200,11 +1215,6 @@ int visitable<inventory>::amount_of( const itype_id &what, bool pseudo, int limi
                                      const std::function<bool( const item & )> &filter ) const
 {
     const auto &binned = static_cast<const inventory *>( this )->get_binned_items();
-    const auto iter = binned.find( what );
-    if( iter == binned.end() && what != itype_id( "any" ) ) {
-        return 0;
-    }
-
     int res = 0;
     if( what.str() == "any" ) {
         for( const auto &kv : binned ) {
@@ -1215,15 +1225,34 @@ int visitable<inventory>::amount_of( const itype_id &what, bool pseudo, int limi
                 }
             }
         }
-    } else {
-        for( const item *it : iter->second ) {
+        return std::min( limit, res );
+    }
+
+    const auto add_amount_from_bin = [&]( const auto &stack ) {
+        for( const item *it : stack ) {
             res = sum_no_wrap( res, it->amount_of( what, pseudo, limit, filter ) );
             if( res >= limit ) {
+                return false;
+            }
+        }
+        return true;
+    };
+    if( const auto iter = binned.find( what ); iter != binned.end() ) {
+        if( !add_amount_from_bin( iter->second ) ) {
+            return std::min( limit, res );
+        }
+    }
+    if( what.is_valid() && what->tool ) {
+        for( const auto &kv : binned ) {
+            if( kv.first == what || kv.second.empty() ||
+                !item_matches_itype( *kv.second.front(), what ) ) {
+                continue;
+            }
+            if( !add_amount_from_bin( kv.second ) ) {
                 break;
             }
         }
     }
-
     return std::min( limit, res );
 }
 

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -4,6 +4,7 @@
 #include "enums.h"
 #include "flag.h"
 #include "item.h"
+#include "item_type_match.h"
 #include "itype.h"
 #include "math_defines.h"
 #include "ret_val.h"
@@ -411,5 +412,29 @@ TEST_CASE("gunmod_weight_volume_test", "[item][gunmod]") {
 
         CHECK(gun->weight() == std::max(w0 - 999_gram, w0 / 100));
         CHECK(gun->volume() == std::max(v0 - 999_ml, v0 / 100));
+    }
+}
+
+TEST_CASE("on_tools_match_their_off_itype", "[item][crafting]") {
+    SECTION("flashlight_on counts as flashlight") {
+        detached_ptr<item> on = item::spawn("flashlight_on");
+        CHECK(item_matches_itype(*on, itype_id("flashlight")));
+        CHECK(item_matches_itype(*on, itype_id("flashlight_on")));
+    }
+
+    SECTION("heavy_flashlight_on does not count as a regular flashlight") {
+        detached_ptr<item> on = item::spawn("heavy_flashlight_on");
+        CHECK(item_matches_itype(*on, itype_id("heavy_flashlight")));
+        CHECK_FALSE(item_matches_itype(*on, itype_id("flashlight")));
+    }
+
+    SECTION("electric lantern on counts as electric lantern") {
+        detached_ptr<item> on = item::spawn("electric_lantern_on");
+        CHECK(item_matches_itype(*on, itype_id("electric_lantern")));
+    }
+
+    SECTION("an armed gas grenade does not count as an empty canister") {
+        detached_ptr<item> armed = item::spawn("gasbomb_makeshift_act");
+        CHECK_FALSE(item_matches_itype(*armed, itype_id("canister_empty")));
     }
 }

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -12,6 +12,7 @@
 #include "map_helpers.h"
 #include "player_activity.h"
 #include "player_helpers.h"
+#include "recipe.h"
 #include "requirements.h"
 #include "state_helpers.h"
 #include "type_id.h"
@@ -146,4 +147,85 @@ TEST_CASE("debug_hammerspace_installs_full_vehicle_battery", "[vehicle][veh_inte
 
     REQUIRE(installed_battery != all_parts.end());
     CHECK(installed_battery->part().ammo_remaining() == installed_battery->part().ammo_capacity());
+}
+
+TEST_CASE("on_tools_count_as_off_crafting_components", "[vehicle][crafting]") {
+    clear_all_state();
+    avatar& you = get_avatar();
+    clear_avatar();
+    you.setpos(tripoint_bub_ms(60, 60, 0));
+    you.wear_item(item::spawn("backpack"), false);
+
+    SECTION("inventory sees a lit flashlight as a flashlight") {
+        you.i_add(item::spawn("flashlight_on"));
+        you.mod_moves(1);
+        const inventory crafting_inv = you.crafting_inventory();
+        CHECK(crafting_inv.has_components(itype_id("flashlight"), 1, is_crafting_component));
+        const auto& lights = vpart_id("aisle_lights").obj();
+        CHECK(lights.install_requirements().can_make_with_inventory(
+            crafting_inv, is_crafting_component));
+    }
+
+    SECTION("headlamp recipe sees a lit flashlight") {
+        you.i_add(item::spawn("flashlight_on"));
+        you.mod_moves(1);
+        const inventory crafting_inv = you.crafting_inventory();
+        const recipe& rec = recipe_id("wearable_light").obj();
+        bool found_light = false;
+        for (const auto& opts : rec.simple_requirements().get_components()) {
+            for (const item_comp& comp : opts) {
+                if (comp.type == itype_id("flashlight")) {
+                    found_light = true;
+                    CHECK(comp.has(crafting_inv, rec.get_component_filter(), 1));
+                }
+            }
+        }
+        REQUIRE(found_light);
+    }
+
+    SECTION("consuming a lit flashlight as a flashlight turns it off") {
+        you.i_add(item::spawn("flashlight_on"));
+        you.mod_moves(1);
+        std::vector<item_comp> comps{item_comp(itype_id("flashlight"), 1)};
+        std::vector<detached_ptr<item>> used = you.consume_items(comps, 1, is_crafting_component);
+        REQUIRE(used.size() == 1);
+        CHECK(used[0]->typeId() == itype_id("flashlight"));
+        CHECK_FALSE(used[0]->is_active());
+    }
+
+    SECTION("vehicle install accepts a lit flashlight for aisle lights") {
+        map& here = get_map();
+        const tripoint_bub_ms vehicle_origin(60, 60, 0);
+        you.setpos(vehicle_origin + point_south);
+        you.i_add(item::spawn("screwdriver"));
+        you.i_add(item::spawn("flashlight_on"));
+        you.mod_moves(1);
+
+        vehicle* veh_ptr = here.add_vehicle(vproto_id("bicycle"), vehicle_origin, 0_degrees, 0, 0);
+        REQUIRE(veh_ptr != nullptr);
+
+        const auto install_part_id = vpart_id("aisle_lights");
+        const auto reference_part_index = 0;
+        const auto reference_part = &veh_ptr->part(reference_part_index);
+        const auto reference_pos =
+            map_local_to_abs(here, veh_ptr->bub_part_location(*reference_part));
+
+        you.assign_activity(ACT_VEHICLE, 1, static_cast<int>('i'));
+        you.activity->values = {
+            reference_pos.x(), reference_pos.y(), reference_pos.z(), 0, 0, 0, reference_part_index};
+        you.activity->str_values.push_back(install_part_id.str());
+        for (const tripoint_abs_ms& p : veh_ptr->get_points(true)) {
+            you.activity->coord_set.insert(p);
+        }
+
+        veh_interact::complete_vehicle(you);
+
+        const auto all_parts = veh_ptr->get_all_parts();
+        const auto installed = std::find_if(
+            all_parts.begin(), all_parts.end(), [&install_part_id](const vpart_reference& part) {
+                return part.info().get_id() == install_part_id;
+            });
+        REQUIRE(installed != all_parts.end());
+        CHECK(installed->part().get_base().typeId() == itype_id("flashlight"));
+    }
 }


### PR DESCRIPTION
## Purpose of change (The Why)

I had a flashlight on in my hands and aisle lights still wanted a flashlight. Same item, other itype. The headlamp recipe is the same story.

Turning it off is one key, but the menu is lying.

## Describe the solution (The How)

- A tool counts as type X when it is X, or when it reverts to X and X's transform use turns into this item (the usual on/off pair).
- Counting goes through inventory bins, not only the off itype bucket.
- Consume converts the item to the requested type and deactivates it, so a vehicle part gets `flashlight` not `flashlight_on`.
- An armed gas grenade still does not count as an empty canister. A heavy flashlight still does not count as a regular one.

## Describe alternatives you've considered

Treating every `revert_to` as the same item. That would let a live gas grenade count as `canister_empty`. Vehicle-only alternate base items would miss the headlamp recipe.

## Testing

Catch2: `on_tools_match_their_off_itype` and `on_tools_count_as_off_crafting_components` (inventory, wearable_light recipe, consume converts, bicycle aisle lights).

Did not rebuild the local exe for this PR. Reviewer: turn a flashlight on, open vehicle install, aisle lights should go green.

## Additional context

Follow-up to #10244 (cells in tools) and #10246 (liquid in a jerrycan). Different hole. Not stacked on those PRs.

<!-- BEGIN artifact comment -->
<!-- END artifact comment -->

## Checklist

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
