### PR TITLE
feat(balance): make zombies reliably bash obstacles that have targets above them, increase risk of being knocked out of trees

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12236,8 +12236,8 @@ float Character::stability_roll() const
 
     /** @EFFECT_DEX slightly improves player stability roll */
 
-    /** @EFFECT_DODGE improves player stability roll */
-    return get_dodge() + get_str() + ( get_per() / 3.0f ) + ( get_dex() / 4.0f );
+    /** @EFFECT_MELEE improves player stability roll */
+    return get_melee() + get_str() + ( get_per() / 3.0f ) + ( get_dex() / 4.0f );
 }
 
 bool Character::uncanny_dodge()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -14642,13 +14642,21 @@ void game::vertical_move( int movez, bool force, bool peeking )
             }
         }
     } else {
-        u.moves -= move_cost;
+        if( u.get_stamina() < move_cost ) {
+            add_msg( m_bad, _( "You are too exhausted to climb." ) );
+            return;
+        }
         // Risk of failing, simple stuff like ladders are exempt
         if( climbing && movez == 1 && m.climb_difficulty( u.bub_pos() ) > 1 ) {
             if( g->slip_down() ) {
+                move_cost = std::max( 100, rng( 1, move_cost ) );
+                u.moves -= move_cost;
+                u.burn_move_stamina( move_cost );
                 return;
             }
         }
+        u.moves -= move_cost;
+        u.burn_move_stamina( move_cost );
     }
     for( const auto &np : npcs_to_bring ) {
         if( np->in_vehicle ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4725,20 +4725,19 @@ bash_results map::bash_ter_furn( const tripoint_bub_ms &p, const bash_params &pa
             }
         }
         // Hard impacts have a chance to dislodge targets perching above
-        if( params.strength >= smin / 2 && one_in( smin / 2 ) ) {
-            tripoint_bub_ms above( p.xy(), p.z() + 1 );
-            Character *character = g->critter_at<Character>( above );
-            if( has_flag( TFLAG_UNSTABLE, above ) && character != nullptr ) {
-                character->add_msg_if_player( m_warning,
-                                              _( "You feel the ground beneath you shake from the impact!" ) );
+        tripoint_bub_ms above( p.xy(), p.z() + 1 );
+        Character *character = g->critter_at<Character>( above );
+        // Only warn player and roll for it if we actually have any chance at triggering it
+        if( has_flag( TFLAG_UNSTABLE, above ) && character != nullptr &&
+            character->stability_roll() < params.strength ) {
+            character->add_msg_if_player( m_warning,
+                                          _( "You feel the ground beneath you shake from the impact!" ) );
 
-                if( character->stability_roll() < rng( 1, params.strength - ( smin / 2 ) ) ) {
-                    character->add_msg_player_or_npc( m_bad, _( "You lose your balance!" ),
-                                                      _( "<npcname> loses their balance!" ) );
+            if( character->stability_roll() < rng( 1, params.strength ) && one_in( 10 ) ) {
+                character->add_msg_player_or_npc( m_bad, _( "You lose your balance!" ),
+                                                  _( "<npcname> loses their balance!" ) );
 
-                    g->fling_creature( character, rng_float( 0_degrees, 360_degrees ), 10 );
-                }
-
+                g->fling_creature( character, rng_float( 0_degrees, 360_degrees ), 10 );
             }
         }
     } else {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1390,7 +1390,6 @@ monster_action_t monster::decide_action() const
                     if( att == Attitude::A_HOSTILE && sees( candidate + tripoint_above ) ) {
                         enemy_above = true;
                     }
-
                 }
                 if( estimate <= 0 && !enemy_above ) {
                     continue;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1383,7 +1383,16 @@ monster_action_t monster::decide_action() const
                     continue;
                 }
                 const auto estimate = here.bash_rating( bash_estimate( candidate ), candidate );
-                if( estimate <= 0 ) {
+                bool enemy_above = false;
+                const auto *critter_above = g->critter_at( candidate + tripoint_above, hallucination );
+                if( here.inbounds_z( candidate.z() + 1 ) && critter_above != nullptr ) {
+                    const auto att = attitude_to( *critter_above );
+                    if( att == Attitude::A_HOSTILE && sees( candidate + tripoint_above ) ) {
+                        enemy_above = true;
+                    }
+
+                }
+                if( estimate <= 0 && !enemy_above ) {
                     continue;
                 }
                 if( estimate < 5 ) {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

<!-- e.g resolves #1234 / continuation of #5678 / monster A is too OP despite being an early-game mob -->

Follows up on https://github.com/cataclysmbn/Cataclysm-BN/pull/7993, which after playtesting had two flaws in my opinion:
1. Monsters still would basically never even attempt to knock you out of trees unless they did enough damage that chances are they'd be able to smash the target terrain anyway.
2. Because of this, the feature basically never mattered for most unstable terrain. For gutters over normal walls, a good horde could just bash the wall underneath and collapse it out from under you more far more often than it'd trigger the dislodge roll. Meanwhile for trees, they'd just not see it worth bashing and even if they did trees are tough enough that the roll would rarely trigger.

Also does a few associated tweaks.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In character.cpp, reverted the change in `Character::stability_roll` that set it to use effective dodge instead of melee skill. It sounded like a good idea in theory since that makes dodge mutations affect it. In practice, being on unstable footing cuts effective dodge to a quarter its value, so for the thing we're using it for it ends up being a de-facto massive nerf that completely cripples the one part of the stability roll tied to a skill level and thus something the player's expected to improve at later in the game.
2. In game.cpp, `game::vertical_move` now has it so that climbing up a z-level enforces a stamina cost along with its move cost, so a tree is no longer a last-minute escape option if you're already exhausted. In exchange however, failing to climb now consumes less time than a successful climb, with accordingly reduced stamina cost, with it being randomized.
3. In map.cpp, the bit in `map::bash_ter_furn` that handles shaking the player out of trees or other unstable terrain no longer cares about the bash strength of what's being bashed. Instead it purely checks stability roll (which reminder is not actually a ROLL) vs a number between 1 and the bash strength. To compensate, an extra 1 in 10 roll was added that also needs to trigger so that being jostled out of a tree is a threat to a low-skill character without being something that'll instantly trigger every single time if a single brute waddles up to it. As before, it's set so the message won't print if the damage is low enough that it would never trigger.
4. In monmove.cpp, `monster::decide_action` now looks for critters in the tile above it's destination in the section where it's deciding whether trying to bash that terrain is a valid option. If there is an inbounds critter in that spot, and the monster can see there, and the target is hostile, then it will skip over the bit that tells it to skip out on even trying to bash if it wouldn't damage the structure. Idea is this means that if you're stuck up a tree, zombies on ground level will always try smacking the tree if that's their only option, without this affecting normal behavior (unless they just happen to be chasing someone on ground level and run into a wall that has another desirable target perched on the roof, but in that case it's basically zero chance that if they see the goober right above them and they're hostile that they wouldn't consider it their target to begin with).

## Describe alternatives you've considered

1. Changing `Character::stability_roll` to use raw dodge skill instead?
2. Making the stamina cost significantly higher.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Temporarily inserted some test messages to confirm numbers for bash rolls, stability roll, and movecost of climbing do what I expected them to do.
3. Spawned a zombie, confirmed they don't do anything weird like sit in front of a tree trying and failing to bash it normally but will happily slam the tree repeatedly if you're on it. 
4. Confirmed via test messages that a lone zombie's bash damage is never high enough to trigger dislodge rolls for a basic all-8-stats-0-skills character, with the warning message and a low risk of being dislodged kicking in when you get 2 or more basic zeds under you if they can get in the correct tiles.
5. Confirmed that raising my melee skill now has a noticeable effect on the printed numbers and thus the damage requird before dislodge rolls can trigger.
6. Tested climbing a tree repeatedly, printed move cost was randomized on a failure as expected, can't climb if I empty my stamina.
7. Spawned a tree and some floors up on z-level +10, zombie didn't do anything weird or crash the game when path was blocked by trees.
8. Checked affected files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [71098cd](https://github.com/cataclysmbn/Cataclysm-BN/commit/71098cdef87c881a672f090f04ae7c9719d6f46f) (Merge remote-tracking branch 'upstream/main' into explodes-trees-with-mind) on 2026-09-13 20:24:16

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34776804374/artifacts/10324197123)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34776804374/artifacts/10323368682)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34776804374/artifacts/10323612746)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34776804374/artifacts/10324336934)
<!-- END artifact comment -->