### PR TITLE
fix: fix reference cleanup for npcs

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1869,6 +1869,10 @@ bool game::cleanup_at_end()
     avatar &player_character = get_avatar();
     player_character = avatar();
 
+    // Unload active NPCs before cleaning up safe_reference records.
+    // Without this, cleanup_references() would find live mem_count entries.
+    unload_npcs();
+
     cleanup_references();
     cleanup_arenas();
     DynamicDataLoader::get_instance().unload_data();

--- a/tests/npc_safe_reference_test.cpp
+++ b/tests/npc_safe_reference_test.cpp
@@ -1,0 +1,75 @@
+#include "avatar.h"
+#include "catch/catch.hpp"
+#include "coordinates.h"
+#include "debug.h"
+#include "game.h"
+#include "item.h"
+#include "itype.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "npc.h"
+#include "overmapbuffer.h"
+#include "overmapbuffer_registry.h"
+#include "player_activity.h"
+#include "player_helpers.h"
+#include "safe_reference.h"
+#include "state_helpers.h"
+#include "type_id.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+static const activity_id ACT_READ("ACT_READ");
+
+/// Reproduces the bug where saving while a nearby NPC is studying a book leaves
+/// a dangling safe_reference record.  The NPC's ACT_READ activity holds a
+/// safe_reference<item> to the book; if the NPC is not unloaded before
+/// cleanup_references() runs, the record still has mem_count > 0 and
+/// cleanup_references() both warns and deletes the record out from under the
+/// still-live safe_reference, causing a use-after-free.
+TEST_CASE("npc_book_activity_safe_reference_cleanup", "[npc][safe_reference]") {
+    clear_all_state();
+    const auto cleanup = on_out_of_scope([] { clear_all_state(); });
+
+    // Spawn an NPC and give it a book to read.
+    npc& reader = spawn_npc(tripoint_bub_ms(60, 60, 0), "test_talker");
+    detached_ptr<item> det = item::spawn("novel_western");
+    item& book = *det;
+    reader.i_add(std::move(det));
+    REQUIRE(book.type->book);
+
+    // Assign an ACT_READ activity with the book as target.  This creates a
+    // safe_reference<item> with mem_count > 0, exactly as npc::start_read does.
+    auto act = std::make_unique<player_activity>(ACT_READ, 100, 0,
+                reader.getID().get_value());
+    act->targets.emplace_back(book);
+    reader.assign_activity(std::move(act));
+
+    REQUIRE(reader.activity->id() == ACT_READ);
+    REQUIRE(!reader.activity->targets.empty());
+    REQUIRE(reader.activity->targets.front().is_accessible());
+
+    // Simulate the teardown sequence from game::cleanup_at_end() that is
+    // relevant to this bug: clear the overmapbuffers (releasing the
+    // overmapbuffer's shared_ptr to the NPC), then unload NPCs (clearing
+    // active_npc and destroying the NPC, which releases its safe_reference),
+    // then call cleanup_references().
+
+    // Clear overmapbuffers so the NPC is only held by active_npc.
+    for_each_overmapbuffer([](const dimension_id&, overmapbuffer& buf) {
+        buf.clear();
+    });
+
+    // Unload NPCs — reload_npcs() calls unload_npcs() (clearing active_npc,
+    // which destroys the NPC and releases its safe_reference) then load_npcs()
+    // (a no-op since the overmapbuffers were just cleared).
+    g->reload_npcs();
+
+    // cleanup_references() must not find any records with mem_count > 0.
+    const auto debug_msg = capture_debugmsg_during([]() {
+        cleanup_references();
+    });
+
+    CHECK(debug_msg.find("mem_count") == std::string::npos);
+}

--- a/tests/npc_safe_reference_test.cpp
+++ b/tests/npc_safe_reference_test.cpp
@@ -22,12 +22,7 @@
 
 static const activity_id ACT_READ("ACT_READ");
 
