### PR TITLE
fix: allow tooling to recursively search through src/ while excluding vendored folders

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -39,6 +39,7 @@
     "jsr:@std/internal@^1.0.9": "1.0.12",
     "jsr:@std/io@0.225": "0.225.2",
     "jsr:@std/io@0.225.0": "0.225.0",
+    "jsr:@std/path@*": "1.1.4",
     "jsr:@std/path@1": "1.1.2",
     "jsr:@std/path@1.0.8": "1.0.8",
     "jsr:@std/path@1.1.2": "1.1.2",

--- a/doxygen_doc/Doxyfile
+++ b/doxygen_doc/Doxyfile
@@ -753,7 +753,7 @@ FILE_PATTERNS          = *.h *.cpp
 # should be searched for input files as well. Possible values are YES and NO.
 # If left blank NO is used.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a
@@ -761,7 +761,7 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = ./src/lua ./src/sol ./src/third-party
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/lang/update_pot.sh
+++ b/lang/update_pot.sh
@@ -23,6 +23,22 @@ then
     exit 1
 fi
 
+SOURCE_FILES=$(mktemp) || exit 1
+
+trap 'rm -f "$SOURCE_FILES"' 0 # Gets rid of "$SOURCE_FILES" on exit
+
+if ! find src \
+  \( -path src/lua -o -path src/sol -o -path src/third-party \) -prune -o \
+  -type f \( -name '*.cpp' -o -name '*.h' \) -print > "$SOURCE_FILES"; then # Should probably use a constant to point to folders/files that shouldn't be targeted.
+    echo "Failed to discover source files." >&2
+    exit 1
+fi
+
+if [ ! -s "$SOURCE_FILES" ]; then
+  echo "No source files found." >&2
+  exit 1
+fi
+
 echo "> Extracting strings from source code"
 xgettext --default-domain="cataclysm-bn" \
          --add-comments="~" \
@@ -39,7 +55,7 @@ xgettext --default-domain="cataclysm-bn" \
          --keyword="pl_translation:1,2,2t" \
          --keyword="pl_translation:1c,2,3,3t" \
          --from-code="UTF-8" \
-         src/*.cpp src/*.h
+         --files-from"$SOURCE_FILES"
 if [ $? -ne 0 ]; then
     echo "Error in xgettext. Aborting"
     exit 1

--- a/scripts/affected_files.ts
+++ b/scripts/affected_files.ts
@@ -11,6 +11,7 @@ import { partition } from "jsr:@std/collections"
 import { walk, type WalkEntry, type WalkOptions } from "jsr:@std/fs"
 import { Command } from "@cliffy/command"
 import { changedFilesFromGit, type PullFileStatus } from "./git_changed_files.ts"
+import { dirname, join, normalize } from "jsr:@std/path/posix"
 
 const paths = ["src", "tests"]
 
@@ -27,10 +28,25 @@ const getDiffs = async (base: string, head: string) => {
 const includeRegex = /#include\s+"([^"]+)"/g
 const getIncludes = (content: string) => Array.from(content.matchAll(includeRegex)).map((x) => x[1])
 
-const getSourceDependencies = (nameToPath: Map<string, string>) => async ({ path }: WalkEntry) => {
-  const text = await Deno.readTextFile(path)
-  const includes = getIncludes(text).map((x) => nameToPath.get(x)!)
-  return [path, includes] as const
+const sourcePath = (path: string): string => normalize(path.replaceAll("\\", "/"));
+
+const getSourceDependencies = (sourceFiles: Set<string>) => async ({ path }: WalkEntry) => {
+    const text = await Deno.readTextFile(path);
+    const source = sourcePath(path);
+    const includes: string[] = [];
+
+    for (const include of getIncludes(text)) {
+        const localPath = join(dirname(source), include);
+        const rootPath = join("src", include);
+
+        if (sourceFiles.has(localPath)) {
+            includes.push(localPath);
+        } else if (sourceFiles.has(rootPath)) {
+            includes.push(rootPath);
+        }
+    }
+
+    return [source, includes] as const;
 }
 
 const getAllSourceFiles = async (): Promise<WalkEntry[]> => {
@@ -48,8 +64,8 @@ type Deps = Map<string, Set<string>>
  * creates mapping between header file and all source files that include it
  */
 const getAllDependencies = async (xs: WalkEntry[]): Promise<Deps> => {
-  const nameToPath = new Map(xs.map((x) => [x.name, x.path]))
-  const ys = await Promise.all(xs.map(getSourceDependencies(nameToPath)))
+  const sourceFiles = new Set(xs.map((x) => sourcePath(x.path)))
+  const ys = await Promise.all(xs.map(getSourceDependencies(sourceFiles)))
 
   const deps: Deps = new Map()
   for (const [path, includes] of ys) {


### PR DESCRIPTION
## Purpose of change (The Why)

During some previous work on migrating folders from the main src/ folder into subfolders (#10228 , #10235 ), I found that some tooling only worked on a flat src/ structure. This change should allow said tools to correctly search through relevant subfolders within the src/ directory. 

## Describe the solution (The How)

1. For `update_pot.sh`, a temporary file is created that stores a list of all of the src/ files to scan through for translatable strings, which is then read by xgettext.
2. For `Doxyfile`, changing a couple config values did the trick.
3. For `affected_files.ts`, tore my hair out trying to figure out how typescript works, before pulling in a library for posix path operations to scan files, normalize paths, push either the local path or root path and return the paths and includes such that it'll properly identify them within the correct location.

## Describe alternatives you've considered

Considered converting `update_pot.sh` to python due to better domain knowledge of python; rejected it as I deemed it too large of a change to make in this PR.

## Testing

Ran shell script, used deno's tasks for a dry run between a commit before my vehicle organization and after the vehicle organization, built documentation with Doxyfile and verified files in src/vehicle/ was present while src/lua/ wasn't.

## Additional context

Related: #10233 

![](https://i.imgur.com/X092njf.png)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [X] This is a PR that modifies build process or code organization.
  - [X] Please document the changes in the appropriate location in the `docs/` folder.
  - [X] If documentation for this feature or process does not exist, please write it.
  - [X] If the change alters versions of software required to build or work with the game, please document it.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [a4b2dc8](https://github.com/cataclysmbn/Cataclysm-BN/commit/a4b2dc890275a098f98ea808343d07bf487d5dcb) (chore: do autofix-ci's job since it's having a bad day) on 2026-09-13 17:55:03

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34772055686/artifacts/10322920358)
- [❌ Windows tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34772055686)
- [❌ macOS tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34772055686)
- [❌ Android tiles — build failed](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34772055686)
<!-- END artifact comment -->