-/// Reproduces the bug where saving while a nearby NPC is studying a book leaves
-/// a dangling safe_reference record.  The NPC's ACT_READ activity holds a
-/// safe_reference<item> to the book; if the NPC is not unloaded before
-/// cleanup_references() runs, the record still has mem_count > 0 and
-/// cleanup_references() both warns and deletes the record out from under the
-/// still-live safe_reference, causing a use-after-free.
+
 TEST_CASE("npc_book_activity_safe_reference_cleanup", "[npc][safe_reference]") {
     clear_all_state();
     const auto cleanup = on_out_of_scope([] { clear_all_state(); });
@@ -39,8 +34,7 @@ TEST_CASE("npc_book_activity_safe_reference_cleanup", "[npc][safe_reference]") {
     reader.i_add(std::move(det));
     REQUIRE(book.type->book);
 
-    // Assign an ACT_READ activity with the book as target.  This creates a
-    // safe_reference<item> with mem_count > 0, exactly as npc::start_read does.
+    // Assign an ACT_READ activity with the book as target.
     auto act = std::make_unique<player_activity>(ACT_READ, 100, 0,
                 reader.getID().get_value());
     act->targets.emplace_back(book);
@@ -50,12 +44,6 @@ TEST_CASE("npc_book_activity_safe_reference_cleanup", "[npc][safe_reference]") {
     REQUIRE(!reader.activity->targets.empty());
     REQUIRE(reader.activity->targets.front().is_accessible());
 
-    // Simulate the teardown sequence from game::cleanup_at_end() that is
-    // relevant to this bug: clear the overmapbuffers (releasing the
-    // overmapbuffer's shared_ptr to the NPC), then unload NPCs (clearing
-    // active_npc and destroying the NPC, which releases its safe_reference),
-    // then call cleanup_references().
-
     // Clear overmapbuffers so the NPC is only held by active_npc.
     for_each_overmapbuffer([](const dimension_id&, overmapbuffer& buf) {
         buf.clear();
@@ -63,10 +51,8 @@ TEST_CASE("npc_book_activity_safe_reference_cleanup", "[npc][safe_reference]") {
 
     // Unload NPCs — reload_npcs() calls unload_npcs() (clearing active_npc,
     // which destroys the NPC and releases its safe_reference) then load_npcs()
-    // (a no-op since the overmapbuffers were just cleared).
     g->reload_npcs();
 
-    // cleanup_references() must not find any records with mem_count > 0.
     const auto debug_msg = capture_debugmsg_during([]() {
         cleanup_references();
     });


### PR DESCRIPTION
## Purpose of change (The Why)

Resolves #9899

Resolves #9894 

## Describe the solution (The How)

Call unload_npcs() before cleaning references

## Describe alternatives you've considered

## Testing

- Start new game
- Persuade npc to be a follower
- Spawn book and give it to the npc
- Ask the npc to study
- Save (No bug)
- Reload and verify the npc is till reading.

Tested both with npc holding the book and with the book on the floor.

BONUS!
- Loaded save from 9894
- Save N Quit, no error
- Swap to main
- Load save
- Save N Quit, error

## Additional context

Sadly, this fix was entirely made by the slop machine but its a very small scope for an important fix.

Also fixed a small issue where the Npc would stop reading after levelling once if it wasn't in range.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

- [x] This PR used AI assistance.
  - [x] I added an [`Assisted-by:` trailer](https://docs.cataclysmbn.org/contribute/contributing/#ai-assisted-pull-requests) to every AI-assisted commit in the [Linux kernel format](https://docs.kernel.org/process/coding-assistants.html).
- [ ] This PR ports someone else's contribution (e.g from DDA or other fork).
  - [ ] I have added [`port` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#port%3A-ports-from-dda-or-other-forks) to the PR title.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `docs/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
- [ ] This PR adds/removes a mod.
  - [ ] I have added [`mods` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#mods-or-mods%2F<mod_id>%3A-mods) to the PR title.
  - [ ] The `mod_name` in `data/mods/<mod_name>` matches `id` in `modinfo.json`.
- [ ] This PR modifies lua scripts or the lua API.
  - [ ] I have added [`lua` scope](https://docs.cataclysmbn.org/contribute/changelog_guidelines/#lua%3A-changes-to-lua-api) to the PR title.
  - [ ] I have added [type annotations](https://emmylua.github.io/annotation.html) to functions so that it's safe and easy to maintain.

<!-- BEGIN artifact comment -->

## Build Artifacts

PR build for commit [e6999c2](https://github.com/cataclysmbn/Cataclysm-BN/commit/e6999c20aa5fd5534c96860879bc14623698edf0) (Merge branch 'main' into pr/10253) on 2026-09-13 22:16:29

- [✅ Linux tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784243588/artifacts/10325689042)
- [✅ Windows tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784243588/artifacts/10326586155)
- [✅ macOS tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784243588/artifacts/10325933292)
- [✅ Android tiles — download](https://github.com/cataclysmbn/Cataclysm-BN/actions/runs/34784243588/artifacts/10327060131)
<!-- END artifact comment -->